### PR TITLE
feat: remember window position and size of Podman Desktop window

### DIFF
--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -32,6 +32,7 @@ import type { ExtensionLoader } from './plugin/extension-loader.js';
 import { PluginSystem } from './plugin/index.js';
 import { Deferred } from './plugin/util/deferred.js';
 import { StartupInstall } from './system/startup-install.js';
+import { WindowHandler } from './system/window/window-handler.js';
 import { AnimatedTray } from './tray-animate-icon.js';
 import { TrayMenu } from './tray-menu.js';
 import { isMac, isWindows, stoppedExtensions } from './util.js';
@@ -241,6 +242,19 @@ app.whenReady().then(
 
       // Share configuration registry with renderer process
       ipcMain.emit('configuration-registry', '', configurationRegistry);
+
+      // Register the window configuration
+      // This is used to save/restore the window size and position
+      mainWindowDeferred.promise
+        .then(browserWindow => {
+          const windowHandler = new WindowHandler(configurationRegistry, browserWindow);
+          windowHandler.init();
+          // send window Handler
+          ipcMain.emit('window-handler', '', windowHandler);
+        })
+        .catch((error: unknown) => {
+          console.error('Error initializing window handler', error);
+        });
 
       // Configure automatic startup
       const automaticStartup = new StartupInstall(configurationRegistry);

--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -19,7 +19,7 @@
 import { join } from 'node:path';
 import { URL } from 'node:url';
 
-import type { BrowserWindowConstructorOptions } from 'electron';
+import type { BrowserWindowConstructorOptions, Rectangle } from 'electron';
 import { app, autoUpdater, BrowserWindow, ipcMain, Menu, nativeTheme, screen } from 'electron';
 import contextMenu from 'electron-context-menu';
 import { aboutMenuItem } from 'electron-util/main';
@@ -27,6 +27,7 @@ import { aboutMenuItem } from 'electron-util/main';
 import { NavigationItemsMenuBuilder } from './navigation-items-menu-builder.js';
 import { OpenDevTools } from './open-dev-tools.js';
 import type { ConfigurationRegistry } from './plugin/configuration-registry.js';
+import type { WindowHandler } from './system/window/window-handler.js';
 import { isLinux, isMac, stoppedExtensions } from './util.js';
 
 const openDevTools = new OpenDevTools();
@@ -72,18 +73,20 @@ async function createWindow(): Promise<BrowserWindow> {
   }
 
   const browserWindow = new BrowserWindow(browserWindowConstructorOptions);
+
   const { getCursorScreenPoint, getDisplayNearestPoint } = screen;
   const workArea = getDisplayNearestPoint(getCursorScreenPoint()).workArea;
 
   const x = Math.round(workArea.width / 2 - INITIAL_APP_WIDTH / 2 + workArea.x);
   const y = Math.round(workArea.height / 2 - INITIAL_APP_HEIGHT / 2);
 
-  browserWindow.setBounds({
+  const initialBounds: Rectangle = {
     x: x,
     y: y,
-    width: browserWindowConstructorOptions.width,
-    height: browserWindowConstructorOptions.height,
-  });
+    width: INITIAL_APP_WIDTH,
+    height: INITIAL_APP_HEIGHT,
+  };
+  browserWindow.setBounds(initialBounds);
 
   /**
    * If you install `show: true` then it can cause issues when trying to close the window.
@@ -110,6 +113,21 @@ async function createWindow(): Promise<BrowserWindow> {
 
     // open dev tools (if required)
     openDevTools.open(browserWindow, configurationRegistry);
+  });
+
+  let windowHandler: WindowHandler | undefined;
+  ipcMain.on('window-handler', (_, windowHandlerParam) => {
+    // try to restore the window position and size
+    windowHandler = windowHandlerParam;
+    windowHandler?.restore(initialBounds);
+  });
+
+  browserWindow.on('resize', () => {
+    windowHandler?.savePositionAndSize();
+  });
+
+  browserWindow.on('move', () => {
+    windowHandler?.savePositionAndSize();
   });
 
   // receive the navigation items

--- a/packages/main/src/system/window/window-handler.spec.ts
+++ b/packages/main/src/system/window/window-handler.spec.ts
@@ -1,0 +1,148 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Configuration } from '@podman-desktop/api';
+import type { BrowserWindow, Display, Rectangle } from 'electron';
+import { screen } from 'electron';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { ConfigurationRegistry } from '/@/plugin/configuration-registry.js';
+
+import { WindowHandler } from './window-handler.js';
+import { WindowSettings } from './window-settings.js';
+
+let windowHandler: WindowHandler;
+
+const configurationMock = {
+  get: vi.fn(),
+  update: vi.fn(),
+} as unknown as Configuration;
+
+const getConfigurationMock = vi.fn();
+
+const configurationRegistryMock = {
+  getConfiguration: getConfigurationMock,
+  registerConfigurations: vi.fn(),
+} as unknown as ConfigurationRegistry;
+
+const browserWindowMock = {
+  setBounds: vi.fn(),
+  getBounds: vi.fn(),
+} as unknown as BrowserWindow;
+
+vi.mock('electron', async () => {
+  return {
+    screen: {
+      getDisplayMatching: vi.fn(),
+    },
+  };
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  getConfigurationMock.mockReturnValue(configurationMock);
+  windowHandler = new WindowHandler(configurationRegistryMock, browserWindowMock);
+});
+
+describe('restore window', () => {
+  const initialBounds = { height: 768, width: 1024, x: 100, y: 200 };
+
+  test('perform restore should be skipped if configuration is disabled', async () => {
+    vi.mocked(configurationMock.get).mockReturnValueOnce(false);
+
+    windowHandler.restore(initialBounds);
+
+    // should be the directory provided as env var
+    expect(configurationRegistryMock.getConfiguration).toBeCalledWith('window');
+
+    // first call should be false
+    expect(getConfigurationMock).toBeCalledWith('window');
+
+    // only one call to get the configuration
+    expect(vi.mocked(configurationMock.get)).toBeCalledTimes(1);
+
+    expect(vi.mocked(browserWindowMock).setBounds).not.toBeCalled();
+  });
+
+  test('perform restore if configuration is enabled', async () => {
+    const savedBounds: Rectangle = { height: 500, width: 1000, x: 50, y: 250 };
+    vi.mocked(screen.getDisplayMatching).mockReturnValue({
+      workArea: { x: 0, y: 0, width: 1920, height: 1080 },
+    } as Display);
+    vi.mocked(configurationMock.get).mockReturnValueOnce(true);
+    vi.mocked(configurationMock.get).mockReturnValueOnce(savedBounds);
+
+    windowHandler.restore(initialBounds);
+
+    // should be the directory provided as env var
+    expect(configurationRegistryMock.getConfiguration).toBeCalledWith('window');
+
+    // first call should be false
+    expect(getConfigurationMock).toBeCalledWith('window');
+
+    // 5 calls to get the configuration
+    expect(vi.mocked(configurationMock.get)).toBeCalledTimes(2);
+
+    expect(vi.mocked(browserWindowMock).setBounds).toBeCalledWith(savedBounds);
+  });
+});
+
+describe('save window', () => {
+  test('perform save', async () => {
+    const bounds = { height: 768, width: 1024, x: 100, y: 200 };
+    vi.mocked(screen.getDisplayMatching).mockReturnValue({
+      workArea: { x: 0, y: 0, width: 1920, height: 1080 },
+    } as Display);
+    vi.mocked(browserWindowMock.getBounds).mockReturnValue(bounds);
+    vi.mocked(configurationMock.get).mockReturnValueOnce(false);
+
+    // perform 5 save in a row
+    windowHandler.savePositionAndSize();
+    windowHandler.savePositionAndSize();
+    windowHandler.savePositionAndSize();
+    windowHandler.savePositionAndSize();
+    windowHandler.savePositionAndSize();
+
+    // wait that this.#browserWindow.getBounds is called
+    await vi.waitFor(() => expect(vi.mocked(browserWindowMock.getBounds)).toHaveBeenCalled());
+
+    expect(configurationMock.update).toBeCalledWith(WindowSettings.Bounds, bounds);
+  });
+});
+
+test('should register a configuration', async () => {
+  // register configuration
+  windowHandler.init();
+
+  // should be the directory provided as env var
+  expect(configurationRegistryMock.registerConfigurations).toBeCalled();
+
+  // take first argument of first call
+  const configurationNode = vi.mocked(configurationRegistryMock).registerConfigurations.mock.calls[0][0][0];
+  expect(configurationNode.id).toBe('preferences.savePosition');
+  expect(configurationNode.title).toBe('Window');
+  expect(configurationNode.type).toBe('object');
+  expect(configurationNode.properties).toBeDefined();
+  expect(configurationNode.properties?.['window.bounds']).toBeDefined();
+  expect(configurationNode.properties?.['window.bounds'].description).toBe('bounds of the window');
+  expect(configurationNode.properties?.['window.restorePosition'].type).toBe('boolean');
+  expect(configurationNode.properties?.['window.restorePosition'].description).toBe(
+    'Restore position and size of the window after a restart',
+  );
+  expect(configurationNode.properties?.['window.restorePosition'].default).toBeTruthy();
+});

--- a/packages/main/src/system/window/window-handler.spec.ts
+++ b/packages/main/src/system/window/window-handler.spec.ts
@@ -41,7 +41,8 @@ const configurationRegistryMock = {
 } as unknown as ConfigurationRegistry;
 
 const browserWindowMock = {
-  setBounds: vi.fn(),
+  setSize: vi.fn(),
+  setPosition: vi.fn(),
   getBounds: vi.fn(),
 } as unknown as BrowserWindow;
 
@@ -76,7 +77,8 @@ describe('restore window', () => {
     // only one call to get the configuration
     expect(vi.mocked(configurationMock.get)).toBeCalledTimes(1);
 
-    expect(vi.mocked(browserWindowMock).setBounds).not.toBeCalled();
+    expect(vi.mocked(browserWindowMock).setPosition).not.toBeCalled();
+    expect(vi.mocked(browserWindowMock).setSize).not.toBeCalled();
   });
 
   test('perform restore if configuration is enabled', async () => {
@@ -98,7 +100,8 @@ describe('restore window', () => {
     // 5 calls to get the configuration
     expect(vi.mocked(configurationMock.get)).toBeCalledTimes(2);
 
-    expect(vi.mocked(browserWindowMock).setBounds).toBeCalledWith(savedBounds);
+    expect(vi.mocked(browserWindowMock).setSize).toBeCalledWith(savedBounds.width, savedBounds.height);
+    expect(vi.mocked(browserWindowMock).setPosition).toBeCalledWith(savedBounds.x, savedBounds.y);
   });
 
   test('perform restore if configuration is enabled but screen is different with saved width/height', async () => {
@@ -128,7 +131,8 @@ describe('restore window', () => {
     centeredBounds.x = Math.floor(display.workArea.x + (display.workArea.width - savedBounds.width) / 2);
     centeredBounds.y = Math.floor(display.workArea.y + (display.workArea.height - savedBounds.height) / 2);
 
-    expect(vi.mocked(browserWindowMock).setBounds).toBeCalledWith(centeredBounds);
+    expect(vi.mocked(browserWindowMock).setSize).toBeCalledWith(centeredBounds.width, centeredBounds.height);
+    expect(vi.mocked(browserWindowMock).setPosition).toBeCalledWith(centeredBounds.x, centeredBounds.y);
   });
 
   test('perform restore if configuration is enabled but screen is different with initial width/height', async () => {
@@ -154,12 +158,8 @@ describe('restore window', () => {
 
     // expect we got the initial bounds as it is not fitting
 
-    expect(vi.mocked(browserWindowMock).setBounds).toBeCalledWith({
-      height: 768,
-      width: 1024,
-      x: 100,
-      y: 200,
-    });
+    expect(vi.mocked(browserWindowMock).setSize).toBeCalledWith(1024, 768);
+    expect(vi.mocked(browserWindowMock).setPosition).toBeCalledWith(100, 200);
   });
 });
 

--- a/packages/main/src/system/window/window-handler.ts
+++ b/packages/main/src/system/window/window-handler.ts
@@ -37,7 +37,7 @@ export class WindowHandler {
   }
 
   // try to restore the window position and size
-  restore(initalBounds: Rectangle): void {
+  restore(initialBounds: Rectangle): void {
     // grab value of the width and height from the configuration
     const windowPreferences = this.#configurationRegistry.getConfiguration(WindowSettings.SectionName);
     const restore = windowPreferences.get<boolean>(WindowSettings.RestorePosition);
@@ -61,7 +61,29 @@ export class WindowHandler {
         bounds.y > screenArea.y + screenArea.height
       ) {
         // Previous stored location is no longer available, restore window into an initial state
-        this.#browserWindow.setBounds(initalBounds);
+
+        // check if we can restore using the current width and height
+        const centeredBounds = {
+          x: Math.floor(screenArea.x + (screenArea.width - bounds.width) / 2),
+          y: Math.floor(screenArea.y + (screenArea.height - bounds.height) / 2),
+          width: bounds.width,
+          height: bounds.height,
+        };
+        const newScreenArea = screen.getDisplayMatching(centeredBounds).workArea;
+
+        // does it fit ?
+        if (
+          centeredBounds.x > newScreenArea.x + newScreenArea.width ||
+          centeredBounds.x < newScreenArea.x ||
+          centeredBounds.y < newScreenArea.y ||
+          centeredBounds.y > newScreenArea.y + newScreenArea.height
+        ) {
+          // no, restore to initial bounds (default size and location)
+          this.#browserWindow.setBounds(initialBounds);
+        } else {
+          // restore it centered but using the saved width and height
+          this.#browserWindow.setBounds(centeredBounds);
+        }
       } else {
         // restore the window position and size to its saved state
         this.#browserWindow.setBounds(bounds);

--- a/packages/main/src/system/window/window-handler.ts
+++ b/packages/main/src/system/window/window-handler.ts
@@ -1,0 +1,117 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { type BrowserWindow, type Rectangle, screen } from 'electron';
+
+import type { ConfigurationRegistry, IConfigurationNode } from '/@/plugin/configuration-registry.js';
+
+import { WindowSettings } from './window-settings.js';
+
+/**
+ * Handle save and restore of the window position and size.
+ */
+export class WindowHandler {
+  readonly #browserWindow: BrowserWindow;
+  readonly #configurationRegistry: ConfigurationRegistry;
+
+  #debounceSaveTimeout: NodeJS.Timeout | undefined;
+
+  constructor(configurationRegistry: ConfigurationRegistry, browserWindow: BrowserWindow) {
+    this.#browserWindow = browserWindow;
+    this.#configurationRegistry = configurationRegistry;
+  }
+
+  // try to restore the window position and size
+  restore(initalBounds: Rectangle): void {
+    // grab value of the width and height from the configuration
+    const windowPreferences = this.#configurationRegistry.getConfiguration(WindowSettings.SectionName);
+    const restore = windowPreferences.get<boolean>(WindowSettings.RestorePosition);
+    if (!restore) {
+      return;
+    }
+    const bounds = windowPreferences.get<Rectangle>(WindowSettings.Bounds);
+
+    if (
+      bounds &&
+      typeof bounds.width === 'number' &&
+      typeof bounds.height === 'number' &&
+      typeof bounds.x === 'number' &&
+      typeof bounds.y === 'number'
+    ) {
+      const screenArea = screen.getDisplayMatching(bounds).workArea;
+      if (
+        bounds.x > screenArea.x + screenArea.width ||
+        bounds.x < screenArea.x ||
+        bounds.y < screenArea.y ||
+        bounds.y > screenArea.y + screenArea.height
+      ) {
+        // Previous stored location is no longer available, restore window into an initial state
+        this.#browserWindow.setBounds(initalBounds);
+      } else {
+        // restore the window position and size to its saved state
+        this.#browserWindow.setBounds(bounds);
+      }
+    }
+  }
+
+  // save the window position but using debounce to avoid calling it too often
+  savePositionAndSize(): void {
+    if (this.#debounceSaveTimeout) {
+      clearTimeout(this.#debounceSaveTimeout);
+    }
+    // call the doSavePositionAndSize after 300ms if no other call to savePositionAndSize is made
+    this.#debounceSaveTimeout = setTimeout(() => {
+      this.doSavePositionAndSize().catch((e: unknown) => {
+        console.error('Error saving window position and size', e);
+      });
+    }, 300);
+  }
+
+  protected async doSavePositionAndSize(): Promise<void> {
+    const bounds = this.#browserWindow.getBounds();
+    const windowPreferences = this.#configurationRegistry.getConfiguration(WindowSettings.SectionName);
+    await windowPreferences?.update(WindowSettings.Bounds, bounds);
+  }
+
+  init(): void {
+    const boundsKey = `${WindowSettings.SectionName}.${WindowSettings.Bounds}`;
+    const restorePosition = `${WindowSettings.SectionName}.${WindowSettings.RestorePosition}`;
+
+    const windowConfiguration: IConfigurationNode = {
+      id: 'preferences.savePosition',
+      title: 'Window',
+      type: 'object',
+      properties: {
+        // hidden property to store the bounds of the window
+        [boundsKey]: {
+          description: 'bounds of the window',
+          type: 'object',
+          hidden: true,
+        },
+        [restorePosition]: {
+          description: 'Restore position and size of the window after a restart',
+          type: 'boolean',
+          default: true,
+          hidden: false,
+        },
+      },
+    };
+
+    this.#configurationRegistry.registerConfigurations([windowConfiguration]);
+  }
+}

