### PR TITLE
feat: allow to manually refresh the catalog

### DIFF
--- a/packages/main/src/plugin/extensions-catalog/extensions-catalog.spec.ts
+++ b/packages/main/src/plugin/extensions-catalog/extensions-catalog.spec.ts
@@ -22,6 +22,7 @@ import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
 import type { ConfigurationRegistry } from '/@/plugin/configuration-registry.js';
 
+import type { ApiSenderType } from '../api.js';
 import type { Certificates } from '../certificates.js';
 import { Emitter } from '../events/emitter.js';
 import type { Proxy } from '../proxy.js';
@@ -32,6 +33,11 @@ let extensionsCatalog: ExtensionsCatalog;
 const fooAssetIcon = {
   assetType: 'icon',
   data: 'fooIcon',
+};
+
+const apiSender: ApiSenderType = {
+  send: vi.fn(),
+  receive: vi.fn(),
 };
 
 // unlisted field is not present (assuming it should be listed then)
@@ -122,7 +128,7 @@ const configurationRegistry: ConfigurationRegistry = {
 
 const originalConsoleError = console.error;
 beforeEach(() => {
-  extensionsCatalog = new ExtensionsCatalog(certificates, proxy, configurationRegistry);
+  extensionsCatalog = new ExtensionsCatalog(certificates, proxy, configurationRegistry, apiSender);
   vi.resetAllMocks();
   console.error = vi.fn();
   vi.mocked(configurationRegistry.getConfiguration).mockReturnValue({
@@ -193,7 +199,7 @@ test('check getHttpOptions with Proxy', async () => {
     httpsProxy: 'http://localhost',
     noProxy: 'localhost',
   });
-  extensionsCatalog = new ExtensionsCatalog(certificates, proxy, configurationRegistry);
+  extensionsCatalog = new ExtensionsCatalog(certificates, proxy, configurationRegistry, apiSender);
 
   const options = extensionsCatalog.getHttpOptions();
   expect(options).toBeDefined();
@@ -318,7 +324,7 @@ test('Should use proxy object if proxySettings is undefined', () => {
     httpsProxy: 'https://localhost',
     noProxy: 'localhost',
   });
-  extensionsCatalog = new ExtensionsCatalog(certificates, proxy, configurationRegistry);
+  extensionsCatalog = new ExtensionsCatalog(certificates, proxy, configurationRegistry, apiSender);
   const options = extensionsCatalog.getHttpOptions();
 
   expect(options).toBeDefined();

--- a/packages/main/src/plugin/extensions-catalog/extensions-catalog.ts
+++ b/packages/main/src/plugin/extensions-catalog/extensions-catalog.ts
@@ -27,6 +27,7 @@ import type {
 } from '/@/plugin/extensions-catalog/extensions-catalog-api.js';
 import type { Proxy } from '/@/plugin/proxy.js';
 
+import type { ApiSenderType } from '../api.js';
 import type { ConfigurationRegistry, IConfigurationNode } from '../configuration-registry.js';
 import { ExtensionsCatalogSettings } from './extensions-catalog-settings.js';
 
@@ -44,6 +45,7 @@ export class ExtensionsCatalog {
     private certificates: Certificates,
     private proxy: Proxy,
     private configurationRegistry: ConfigurationRegistry,
+    private apiSender: ApiSenderType,
   ) {}
 
   init(): void {
@@ -82,6 +84,7 @@ export class ExtensionsCatalog {
       this.cachedCatalog = JSON.parse(response.body) as InternalCatalogJSON;
       const endTime = performance.now();
       console.log(`Fetched ${catalogUrl} in ${endTime - startTime}ms`);
+      this.apiSender.send('refresh-catalog');
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (requestErr: any) {

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1614,6 +1614,10 @@ export class PluginSystem {
       return extensionsCatalog.getExtensions();
     });
 
+    this.ipcHandle('catalog:refreshExtensions', async (): Promise<void> => {
+      return extensionsCatalog.refreshCatalog();
+    });
+
     this.ipcHandle('commands:getCommandPaletteCommands', async (): Promise<CommandInfo[]> => {
       return commandRegistry.getCommandPaletteCommands();
     });

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -651,7 +651,7 @@ export class PluginSystem {
     );
     await this.extensionLoader.init();
 
-    const extensionsCatalog = new ExtensionsCatalog(certificates, proxy, configurationRegistry);
+    const extensionsCatalog = new ExtensionsCatalog(certificates, proxy, configurationRegistry, apiSender);
     extensionsCatalog.init();
     const featured = new Featured(this.extensionLoader, extensionsCatalog);
 

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1317,6 +1317,10 @@ export function initExposure(): void {
     return ipcInvoke('catalog:getExtensions');
   });
 
+  contextBridge.exposeInMainWorld('refreshCatalogExtensions', async (): Promise<void> => {
+    return ipcInvoke('catalog:refreshExtensions');
+  });
+
   contextBridge.exposeInMainWorld('getCommandPaletteCommands', async (): Promise<CommandInfo[]> => {
     return ipcInvoke('commands:getCommandPaletteCommands');
   });

--- a/packages/renderer/src/lib/extensions/CatalogExtensionList.svelte
+++ b/packages/renderer/src/lib/extensions/CatalogExtensionList.svelte
@@ -1,13 +1,43 @@
 <script lang="ts">
+import { faPuzzlePiece } from '@fortawesome/free-solid-svg-icons';
+import { Button, EmptyScreen } from '@podman-desktop/ui-svelte';
+
 import type { CatalogExtensionInfoUI } from './catalog-extension-info-ui';
 import CatalogExtension from './CatalogExtension.svelte';
 
 export let catalogExtensions: CatalogExtensionInfoUI[];
+
+async function fetchCatalog() {
+  try {
+    await window.refreshCatalogExtensions();
+  } catch (error) {
+    window.showMessageBox({
+      type: 'error',
+      title: 'Error',
+      message: 'Failed to refresh the catalog',
+      detail: String(error),
+    });
+  }
+}
 </script>
 
 <div class="flex flex-col grow px-5 py-3">
   {#if catalogExtensions.length > 0}
-    <div class="pb-4 text-[var(--pd-content-header)]">Available extensions</div>
+    <div class="mb-4 flex flex-row">
+      <div class="flex items-center text-[var(--pd-content-header)]">Available extensions</div>
+      <div class="flex-1 text-right">
+        <Button type="link" on:click={() => fetchCatalog()}>Refresh the catalog</Button>
+      </div>
+    </div>
+  {:else}
+    <EmptyScreen
+      title="No extensions in the catalog"
+      message="No extensions from the catalog. It seems that the internet connection was not available to download the catalog."
+      icon={faPuzzlePiece}>
+      <div class="flex gap-2 justify-center">
+        <Button type="link" on:click={() => fetchCatalog()}>Refresh the catalog</Button>
+      </div>
+    </EmptyScreen>
   {/if}
 
   <div class="flex flex-col w-full">

--- a/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.spec.ts
@@ -118,7 +118,7 @@ const testProvidersInfoWithoutSessionRequests = [
 test('Expect Sign in button to be hidden when there are no session requests', async () => {
   authenticationProviders.set(testProvidersInfoWithoutSessionRequests);
   render(PreferencesAuthenticationProvidersRendering, {});
-  const menuButton = screen.queryAllByRole('button');
+  const menuButton = screen.queryAllByRole('button', { name: 'Sign in' });
   expect(menuButton.length).equals(0); // no menu button
 });
 
@@ -144,7 +144,7 @@ test('Expect Sign In button to be visible when there is only one session request
   const requestSignInMock = vi.fn();
   (window as any).requestAuthenticationProviderSignIn = requestSignInMock;
   render(PreferencesAuthenticationProvidersRendering, {});
-  const menuButton = screen.getByRole('button');
+  const menuButton = screen.getByRole('button', { name: 'Sign in' });
   const tooltip = screen.getByText('Sign in to use Extension Label');
   expect(tooltip).toBeInTheDocument();
   await fireEvent.click(menuButton);
@@ -179,7 +179,7 @@ test('Expect Sign In popup menu to be visible when there is more than one sessio
   authenticationProviders.set(testProvidersInfoWithMultipleSessionRequests);
   (window as any).requestAuthenticationProviderSignIn = vi.fn();
   render(PreferencesAuthenticationProvidersRendering, {});
-  const menuButton = screen.getByRole('button');
+  const menuButton = screen.getByRole('button', { name: 'kebab menu' });
   await fireEvent.click(menuButton);
   // test sign in with extension1
   const menuItem1 = screen.getByText('Sign in to use Extension1 Label');

--- a/packages/renderer/src/stores/catalog-extensions.spec.ts
+++ b/packages/renderer/src/stores/catalog-extensions.spec.ts
@@ -130,3 +130,17 @@ test('catalog extension should be updated in case of a container is removed', as
   expect(secondExtension).toBeDefined();
   expect(secondExtension?.unlisted).toBeTruthy();
 });
+
+test('catalog extension should be updated in refresh event is published', async () => {
+  // initial catalog is empty
+  getCatalogExtensionsMock.mockResolvedValue([]);
+  getCatalogExtensionsMock.mockReset();
+
+  const callback = callbacks.get('refresh-catalog');
+  // send 'refresh-catalog' event
+  expect(callback).toBeDefined();
+  await callback();
+
+  // check that getCatalogExtensionsMock is called
+  expect(getCatalogExtensionsMock).toBeCalled();
+});

--- a/packages/renderer/src/stores/catalog-extensions.ts
+++ b/packages/renderer/src/stores/catalog-extensions.ts
@@ -21,7 +21,7 @@ import { type Writable, writable } from 'svelte/store';
 import type { CatalogExtension } from '../../../main/src/plugin/extensions-catalog/extensions-catalog-api';
 import { EventStore } from './event-store';
 
-const windowEvents: string[] = [];
+const windowEvents: string[] = ['refresh-catalog'];
 const windowListeners = ['system-ready'];
 
 export async function checkForUpdate(): Promise<boolean> {


### PR DESCRIPTION
### What does this PR do?
Add an option to manually refresh the catalog (and see the error in case of error)

### Screenshot / video of UI

![image](https://github.com/user-attachments/assets/e7547af8-10ca-4940-9121-40b49ea555fd)


Also add an empty screen section
![image](https://github.com/user-attachments/assets/b03a55e8-ce2e-49c6-b6f9-e82a630c2428)



### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/5349

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
