### PR TITLE
chore(tests): prolong the timeout for podman to start up

### DIFF
--- a/tests/playwright/src/specs/container-smoke.spec.ts
+++ b/tests/playwright/src/specs/container-smoke.spec.ts
@@ -289,7 +289,7 @@ describe('Verification of container creation workflow', async () => {
     await containersPage.pruneContainers();
     for (const container of containerList) {
       await playExpect
-        .poll(async () => await containersPage.containerExists(container), { timeout: 15000 })
+        .poll(async () => await containersPage.containerExists(container), { timeout: 30000 })
         .toBeFalsy();
     }
   }, 120000);

--- a/tests/playwright/src/utility/wait.ts
+++ b/tests/playwright/src/utility/wait.ts
@@ -121,7 +121,7 @@ export async function executeWithTimeout(
   });
 }
 
-export async function waitForPodmanMachineStartup(page: Page, timeoutOut = 15000): Promise<void> {
+export async function waitForPodmanMachineStartup(page: Page, timeoutOut = 30000): Promise<void> {
   const dashboardPage = await new NavigationBar(page).openDashboard();
   await playExpect(dashboardPage.heading).toBeVisible();
   await waitUntil(async () => await dashboardPage.podmanStatusLabel.isVisible(), {


### PR DESCRIPTION
### What does this PR do?
Prolong the timeout to wait for a podman or podman machine to come up after e2e test start.
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#8364 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
