### PR TITLE
Cancel image layers loading when Files tab is closed

### DIFF
--- a/packages/renderer/src/lib/image/ImageDetailsFiles.svelte
+++ b/packages/renderer/src/lib/image/ImageDetailsFiles.svelte
@@ -19,6 +19,7 @@ let filesProvider: ImageFilesInfo;
 let selectedLayer: ImageFilesystemLayerUI;
 let showLayerOnly: boolean;
 let loading: boolean;
+let cancellableTokenId: number = 0;
 
 function onSelectedLayer(event: CustomEvent<ImageFilesystemLayerUI>) {
   selectedLayer = event.detail;
@@ -29,19 +30,23 @@ onMount(async () => {
     if (providers.length === 1 && imageInfo) {
       filesProvider = providers[0];
       loading = true;
-      window
-        .imageGetFilesystemLayers(filesProvider.id, imageInfo)
-        .then(layers => {
-          imageLayers = layers;
-        })
-        .finally(() => {
-          loading = false;
-        });
+      window.getCancellableTokenSource().then(token => {
+        cancellableTokenId = token;
+        window
+          .imageGetFilesystemLayers(filesProvider.id, imageInfo, cancellableTokenId)
+          .then(layers => {
+            imageLayers = layers;
+          })
+          .finally(() => {
+            loading = false;
+          });
+      });
     }
   });
 });
 
 onDestroy(() => {
+  window.cancelToken(cancellableTokenId);
   filesProvidersUnsubscribe?.();
 });
 </script>

--- a/packages/renderer/src/lib/image/imageDetailsFiles.spec.ts
+++ b/packages/renderer/src/lib/image/imageDetailsFiles.spec.ts
@@ -17,159 +17,261 @@
  ***********************************************************************/
 
 import type { ImageFilesystemLayer } from '@podman-desktop/api';
-import { expect, test } from 'vitest';
+import { render } from '@testing-library/svelte';
+import { tick } from 'svelte';
+import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { imageFilesProviders } from '/@/stores/image-files-providers';
 
 import { toImageFilesystemLayerUIs } from './imageDetailsFiles';
+import ImageDetailsFiles from './ImageDetailsFiles.svelte';
 
