### PR TITLE
chore: update xterm to v5.5.0

### DIFF
--- a/packages/main/src/plugin/terminal-theme.spec.ts
+++ b/packages/main/src/plugin/terminal-theme.spec.ts
@@ -16,8 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ITheme } from '@xterm/xterm';
 import { describe, expect, test, vi } from 'vitest';
-import type { ITheme } from 'xterm';
 
 import { getTerminalTheme } from './terminal-theme.js';
 

--- a/packages/main/src/plugin/terminal-theme.ts
+++ b/packages/main/src/plugin/terminal-theme.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ITheme } from 'xterm';
+import type { ITheme } from '@xterm/xterm';
 
 // Array of strings to extract from the CSS variables
 // we list it here as we cannot infer the properties from the ITheme type at runtime. Another reason is to avoid

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -47,8 +47,8 @@
     "typescript": "^5.5.4",
     "vite": "^5.4.1",
     "vitest": "^1.6.0",
-    "xterm": "^5.3.0",
-    "xterm-addon-fit": "^0.8.0",
+    "@xterm/xterm": "^5.5.0",
+    "@xterm/addon-fit": "^0.10.0",
     "yaml": "^2.5.0"
   },
   "dependencies": {

--- a/packages/renderer/src/lib/compose/ComposeDetails.spec.ts
+++ b/packages/renderer/src/lib/compose/ComposeDetails.spec.ts
@@ -35,7 +35,7 @@ const listContainersMock = vi.fn();
 const getProviderInfosMock = vi.fn();
 const getContributedMenusMock = vi.fn();
 
-vi.mock('xterm', () => {
+vi.mock('@xterm/xterm', () => {
   return {
     Terminal: vi.fn().mockReturnValue({ loadAddon: vi.fn(), open: vi.fn(), write: vi.fn(), clear: vi.fn() }),
   };

--- a/packages/renderer/src/lib/compose/ComposeDetailsLogs.spec.ts
+++ b/packages/renderer/src/lib/compose/ComposeDetailsLogs.spec.ts
@@ -26,7 +26,7 @@ import { ContainerGroupInfoTypeUI, type ContainerInfoUI } from '../container/Con
 import ComposeDetailsLogs from './ComposeDetailsLogs.svelte';
 import type { ComposeInfoUI } from './ComposeInfoUI';
 
-vi.mock('xterm', () => {
+vi.mock('@xterm/xterm', () => {
   return {
     Terminal: vi.fn().mockReturnValue({ loadAddon: vi.fn(), open: vi.fn(), write: vi.fn(), clear: vi.fn() }),
   };

--- a/packages/renderer/src/lib/compose/ComposeDetailsLogs.svelte
+++ b/packages/renderer/src/lib/compose/ComposeDetailsLogs.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-import 'xterm/css/xterm.css';
+import '@xterm/xterm/css/xterm.css';
 
 import { EmptyScreen } from '@podman-desktop/ui-svelte';
+import { FitAddon } from '@xterm/addon-fit';
+import { Terminal } from '@xterm/xterm';
 import { onDestroy, onMount } from 'svelte';
-import { Terminal } from 'xterm';
-import { FitAddon } from 'xterm-addon-fit';
 
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
 import { getTerminalTheme } from '../../../../main/src/plugin/terminal-theme';

--- a/packages/renderer/src/lib/container/ContainerDetails.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerDetails.spec.ts
@@ -55,7 +55,7 @@ const myContainer: ContainerInfo = {
 const deleteContainerMock = vi.fn();
 const getContributedMenusMock = vi.fn();
 
-vi.mock('xterm', () => {
+vi.mock('@xterm/xterm', () => {
   return {
     Terminal: vi.fn().mockReturnValue({ loadAddon: vi.fn(), open: vi.fn(), write: vi.fn(), clear: vi.fn() }),
   };

--- a/packages/renderer/src/lib/container/ContainerDetails.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetails.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import 'xterm/css/xterm.css';
+import '@xterm/xterm/css/xterm.css';
 
 import { ErrorMessage, Link, StatusIcon, Tab } from '@podman-desktop/ui-svelte';
 import { ContainerIcon } from '@podman-desktop/ui-svelte/icons';

--- a/packages/renderer/src/lib/container/ContainerDetailsLogs.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsLogs.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-import 'xterm/css/xterm.css';
+import '@xterm/xterm/css/xterm.css';
 
 import { EmptyScreen } from '@podman-desktop/ui-svelte';
+import { FitAddon } from '@xterm/addon-fit';
+import { Terminal } from '@xterm/xterm';
 import { onDestroy, onMount } from 'svelte';
-import { Terminal } from 'xterm';
-import { FitAddon } from 'xterm-addon-fit';
 
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
 import { getTerminalTheme } from '../../../../main/src/plugin/terminal-theme';

--- a/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-import 'xterm/css/xterm.css';
+import '@xterm/xterm/css/xterm.css';
 
 import { EmptyScreen } from '@podman-desktop/ui-svelte';
+import { FitAddon } from '@xterm/addon-fit';
+import { Terminal } from '@xterm/xterm';
 import { onDestroy, onMount } from 'svelte';
 import { router } from 'tinro';
-import { Terminal } from 'xterm';
-import { FitAddon } from 'xterm-addon-fit';
 
 import { getExistingTerminal, registerTerminal } from '/@/stores/container-terminal-store';
 

--- a/packages/renderer/src/lib/container/ContainerDetailsTtyTerminal.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsTtyTerminal.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-import 'xterm/css/xterm.css';
+import '@xterm/xterm/css/xterm.css';
 
 import { EmptyScreen } from '@podman-desktop/ui-svelte';
+import { FitAddon } from '@xterm/addon-fit';
+import { Terminal } from '@xterm/xterm';
 import { onDestroy, onMount } from 'svelte';
 import { router } from 'tinro';
-import { Terminal } from 'xterm';
-import { FitAddon } from 'xterm-addon-fit';
 
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
 import { getTerminalTheme } from '../../../../main/src/plugin/terminal-theme';

--- a/packages/renderer/src/lib/dashboard/ProviderConfiguring.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderConfiguring.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-import 'xterm/css/xterm.css';
+import '@xterm/xterm/css/xterm.css';
 
 import { Spinner } from '@podman-desktop/ui-svelte';
+import { FitAddon } from '@xterm/addon-fit';
+import { Terminal } from '@xterm/xterm';
 import { onDestroy, onMount } from 'svelte';
-import { Terminal } from 'xterm';
-import { FitAddon } from 'xterm-addon-fit';
 
 import type { CheckStatus, ProviderInfo } from '/@api/provider-info';
 

--- a/packages/renderer/src/lib/dashboard/ProviderInstalled.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ProviderInstalled.spec.ts
@@ -30,7 +30,7 @@ import type { ProviderInfo } from '/@api/provider-info';
 
 import { verifyStatus } from './ProviderStatusTestHelper.spec';
 
-vi.mock('xterm', () => {
+vi.mock('@xterm/xterm', () => {
   return {
     Terminal: vi.fn().mockReturnValue({ loadAddon: vi.fn(), open: vi.fn(), write: vi.fn(), clear: vi.fn() }),
   };

--- a/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-import 'xterm/css/xterm.css';
+import '@xterm/xterm/css/xterm.css';
 
 import { Spinner } from '@podman-desktop/ui-svelte';
+import { FitAddon } from '@xterm/addon-fit';
+import { Terminal } from '@xterm/xterm';
 import { onDestroy, onMount } from 'svelte';
-import { Terminal } from 'xterm';
-import { FitAddon } from 'xterm-addon-fit';
 
 import type { CheckStatus, ProviderInfo } from '/@api/provider-info';
 

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
@@ -34,7 +34,7 @@ import { recommendedRegistries } from '/@/stores/recommendedRegistries';
 import type { ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provider-info';
 
 // xterm is used in the UI, but not tested, added in order to avoid the multiple warnings being shown during the test.
-vi.mock('xterm', () => {
+vi.mock('@xterm/xterm', () => {
   return {
     Terminal: vi
       .fn()

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
@@ -4,9 +4,9 @@
 import { faCube, faMinusCircle, faPlusCircle } from '@fortawesome/free-solid-svg-icons';
 import type { OpenDialogOptions } from '@podman-desktop/api';
 import { Button, Input } from '@podman-desktop/ui-svelte';
+import type { Terminal } from '@xterm/xterm';
 import { onDestroy, onMount } from 'svelte';
 import { get } from 'svelte/store';
-import type { Terminal } from 'xterm';
 
 import FileInput from '/@/lib/ui/FileInput.svelte';
 import { type BuildImageInfo, buildImagesInfo } from '/@/stores/build-images';

--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 import { faArrowCircleDown, faCog } from '@fortawesome/free-solid-svg-icons';
 import { Button, ErrorMessage } from '@podman-desktop/ui-svelte';
+import type { Terminal } from '@xterm/xterm';
 import { onMount, tick } from 'svelte';
 import { router } from 'tinro';
-import type { Terminal } from 'xterm';
 
 import type { ProviderContainerConnectionInfo } from '/@api/provider-info';
 import type { PullEvent } from '/@api/pull-event';

--- a/packages/renderer/src/lib/image/PushImageModal.spec.ts
+++ b/packages/renderer/src/lib/image/PushImageModal.spec.ts
@@ -28,7 +28,7 @@ import type { ImageInspectInfo } from '/@api/image-inspect-info';
 import type { ImageInfoUI } from './ImageInfoUI';
 import PushImageModal from './PushImageModal.svelte';
 
-vi.mock('xterm', () => {
+vi.mock('@xterm/xterm', () => {
   return {
     Terminal: vi
       .fn()

--- a/packages/renderer/src/lib/image/PushImageModal.svelte
+++ b/packages/renderer/src/lib/image/PushImageModal.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
 import { faCheckCircle, faCircleArrowUp, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
 import { Button, Link } from '@podman-desktop/ui-svelte';
+import { FitAddon } from '@xterm/addon-fit';
+import { Terminal } from '@xterm/xterm';
 import { onMount, tick } from 'svelte';
 import Fa from 'svelte-fa';
 import { router } from 'tinro';
-import { Terminal } from 'xterm';
-import { FitAddon } from 'xterm-addon-fit';
 
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
 import { getTerminalTheme } from '../../../../main/src/plugin/terminal-theme';

--- a/packages/renderer/src/lib/image/PushManifestModal.spec.ts
+++ b/packages/renderer/src/lib/image/PushManifestModal.spec.ts
@@ -26,7 +26,7 @@ import { beforeAll, expect, test, vi } from 'vitest';
 import type { ImageInfoUI } from './ImageInfoUI';
 import PushManifestModal from './PushManifestModal.svelte';
 
-vi.mock('xterm', () => {
+vi.mock('@xterm/xterm', () => {
   return {
     Terminal: vi
       .fn()

--- a/packages/renderer/src/lib/image/PushManifestModal.svelte
+++ b/packages/renderer/src/lib/image/PushManifestModal.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 import { faCircleArrowUp } from '@fortawesome/free-solid-svg-icons';
 import { Button } from '@podman-desktop/ui-svelte';
+import { FitAddon } from '@xterm/addon-fit';
+import { Terminal } from '@xterm/xterm';
 import { tick } from 'svelte';
 import { router } from 'tinro';
-import { Terminal } from 'xterm';
-import { FitAddon } from 'xterm-addon-fit';
 
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
 import { getTerminalTheme } from '../../../../main/src/plugin/terminal-theme';

--- a/packages/renderer/src/lib/pod/KubernetesTerminal.svelte
+++ b/packages/renderer/src/lib/pod/KubernetesTerminal.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
+import { FitAddon } from '@xterm/addon-fit';
+import { type IDisposable, Terminal } from '@xterm/xterm';
 import { onDestroy, onMount } from 'svelte';
 import { router } from 'tinro';
-import { type IDisposable, Terminal } from 'xterm';
-import { FitAddon } from 'xterm-addon-fit';
 
 import { terminalStates } from '/@/stores/kubernetes-terminal-state-store';
 

--- a/packages/renderer/src/lib/pod/PodDetails.spec.ts
+++ b/packages/renderer/src/lib/pod/PodDetails.spec.ts
@@ -32,7 +32,7 @@ import PodDetails from './PodDetails.svelte';
 const mocks = vi.hoisted(() => ({
   TerminalMock: vi.fn(),
 }));
-vi.mock('xterm', () => ({
+vi.mock('@xterm/xterm', () => ({
   Terminal: mocks.TerminalMock,
 }));
 

--- a/packages/renderer/src/lib/pod/PodDetailsLogs.svelte
+++ b/packages/renderer/src/lib/pod/PodDetailsLogs.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-import 'xterm/css/xterm.css';
+import '@xterm/xterm/css/xterm.css';
 
 import { EmptyScreen } from '@podman-desktop/ui-svelte';
+import { FitAddon } from '@xterm/addon-fit';
+import { Terminal } from '@xterm/xterm';
 import { onDestroy, onMount } from 'svelte';
-import { Terminal } from 'xterm';
-import { FitAddon } from 'xterm-addon-fit';
 
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
 import { getTerminalTheme } from '../../../../main/src/plugin/terminal-theme';

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
@@ -2,12 +2,12 @@
 import { faCubes } from '@fortawesome/free-solid-svg-icons';
 import type { AuditRequestItems, AuditResult, ConfigurationScope } from '@podman-desktop/api';
 import { Button, EmptyScreen, ErrorMessage, LinearProgress, Spinner } from '@podman-desktop/ui-svelte';
+import type { Terminal } from '@xterm/xterm';
 import { onDestroy, onMount } from 'svelte';
 /* eslint-disable import/no-duplicates */
 // https://github.com/import-js/eslint-plugin-import/issues/1479
 import { get, type Unsubscriber } from 'svelte/store';
 import { router } from 'tinro';
-import type { Terminal } from 'xterm';
 
 import type { ContextUI } from '/@/lib/context/context';
 import { context } from '/@/stores/context';

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsLogs.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsLogs.spec.ts
@@ -23,8 +23,8 @@
 import '@testing-library/jest-dom/vitest';
 
 import { render, screen } from '@testing-library/svelte';
+import { Terminal } from '@xterm/xterm';
 import { beforeAll, expect, test, vi } from 'vitest';
-import { Terminal } from 'xterm';
 
 import type { ProviderContainerConnectionInfo } from '/@api/provider-info';
 

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsLogs.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsLogs.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-import 'xterm/css/xterm.css';
+import '@xterm/xterm/css/xterm.css';
 
 import { EmptyScreen } from '@podman-desktop/ui-svelte';
+import { FitAddon } from '@xterm/addon-fit';
+import { Terminal } from '@xterm/xterm';
 import { onDestroy, onMount } from 'svelte';
-import { Terminal } from 'xterm';
-import { FitAddon } from 'xterm-addon-fit';
 
 import type { ProviderContainerConnectionInfo, ProviderKubernetesConnectionInfo } from '/@api/provider-info';
 

--- a/packages/renderer/src/lib/preferences/PreferencesProviderRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProviderRendering.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 import { faHistory, faPlay, faStop } from '@fortawesome/free-solid-svg-icons';
 import { Button, ErrorMessage, Modal } from '@podman-desktop/ui-svelte';
+import type { Terminal } from '@xterm/xterm';
 import { onMount } from 'svelte';
 import { router } from 'tinro';
-import type { Terminal } from 'xterm';
 
 import { operationConnectionsInfo } from '/@/stores/operation-connections';
 import type {

--- a/packages/renderer/src/lib/ui/TerminalWindow.svelte
+++ b/packages/renderer/src/lib/ui/TerminalWindow.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-import 'xterm/css/xterm.css';
+import '@xterm/xterm/css/xterm.css';
 
+import { FitAddon } from '@xterm/addon-fit';
+import { Terminal } from '@xterm/xterm';
 import { createEventDispatcher, onDestroy, onMount } from 'svelte';
-import { Terminal } from 'xterm';
-import { FitAddon } from 'xterm-addon-fit';
 
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
 import { getTerminalTheme } from '../../../../main/src/plugin/terminal-theme';

--- a/packages/renderer/src/stores/container-terminal-store.ts
+++ b/packages/renderer/src/stores/container-terminal-store.ts
@@ -16,9 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { Terminal } from '@xterm/xterm';
 import type { Writable } from 'svelte/store';
 import { get, writable } from 'svelte/store';
-import type { Terminal } from 'xterm';
 
 import { containersInfos } from './containers';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7255,6 +7255,16 @@
   resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.10.tgz#a1337ca426aa61cef9fe15b5b28e340a72f6fa99"
   integrity sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==
 
+"@xterm/addon-fit@^0.10.0":
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@xterm/addon-fit/-/addon-fit-0.10.0.tgz#bebf87fadd74e3af30fdcdeef47030e2592c6f55"
+  integrity sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==
+
+"@xterm/xterm@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@xterm/xterm/-/xterm-5.5.0.tgz#275fb8f6e14afa6e8a0c05d4ebc94523ff775396"
+  integrity sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"
@@ -20463,16 +20473,6 @@ xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
-
-xterm-addon-fit@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/xterm-addon-fit/-/xterm-addon-fit-0.8.0.tgz#48ca99015385141918f955ca7819e85f3691d35f"
-  integrity sha512-yj3Np7XlvxxhYF/EJ7p3KHaMt6OdwQ+HDu573Vx1lRXsVxOcnVJs51RgjZOouIZOczTsskaS+CpXspK81/DLqw==
-
-xterm@^5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/xterm/-/xterm-5.3.0.tgz#867daf9cc826f3d45b5377320aabd996cb0fce46"
-  integrity sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==
 
 xvfb-maybe@^0.2.1:
   version "0.2.1"


### PR DESCRIPTION
### What does this PR do?
xterm has changed its namespace
replace package (xterm --> @xterm/**) namespace

and bump to v5.5.0

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