--- a/packages/main/src/system/window/window-handler.ts
+++ b/packages/main/src/system/window/window-handler.ts
@@ -36,6 +36,13 @@ export class WindowHandler {
     this.#configurationRegistry = configurationRegistry;
   }
 
+  // sets the bounds of the Window
+  protected resizeWindow(bounds: Rectangle): void {
+    // we do not use setBounds as it seems it's setting/keeping data per screen
+    this.#browserWindow.setSize(bounds.width, bounds.height);
+    this.#browserWindow.setPosition(bounds.x, bounds.y);
+  }
+
   // try to restore the window position and size
   restore(initialBounds: Rectangle): void {
     // grab value of the width and height from the configuration
@@ -79,14 +86,14 @@ export class WindowHandler {
           centeredBounds.y > newScreenArea.y + newScreenArea.height
         ) {
           // no, restore to initial bounds (default size and location)
-          this.#browserWindow.setBounds(initialBounds);
+          this.resizeWindow(initialBounds);
         } else {
           // restore it centered but using the saved width and height
-          this.#browserWindow.setBounds(centeredBounds);
+          this.resizeWindow(centeredBounds);
         }
       } else {
         // restore the window position and size to its saved state
-        this.#browserWindow.setBounds(bounds);
+        this.resizeWindow(bounds);
       }
     }
   }

--- a/packages/main/src/system/window/window-settings.ts
+++ b/packages/main/src/system/window/window-settings.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export enum WindowSettings {
+  SectionName = 'window',
+  Bounds = 'bounds',
+  RestorePosition = 'restorePosition',
+}


### PR DESCRIPTION
### What does this PR do?
remember window position and size of Podman Desktop window

in case we can't restore, use the initial position (centered on the current screen)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/6115

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
