### PR TITLE
fix: update webview urls on change

### DIFF
--- a/packages/renderer/src/lib/ui/NavItem.svelte
+++ b/packages/renderer/src/lib/ui/NavItem.svelte
@@ -16,6 +16,7 @@ export let onClick: MouseEventHandler<HTMLAnchorElement> | undefined = undefined
 export let counter: number | undefined = undefined;
 
 let inSection: boolean = false;
+let uri: string;
 $: uri = encodeURI(href);
 let selected: boolean;
 $: selected = meta.url === uri || (uri !== '/' && meta.url.startsWith(uri));

--- a/packages/renderer/src/lib/ui/NavItem.svelte
+++ b/packages/renderer/src/lib/ui/NavItem.svelte
@@ -16,7 +16,7 @@ export let onClick: MouseEventHandler<HTMLAnchorElement> | undefined = undefined
 export let counter: number | undefined = undefined;
 
 let inSection: boolean = false;
-let uri = encodeURI(href);
+$: uri = encodeURI(href);
 let selected: boolean;
 $: selected = meta.url === uri || (uri !== '/' && meta.url.startsWith(uri));
 


### PR DESCRIPTION
### What does this PR do?

NavItems were never built to be reactive, i.e. have the href or title change after they are created. However, the new navigation registry causes exactly that: when the list of webviews change any existing items are getting updated instead of replaced and so any remaining ones have old uris. This change just makes the uri property reactive to match the others.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #8291.

### How to test this PR?

Add/remove/hide/unhide with multiple webviews and confirm you can still open each of them.