### PR TITLE
chore: fix linux flatpak issue, remove 7.5.8 semver for 7.6.3

### DIFF
--- a/extensions/kubectl-cli/package.json
+++ b/extensions/kubectl-cli/package.json
@@ -147,7 +147,7 @@
   "dependencies": {
     "@podman-desktop/api": "^0.0.1",
     "@octokit/rest": "^21.0.1",
-    "semver": "^7.5.8",
+    "semver": "^7.6.3",
     "shell-path": "^3.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -17952,7 +17952,7 @@ semver@^6.0.0, semver@^6.2.0, semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.2.1, semver@^7.3.2, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@^7.5.3, semver@^7.5.4, semver@^7.5.8, semver@^7.6.0, semver@^7.6.1, semver@^7.6.2, semver@^7.6.3:
+semver@^7.2.1, semver@^7.3.2, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.6.1, semver@^7.6.2, semver@^7.6.3:
   version "7.6.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
   integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==


### PR DESCRIPTION
chore: fix linux flatpak issue, remove 7.5.8 semver for 7.6.3

### What does this PR do?

* Semver 7.5.8 doesn't exist, so when building flatpak it will try and
  find 7.5.8 which isn't there:
  https://www.npmjs.com/package/semver?activeTab=versions however,
  types/semver has 7.5.8 hence the confusion when it was added
* Update to 7.6.3 which DOES exist for semver

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Fixes https://github.com/containers/podman-desktop/issues/8450
References
https://github.com/flathub/io.podman_desktop.PodmanDesktop/pull/47 build
issue

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

N/A, dependency update

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