-test('toImageFilesystemLayerUIs with only added files', () => {
-  const input: ImageFilesystemLayer[] = [
-    {
-      id: 'layer1',
-      files: [
-        {
-          path: 'A/B/C.txt',
-          type: 'file',
-          mode: 0o644,
-          uid: 1,
-          gid: 1,
-          ctime: new Date(),
-          atime: new Date(),
-          mtime: new Date(),
-          size: 100,
-        },
-        {
-          path: 'A/B/D.txt',
-          type: 'file',
-          mode: 0o644,
-          uid: 1,
-          gid: 1,
-          ctime: new Date(),
-          atime: new Date(),
-          mtime: new Date(),
-          size: 50,
-        },
-      ],
-    },
-    {
-      id: 'layer2',
-      files: [
-        {
-          path: 'A/B/E.txt',
-          type: 'file',
-          mode: 0o644,
-          uid: 1,
-          gid: 1,
-          ctime: new Date(),
-          atime: new Date(),
-          mtime: new Date(),
-          size: 20,
-        },
-      ],
-    },
-  ];
-  const result = toImageFilesystemLayerUIs(input);
-  expect(result[0].sizeInArchive).toBe(150);
-  expect(result[0].sizeInContainer).toBe(150);
-  expect(result[0].stackTree.size).toBe(150);
-  expect(result[1].sizeInArchive).toBe(20);
-  expect(result[1].sizeInContainer).toBe(20);
-  expect(result[1].stackTree.size).toBe(170);
+describe('toImageFilesystemLayerUIs', () => {
+  test('toImageFilesystemLayerUIs with only added files', () => {
+    const input: ImageFilesystemLayer[] = [
+      {
+        id: 'layer1',
+        files: [
+          {
+            path: 'A/B/C.txt',
+            type: 'file',
+            mode: 0o644,
+            uid: 1,
+            gid: 1,
+            ctime: new Date(),
+            atime: new Date(),
+            mtime: new Date(),
+            size: 100,
+          },
+          {
+            path: 'A/B/D.txt',
+            type: 'file',
+            mode: 0o644,
+            uid: 1,
+            gid: 1,
+            ctime: new Date(),
+            atime: new Date(),
+            mtime: new Date(),
+            size: 50,
+          },
+        ],
+      },
+      {
+        id: 'layer2',
+        files: [
+          {
+            path: 'A/B/E.txt',
+            type: 'file',
+            mode: 0o644,
+            uid: 1,
+            gid: 1,
+            ctime: new Date(),
+            atime: new Date(),
+            mtime: new Date(),
+            size: 20,
+          },
+        ],
+      },
+    ];
+    const result = toImageFilesystemLayerUIs(input);
+    expect(result[0].sizeInArchive).toBe(150);
+    expect(result[0].sizeInContainer).toBe(150);
+    expect(result[0].stackTree.size).toBe(150);
+    expect(result[1].sizeInArchive).toBe(20);
+    expect(result[1].sizeInContainer).toBe(20);
+    expect(result[1].stackTree.size).toBe(170);
+  });
+
+  test('toImageFilesystemLayerUIs with a modified file', () => {
+    const input: ImageFilesystemLayer[] = [
+      {
+        id: 'layer1',
+        files: [
+          {
+            path: 'A/B/C.txt',
+            type: 'file',
+            mode: 0o644,
+            uid: 1,
+            gid: 1,
+            ctime: new Date(),
+            atime: new Date(),
+            mtime: new Date(),
+            size: 100,
+          },
+          {
+            path: 'A/B/D.txt',
+            type: 'file',
+            mode: 0o644,
+            uid: 1,
+            gid: 1,
+            ctime: new Date(),
+            atime: new Date(),
+            mtime: new Date(),
+            size: 50,
+          },
+        ],
+      },
+      {
+        id: 'layer2',
+        files: [
+          {
+            path: 'A/B/D.txt',
+            type: 'file',
+            mode: 0o644,
+            uid: 1,
+            gid: 1,
+            ctime: new Date(),
+            atime: new Date(),
+            mtime: new Date(),
+            size: 42,
+          },
+        ],
+      },
+    ];
+    const result = toImageFilesystemLayerUIs(input);
+    expect(result[0].sizeInArchive).toBe(150);
+    expect(result[0].sizeInContainer).toBe(150);
+    expect(result[0].stackTree.size).toBe(150);
+    expect(result[1].sizeInArchive).toBe(42);
+    expect(result[1].sizeInContainer).toBe(-8);
+    expect(result[1].stackTree.size).toBe(142);
+  });
+
+  test('toImageFilesystemLayerUIs with an file', () => {
+    const input: ImageFilesystemLayer[] = [
+      {
+        id: 'layer1',
+        files: [
+          {
+            path: 'A/B/C.txt',
+            type: 'file',
+            mode: 0o644,
+            uid: 1,
+            gid: 1,
+            ctime: new Date(),
+            atime: new Date(),
+            mtime: new Date(),
+            size: 100,
+          },
+          {
+            path: 'A/B/D.txt',
+            type: 'file',
+            mode: 0o644,
+            uid: 1,
+            gid: 1,
+            ctime: new Date(),
+            atime: new Date(),
+            mtime: new Date(),
+            size: 50,
+          },
+        ],
+      },
+      {
+        id: 'layer2',
+        whiteouts: ['A/B/D.txt'],
+      },
+    ];
+    const result = toImageFilesystemLayerUIs(input);
+    expect(result[0].sizeInArchive).toBe(150);
+    expect(result[0].sizeInContainer).toBe(150);
+    expect(result[0].stackTree.size).toBe(150);
+    expect(result[1].sizeInArchive).toBe(0);
+    expect(result[1].sizeInContainer).toBe(-50);
+    expect(result[1].stackTree.size).toBe(100);
+  });
 });
 
-test('toImageFilesystemLayerUIs with a modified file', () => {
-  const input: ImageFilesystemLayer[] = [
-    {
-      id: 'layer1',
-      files: [
-        {
-          path: 'A/B/C.txt',
-          type: 'file',
-          mode: 0o644,
-          uid: 1,
-          gid: 1,
-          ctime: new Date(),
-          atime: new Date(),
-          mtime: new Date(),
-          size: 100,
-        },
-        {
-          path: 'A/B/D.txt',
-          type: 'file',
-          mode: 0o644,
-          uid: 1,
-          gid: 1,
-          ctime: new Date(),
-          atime: new Date(),
-          mtime: new Date(),
-          size: 50,
-        },
-      ],
-    },
-    {
-      id: 'layer2',
-      files: [
-        {
-          path: 'A/B/D.txt',
-          type: 'file',
-          mode: 0o644,
-          uid: 1,
-          gid: 1,
-          ctime: new Date(),
-          atime: new Date(),
-          mtime: new Date(),
-          size: 42,
-        },
-      ],
-    },
-  ];
-  const result = toImageFilesystemLayerUIs(input);
-  expect(result[0].sizeInArchive).toBe(150);
-  expect(result[0].sizeInContainer).toBe(150);
-  expect(result[0].stackTree.size).toBe(150);
-  expect(result[1].sizeInArchive).toBe(42);
-  expect(result[1].sizeInContainer).toBe(-8);
-  expect(result[1].stackTree.size).toBe(142);
-});
+describe('ImageDetailsFiles component', () => {
+  const imageGetFilesystemLayersMock = vi.fn();
+  const cancelTokenMock = vi.fn();
+  const getCancellableTokenSourceMock = vi.fn();
 
-test('toImageFilesystemLayerUIs with an file', () => {
-  const input: ImageFilesystemLayer[] = [
+  beforeAll(() => {
+    (window as any).imageGetFilesystemLayers = imageGetFilesystemLayersMock;
+    (window as any).cancelToken = cancelTokenMock;
+    (window as any).window.getCancellableTokenSource = getCancellableTokenSourceMock;
+  });
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    imageFilesProviders.set([]);
+  });
+
+  test.each([
     {
-      id: 'layer1',
-      files: [
-        {
-          path: 'A/B/C.txt',
-          type: 'file',
-          mode: 0o644,
-          uid: 1,
-          gid: 1,
-          ctime: new Date(),
-          atime: new Date(),
-          mtime: new Date(),
-          size: 100,
-        },
-        {
-          path: 'A/B/D.txt',
-          type: 'file',
-          mode: 0o644,
-          uid: 1,
-          gid: 1,
-          ctime: new Date(),
-          atime: new Date(),
-          mtime: new Date(),
-          size: 50,
-        },
+      name: 'imageGetFilesystemLayers is called if there is one provider',
+      providers: [{ id: 'provider1', label: 'Provider 1' }],
+      calledExpected: true,
+    },
+    {
+      name: 'imageGetFilesystemLayers is not called if there is no provider',
+      providers: [],
+      calledExpected: false,
+    },
+    {
+      name: 'imageGetFilesystemLayers is not called if there are two providers',
+      providers: [
+        { id: 'provider1', label: 'Provider 1' },
+        { id: 'provider2', label: 'Provider 2' },
       ],
+      calledExpected: false,
     },
-    {
-      id: 'layer2',
-      whiteouts: ['A/B/D.txt'],
-    },
-  ];
-  const result = toImageFilesystemLayerUIs(input);
-  expect(result[0].sizeInArchive).toBe(150);
-  expect(result[0].sizeInContainer).toBe(150);
-  expect(result[0].stackTree.size).toBe(150);
-  expect(result[1].sizeInArchive).toBe(0);
-  expect(result[1].sizeInContainer).toBe(-50);
-  expect(result[1].stackTree.size).toBe(100);
+  ])('$name', async ({ providers, calledExpected }) => {
+    getCancellableTokenSourceMock.mockResolvedValue(101010);
+    imageGetFilesystemLayersMock.mockResolvedValue({ layers: [] });
+    const imageInfo = {
+      engineId: 'podman.Podman',
+      engineName: 'Podman',
+      Id: 'sha256:3696f18be9a51a60395a7c2667e2fcebd2d913af0ad6da287e03810fda566833',
+      ParentId: '7f8297e79d497136a7d75d506781b545b20ea599041f02ab14aa092e24f110b7',
+      RepoTags: ['quay.io/user/image-name:v0.0.1'],
+      Created: 1701338214,
+      Size: 34134140,
+      VirtualSize: 34134140,
+      SharedSize: 0,
+      Labels: {},
+      Containers: 0,
+      Digest: '',
+    };
+    render(ImageDetailsFiles, {
+      imageInfo,
+    });
+    imageFilesProviders.set(providers);
+    await tick();
+    await tick();
+    if (calledExpected) {
+      expect(imageGetFilesystemLayersMock).toHaveBeenCalled();
+    } else {
+      expect(imageGetFilesystemLayersMock).not.toHaveBeenCalled();
+    }
+  });
+
+  test('token is canceled when component is unmounted', async () => {
+    const TOKEN_ID = 101010;
+    getCancellableTokenSourceMock.mockResolvedValue(TOKEN_ID);
+    imageGetFilesystemLayersMock.mockResolvedValue({ layers: [] });
+    const imageInfo = {
+      engineId: 'podman.Podman',
+      engineName: 'Podman',
+      Id: 'sha256:3696f18be9a51a60395a7c2667e2fcebd2d913af0ad6da287e03810fda566833',
+      ParentId: '7f8297e79d497136a7d75d506781b545b20ea599041f02ab14aa092e24f110b7',
+      RepoTags: ['quay.io/user/image-name:v0.0.1'],
+      Created: 1701338214,
+      Size: 34134140,
+      VirtualSize: 34134140,
+      SharedSize: 0,
+      Labels: {},
+      Containers: 0,
+      Digest: '',
+    };
+    const component = render(ImageDetailsFiles, {
+      imageInfo,
+    });
+    imageFilesProviders.set([{ id: 'provider1', label: 'Provider 1' }]);
+    await tick();
+    await tick();
+    expect(imageGetFilesystemLayersMock).toHaveBeenCalledWith(expect.anything(), expect.anything(), TOKEN_ID);
+    component.unmount();
+    expect(cancelTokenMock).toHaveBeenCalledWith(TOKEN_ID);
+  });
 });


### PR DESCRIPTION
### What does this PR do?

Cancel image layers loading when Files tab is closed

### Screenshot / video of UI

### What issues does this PR fix or reference?

Fixes #8211 

### How to test this PR?

Can be tested with this version of extension: https://github.com/containers/podman-desktop-extension-layers-explorer/pull/6

- [x] Tests are covering the bug fix or the new feature
