### PR TITLE
fix: update native theme directly on config change

### DIFF
--- a/packages/main/src/plugin/appearance-init.spec.ts
+++ b/packages/main/src/plugin/appearance-init.spec.ts
@@ -53,7 +53,7 @@ test('Expect appearance configuration change to update native theme', async () =
 
   expect(spyOnDidChange).toHaveBeenCalled();
   // grab the anonymous function that is the first argument of the first call
-  const callback = spyOnDidChange.mock.calls[0][0];
+  const callback = spyOnDidChange.mock.calls[0]?.[0];
   expect(callback).toBeDefined();
 
   // call the callback
@@ -75,7 +75,7 @@ test('Expect unrelated configuration change not to update native theme', async (
 
   expect(spyOnDidChange).toHaveBeenCalled();
   // grab the anonymous function that is the first argument of the first call
-  const callback = spyOnDidChange.mock.calls[0][0];
+  const callback = spyOnDidChange.mock.calls[0]?.[0];
   expect(callback).toBeDefined();
 
   // call the callback

--- a/packages/main/src/plugin/appearance-init.spec.ts
+++ b/packages/main/src/plugin/appearance-init.spec.ts
@@ -1,0 +1,116 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { nativeTheme } from 'electron';
+import { beforeAll, expect, test, vi } from 'vitest';
+
+import type { ApiSenderType } from './api.js';
+import { AppearanceInit } from './appearance-init.js';
+import { AppearanceSettings } from './appearance-settings.js';
+import type { IConfigurationChangeEvent } from './configuration-registry.js';
+import { ConfigurationRegistry } from './configuration-registry.js';
+import type { Directories } from './directories.js';
+
+let configurationRegistry: ConfigurationRegistry;
+
+vi.mock('electron', () => {
+  return {
+    nativeTheme: {},
+  };
+});
+
+/* eslint-disable @typescript-eslint/no-empty-function */
+beforeAll(() => {
+  configurationRegistry = new ConfigurationRegistry({} as ApiSenderType, {} as Directories);
+  configurationRegistry.registerConfigurations = vi.fn();
+  configurationRegistry.deregisterConfigurations = vi.fn();
+});
+
+test('Expect appearance configuration change to update native theme', async () => {
+  const spyOnDidChange = vi.spyOn(configurationRegistry, 'onDidChangeConfiguration');
+
+  const appearanceInit: AppearanceInit = new AppearanceInit(configurationRegistry);
+  const spyOnUpdateNativeTheme = vi.spyOn(appearanceInit, 'updateNativeTheme');
+
+  appearanceInit.init();
+
+  expect(spyOnDidChange).toHaveBeenCalled();
+  // grab the anonymous function that is the first argument of the first call
+  const callback = spyOnDidChange.mock.calls[0][0];
+  expect(callback).toBeDefined();
+
+  // call the callback
+  callback?.({
+    key: `${AppearanceSettings.SectionName}.${AppearanceSettings.Appearance}`,
+  } as unknown as IConfigurationChangeEvent);
+
+  // check we have called updateNativeTheme
+  expect(spyOnUpdateNativeTheme).toHaveBeenCalled();
+});
+
+test('Expect unrelated configuration change not to update native theme', async () => {
+  const spyOnDidChange = vi.spyOn(configurationRegistry, 'onDidChangeConfiguration');
+
+  const appearanceInit: AppearanceInit = new AppearanceInit(configurationRegistry);
+  const spyOnUpdateNativeTheme = vi.spyOn(appearanceInit, 'updateNativeTheme');
+
+  appearanceInit.init();
+
+  expect(spyOnDidChange).toHaveBeenCalled();
+  // grab the anonymous function that is the first argument of the first call
+  const callback = spyOnDidChange.mock.calls[0][0];
+  expect(callback).toBeDefined();
+
+  // call the callback
+  callback?.({
+    key: `dummyKey`,
+  } as unknown as IConfigurationChangeEvent);
+
+  // check we have not called updateNativeTheme
+  expect(spyOnUpdateNativeTheme).not.toHaveBeenCalled();
+});
+
+test('Expect native theme to be set to light', async () => {
+  const appearanceInit: AppearanceInit = new AppearanceInit(configurationRegistry);
+  appearanceInit.updateNativeTheme('light');
+
+  expect(nativeTheme.themeSource).toEqual('light');
+});
+
+test('Expect native theme to be set to dark', async () => {
+  const appearanceInit: AppearanceInit = new AppearanceInit(configurationRegistry);
+  appearanceInit.updateNativeTheme('dark');
+
+  expect(nativeTheme.themeSource).toEqual('dark');
+});
+
+test('Expect native theme to be set to system', async () => {
+  const appearanceInit: AppearanceInit = new AppearanceInit(configurationRegistry);
+  appearanceInit.updateNativeTheme('system');
+
+  expect(nativeTheme.themeSource).toEqual('system');
+});
+
+test('Expect native theme to be set to system', async () => {
+  const appearanceInit: AppearanceInit = new AppearanceInit(configurationRegistry);
+  appearanceInit.updateNativeTheme('unknown');
+
+  expect(nativeTheme.themeSource).toEqual('system');
+});

--- a/packages/main/src/plugin/appearance-init.ts
+++ b/packages/main/src/plugin/appearance-init.ts
@@ -21,6 +21,8 @@ import { nativeTheme } from 'electron';
 import { AppearanceSettings } from './appearance-settings.js';
 import type { IConfigurationNode, IConfigurationRegistry } from './configuration-registry.js';
 
+const APPEARANCE_FULL_KEY = `${AppearanceSettings.SectionName}.${AppearanceSettings.Appearance}`;
+
 export class AppearanceInit {
   constructor(private configurationRegistry: IConfigurationRegistry) {}
 
@@ -30,7 +32,7 @@ export class AppearanceInit {
       title: 'Appearance',
       type: 'object',
       properties: {
-        [AppearanceSettings.SectionName + '.' + AppearanceSettings.Appearance]: {
+        [APPEARANCE_FULL_KEY]: {
           description: 'Select between light or dark mode, or use your system setting.',
           type: 'string',
           enum: ['system', 'dark', 'light'],
@@ -42,7 +44,7 @@ export class AppearanceInit {
     this.configurationRegistry.registerConfigurations([appearanceConfiguration]);
 
     this.configurationRegistry.onDidChangeConfiguration(async e => {
-      if (e.key === AppearanceSettings.SectionName + '.' + AppearanceSettings.Appearance) {
+      if (e.key === APPEARANCE_FULL_KEY) {
         this.updateNativeTheme(e.value);
       }
     });

--- a/packages/main/src/plugin/appearance-init.ts
+++ b/packages/main/src/plugin/appearance-init.ts
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { nativeTheme } from 'electron';
+
 import { AppearanceSettings } from './appearance-settings.js';
 import type { IConfigurationNode, IConfigurationRegistry } from './configuration-registry.js';
 
@@ -38,5 +40,22 @@ export class AppearanceInit {
     };
 
     this.configurationRegistry.registerConfigurations([appearanceConfiguration]);
+
+    this.configurationRegistry.onDidChangeConfiguration(async e => {
+      if (e.key === AppearanceSettings.SectionName + '.' + AppearanceSettings.Appearance) {
+        this.updateNativeTheme(e.value);
+      }
+    });
+  }
+
+  updateNativeTheme(appearance: string): void {
+    // appearance config values match the enum values for themeSource, but lets be expicit
+    if (appearance === AppearanceSettings.LightEnumValue) {
+      nativeTheme.themeSource = 'light';
+    } else if (appearance === AppearanceSettings.DarkEnumValue) {
+      nativeTheme.themeSource = 'dark';
+    } else {
+      nativeTheme.themeSource = 'system';
+    }
   }
 }

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -42,7 +42,7 @@ import type * as containerDesktopAPI from '@podman-desktop/api';
 import checkDiskSpacePkg from 'check-disk-space';
 import type Dockerode from 'dockerode';
 import type { WebContents } from 'electron';
-import { app, BrowserWindow, clipboard, ipcMain, nativeTheme, shell } from 'electron';
+import { app, BrowserWindow, clipboard, ipcMain, shell } from 'electron';
 import type { IpcMainInvokeEvent } from 'electron/main';
 
 import type { KubernetesGeneratorInfo } from '/@/plugin/api/KubernetesGeneratorInfo.js';
@@ -1892,10 +1892,6 @@ export class PluginSystem {
     });
     this.ipcHandle('os:getHostCpu', async (): Promise<number> => {
       return os.cpus().length;
-    });
-
-    this.ipcHandle('native:theme', async (_listener, themeSource: 'system' | 'light' | 'dark'): Promise<void> => {
-      nativeTheme.themeSource = themeSource;
     });
 
     this.ipcHandle(

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -2059,10 +2059,6 @@ export function initExposure(): void {
     return ipcInvoke('os:getHostCpu');
   });
 
-  contextBridge.exposeInMainWorld('setNativeTheme', async (themeSource: 'system' | 'light' | 'dark'): Promise<void> => {
-    return ipcInvoke('native:theme', themeSource);
-  });
-
   contextBridge.exposeInMainWorld('sendFeedback', async (feedback: FeedbackProperties): Promise<void> => {
     return ipcInvoke('feedback:send', feedback);
   });

--- a/packages/renderer/src/lib/appearance/Appearance.svelte
+++ b/packages/renderer/src/lib/appearance/Appearance.svelte
@@ -15,11 +15,9 @@ async function updateAppearance(): Promise<void> {
   if (isDark) {
     html.classList.add('dark');
     html.setAttribute('style', 'color-scheme: dark;');
-    window.setNativeTheme('dark');
   } else {
     html.classList.remove('dark');
     html.setAttribute('style', 'color-scheme: light;');
-    window.setNativeTheme('light');
   }
 }
 


### PR DESCRIPTION
### What does this PR do?

PR #8289 set the native theme so that extensions render correctly, but once we set the native theme, window.matchMedia('(prefers-color-scheme: dark)') just returns what we set the native theme to - i.e. if system is in light mode and you explicitly set our config value to dark mode and then to system, we will ask the system what it prefers and it still says 'dark', because that's what we told it last. This leads to some parts of the UI updating correctly while other parts don't; restarting fixes the issue.

The fix is to set the native theme directly (and immediately) based on the value of our configuration setting. That way when we call isDarkMode() later on and we're in system mode we will get the correct value from prefers-color-scheme.

Since we don't need nativeTheme exposed to renderer anymore I'm removing it.

FWIW I also tried updating native theme on config change in Appearance's onDidChangeConfigurationCallback. It works fine, but overall this felt simpler and more direct.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #8477.

### How to test this PR?

Install at least one Docker Desktop extension and one extension with a webview (e.g. AI Lab or bootc), then:
- Set the appearance to dark mode, verify that Podman Desktop and the extensions change.
- Set the appearance to system, verify that Podman Desktop and the extensions change.
- Set the appearance to light mode, verify that Podman Desktop and the extensions change.
- Set the appearance to system, verify that Podman Desktop and the extensions change.

- [x] Tests are covering the bug fix or the new feature