### PR TITLE
chore: fix codesigning on macOS binaries

### DIFF
--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -175,7 +175,6 @@ const config = {
     icon: './buildResources/icon-512x512.png',
     target: ['flatpak', 'tar.gz'],
   },
-  afterSign: 'electron-builder-notarize',
   mac: {
     artifactName: `podman-desktop${artifactNameSuffix}-\${version}-\${arch}.\${ext}`,
     hardenedRuntime: true,
@@ -220,6 +219,12 @@ if (process.env.AIRGAP_DOWNLOAD) {
     publishAutoUpdate: false,
     provider: 'github'
   };
+}
+
+if (process.env.APPLE_TEAM_ID) {
+  config.mac.notarize = {
+    teamId: process.env.APPLE_TEAM_ID,
+  }
 }
 
 const azureCodeSign = filePath => {


### PR DESCRIPTION

### What does this PR do?
configuration of electron-builder has changed for macOS for signing binaries

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related issue: https://github.com/electron-userland/electron-builder/issues/8103


### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
