### PR TITLE
chore: allow simple column to wrap to 2 lines

### DIFF
--- a/packages/ui/src/lib/table/SimpleColumn.spec.ts
+++ b/packages/ui/src/lib/table/SimpleColumn.spec.ts
@@ -31,6 +31,6 @@ test('Expect simple column styling', async () => {
   expect(text).toBeInTheDocument();
   expect(text).toHaveClass('text-[var(--pd-table-body-text)]');
   expect(text).toHaveClass('max-w-full');
-  expect(text).toHaveClass('overflow-hidden');
-  expect(text).toHaveClass('text-ellipsis');
+  expect(text).toHaveClass('text-wrap');
+  expect(text).toHaveClass('line-clamp-2');
 });

--- a/packages/ui/src/lib/table/SimpleColumn.svelte
+++ b/packages/ui/src/lib/table/SimpleColumn.svelte
@@ -2,6 +2,6 @@
 export let object: string;
 </script>
 
-<div class="text-[var(--pd-table-body-text)] max-w-full overflow-hidden text-ellipsis">
+<div class="text-[var(--pd-table-body-text)] max-w-full text-wrap line-clamp-2">
   {object}
 </div>


### PR DESCRIPTION
### What does this PR do?

I had a change to make service port a special column that could wrap to two lines, but then I figured why not all simple columns? If text is too wide to fit into a column this will cause it to wrap to two lines. Longer text will still use ellipsis. (we could go to 3 or 4 lines, but allowing twice as much text seemed like a reasonable balance that doesn't affect the rest of the table layout)

### Screenshot / video of UI

Before:

<img width="401" alt="Screenshot 2024-08-08 at 2 57 41 PM" src="https://github.com/user-attachments/assets/bcdacc90-df08-4192-b5a2-ac337d342b72">

After:

<img width="401" alt="Screenshot 2024-08-08 at 2 56 46 PM" src="https://github.com/user-attachments/assets/42e7becd-f442-4a58-86a4-0608b741cb04">

### What issues does this PR fix or reference?

Fixes #5442.

### How to test this PR?

Having multiple service ports are the most obvious way to trigger this, but on very narrow columns something like "2 months" will be wrapped to: "2
months"
instead of:
"2 mo..."

- [x] Tests are covering the bug fix or the new feature