### PR TITLE
chore: light mode for deploy pod to kube status

### DIFF
--- a/packages/renderer/src/lib/pod/DeployPodToKube.svelte
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.svelte
@@ -532,7 +532,7 @@ function updateKubeResult() {
     {/if}
 
     {#if createdPod}
-      <div class="bg-charcoal-800 p-5 my-4">
+      <div class="bg-[var(--pd-content-card-inset-bg)] p-5 my-4">
         <div class="flex flex-row items-center">
           <div>Created pod:</div>
           {#if openshiftConsoleURL && createdPod?.metadata?.name}


### PR DESCRIPTION
### What does this PR do?

Just sets the correct light mode bg color for deploying pod to Kubernetes.

### Screenshot / video of UI

<img width="344" alt="Screenshot 2024-08-08 at 9 29 15 AM" src="https://github.com/user-attachments/assets/2acb7922-de94-43e5-bc32-8611e0a4ed61">

### What issues does this PR fix or reference?

Fixes #8393.

### How to test this PR?

Deploy a pod to Kube.