### PR TITLE
chore: move /images/run to /image/run for creating containers

### DIFF
--- a/packages/renderer/src/App.spec.ts
+++ b/packages/renderer/src/App.spec.ts
@@ -59,11 +59,11 @@ beforeEach(() => {
   router.goto('/');
 });
 
-test('test /images/run/* route', async () => {
+test('test /image/run/* route', async () => {
   render(App);
   expect(mocks.RunImage).not.toHaveBeenCalled();
   expect(mocks.DashboardPage).toHaveBeenCalled();
-  router.goto('/images/run/basic');
+  router.goto('/image/run/basic');
   await tick();
   expect(mocks.RunImage).toHaveBeenCalled();
 });

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -128,7 +128,7 @@ window.events?.receive('navigate', (navigationRequest: unknown) => {
         <Route path="/kube/play" breadcrumb="Play Kubernetes YAML">
           <KubePlayYAML />
         </Route>
-        <Route path="/image/run/*" breadcrumb="Images">
+        <Route path="/image/run/*" breadcrumb="Run Image">
           <RunImage />
         </Route>
         <Route path="/images" breadcrumb="Images" navigationHint="root">

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -128,12 +128,11 @@ window.events?.receive('navigate', (navigationRequest: unknown) => {
         <Route path="/kube/play" breadcrumb="Play Kubernetes YAML">
           <KubePlayYAML />
         </Route>
-
+        <Route path="/image/run/*" breadcrumb="Images">
+          <RunImage />
+        </Route>
         <Route path="/images" breadcrumb="Images" navigationHint="root">
           <ImagesList />
-        </Route>
-        <Route path="/images/run/*" breadcrumb="Run Image">
-          <RunImage />
         </Route>
         <Route path="/images/:id/:engineId" breadcrumb="Images" let:meta navigationHint="root">
           <ImagesList searchTerm={meta.params.id} imageEngineId={meta.params.engineId} />

--- a/packages/renderer/src/lib/image/ImageActions.svelte
+++ b/packages/renderer/src/lib/image/ImageActions.svelte
@@ -59,7 +59,7 @@ onDestroy(() => {
 
 async function runImage(imageInfo: ImageInfoUI) {
   runImageInfo.set(imageInfo);
-  router.goto('/images/run/basic');
+  router.goto('/image/run/basic');
 }
 
 async function deleteImage(): Promise<void> {


### PR DESCRIPTION
chore: move /images/run to /image/run for creating containers

### What does this PR do?

The following conflicts with `/images/run/*`:

```ts
        <Route path="/images/:id/:engineId" breadcrumb="Images" let:meta navigationHint="root">
          <ImagesList searchTerm={meta.params.id} imageEngineId={meta.params.engineId} />
        </Route>
```

Due to the route also going to /images/:id for example
`/images/run/basic` will also be routes to `/images/:id/:engineId`.

It is better to instead move this route to `/image/run/basic` instead.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->



Should look normal now.

Before:

![image](https://github.com/user-attachments/assets/58dcd1a9-2bd9-4553-8ba9-c459062b3f5d)


After:
![Screenshot 2024-08-07 at 10 42 57 AM](https://github.com/user-attachments/assets/22d5d028-6725-4030-84f6-d6f201d5d483)



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/8373

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

1. You can create a container like normal.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
