### PR TITLE
chore: generate a test key on the fly

### DIFF
--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -390,11 +390,13 @@
   },
   "devDependencies": {
     "@types/ssh2": "^1.15.0",
+    "@types/sshpk": "^1.17.4",
     "adm-zip": "^0.5.14",
     "hasha": "^6.0.0",
     "mkdirp": "^3.0.1",
     "nock": "^14.0.0-beta.7",
     "octokit": "^4.0.2",
+    "sshpk": "^1.18.0",
     "tsx": "^4.16.4",
     "vite": "^5.3.5",
     "vitest": "^1.6.0"

--- a/extensions/podman/src/podman-remote-ssh-tunnel.spec.ts
+++ b/extensions/podman/src/podman-remote-ssh-tunnel.spec.ts
@@ -23,7 +23,8 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { Server } from 'ssh2';
-import { beforeEach, expect, test, vi } from 'vitest';
+import { generatePrivateKey } from 'sshpk';
+import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
 import { PodmanRemoteSshTunnel } from './podman-remote-ssh-tunnel';
 
@@ -46,17 +47,12 @@ class TestPodmanRemoteSshTunnel extends PodmanRemoteSshTunnel {
   }
 }
 
-// this is a dummy key for testing
-// no leakeage there
-const DUMMY_KEY = `
------BEGIN OPENSSH PRIVATE KEY-----
-b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
-QyNTUxOQAAACA64q3c1wk0Gwey/p+UnWB3gbX2j6EQBp7rVfIBuUbXxQAAAJhWRLISVkSy
-EgAAAAtzc2gtZWQyNTUxOQAAACA64q3c1wk0Gwey/p+UnWB3gbX2j6EQBp7rVfIBuUbXxQ
-AAAECMAo9dAwYs3Z1Jwn+fVhF/bG6FBMn2QnEWWqdEmAKM+TrirdzXCTQbB7L+n5SdYHeB
-tfaPoRAGnutV8gG5RtfFAAAAFGJlbm9pdGZARmxvcmVudHMtTUJQAQ==
------END OPENSSH PRIVATE KEY-----
-`; // notsecret
+let dummyKey: string;
+beforeAll(async () => {
+  // generate on the fly a dummy key
+  dummyKey = generatePrivateKey('ed25519').toString('ssh');
+});
+
 test('should be able to connect', async () => {
   let sshPort = 0;
   let connected = false;
@@ -65,7 +61,7 @@ test('should be able to connect', async () => {
   // create ssh server
   const sshServer = new Server(
     {
-      hostKeys: [DUMMY_KEY],
+      hostKeys: [dummyKey],
     },
     client => {
       connected = true;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6013,6 +6013,13 @@
   resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-5.0.1.tgz#3286741fb8f1e1580ac28784add4c7a1d49bdfbc"
   integrity sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==
 
+"@types/asn1@*":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@types/asn1/-/asn1-0.2.4.tgz#a0f89f9ddad8186c9c081c5df2e5cade855d2ac0"
+  integrity sha512-V91DSJ2l0h0gRhVP4oBfBzRBN9lAbPUkGDMCnwedqPKX2d84aAMc9CulOvxdw1f7DfEYx99afab+Rsm3e52jhA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/aws-lambda@^8.10.83":
   version "8.10.97"
   resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.97.tgz#9b2f2adfa63a215173a9da37604e4f65dd56cb98"
@@ -6619,6 +6626,14 @@
   integrity sha512-YcT8jP5F8NzWeevWvcyrrLB3zcneVjzYY9ZDSMAMboI+2zR1qYWFhwsyOFVzT7Jorn67vqxC0FRiw8YyG9P1ww==
   dependencies:
     "@types/node" "^18.11.18"
+
+"@types/sshpk@^1.17.4":
+  version "1.17.4"
+  resolved "https://registry.yarnpkg.com/@types/sshpk/-/sshpk-1.17.4.tgz#239f86cc7f39c74285d4aea1cfee9fb3288f856f"
+  integrity sha512-5gI/7eJn6wmkuIuFY8JZJ1g5b30H9K5U5vKrvOuYu+hoZLb2xcVEgxhYZ2Vhbs0w/ACyzyfkJq0hQtBfSCugjw==
+  dependencies:
+    "@types/asn1" "*"
+    "@types/node" "*"
 
 "@types/stream-chain@*":
   version "2.0.1"
@@ -18238,6 +18253,21 @@ ssh2@1.11.0, ssh2@^1.15.0:
   optionalDependencies:
     cpu-features "~0.0.4"
     nan "^2.16.0"
+
+sshpk@^1.18.0:
+  version "1.18.0"
+  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.18.0.tgz#1663e55cddf4d688b86a46b77f0d5fe363aba028"
+  integrity sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==
+  dependencies:
+    asn1 "~0.2.3"
+    assert-plus "^1.0.0"
+    bcrypt-pbkdf "^1.0.0"
+    dashdash "^1.12.0"
+    ecc-jsbn "~0.1.1"
+    getpass "^0.1.1"
+    jsbn "~0.1.0"
+    safer-buffer "^2.0.2"
+    tweetnacl "~0.14.0"
 
 sshpk@^1.7.0:
   version "1.17.0"


### PR DESCRIPTION
### What does this PR do?
generate a test key on the fly
it is avoiding scanners to think we're leaking a ssh key publicly

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
