### PR TITLE
feat: improved environment column (provider info)

### DIFF
--- a/packages/renderer/src/lib/ui/ProviderInfo.spec.ts
+++ b/packages/renderer/src/lib/ui/ProviderInfo.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +19,30 @@
 import '@testing-library/jest-dom/vitest';
 
 import { render, screen } from '@testing-library/svelte';
-import { expect, test } from 'vitest';
+import { writable } from 'svelte/store';
+import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
+import * as kubeContexts from '/@/stores/kubernetes-contexts';
+
+import type { KubeContext } from '../../../../main/src/plugin/kubernetes-context';
 import ProviderInfo from './ProviderInfo.svelte';
+
+const getProviderInfosMock = vi.fn();
+
+beforeAll(() => {
+  (window as any).getProviderInfos = getProviderInfosMock;
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.clearAllMocks();
+});
+
+vi.mock('/@/stores/kubernetes-contexts', async () => {
+  return {
+    kubernetesContexts: vi.fn(),
+  };
+});
 
 test('Expect podman is purple', async () => {
   const provider = 'podman';
@@ -54,4 +75,68 @@ test('Expect docker is blue', async () => {
   expect(label).toBeInTheDocument();
   expect(label.parentElement?.firstChild).toBeInTheDocument();
   expect(label.parentElement?.firstChild).toHaveClass('bg-sky-400');
+});
+
+test('Expect to use Kubernetes provider name', async () => {
+  const name = 'my-kube';
+  const context = {
+    name: name,
+    cluster: 'test',
+    user: 'test',
+    currentContext: true,
+    clusterInfo: {
+      name: 'test',
+      server: 'https://127.0.0.1/mycluster',
+    },
+  } as KubeContext;
+  const contexts = writable<KubeContext[]>([context]);
+  vi.mocked(kubeContexts).kubernetesContexts = contexts;
+  getProviderInfosMock.mockReturnValue([
+    { name: name, kubernetesConnections: [{ endpoint: { apiURL: 'https://localhost/mycluster' } }] },
+  ]);
+
+  render(ProviderInfo, {
+    props: {
+      provider: 'kubernetes',
+      context: 'test',
+    },
+  });
+
+  await new Promise(resolve => setTimeout(resolve, 10));
+  const label = screen.getByText(name);
+  expect(label).toBeInTheDocument();
+});
+
+test('Expect to use container provider name', async () => {
+  const name = 'Podman4ever';
+  const providerId = 'podman1';
+  getProviderInfosMock.mockReturnValue([{ name: name, id: providerId }]);
+  render(ProviderInfo, {
+    props: {
+      provider: 'podman',
+      context: providerId + '.connection',
+    },
+  });
+
+  await new Promise(resolve => setTimeout(resolve, 10));
+  const label = screen.getByText(name);
+  expect(label).toBeInTheDocument();
+});
+
+test('Expect connection name when there are multiple connections', async () => {
+  const connectionName = 'my-podman';
+  const providerId = 'podman1';
+  getProviderInfosMock.mockReturnValue([
+    { id: providerId, containerConnections: [{ name: connectionName }, { name: 'my-other-podman' }] },
+  ]);
+  render(ProviderInfo, {
+    props: {
+      provider: 'podman',
+      context: providerId + '.' + connectionName,
+    },
+  });
+
+  await new Promise(resolve => setTimeout(resolve, 10));
+  const label = screen.getByText(connectionName);
+  expect(label).toBeInTheDocument();
 });


### PR DESCRIPTION
### What does this PR do?

Currently, the environment columns all show a ProviderInfo that only says 'Podman', 'Docker', or 'Kubernetes'. When you have multiple Podman instances or switch Kubernetes contexts it would be more useful to provide some more information.

This PR makes changes to both environments:
- For Kubernetes contexts, use the name of the provider (e.g. Kind or OpenShift Local) if we can find it based on the current context endpoint (since we only support the current context).
- For container providers, use the name of the provider, e.g. 'Podman'. If the provider has more than one connection (e.g. I have two Podman machines), use the name of the connection (machine)

### Screenshot / video of UI

Before:

<img width="132" alt="Screenshot 2024-07-31 at 10 27 18 AM" src="https://github.com/user-attachments/assets/850025ab-5061-463e-bfb9-df3a58992af4">

After:

<img width="132" alt="Screenshot 2024-07-31 at 10 26 58 AM" src="https://github.com/user-attachments/assets/74b1bb53-2a98-4094-83f9-e4b66b7c2570">

### What issues does this PR fix or reference?

Part of #8281.

### How to test this PR?

Try in a simple setup with just one machine/Kubernetes context, as well as with multiple machines, switching context, etc.

Would especially like some feedback from people who have tried the Podman remote support.

- [x] Tests are covering the bug fix or the new feature