### PR TITLE
feat: enable podman desktop running in electron

### DIFF
--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -132,7 +132,7 @@ const config = {
   afterPack: async context => {
     await addElectronFuses(context);
   },
-  files: ['packages/**/dist/**', 'extensions/**/builtin/*.cdix/**'],
+  files: ['packages/**/dist/**', 'extensions/**/builtin/*.cdix/**', 'packages/main/src/assets/**'],
   portable: {
     artifactName: `podman-desktop${artifactNameSuffix}-\${version}-\${arch}.\${ext}`,
   },

--- a/packages/main/src/tray-animate-icon.spec.ts
+++ b/packages/main/src/tray-animate-icon.spec.ts
@@ -51,31 +51,13 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-test('valid path on Production', () => {
-  // ensure we are on production mode
-  const onSpy = vi.spyOn(testAnimatedTray, 'isProd').mockReturnValue(true);
-
-  const processResourcesPathValue = path.resolve(__dirname, 'process-resourcesPath-value');
-
-  // setup the process resourcesPath property using defineProperty
-  Object.defineProperty(process, 'resourcesPath', {
-    value: processResourcesPathValue,
-    writable: true,
-  });
-  const assetFolder = testAnimatedTray.getAssetsFolder();
-  expect(assetFolder).toBe(path.resolve(processResourcesPathValue, AnimatedTray.MAIN_ASSETS_FOLDER));
-  expect(onSpy).toHaveBeenCalled();
-});
-
-test('valid path on Development', () => {
+test('valid path for icons', () => {
   // ensure we are not in prod mode
-  const onSpy = vi.spyOn(testAnimatedTray, 'isProd').mockReturnValue(false);
   const appPathValue = path.resolve(__dirname, 'appPath-value');
 
   const spyElectronGetAppPath = vi.spyOn(app, 'getAppPath').mockReturnValue(appPathValue);
 
   const assetFolder = testAnimatedTray.getAssetsFolder();
   expect(assetFolder).toBe(path.resolve(appPathValue, AnimatedTray.MAIN_ASSETS_FOLDER));
-  expect(onSpy).toHaveBeenCalled();
   expect(spyElectronGetAppPath).toHaveBeenCalled();
 });

--- a/packages/main/src/tray-animate-icon.ts
+++ b/packages/main/src/tray-animate-icon.ts
@@ -48,16 +48,7 @@ export class AnimatedTray {
   }
 
   protected getAssetsFolder(): string {
-    // choose right folder for resources
-    // see extraResources in electron-builder config file
-    let assetsFolder;
-    if (this.isProd()) {
-      assetsFolder = path.resolve(process.resourcesPath, AnimatedTray.MAIN_ASSETS_FOLDER);
-    } else {
-      assetsFolder = path.resolve(app.getAppPath(), AnimatedTray.MAIN_ASSETS_FOLDER);
-    }
-
-    return assetsFolder;
+    return path.resolve(app.getAppPath(), AnimatedTray.MAIN_ASSETS_FOLDER);
   }
 
   protected animateTrayIcon(): void {


### PR DESCRIPTION
### What does this PR do?

This fix will let running podman-desktop in
electron as close as possible to production env.

To run podman-desktop locally with electron

`pnpm install && pnpm buld && node_modules/.bin/electron .`

The 'packages/main/src/assets' moved to app.asar file for runtime so it works after installing podman desktop with installer.

`pnpm watch`

is not affected because app.getAppPath() returns root of podman-desktop repository.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Related to #5265 and let to replicate it without building installer

### How to test this PR?

1. Pull the branch
2. `pnpm install`
3. `pnpm build`
4. `node_modules/.bin/electron .`
5. You see podman-desktop dashboard

- [ ] Tests are covering the bug fix or the new feature
