### PR TITLE
chore: add try/catch to ssh connection

### DIFF
--- a/extensions/podman/src/podman-remote-connections.ts
+++ b/extensions/podman/src/podman-remote-connections.ts
@@ -169,7 +169,11 @@ export class PodmanRemoteConnections {
       const sshTunnel = this.createTunnel(host, port, username, privateKey, remotePath, localPath);
 
       // connect the tunnel
-      sshTunnel.connect();
+      try {
+        sshTunnel.connect();
+      } catch (error) {
+        console.error(`Error connecting to Podman SSH Remote: ${error}`);
+      }
 
       //delay before registering the socket
       await new Promise(resolve => setTimeout(resolve, 1000));


### PR DESCRIPTION
chore: add try/catch to ssh connection

### What does this PR do?

Right now we have no error out put when we cannot initially connect, for
example, having a bad key being passed in.

This adds a try / catch so we can make sure that we at least put the
error output in the console.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

N/A

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

N/A, adds try/catch.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
