### PR TITLE
chore: electron-builder is using new environment variables

### DIFF
--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -147,7 +147,7 @@ jobs:
           echo "CSC_LINK=${{secrets.CSC_LINK}}" >> $GITHUB_ENV
           echo "CSC_KEY_PASSWORD=${{secrets.CSC_KEY_PASSWORD}}" >> $GITHUB_ENV
           echo "APPLE_ID=${{secrets.APPLE_ID}}" >> $GITHUB_ENV
-          echo "APPLE_ID_PASSWORD=${{secrets.APPLE_ID_PASSWORD}}" >> $GITHUB_ENV
+          echo "APPLE_APP_SPECIFIC_PASSWORD=${{secrets.APPLE_APP_SPECIFIC_PASSWORD}}" >> $GITHUB_ENV
           echo "APPLE_TEAM_ID=${{secrets.APPLE_TEAM_ID}}" >> $GITHUB_ENV
 
       - name: Install Azure SignTool on Windows

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -200,7 +200,7 @@ jobs:
           echo "CSC_LINK=${{secrets.CSC_LINK}}" >> $GITHUB_ENV
           echo "CSC_KEY_PASSWORD=${{secrets.CSC_KEY_PASSWORD}}" >> $GITHUB_ENV
           echo "APPLE_ID=${{secrets.APPLE_ID}}" >> $GITHUB_ENV
-          echo "APPLE_ID_PASSWORD=${{secrets.APPLE_ID_PASSWORD}}" >> $GITHUB_ENV
+          echo "APPLE_APP_SPECIFIC_PASSWORD=${{secrets.APPLE_APP_SPECIFIC_PASSWORD}}" >> $GITHUB_ENV
           echo "APPLE_TEAM_ID=${{secrets.APPLE_TEAM_ID}}" >> $GITHUB_ENV
 
       - name: Install Azure SignTool on Windows


### PR DESCRIPTION
### What does this PR do?
APPLE_ID_PASSWORD has been replaced by APPLE_APP_SPECIFIC_PASSWORD in electron-builder

using https://github.com/electron-userland/electron-builder/pull/7310


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

we can't build anymore signed binaries on macOS

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
