### PR TITLE
chore: add dispose to Xterm terminal UI component

### DIFF
--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
@@ -36,7 +36,9 @@ import type { ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provid
 // xterm is used in the UI, but not tested, added in order to avoid the multiple warnings being shown during the test.
 vi.mock('xterm', () => {
   return {
-    Terminal: vi.fn().mockReturnValue({ loadAddon: vi.fn(), open: vi.fn(), write: vi.fn(), clear: vi.fn() }),
+    Terminal: vi
+      .fn()
+      .mockReturnValue({ loadAddon: vi.fn(), open: vi.fn(), write: vi.fn(), clear: vi.fn(), dispose: vi.fn() }),
   };
 });
 

--- a/packages/renderer/src/lib/ui/TerminalWindow.svelte
+++ b/packages/renderer/src/lib/ui/TerminalWindow.svelte
@@ -52,6 +52,7 @@ onMount(async () => {
 
 onDestroy(() => {
   window.removeEventListener('resize', resizeHandler);
+  terminal?.dispose();
 });
 </script>
 


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Disposes the Xterm terminal on destroy

### Screenshot / video of UI
before:

[Screencast from 2024-08-09 14-45-30.webm](https://github.com/user-attachments/assets/1e4199a2-79b0-411d-be82-47111c79a262)

after:

[Screencast from 2024-08-09 14-53-41.webm](https://github.com/user-attachments/assets/302c7aec-2dc8-4c36-adbd-1ed85160540b)


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Related to https://github.com/containers/podman-desktop/issues/8197

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
