### PR TITLE
chore: adds missing colors for modal dropdown element

### DIFF
--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -1090,6 +1090,8 @@ export class ColorRegistry {
   protected initDropdown(): void {
     const dropdown = 'dropdown-';
     const select = 'select-';
+    const modal = 'modal-';
+    const input = 'input-';
 
     this.registerColor(`${dropdown}bg`, {
       dark: colorPalette.charcoal[600],
@@ -1132,6 +1134,19 @@ export class ColorRegistry {
     this.registerColor(`${dropdown}disabled-item-bg`, {
       dark: colorPalette.charcoal[800],
       light: colorPalette.gray[200],
+    });
+
+    this.registerColor(`${modal}${dropdown}highlight`, {
+      dark: colorPalette.purple[600],
+      light: colorPalette.purple[300],
+    });
+    this.registerColor(`${modal}${dropdown}text`, {
+      dark: colorPalette.white,
+      light: colorPalette.charcoal[900],
+    });
+    this.registerColor(`${input}${select}hover-text`, {
+      dark: colorPalette.gray[900],
+      light: colorPalette.charcoal[200],
     });
   }
 


### PR DESCRIPTION
### What does this PR do?
Adds missing colors for modal dropdown element

Reference:
https://github.com/user-attachments/files/16070597/Modal.Dialog.pdf

### What issues does this PR fix or reference?
First of two PRs for 8411 "Light Mode: Input boxes (changing kube-context) still using dark theme when in Light Mode"
Link to second one: https://github.com/containers/podman-desktop/pull/8549

- [x] Tests are covering the bug fix or the new feature
