### PR TITLE
chore: fix typedoc documentation

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -139,7 +139,7 @@ declare module '@podman-desktop/api' {
     event: Event<T>;
     /**
      * To fire an event to the subscribers
-     * @param event The event to send to the registered listeners
+     * @param data The event to send to the registered listeners
      */
     fire(data: T): void;
     /**
@@ -2114,7 +2114,6 @@ declare module '@podman-desktop/api' {
 
     /**
      * Add a KubernetesGenerator to KubernetesGeneratorRegistry
-     * @param selector
      * @param provider the custom provider to add
      */
     export function registerKubernetesGenerator(provider: KubernetesGeneratorProvider): Disposable;
@@ -3953,7 +3952,7 @@ declare module '@podman-desktop/api' {
      * @param id The unique identifier of the provider.
      * @param label The human-readable name of the provider.
      * @param provider The authentication provider provider.
-     * @params options Additional options for the provider.
+     * @param options Additional options for the provider.
      * @return A [disposable](#Disposable) that unregisters this provider when being disposed.
      */
     export function registerAuthenticationProvider(
@@ -4007,7 +4006,7 @@ declare module '@podman-desktop/api' {
     /**
      * Opens a link externally using the default application. Depending on the
      *
-     * @param target The uri that should be opened.
+     * @param uri The uri that should be opened.
      * @returns A promise indicating if open was successful.
      */
     export function openExternal(uri: Uri): Promise<boolean>;


### PR DESCRIPTION

Signed-off-by: Florent Benoit <fbenoit@redhat.com>

### What does this PR do?
I see some invalid typedoc tags when generating the website

```
Warning: e/runner/work/podman-desktop/podman-desktop/packages/extension-api/src/extension-api.d.ts:3956:7 - [warning] Encountered an unknown block tag @params
[10](https://github.com/containers/podman-desktop/actions/runs/10384785243/job/28753883944?pr=8466#step:7:11)
3956         * @params options Additional options for the provider.
[11](https://github.com/containers/podman-desktop/actions/runs/10384785243/job/28753883944?pr=8466#step:7:12)
[warning] The signature EventEmitter.fire has an @param with name "event", which was not used
[12](https://github.com/containers/podman-desktop/actions/runs/10384785243/job/28753883944?pr=8466#step:7:13)
[warning] The signature kubernetes.registerKubernetesGenerator has an @param with name "selector", which was not used
[13](https://github.com/containers/podman-desktop/actions/runs/10384785243/job/28753883944?pr=8466#step:7:14)
[warning] The signature env.openExternal has an @param with name "target", which was not used
```

fixing the typedoc

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
