### PR TITLE
chore: add registry dialog

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.spec.ts
@@ -75,7 +75,7 @@ describe('PreferencesRegistriesEditing', () => {
     expect(button).toBeEnabled();
   });
 
-  test('Expect that adding a registry enables a form, and Login button is initially disabled', async () => {
+  test('Expect that adding a registry enables a form, and Add button is initially disabled', async () => {
     render(PreferencesRegistriesEditing, { showNewRegistryForm: true });
 
     const button = screen.getByRole('button', { name: 'Add registry' });
@@ -85,7 +85,7 @@ describe('PreferencesRegistriesEditing', () => {
     const entry = screen.getByPlaceholderText('https://registry.io');
     expect(entry).toBeInTheDocument();
 
-    const loginButton = screen.getByRole('button', { name: 'Login' });
+    const loginButton = screen.getByRole('button', { name: 'Add' });
     expect(loginButton).toBeInTheDocument();
     expect(loginButton).toBeDisabled();
   });
@@ -94,7 +94,7 @@ describe('PreferencesRegistriesEditing', () => {
     render(PreferencesRegistriesEditing);
     const addRegistryBtn = screen.getByRole('button', { name: 'Add registry' });
     await userEvent.click(addRegistryBtn);
-    const button = screen.getByRole('button', { name: 'Login' });
+    const button = screen.getByRole('button', { name: 'Add' });
     const password = screen.getByPlaceholderText('password');
     const username = screen.getByPlaceholderText('username');
     const url = screen.getByPlaceholderText('https://registry.io');

--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { Registry } from '@podman-desktop/api';
-import { fireEvent, waitFor } from '@testing-library/dom';
+import { waitFor } from '@testing-library/dom';
 import { render, screen } from '@testing-library/svelte';
 import { default as userEvent } from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
@@ -82,7 +82,7 @@ describe('PreferencesRegistriesEditing', () => {
     expect(button).toBeInTheDocument();
     expect(button).toBeDisabled();
 
-    const entry = screen.getByPlaceholderText('URL (HTTPS only)');
+    const entry = screen.getByPlaceholderText('https://registry.io');
     expect(entry).toBeInTheDocument();
 
     const loginButton = screen.getByRole('button', { name: 'Login' });
@@ -95,9 +95,9 @@ describe('PreferencesRegistriesEditing', () => {
     const addRegistryBtn = screen.getByRole('button', { name: 'Add registry' });
     await userEvent.click(addRegistryBtn);
     const button = screen.getByRole('button', { name: 'Login' });
-    const password = screen.getByPlaceholderText('Password');
-    const username = screen.getByPlaceholderText('Username');
-    const url = screen.getByPlaceholderText('URL (HTTPS only)');
+    const password = screen.getByPlaceholderText('password');
+    const username = screen.getByPlaceholderText('username');
+    const url = screen.getByPlaceholderText('https://registry.io');
     expect(button).toBeVisible();
     expect(button).toBeDisabled();
     expect(password).toBeVisible();

--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
@@ -172,6 +172,11 @@ async function loginToRegistry(registry: containerDesktopAPI.Registry) {
   registry.source = defaultProviderSourceName;
 
   const newRegistry = registry === newRegistryRequest;
+  if (newRegistry) {
+    registry.serverUrl = registry.serverUrl.trim();
+    registry.username = registry.username.trim();
+    registry.secret = registry.secret.trim();
+  }
 
   // Always check credentials before creating image / updating to see if they pass.
   // if we happen to get a certificate verification issue, as the user if they would like to
@@ -481,9 +486,11 @@ function removeExistingRegistry(registry: containerDesktopAPI.Registry) {
       <Button type="link" on:click={() => (showNewRegistryForm = false)}>Cancel</Button>
       <Button
         type="primary"
-        disabled={!newRegistryRequest.serverUrl || !newRegistryRequest.username || !newRegistryRequest.secret}
+        disabled={!newRegistryRequest.serverUrl.trim() ||
+          !newRegistryRequest.username.trim() ||
+          !newRegistryRequest.secret.trim()}
         inProgress={loggingIn}
-        on:click={() => loginToRegistry(newRegistryRequest)}>Login</Button>
+        on:click={() => loginToRegistry(newRegistryRequest)}>Add</Button>
     </svelte:fragment>
   </Dialog>
 {/if}

--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
 import { faPlusCircle, faTrash, faUser, faUserPen } from '@fortawesome/free-solid-svg-icons';
 import type * as containerDesktopAPI from '@podman-desktop/api';
-import { Button, DropdownMenu, Input } from '@podman-desktop/ui-svelte';
+import { Button, DropdownMenu, ErrorMessage, Input } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 
 import PasswordInput from '/@/lib/ui/PasswordInput.svelte';
 
 import { registriesInfos, registriesSuggestedInfos } from '../../stores/registries';
+import Dialog from '../dialogs/Dialog.svelte';
 import SettingsPage from './SettingsPage.svelte';
 
 // contains the original instances of registries when user clicks on `Edit password` menu item
@@ -438,46 +439,51 @@ function removeExistingRegistry(registry: containerDesktopAPI.Registry) {
         </div>
         <!-- Add new registry form end -->
       {/each}
-
-      {#if showNewRegistryForm}
-        <!-- Add new registry form start -->
-        <div class="flex flex-col w-full border-t border-gray-900 text-[var(--pd-invert-content-card-text)]">
-          <div class="flex flex-row items-center pt-4 pb-3 space-x-2">
-            <div class="pl-5 w-2/5">
-              <Input
-                placeholder="URL (HTTPS only)"
-                aria-label="Register URL"
-                bind:value={newRegistryRequest.serverUrl} />
-            </div>
-            <div class="w-1/5">
-              <Input placeholder="Username" aria-label="Username" bind:value={newRegistryRequest.username} />
-            </div>
-            <div class="w-1/5">
-              <PasswordInput
-                id="newRegistryRequest"
-                bind:password={newRegistryRequest.secret}
-                on:action={() =>
-                  setPasswordForRegistryVisible(newRegistryRequest, !showPasswordForServerUrls.some(r => r === ''))} />
-            </div>
-            <div class="w-1/5 flex space-x-2 justify-end" role="cell">
-              <Button
-                on:click={() => loginToRegistry(newRegistryRequest)}
-                disabled={!newRegistryRequest.serverUrl || !newRegistryRequest.username || !newRegistryRequest.secret}
-                inProgress={loggingIn}>
-                Login
-              </Button>
-              <Button on:click={() => setNewRegistryFormVisible(false)} type="link">Cancel</Button>
-            </div>
-          </div>
-          <div class="flex flex-row w-full pb-3 -mt-2 pl-10">
-            <span class="font-bold whitespace-pre-line">
-              {errorResponses.find(o => o.serverUrl === newRegistryRequest.serverUrl)?.error ?? ''}
-            </span>
-          </div>
-        </div>
-        <!-- Add new registry form end -->
-      {/if}
     </div>
     <!-- Registries table end -->
   </div>
 </SettingsPage>
+
+{#if showNewRegistryForm}
+  <Dialog
+    title="Add Registry"
+    on:close={() => {
+      setNewRegistryFormVisible(false);
+    }}>
+    <div slot="content" class="flex flex-col text-[var(--pd-modal-text)] space-y-5">
+      <div>
+        <div>URL (HTTPS only)</div>
+        <Input placeholder="https://registry.io" bind:value={newRegistryRequest.serverUrl}></Input>
+      </div>
+
+      <div class="flex flex-row space-x-5 justify-stretch w-full">
+        <div class="w-full">
+          <div>Username</div>
+          <Input placeholder="username" bind:value={newRegistryRequest.username}></Input>
+        </div>
+
+        <div class="w-full">
+          <div>Password</div>
+          <PasswordInput
+            id="newRegistryRequest"
+            bind:password={newRegistryRequest.secret}
+            on:action={() =>
+              setPasswordForRegistryVisible(newRegistryRequest, !showPasswordForServerUrls.some(r => r === ''))}
+          ></PasswordInput>
+        </div>
+      </div>
+    </div>
+    <svelte:fragment slot="validation"
+      ><ErrorMessage error={errorResponses.find(o => o.serverUrl === newRegistryRequest.serverUrl)?.error ?? ''}
+      ></ErrorMessage
+      ></svelte:fragment>
+    <svelte:fragment slot="buttons">
+      <Button type="link" on:click={() => (showNewRegistryForm = false)}>Cancel</Button>
+      <Button
+        type="primary"
+        disabled={!newRegistryRequest.serverUrl || !newRegistryRequest.username || !newRegistryRequest.secret}
+        inProgress={loggingIn}
+        on:click={() => loginToRegistry(newRegistryRequest)}>Login</Button>
+    </svelte:fragment>
+  </Dialog>
+{/if}

--- a/packages/renderer/src/lib/ui/PasswordInput.svelte
+++ b/packages/renderer/src/lib/ui/PasswordInput.svelte
@@ -30,7 +30,7 @@ async function onShowHide() {
   class={$$props.class || ''}
   id="password-{id}"
   name="password-{id}"
-  placeholder="Password"
+  placeholder="password"
   bind:value={password}
   aria-label="password {id}"
   bind:readonly={readonly}


### PR DESCRIPTION
### What does this PR do?

First part of #8103. Switches adding a new registry from a row at the bottom of the table to a dialog, as per the design.

Keeping this relatively simple for the first step. Future PRs could modify the dialog to support editing as well.

### Screenshot / video of UI

<img width="974" alt="Screenshot 2024-08-08 at 1 52 16 PM" src="https://github.com/user-attachments/assets/14835903-370f-4b18-a090-26b12277bc8a">

### What issues does this PR fix or reference?

First part of #8103.

### How to test this PR?

Add a new registry.

- [x] Tests are covering the bug fix or the new feature