### PR TITLE
docs: add notes about accessing opening devtools of extension

### DIFF
--- a/website/docs/extensions/developing/index.md
+++ b/website/docs/extensions/developing/index.md
@@ -371,7 +371,7 @@ export default config;
 
 - All runtime dependencies are inside the final binary.
 
-## Testing and running an extension
+## Running and debugging an extension
 
 #### Prerequisites
 
@@ -380,11 +380,16 @@ export default config;
 
 #### Procedure
 
-1. To start Podman Desktop with your extension loaded, run the following from your clone of the Podman Desktop repo:
+To start Podman Desktop with your extension loaded, run the following from your clone of the Podman Desktop repo:
 
 ```shell
 yarn watch --extension-folder /path/to/your/extension
 ```
+
+If you have a webview created, debugging / accessing the the console of the extension can be done by:
+
+1. Clicking on the extension icon in the sidebar.
+2. Right-click and select **Open Devtools of the webview**.
 
 ## Expanding your extension
 


### PR DESCRIPTION
docs: add notes about accessing opening devtools of extension

### What does this PR do?

* Adds some small notes regarding that you can open the devtools to the
  extensions documentation

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A, docs related

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/6525

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

N/A

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
