### PR TITLE
fix: update minimum version for libkrun support

### DIFF
--- a/extensions/podman/src/extension.spec.ts
+++ b/extensions/podman/src/extension.spec.ts
@@ -2101,3 +2101,21 @@ describe('checkRosettaMacArm', async () => {
     expect(extensionApi.window.showInformationMessage).toBeCalled();
   });
 });
+
+test('isLibkrunSupported should return true with prelease older than rc1', async () => {
+  vi.mocked(isMac).mockReturnValue(true);
+  const enabled = extension.isLibkrunSupported('5.2.0-rc2');
+  expect(enabled).toBeTruthy();
+});
+
+test('isLibkrunSupported should return true with 5.2.0 version', async () => {
+  vi.mocked(isMac).mockReturnValue(true);
+  const enabled = extension.isLibkrunSupported('5.2.0');
+  expect(enabled).toBeTruthy();
+});
+
+test('isLibkrunSupported should return false with previous 5.1.2 version', async () => {
+  vi.mocked(isMac).mockReturnValue(true);
+  const enabled = extension.isLibkrunSupported('5.1.2');
+  expect(enabled).toBeFalsy();
+});

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -1759,7 +1759,7 @@ export function isUserModeNetworkingSupported(podmanVersion: string): boolean {
   return isWindows() && compareVersions(podmanVersion, PODMAN_MINIMUM_VERSION_FOR_USER_MODE_NETWORKING) >= 0;
 }
 
-const PODMAN_MINIMUM_VERSION_FOR_LIBKRUN_SUPPORT = '5.2.0';
+const PODMAN_MINIMUM_VERSION_FOR_LIBKRUN_SUPPORT = '5.2.0-rc1';
 
 // Checks if libkrun is supported. Only Mac platform allows this parameter to be tuned
 export function isLibkrunSupported(podmanVersion: string): boolean {


### PR DESCRIPTION
### What does this PR do?

It reduces the minimum podman version to enable libkrun support. This is needed to allow QE for testing it using 5.2.0-rc2

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

N/A

- [x] Tests are covering the bug fix or the new feature
