### PR TITLE
chore: refactor how to propagate configuration registry

### DIFF
--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -25,6 +25,9 @@ import { app, ipcMain, Tray } from 'electron';
 
 import { createNewWindow, restoreWindow } from '/@/mainWindow.js';
 
+import type { ConfigurationRegistry } from './plugin/configuration-registry.js';
+import type { Event } from './plugin/events/emitter.js';
+import { Emitter } from './plugin/events/emitter.js';
 import type { ExtensionLoader } from './plugin/extension-loader.js';
 import { PluginSystem } from './plugin/index.js';
 import { Deferred } from './plugin/util/deferred.js';
@@ -220,28 +223,31 @@ app.whenReady().then(
     animatedTray.setTray(tray);
     const trayMenu = new TrayMenu(tray, animatedTray);
 
+    const _onDidCreatedConfigurationRegistry = new Emitter<ConfigurationRegistry>();
+    const onDidCreatedConfigurationRegistry: Event<ConfigurationRegistry> = _onDidCreatedConfigurationRegistry.event;
+
     // Start extensions
     const pluginSystem = new PluginSystem(trayMenu, mainWindowDeferred);
-    extensionLoader = await pluginSystem.initExtensions();
 
-    // Get the configuration registry (saves all our settings)
-    const configurationRegistry = extensionLoader.getConfigurationRegistry();
-
-    // If we've manually set the tray icon color, update the tray icon. This can only be done
-    // after configurationRegistry is loaded. Windows or Linux support only for icon color change.
-    if (!isMac()) {
-      const color = configurationRegistry.getConfiguration('preferences').get('TrayIconColor');
-      if (typeof color === 'string') {
-        animatedTray.setColor(color);
+    onDidCreatedConfigurationRegistry(async (configurationRegistry: ConfigurationRegistry) => {
+      // If we've manually set the tray icon color, update the tray icon. This can only be done
+      // after configurationRegistry is loaded. Windows or Linux support only for icon color change.
+      if (!isMac()) {
+        const color = configurationRegistry.getConfiguration('preferences').get('TrayIconColor');
+        if (typeof color === 'string') {
+          animatedTray.setColor(color);
+        }
       }
-    }
 
-    // Share configuration registry with renderer process
-    ipcMain.emit('configuration-registry', '', configurationRegistry);
+      // Share configuration registry with renderer process
+      ipcMain.emit('configuration-registry', '', configurationRegistry);
 
-    // Configure automatic startup
-    const automaticStartup = new StartupInstall(configurationRegistry);
-    await automaticStartup.configure();
+      // Configure automatic startup
+      const automaticStartup = new StartupInstall(configurationRegistry);
+      await automaticStartup.configure();
+    });
+
+    extensionLoader = await pluginSystem.initExtensions(_onDidCreatedConfigurationRegistry);
   },
   (e: unknown) => console.error('Failed to start app:', e),
 );

--- a/packages/main/src/plugin/index.spec.ts
+++ b/packages/main/src/plugin/index.spec.ts
@@ -18,19 +18,37 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { EventEmitter } from 'node:events';
+import { tmpdir } from 'node:os';
 
 import type { BrowserWindow, WebContents } from 'electron';
 import { clipboard, shell } from 'electron';
 import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
+import type { NotificationCardOptions } from '/@api/notification.js';
+
 import { securityRestrictionCurrentHandler } from '../security-restrictions-handler.js';
 import type { TrayMenu } from '../tray-menu.js';
+import type { ApiSenderType } from './api.js';
 import { CancellationTokenRegistry } from './cancellation-token-registry.js';
+import type { ConfigurationRegistry } from './configuration-registry.js';
+import type { Directories } from './directories.js';
+import { Emitter } from './events/emitter.js';
 import { PluginSystem } from './index.js';
 import type { MessageBox } from './message-box.js';
 import { Deferred } from './util/deferred.js';
 
-let pluginSystem: PluginSystem;
+let pluginSystem: TestPluginSystem;
+
+class TestPluginSystem extends PluginSystem {
+  initConfigurationRegistry(
+    apiSender: ApiSenderType,
+    directories: Directories,
+    notifications: NotificationCardOptions[],
+    configurationRegistryEmitter: Emitter<ConfigurationRegistry>,
+  ): ConfigurationRegistry {
+    return super.initConfigurationRegistry(apiSender, directories, notifications, configurationRegistryEmitter);
+  }
+}
 
 const emitter = new EventEmitter();
 const webContents = emitter as unknown as WebContents;
@@ -56,7 +74,7 @@ beforeAll(() => {
     };
   });
   const trayMenuMock = {} as unknown as TrayMenu;
-  pluginSystem = new PluginSystem(trayMenuMock, mainWindowDeferred);
+  pluginSystem = new TestPluginSystem(trayMenuMock, mainWindowDeferred);
 });
 
 beforeEach(() => {
@@ -237,4 +255,32 @@ test('Should return AbortController that should be aborted if token is cancelled
   token?.cancel();
 
   expect(abortMock).toBeCalled();
+});
+
+test('configurationRegistry propagated', async () => {
+  const configurationRegistryEmitter = new Emitter<ConfigurationRegistry>();
+  const onDidCallConfigurationRegistry = configurationRegistryEmitter.event;
+
+  const spyFire = vi.spyOn(configurationRegistryEmitter, 'fire');
+
+  let receivedConfig: ConfigurationRegistry | undefined;
+  onDidCallConfigurationRegistry(config => (receivedConfig = config));
+
+  const apiSenderMock = {} as unknown as ApiSenderType;
+  const directoriesMock = {
+    getConfigurationDirectory: vi.fn().mockReturnValue(tmpdir()),
+  } as unknown as Directories;
+  const notifications: NotificationCardOptions[] = [];
+
+  const configurationRegistry = pluginSystem.initConfigurationRegistry(
+    apiSenderMock,
+    directoriesMock,
+    notifications,
+    configurationRegistryEmitter,
+  );
+
+  expect(spyFire).toHaveBeenCalled();
+  expect(receivedConfig).toBeDefined();
+  expect(receivedConfig).toBe(configurationRegistry);
+  expect(notifications.length).toBe(0);
 });


### PR DESCRIPTION
### What does this PR do?
propagate configuration registry as soon as we have it initialized.

when implementing https://github.com/containers/podman-desktop/issues/6115 there was a delay where the window stayed for a while before being moved. It's because as we were receiving the configuration registry at the end of the initialization, the window was already displayed (and then moved)
By receiving it earlier, we don't notice this delay/move

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
