### PR TITLE
fix: support light theme for auth provider in 'Logged In' state

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.svelte
@@ -92,16 +92,16 @@ import SettingsPage from './SettingsPage.svelte';
                 {#each provider.accounts as account}
                   <div class="flex flex-row">
                     <div class="flex items-center w-full">
-                      <div class="flex flex-row text-xs bg-charcoal-800 p-2 rounded-lg mt-1">
+                      <div class="flex flex-row text-xs p-2 rounded-lg mt-1 bg-[var(--pd-invert-content-bg)]">
                         <span
-                          class="my-auto font-bold col-span-1 text-ellipsis overflow-hidden max-w-64"
+                          class="my-auto font-bold col-span-1 text-ellipsis overflow-hidden max-w-64 text-[var(--pd-invert-content-card-text)]"
                           aria-label="Logged In Username">
                           {account.label}
                         </span>
                         <Tooltip bottomRight tip="Sign out of {account.label}">
                           <button
                             aria-label="Sign out of {account.label}"
-                            class="pl-2 hover:cursor-pointer hover:text-white text-white"
+                            class="pl-2 hover:cursor-pointer"
                             on:click={() => window.requestAuthenticationProviderSignOut(provider.id, account.id)}>
                             <Fa class="h-3 w-3 text-md mr-2" icon={faRightFromBracket} />
                           </button>


### PR DESCRIPTION
### What does this PR do?

Fix authentication provider card colors for light theme when state is 'Logged In'

### Screenshot / video of UI

before fix

![image](https://github.com/user-attachments/assets/61c69b27-e313-4f22-ae26-43567592ed86)

![image](https://github.com/user-attachments/assets/be1d22f5-da87-4096-8451-42d2cdb2a4d7)


after fix

![image](https://github.com/user-attachments/assets/7bceee02-a792-4723-a0ec-2f3970ec6a0d)

![image](https://github.com/user-attachments/assets/f1f90bd1-b8af-45cd-a7b1-8c7e699f7239)



<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
