### PR TITLE
indicate tag image when deleting image

### DIFF
--- a/packages/renderer/src/lib/image/ImageActions.spec.ts
+++ b/packages/renderer/src/lib/image/ImageActions.spec.ts
@@ -21,7 +21,7 @@ import '@testing-library/jest-dom/vitest';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { router } from 'tinro';
-import { beforeAll, expect, test, vi } from 'vitest';
+import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
 import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
 import ImageActions from '/@/lib/image/ImageActions.svelte';
@@ -61,9 +61,12 @@ const fakedImage: ImageInfoUI = {
   name: 'dummy',
 } as unknown as ImageInfoUI;
 
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
 test('Expect showMessageBox to be called when error occurs', async () => {
-  // Mock the showMessageBox to return 0 (yes)
-  showMessageBoxMock.mockResolvedValue({ response: 0 });
+  vi.mocked(withConfirmation).mockImplementation(f => f());
   getContributedMenusMock.mockImplementation(() => Promise.resolve([]));
 
   const image: ImageInfoUI = {
@@ -177,8 +180,6 @@ test('Expect no dropdown when several contributions and dropdownMenu mode on', a
 });
 
 test('Expect Push image to be there', async () => {
-  // Mock the showMessageBox to return 0 (yes)
-  showMessageBoxMock.mockResolvedValue({ response: 0 });
   getContributedMenusMock.mockImplementation(() => Promise.resolve([]));
 
   const image: ImageInfoUI = {
@@ -197,6 +198,7 @@ test('Expect Push image to be there', async () => {
 });
 
 test('Expect Save image to be there', async () => {
+  getContributedMenusMock.mockImplementation(() => Promise.resolve([]));
   const goToMock = vi.spyOn(router, 'goto');
 
   const image: ImageInfoUI = {

--- a/packages/renderer/src/lib/image/ImageActions.svelte
+++ b/packages/renderer/src/lib/image/ImageActions.svelte
@@ -103,7 +103,7 @@ function saveImage() {
 
 <ListItemButtonIcon
   title="Delete Image"
-  onClick={() => withConfirmation(deleteImage, `delete image ${image.name}`)}
+  onClick={() => withConfirmation(deleteImage, `delete image ${image.name}:${image.tag}`)}
   detailed={detailed}
   icon={faTrash}
   enabled={image.status === 'UNUSED'} />


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

indicate tag image when deleting image
### Screenshot / video of UI

Before:
![delete-image-no-tag](https://github.com/user-attachments/assets/2b9ee4a5-6892-4578-b245-edbd6d4486c8)

After:
![image-delete-tag](https://github.com/user-attachments/assets/01162351-a019-4033-a5d0-2db0a77e29fb)


### What issues does this PR fix or reference?

Fixes #8319 

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
