### PR TITLE
feat: add tooltip with full path when cli tool is detected

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesCliTool.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesCliTool.spec.ts
@@ -117,7 +117,7 @@ suite('CLI Tool item', () => {
     const versionElement = screen.getByLabelText('cli-version');
     expect(versionElement).toBeDefined();
     expect(versionElement.textContent).equal(`${cliToolInfoItem2.name} v${cliToolInfoItem2.version}`);
-    const displayFullPathElement = screen.getByText('Full path: path/to/tool-name-2');
+    const displayFullPathElement = screen.getByText('Path: path/to/tool-name-2');
     expect(displayFullPathElement).toBeInTheDocument();
     const updateLoadingButton = screen.getByRole('button', { name: 'Update' });
     expect(updateLoadingButton).toBeInTheDocument();

--- a/packages/renderer/src/lib/preferences/PreferencesCliTool.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesCliTool.spec.ts
@@ -117,6 +117,8 @@ suite('CLI Tool item', () => {
     const versionElement = screen.getByLabelText('cli-version');
     expect(versionElement).toBeDefined();
     expect(versionElement.textContent).equal(`${cliToolInfoItem2.name} v${cliToolInfoItem2.version}`);
+    const displayFullPathElement = screen.getByText('Full path: path/to/tool-name-2');
+    expect(displayFullPathElement).toBeInTheDocument();
     const updateLoadingButton = screen.getByRole('button', { name: 'Update' });
     expect(updateLoadingButton).toBeInTheDocument();
     expect(updateLoadingButton).toBeDisabled();

--- a/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
@@ -114,7 +114,7 @@ function getLoggerHandler(_cliToolId: string): ConnectionCallback {
         {#if cliTool.version}
           <div
             class="flex flex-row justify-between align-center bg-[var(--pd-invert-content-bg)] p-2 rounded-lg min-w-[320px] w-fit">
-            <Tooltip area-label="cli-full-path" bottomRight={true} tip="Full path: {cliTool.path}">
+            <Tooltip area-label="cli-full-path" bottomRight={true} tip="Path: {cliTool.path}">
               <div
                 class="flex text-[var(--pd-invert-content-card-text)] font-bold text-sm items-center"
                 aria-label="cli-version">

--- a/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { faCircleArrowUp, faCircleXmark } from '@fortawesome/free-solid-svg-icons';
-import { Button } from '@podman-desktop/ui-svelte';
+import { Button, Tooltip } from '@podman-desktop/ui-svelte';
 import Fa from 'svelte-fa';
 
 import type { CliToolInfo } from '/@api/cli-tool-info';
@@ -114,11 +114,12 @@ function getLoggerHandler(_cliToolId: string): ConnectionCallback {
         {#if cliTool.version}
           <div
             class="flex flex-row justify-between align-center bg-[var(--pd-invert-content-bg)] p-2 rounded-lg min-w-[320px] w-fit">
-            <div
-              class="flex text-[var(--pd-invert-content-card-text)] font-bold text-sm items-center"
-              aria-label="cli-version">
-              {cliTool.name} v{cliTool.version}
-            </div>
+            <Tooltip area-label="cli-full-path" bottomRight={true} tip="Full path: {cliTool.path}">
+              <div
+                class="flex text-[var(--pd-invert-content-card-text)] font-bold text-sm items-center"
+                aria-label="cli-version">
+              </div>
+            </Tooltip>
             {#if cliTool.newVersion}
               <Button
                 type="link"

--- a/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
@@ -118,6 +118,7 @@ function getLoggerHandler(_cliToolId: string): ConnectionCallback {
               <div
                 class="flex text-[var(--pd-invert-content-card-text)] font-bold text-sm items-center"
                 aria-label="cli-version">
+                {cliTool.name} v{cliTool.version}
               </div>
             </Tooltip>
             {#if cliTool.newVersion}


### PR DESCRIPTION
### What does this PR do?

PR adds tooltip with full path when mouse hoover over cli tool name

### Screenshot / video of UI

![image](https://github.com/user-attachments/assets/d9c08241-ceb0-4723-9c23-608d6e97051e)

![image](https://github.com/user-attachments/assets/93bb2b44-edee-4e82-8e86-3e8fa9c08712)


### What issues does this PR fix or reference?

Fix #5215

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
