### PR TITLE
chore: remove double scrollbar from push image dialog

### DIFF
--- a/packages/renderer/src/lib/image/PushImageModal.svelte
+++ b/packages/renderer/src/lib/image/PushImageModal.svelte
@@ -143,7 +143,7 @@ $: window.hasAuthconfigForImage(imageInfoToPush.name).then(result => (isAuthenti
         </p>{/if}
     </div>
 
-    <div bind:this={pushLogsXtermDiv}></div>
+    <div class="max-h-[195px]" bind:this={pushLogsXtermDiv}></div>
   </div>
 
   <svelte:fragment slot="buttons">

--- a/packages/renderer/src/lib/image/PushImageModal.svelte
+++ b/packages/renderer/src/lib/image/PushImageModal.svelte
@@ -143,7 +143,7 @@ $: window.hasAuthconfigForImage(imageInfoToPush.name).then(result => (isAuthenti
         </p>{/if}
     </div>
 
-    <div class="max-h-[195px]" bind:this={pushLogsXtermDiv}></div>
+    <div class="max-h-[185px]" bind:this={pushLogsXtermDiv}></div>
   </div>
 
   <svelte:fragment slot="buttons">


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Removes double scrollbar from the push image dialog window. In https://github.com/containers/podman-desktop/issues/8078, there is a double scrollbar in the dialog window, and due to the style of the scrollbar and theme of the terminal vs background, the terminal's scrollbar looks like empty space/misaligned terminal (at least in mac OS). However, since the terminal is Xterm terminal, the only way to remove the terminal's scrollbar is to directly modify the css file of Xterm in `node_modules`. This PR solve the issue of the double scrollbars, but the problem of the empty space might still arise with certain background and terminal colors, unless we want to directly modify Xterm's css file.

### Screenshot / video of UI
![Screenshot from 2024-08-08 16-44-29](https://github.com/user-attachments/assets/b694c25a-f4d0-435a-834b-689bf9580de7)


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/containers/podman-desktop/issues/8078

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
