### PR TITLE
chore: fix positioning of check circle

### DIFF
--- a/packages/renderer/src/lib/dialogs/Dialog.svelte
+++ b/packages/renderer/src/lib/dialogs/Dialog.svelte
@@ -19,7 +19,7 @@ export let onclose: () => void = () => {
     <CloseButton on:click={() => onclose()} />
   </div>
 
-  <div class="max-h-80 overflow-auto text-[var(--pd-modal-text)] px-10 py-4">
+  <div class="relative max-h-80 overflow-auto text-[var(--pd-modal-text)] px-10 py-4">
     <slot name="content" />
   </div>
 

--- a/packages/renderer/src/lib/image/PushImageModal.svelte
+++ b/packages/renderer/src/lib/image/PushImageModal.svelte
@@ -115,7 +115,7 @@ $: window.hasAuthconfigForImage(imageInfoToPush.name).then(result => (isAuthenti
   on:close={() => {
     closeCallback();
   }}>
-  <div slot="content" class="relative flex flex-col text-sm leading-5 space-y-5">
+  <div slot="content" class="flex flex-col text-sm leading-5 space-y-5">
     <div class="pb-4">
       <label for="modalImageTag" class="block mb-2 text-sm font-medium text-[var(--pd-modal-text)]">Image tag</label>
       {#if isAuthenticatedForThisImage}

--- a/packages/renderer/src/lib/image/PushImageModal.svelte
+++ b/packages/renderer/src/lib/image/PushImageModal.svelte
@@ -116,7 +116,7 @@ $: window.hasAuthconfigForImage(imageInfoToPush.name).then(result => (isAuthenti
     closeCallback();
   }}>
   <div slot="content" class="flex flex-col text-sm leading-5 space-y-5">
-    <div class="pb-4">
+    <div class="relative pb-4">
       <label for="modalImageTag" class="block mb-2 text-sm font-medium text-[var(--pd-modal-text)]">Image tag</label>
       {#if isAuthenticatedForThisImage}
         <Fa class="absolute mt-3 ml-1.5 text-green-300" size="1x" icon={faCheckCircle} />

--- a/packages/renderer/src/lib/image/PushImageModal.svelte
+++ b/packages/renderer/src/lib/image/PushImageModal.svelte
@@ -115,8 +115,8 @@ $: window.hasAuthconfigForImage(imageInfoToPush.name).then(result => (isAuthenti
   on:close={() => {
     closeCallback();
   }}>
-  <div slot="content" class="flex flex-col text-sm leading-5 space-y-5">
-    <div class="relative pb-4">
+  <div slot="content" class="relative flex flex-col text-sm leading-5 space-y-5">
+    <div class="pb-4">
       <label for="modalImageTag" class="block mb-2 text-sm font-medium text-[var(--pd-modal-text)]">Image tag</label>
       {#if isAuthenticatedForThisImage}
         <Fa class="absolute mt-3 ml-1.5 text-green-300" size="1x" icon={faCheckCircle} />


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Fixes the positioning of the check circle in push image page to make sure it stays in the image tag area when scrolling on the dialog box

### Screenshot / video of UI

[Screencast from 2024-08-08 16-50-25.webm](https://github.com/user-attachments/assets/43514c2e-9121-4d29-827f-12e226de1084)


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/containers/podman-desktop/issues/8405

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

Go to the push image page and while having the scroll bar of the dialog box available (during an image push), scroll and check the placement of the check circle

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
