### PR TITLE
chore: use isManifestList for manifest guessing

### DIFF
--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -640,11 +640,16 @@ export class ContainerProviderRegistry {
 
         return Promise.all(
           Array.from(fetchedImages).map(async image => {
+            // If image.isManifestList is NOT undefined (5.0.2+), we can use it to determine if the image is a manifest
+            // rather than guessing
+            const isManifest = image.isManifestList ?? guessIsManifest(image, provider.connection.type);
+
+            // Return the base image with the engineName and engineId as well as our isManifest parameter.
             const baseImage = {
               ...image,
               engineName: provider.name,
               engineId: provider.id,
-              isManifest: guessIsManifest(image, provider.connection.type),
+              isManifest,
               Id: image.Digest ? `sha256:${image.Id}` : image.Id,
               Digest: image.Digest || `sha256:${image.Id}`,
             };


### PR DESCRIPTION
chore: is isManifestList for manifest guessing

### What does this PR do?

* Use isManifestList instead of guessing.
* Guessing has proven to be very accurate, but this instead will use the
  built-in API from podman that was added in 5.0.2 and above: https://github.com/containers/podman/pull/22266

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A, should appear as normal for manifests

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/7543

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

1. Create a manifest
2. View image list like normal and see no changes

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
