### PR TITLE
feat: allow to upgrade/downgrade cli tool

### DIFF
--- a/extensions/compose/src/download.ts
+++ b/extensions/compose/src/download.ts
@@ -40,10 +40,20 @@ export class ComposeDownload {
     return latestReleases[0];
   }
 
+  // Get the latest versions of Compose from GitHub Releases
+  // and return the artifacts metadata
+  async getLatestReleases(): Promise<ComposeGithubReleaseArtifactMetadata[]> {
+    return this.composeGitHubReleases.grabLatestsReleasesMetadata();
+  }
+
   // Create a "quickpick" prompt to ask the user which version of Compose they want to download
-  async promptUserForVersion(): Promise<ComposeGithubReleaseArtifactMetadata> {
+  async promptUserForVersion(currentComposeTag?: string): Promise<ComposeGithubReleaseArtifactMetadata> {
     // Get the latest releases
-    const lastReleasesMetadata = await this.composeGitHubReleases.grabLatestsReleasesMetadata();
+    let lastReleasesMetadata = await this.composeGitHubReleases.grabLatestsReleasesMetadata();
+    // if the user already has an installed version, we remove it from the list
+    if (currentComposeTag) {
+      lastReleasesMetadata = lastReleasesMetadata.filter(release => release.tag.slice(1) !== currentComposeTag);
+    }
 
     // Show the quickpick
     const selectedRelease = await extensionApi.window.showQuickPick(lastReleasesMetadata, {

--- a/extensions/compose/src/extension.spec.ts
+++ b/extensions/compose/src/extension.spec.ts
@@ -227,7 +227,7 @@ describe('registerCLITool', () => {
         images: expect.anything(),
         version: '0.0.0',
         path: 'system-wide-path',
-        installationSource: 'appInstalled',
+        installationSource: 'extension',
       });
     });
 
@@ -254,7 +254,7 @@ describe('registerCLITool', () => {
         images: expect.anything(),
         version: '0.0.0',
         path: 'user-system-wide-path',
-        installationSource: 'userInstalled',
+        installationSource: 'external',
       });
     });
 
@@ -314,7 +314,7 @@ describe('registerCLITool', () => {
     expect(detectMock.getStoragePath).toHaveBeenCalled();
     expect(cliRun.installBinaryToSystem).toHaveBeenCalledWith('extension-storage-path', 'docker-compose');
     expect(cliToolMock.updateVersion).toHaveBeenCalledWith({
-      installationSource: 'appInstalled',
+      installationSource: 'extension',
       version: '1.0.0',
     });
   });

--- a/extensions/compose/src/extension.ts
+++ b/extensions/compose/src/extension.ts
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import * as path from 'node:path';
+
 import { Octokit } from '@octokit/rest';
 import * as extensionApi from '@podman-desktop/api';
 
@@ -180,12 +182,9 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
         composeCliTool?.updateVersion({
           version: versionInstalled,
           path: getSystemBinaryPath(composeCliName),
+          installationSource: 'appInstalled',
         });
         // if installed version is the newest, dispose the updater
-        const lastReleaseMetadata = await composeDownload.getLatestVersionAsset();
-        if (lastReleaseMetadata.tag.replace('v', '').trim() === versionInstalled) {
-          composeCliToolUpdaterDisposable?.dispose();
-        }
         installed = true;
       } finally {
         telemetryLogger?.logUsage('compose.onboarding.installSystemWideCommand', {
@@ -237,25 +236,31 @@ async function registerCLITool(composeDownload: ComposeDownload, detect: Detect)
 
   // let's check for system-wide
   const installedSystemWide = await detect.checkSystemWideDockerCompose();
+  let installationSource: extensionApi.CliToolInstallationSource | undefined;
   if (installedSystemWide) {
     binaryInfo = await detect.getDockerComposeBinaryInfo(executable);
+    const systemPath = getSystemBinaryPath(composeCliName);
+    installationSource =
+      path.normalize(binaryInfo.path) === path.normalize(systemPath) ? 'appInstalled' : 'userInstalled';
   } else {
     // if not installed, let's check for local version
     const extensionExecutable = await detect.getStoragePath();
     // if local version exists
     if (extensionExecutable.length !== 0) {
       binaryInfo = await detect.getDockerComposeBinaryInfo(executable, detect.getExtensionStorageBin());
+      installationSource = 'appInstalled';
     }
   }
 
   // if no binary detected let's just stop here
-  if (!binaryInfo) return;
+  if (!binaryInfo || !installationSource) return;
 
   // update existing CLI tool
   if (composeCliTool) {
     composeCliTool.updateVersion({
       version: removeVersionPrefix(binaryInfo.version),
       path: binaryInfo.path,
+      installationSource,
     });
   } else {
     // Register the CLI tool so it appears in the preferences page.
@@ -268,36 +273,50 @@ async function registerCLITool(composeDownload: ComposeDownload, detect: Detect)
       },
       version: removeVersionPrefix(binaryInfo.version),
       path: binaryInfo.path,
+      installationSource,
     });
   }
 
-  // check if there is a new version to be installed and register the updater
-  const lastReleaseMetadata = await composeDownload.getLatestVersionAsset();
-  const lastReleaseVersion = removeVersionPrefix(lastReleaseMetadata.tag);
-  const currentVersion = removeVersionPrefix(binaryInfo.version);
-
-  if (lastReleaseVersion !== currentVersion) {
-    composeCliToolUpdaterDisposable = composeCliTool.registerUpdate({
-      version: lastReleaseVersion,
-      doUpdate: async _logger => {
-        if (!binaryInfo?.updatable) {
-          throw new Error(
-            `Cannot update ${binaryInfo?.path} version ${currentVersion} to ${lastReleaseVersion} as it was not installed by podman-desktop`,
-          );
-        }
-
-        // download, install system wide and update cli version
-        await composeDownload.download(lastReleaseMetadata);
-        // get the binary in the extension folder
-        const binaryPath = await detect.getStoragePath();
-        await installBinaryToSystem(binaryPath, composeCliName);
-        composeCliTool?.updateVersion({
-          version: lastReleaseVersion,
-        });
-        composeCliToolUpdaterDisposable?.dispose();
-      },
-    });
+  // if the tool has been installed by the user we do not register the updater
+  if (installationSource === 'userInstalled') {
+    return;
   }
+  // register the updater to allow users to upgrade/downgrade their cli
+  let currentVersion = removeVersionPrefix(binaryInfo.version);
+  let releaseToUpdateTo: ComposeGithubReleaseArtifactMetadata | undefined;
+  let releaseVersionToUpdateTo: string | undefined;
+
+  composeCliToolUpdaterDisposable = composeCliTool.registerUpdate({
+    selectVersion: async () => {
+      const selected = await composeDownload.promptUserForVersion(currentVersion);
+      releaseToUpdateTo = selected;
+      releaseVersionToUpdateTo = removeVersionPrefix(selected.tag);
+      return releaseVersionToUpdateTo;
+    },
+    doUpdate: async _logger => {
+      if (!releaseToUpdateTo || !releaseVersionToUpdateTo) {
+        throw new Error(`Cannot update ${binaryInfo?.path} version ${currentVersion}. No release selected.`);
+      }
+      if (!binaryInfo?.updatable) {
+        throw new Error(
+          `Cannot update ${binaryInfo?.path} version ${currentVersion} to ${releaseVersionToUpdateTo} as it was not installed by podman-desktop`,
+        );
+      }
+
+      // download, install system wide and update cli version
+      await composeDownload.download(releaseToUpdateTo);
+      // get the binary in the extension folder
+      const binaryPath = await detect.getStoragePath();
+      await installBinaryToSystem(binaryPath, composeCliName);
+      composeCliTool?.updateVersion({
+        version: releaseVersionToUpdateTo,
+        installationSource: 'appInstalled',
+      });
+      currentVersion = releaseVersionToUpdateTo;
+      releaseVersionToUpdateTo = undefined;
+      releaseToUpdateTo = undefined;
+    },
+  });
 }
 
 function removeVersionPrefix(version: string): string {
@@ -310,4 +329,5 @@ export async function deactivate(): Promise<void> {
     composeCliTool.dispose();
     composeCliTool = undefined;
   }
+  composeCliToolUpdaterDisposable?.dispose();
 }

--- a/extensions/compose/src/extension.ts
+++ b/extensions/compose/src/extension.ts
@@ -182,7 +182,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
         composeCliTool?.updateVersion({
           version: versionInstalled,
           path: getSystemBinaryPath(composeCliName),
-          installationSource: 'appInstalled',
+          installationSource: 'extension',
         });
         // if installed version is the newest, dispose the updater
         installed = true;
@@ -240,15 +240,14 @@ async function registerCLITool(composeDownload: ComposeDownload, detect: Detect)
   if (installedSystemWide) {
     binaryInfo = await detect.getDockerComposeBinaryInfo(executable);
     const systemPath = getSystemBinaryPath(composeCliName);
-    installationSource =
-      path.normalize(binaryInfo.path) === path.normalize(systemPath) ? 'appInstalled' : 'userInstalled';
+    installationSource = path.normalize(binaryInfo.path) === path.normalize(systemPath) ? 'extension' : 'external';
   } else {
     // if not installed, let's check for local version
     const extensionExecutable = await detect.getStoragePath();
     // if local version exists
     if (extensionExecutable.length !== 0) {
       binaryInfo = await detect.getDockerComposeBinaryInfo(executable, detect.getExtensionStorageBin());
-      installationSource = 'appInstalled';
+      installationSource = 'extension';
     }
   }
 
@@ -278,7 +277,7 @@ async function registerCLITool(composeDownload: ComposeDownload, detect: Detect)
   }
 
   // if the tool has been installed by the user we do not register the updater
-  if (installationSource === 'userInstalled') {
+  if (installationSource === 'external') {
     return;
   }
   // register the updater to allow users to upgrade/downgrade their cli
@@ -310,7 +309,7 @@ async function registerCLITool(composeDownload: ComposeDownload, detect: Detect)
       await installBinaryToSystem(binaryPath, composeCliName);
       composeCliTool?.updateVersion({
         version: releaseVersionToUpdateTo,
-        installationSource: 'appInstalled',
+        installationSource: 'extension',
       });
       currentVersion = releaseVersionToUpdateTo;
       releaseVersionToUpdateTo = undefined;

--- a/extensions/kind/src/extension.spec.ts
+++ b/extensions/kind/src/extension.spec.ts
@@ -136,7 +136,7 @@ describe('cli tool', () => {
       name: 'kind',
       images: expect.anything(),
       markdownDescription: expect.any(String),
-      installationSource: 'appInstalled',
+      installationSource: 'extension',
     });
   });
 
@@ -163,7 +163,7 @@ describe('cli tool', () => {
       name: 'kind',
       images: expect.anything(),
       markdownDescription: expect.any(String),
-      installationSource: 'userInstalled',
+      installationSource: 'external',
     });
   });
 
@@ -207,7 +207,7 @@ describe('cli tool', () => {
       name: 'kind',
       images: expect.anything(),
       markdownDescription: expect.any(String),
-      installationSource: 'appInstalled',
+      installationSource: 'extension',
     });
   });
 });

--- a/extensions/kind/src/extension.spec.ts
+++ b/extensions/kind/src/extension.spec.ts
@@ -113,11 +113,12 @@ test('check we received notifications ', async () => {
 });
 
 describe('cli tool', () => {
-  test('activation should register cli tool when available', async () => {
+  test('activation should register cli tool when available, installed by desktop', async () => {
     vi.spyOn(util, 'getKindBinaryInfo').mockResolvedValue({
       path: 'kind',
       version: '0.0.1',
     });
+    vi.spyOn(util, 'getSystemBinaryPath').mockReturnValue('kind');
 
     await activate(
       vi.mocked<extensionApi.ExtensionContext>({
@@ -135,6 +136,34 @@ describe('cli tool', () => {
       name: 'kind',
       images: expect.anything(),
       markdownDescription: expect.any(String),
+      installationSource: 'appInstalled',
+    });
+  });
+
+  test('activation should register cli tool when available, installed by user', async () => {
+    vi.spyOn(util, 'getKindBinaryInfo').mockResolvedValue({
+      path: 'kind',
+      version: '0.0.1',
+    });
+    vi.spyOn(util, 'getSystemBinaryPath').mockReturnValue('user-kind');
+
+    await activate(
+      vi.mocked<extensionApi.ExtensionContext>({
+        storagePath: 'test-storage-path',
+        subscriptions: {
+          push: vi.fn(),
+        },
+      } as unknown as extensionApi.ExtensionContext),
+    );
+
+    expect(podmanDesktopApi.cli.createCliTool).toHaveBeenCalledWith({
+      displayName: 'kind',
+      path: 'kind',
+      version: '0.0.1',
+      name: 'kind',
+      images: expect.anything(),
+      markdownDescription: expect.any(String),
+      installationSource: 'userInstalled',
     });
   });
 
@@ -159,6 +188,8 @@ describe('cli tool', () => {
       path: 'test-storage-path/kind',
     });
 
+    vi.spyOn(util, 'getSystemBinaryPath').mockReturnValue('test-storage-path/kind');
+
     await activate(
       vi.mocked<extensionApi.ExtensionContext>({
         storagePath: 'test-storage-path',
@@ -176,6 +207,7 @@ describe('cli tool', () => {
       name: 'kind',
       images: expect.anything(),
       markdownDescription: expect.any(String),
+      installationSource: 'appInstalled',
     });
   });
 });

--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -342,7 +342,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   try {
     binary = await getKindBinaryInfo('kind');
     const systemPath = getSystemBinaryPath('kind');
-    installationSource = path.normalize(binary.path) === path.normalize(systemPath) ? 'appInstalled' : 'userInstalled';
+    installationSource = path.normalize(binary.path) === path.normalize(systemPath) ? 'extension' : 'external';
   } catch (err: unknown) {
     console.error(err);
   }
@@ -351,7 +351,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   if (!binary) {
     try {
       binary = await getKindBinaryInfo(installer.getInternalDestinationPath());
-      installationSource = 'appInstalled';
+      installationSource = 'extension';
     } catch (err: unknown) {
       console.error(err);
     }
@@ -435,7 +435,7 @@ async function kindInstall(
     path: binaryInfo.path,
     displayName: 'kind',
     markdownDescription: KIND_MARKDOWN,
-    installationSource: 'appInstalled',
+    installationSource: 'extension',
   });
 
   await createProvider(extensionContext, telemetryLogger);

--- a/extensions/kubectl-cli/src/cli-run.ts
+++ b/extensions/kubectl-cli/src/cli-run.ts
@@ -29,6 +29,25 @@ export interface RunOptions {
 
 const localBinDir = '/usr/local/bin';
 
+export function getSystemBinaryPath(binaryName: string): string {
+  switch (process.platform) {
+    case 'win32':
+      return path.join(
+        os.homedir(),
+        'AppData',
+        'Local',
+        'Microsoft',
+        'WindowsApps',
+        binaryName.endsWith('.exe') ? binaryName : `${binaryName}.exe`,
+      );
+    case 'darwin':
+    case 'linux':
+      return path.join(localBinDir, binaryName);
+    default:
+      throw new Error(`unsupported platform: ${process.platform}.`);
+  }
+}
+
 // Takes a binary path (e.g. /tmp/kubectl) and installs it to the system. Renames it based on binaryName
 export async function installBinaryToSystem(binaryPath: string, binaryName: string): Promise<void> {
   const system = process.platform;
@@ -45,19 +64,16 @@ export async function installBinaryToSystem(binaryPath: string, binaryName: stri
 
   // Create the appropriate destination path (Windows uses AppData/Local, Linux and Mac use /usr/local/bin)
   // and the appropriate command to move the binary to the destination path
-  let destinationPath: string;
+  const destinationPath: string = getSystemBinaryPath(binaryName);
   let args: string[] = [];
   let command: string | undefined;
   if (system === 'win32') {
-    destinationPath = path.join(os.homedir(), 'AppData', 'Local', 'Microsoft', 'WindowsApps', `${binaryName}.exe`);
     command = 'copy';
     args = [`"${binaryPath}"`, `"${destinationPath}"`];
   } else if (system === 'darwin') {
-    destinationPath = path.join(localBinDir, binaryName);
     command = 'exec';
     args = ['cp', binaryPath, destinationPath];
   } else if (system === 'linux') {
-    destinationPath = path.join(localBinDir, binaryName);
     command = '/bin/sh';
     args = ['-c', `cp ${binaryPath} ${destinationPath}`];
   }

--- a/extensions/kubectl-cli/src/download.ts
+++ b/extensions/kubectl-cli/src/download.ts
@@ -44,15 +44,17 @@ export class KubectlDownload {
   }
 
   // Create a "quickpick" prompt to ask the user which version of kubectl they want to download
-  async promptUserForVersion(): Promise<KubectlGithubReleaseArtifactMetadata> {
+  async promptUserForVersion(currentKubectlTag?: string): Promise<KubectlGithubReleaseArtifactMetadata> {
     // Get the latest releases
-    const lastReleasesMetadata = await this.kubectlGitHubReleases.grabLatestsReleasesMetadata();
-
+    let lastReleasesMetadata = await this.kubectlGitHubReleases.grabLatestsReleasesMetadata();
+    // if the user already has an installed version, we remove it from the list
+    if (currentKubectlTag) {
+      lastReleasesMetadata = lastReleasesMetadata.filter(release => release.tag.slice(1) !== currentKubectlTag);
+    }
     // Show the quickpick
     const selectedRelease = await extensionApi.window.showQuickPick(lastReleasesMetadata, {
       placeHolder: 'Select kubectl version to download',
     });
-
     if (selectedRelease) {
       return selectedRelease;
     } else {

--- a/extensions/kubectl-cli/src/extension.ts
+++ b/extensions/kubectl-cli/src/extension.ts
@@ -140,7 +140,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
         extensionApi.context.setValue('kubectlIsNotDownloaded', false, 'onboarding');
         kubectlCliTool?.updateVersion({
           version: kubectlVersionMetadata.tag.slice(1),
-          installationSource: 'appInstalled',
+          installationSource: 'extension',
         });
         downloaded = true;
       } finally {
@@ -310,8 +310,8 @@ async function postActivate(
   const installationSource =
     path.normalize(kubectl.path) === path.normalize(systemPath) ||
     path.normalize(kubectl.path) === path.normalize(localStorage)
-      ? 'appInstalled'
-      : 'userInstalled';
+      ? 'extension'
+      : 'external';
   // Register the CLI tool so it appears in the preferences page. We will detect which version is being ran by
   // checking the binary. If it exists, we will run `--version` and parse the information.
   kubectlCliTool = extensionApi.cli.createCliTool({
@@ -329,7 +329,7 @@ async function postActivate(
   extensionContext.subscriptions.push(kubectlCliTool);
 
   // if the tool has been installed by the user externally desktop, it cannot be updated
-  if (installationSource === 'userInstalled') {
+  if (installationSource === 'external') {
     return;
   }
 
@@ -354,7 +354,7 @@ async function postActivate(
       await installBinaryToSystem(binaryPath, 'kubectl');
       kubectlCliTool?.updateVersion({
         version: releaseVersionToUpdateTo,
-        installationSource: 'appInstalled',
+        installationSource: 'extension',
       });
       currentVersion = releaseVersionToUpdateTo;
       releaseVersionToUpdateTo = undefined;

--- a/packages/api/src/cli-tool-info.ts
+++ b/packages/api/src/cli-tool-info.ts
@@ -35,4 +35,5 @@ export interface CliToolInfo {
   version?: string;
   path?: string;
   newVersion?: string;
+  canUpdate: boolean;
 }

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -4300,6 +4300,8 @@ declare module '@podman-desktop/api' {
     export function setValue(key: string, value: any, scope?: 'onboarding'): void;
   }
 
+  export type CliToolInstallationSource = 'userInstalled' | 'appInstalled';
+
   /**
    * Options to create new CliTool instance and register it in podman desktop
    */
@@ -4319,6 +4321,13 @@ declare module '@podman-desktop/api' {
      */
     version: string;
     path: string;
+
+    /**
+     * How the cli tool has been installed
+     * - user: it has been installed by the user externally from podman desktop. Its update process is disable.
+     * - app: it has been installed through podman desktop. It can be updated
+     */
+    installationSource?: CliToolInstallationSource;
   }
 
   /**
@@ -4330,10 +4339,16 @@ declare module '@podman-desktop/api' {
     markdownDescription?: string;
     images?: ProviderImages;
     path?: string;
+    installationSource?: CliToolInstallationSource;
   }
 
   export interface CliToolUpdate {
     version: string;
+    doUpdate: (logger: Logger) => Promise<void>;
+  }
+
+  export interface CliToolSelectUpdate {
+    selectVersion: () => Promise<string>;
     doUpdate: (logger: Logger) => Promise<void>;
   }
 
@@ -4355,7 +4370,7 @@ declare module '@podman-desktop/api' {
     onDidUpdateVersion: Event<string>;
 
     // register cli update flow
-    registerUpdate(update: CliToolUpdate): Disposable;
+    registerUpdate(update: CliToolUpdate | CliToolSelectUpdate): Disposable;
   }
 
   /**

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -4300,7 +4300,7 @@ declare module '@podman-desktop/api' {
     export function setValue(key: string, value: any, scope?: 'onboarding'): void;
   }
 
-  export type CliToolInstallationSource = 'userInstalled' | 'appInstalled';
+  export type CliToolInstallationSource = 'extension' | 'external';
 
   /**
    * Options to create new CliTool instance and register it in podman desktop
@@ -4324,8 +4324,8 @@ declare module '@podman-desktop/api' {
 
     /**
      * How the cli tool has been installed
-     * - user: it has been installed by the user externally from podman desktop. Its update process is disable.
-     * - app: it has been installed through podman desktop. It can be updated
+     * - external: it has been installed by the user externally from podman desktop. Its update process is disable.
+     * - extension: it has been installed by podman desktop extension. It can be updated
      */
     installationSource?: CliToolInstallationSource;
   }

--- a/packages/main/src/plugin/cli-tool-impl.ts
+++ b/packages/main/src/plugin/cli-tool-impl.ts
@@ -82,7 +82,7 @@ export class CliToolImpl implements CliTool, Disposable {
 
   // it returns the installation source of the cli tool. If not specified, we default to user which is the most restrictive way (prevent to update it)
   get installationSource(): CliToolInstallationSource {
-    return this._options.installationSource ?? 'userInstalled';
+    return this._options.installationSource ?? 'external';
   }
 
   dispose(): void {
@@ -97,7 +97,7 @@ export class CliToolImpl implements CliTool, Disposable {
       markdownDescription: options.markdownDescription ?? this._options.markdownDescription,
       path: options.path ?? this._options.path,
       version: options.version,
-      installationSource: 'appInstalled',
+      installationSource: 'extension',
     };
     this._onDidUpdateVersion.fire(options.version);
   }

--- a/packages/main/src/plugin/cli-tool-impl.ts
+++ b/packages/main/src/plugin/cli-tool-impl.ts
@@ -18,7 +18,9 @@
 
 import type {
   CliTool,
+  CliToolInstallationSource,
   CliToolOptions,
+  CliToolSelectUpdate,
   CliToolState,
   CliToolUpdate,
   CliToolUpdateOptions,
@@ -78,6 +80,11 @@ export class CliToolImpl implements CliTool, Disposable {
     return Object.freeze(this._options.images);
   }
 
+  // it returns the installation source of the cli tool. If not specified, we default to user which is the most restrictive way (prevent to update it)
+  get installationSource(): CliToolInstallationSource {
+    return this._options.installationSource ?? 'userInstalled';
+  }
+
   dispose(): void {
     this.registry.disposeCliTool(this);
   }
@@ -90,11 +97,12 @@ export class CliToolImpl implements CliTool, Disposable {
       markdownDescription: options.markdownDescription ?? this._options.markdownDescription,
       path: options.path ?? this._options.path,
       version: options.version,
+      installationSource: 'appInstalled',
     };
     this._onDidUpdateVersion.fire(options.version);
   }
 
-  registerUpdate(update: CliToolUpdate): Disposable {
+  registerUpdate(update: CliToolUpdate | CliToolSelectUpdate): Disposable {
     return this.registry.registerUpdate(this, update);
   }
 }

--- a/packages/main/src/plugin/cli-tool-registry.spec.ts
+++ b/packages/main/src/plugin/cli-tool-registry.spec.ts
@@ -112,7 +112,7 @@ suite('cli module', () => {
         images: {},
         version: '1.0.1',
         path: 'path/to/tool-name',
-        installationSource: 'appInstalled',
+        installationSource: 'extension',
       };
       const updater: CliToolSelectUpdate = {
         doUpdate: vi.fn(),
@@ -142,7 +142,7 @@ suite('cli module', () => {
         images: {},
         version: '1.0.1',
         path: 'path/to/tool-name',
-        installationSource: 'userInstalled',
+        installationSource: 'external',
       };
       const updater: CliToolSelectUpdate = {
         doUpdate: vi.fn(),

--- a/packages/main/src/plugin/cli-tool-registry.spec.ts
+++ b/packages/main/src/plugin/cli-tool-registry.spec.ts
@@ -18,7 +18,7 @@
 
 import { afterEach } from 'node:test';
 
-import type { CliToolOptions, CliToolUpdate, Logger } from '@podman-desktop/api';
+import type { CliToolOptions, CliToolSelectUpdate, CliToolUpdate, Logger } from '@podman-desktop/api';
 import { beforeEach, expect, suite, test, vi } from 'vitest';
 
 import type { CliToolExtensionInfo } from '/@api/cli-tool-info.js';
@@ -26,7 +26,6 @@ import type { CliToolExtensionInfo } from '/@api/cli-tool-info.js';
 import type { ApiSenderType } from './api.js';
 import type { CliToolImpl } from './cli-tool-impl.js';
 import { CliToolRegistry } from './cli-tool-registry.js';
-import type { Telemetry } from './telemetry/telemetry.js';
 import type { Exec } from './util/exec.js';
 
 const apiSender: ApiSenderType = {
@@ -37,7 +36,7 @@ const apiSender: ApiSenderType = {
 let cliToolRegistry: CliToolRegistry;
 suite('cli module', () => {
   beforeEach(() => {
-    cliToolRegistry = new CliToolRegistry(apiSender, vi.fn() as unknown as Exec, vi.fn() as unknown as Telemetry);
+    cliToolRegistry = new CliToolRegistry(apiSender, vi.fn() as unknown as Exec);
   });
 
   afterEach(() => {
@@ -101,6 +100,67 @@ suite('cli module', () => {
         state: newCliTool.state,
         images: newCliTool.images,
         extensionInfo: newCliTool.extensionInfo,
+        canUpdate: false,
+      });
+    });
+
+    test('CLI Tool registry generates CliToolInfo array for created tools, if updater exists and tool has been installed by app, it can be updated', () => {
+      const options: CliToolOptions = {
+        name: 'tool-name',
+        displayName: 'tool-display-name',
+        markdownDescription: 'markdown description',
+        images: {},
+        version: '1.0.1',
+        path: 'path/to/tool-name',
+        installationSource: 'appInstalled',
+      };
+      const updater: CliToolSelectUpdate = {
+        doUpdate: vi.fn(),
+        selectVersion: vi.fn(),
+      };
+      const newCliTool = cliToolRegistry.createCliTool(extensionInfo, options);
+      cliToolRegistry.registerUpdate(newCliTool as CliToolImpl, updater);
+      const infoList = cliToolRegistry.getCliToolInfos();
+      expect(infoList.length).equals(1);
+      expect(infoList[0]).toMatchObject({
+        id: newCliTool.id,
+        name: newCliTool.name,
+        displayName: newCliTool.displayName,
+        description: newCliTool.markdownDescription,
+        state: newCliTool.state,
+        images: newCliTool.images,
+        extensionInfo: newCliTool.extensionInfo,
+        canUpdate: true,
+      });
+    });
+
+    test('CLI Tool registry generates CliToolInfo array for created tools, if updater exists and tool has been installed by user, it can NOT be updated', () => {
+      const options: CliToolOptions = {
+        name: 'tool-name',
+        displayName: 'tool-display-name',
+        markdownDescription: 'markdown description',
+        images: {},
+        version: '1.0.1',
+        path: 'path/to/tool-name',
+        installationSource: 'userInstalled',
+      };
+      const updater: CliToolSelectUpdate = {
+        doUpdate: vi.fn(),
+        selectVersion: vi.fn(),
+      };
+      const newCliTool = cliToolRegistry.createCliTool(extensionInfo, options);
+      cliToolRegistry.registerUpdate(newCliTool as CliToolImpl, updater);
+      const infoList = cliToolRegistry.getCliToolInfos();
+      expect(infoList.length).equals(1);
+      expect(infoList[0]).toMatchObject({
+        id: newCliTool.id,
+        name: newCliTool.name,
+        displayName: newCliTool.displayName,
+        description: newCliTool.markdownDescription,
+        state: newCliTool.state,
+        images: newCliTool.images,
+        extensionInfo: newCliTool.extensionInfo,
+        canUpdate: false,
       });
     });
   });
@@ -167,6 +227,87 @@ suite('cli module', () => {
       await cliToolRegistry.updateCliTool(newCliTool.id, {} as unknown as Logger);
 
       expect(updateMock).not.toBeCalled();
+    });
+  });
+
+  suite('selectCliToolVersionToUpdate', () => {
+    test('throw if there is a no updater registered', async () => {
+      const options: CliToolOptions = {
+        name: 'tool-name',
+        displayName: 'tool-display-name',
+        markdownDescription: 'markdown description',
+        images: {},
+        version: '1.0.1',
+        path: 'path/to/tool-name',
+      };
+      const newCliTool = cliToolRegistry.createCliTool(extensionInfo, options);
+      await expect(cliToolRegistry.selectCliToolVersionToUpdate(newCliTool.id)).rejects.toThrowError(
+        `No updater registered for ${newCliTool.id}`,
+      );
+    });
+
+    test('throw if there is a CliToolUpdate registered', async () => {
+      const updateMock = vi.fn();
+      const updater: CliToolUpdate = {
+        doUpdate: updateMock,
+        version: '1.1.1',
+      };
+      const options: CliToolOptions = {
+        name: 'tool-name',
+        displayName: 'tool-display-name',
+        markdownDescription: 'markdown description',
+        images: {},
+        version: '1.0.1',
+        path: 'path/to/tool-name',
+      };
+      const newCliTool = cliToolRegistry.createCliTool(extensionInfo, options);
+      // register the updater and call the selectCliTool
+      cliToolRegistry.registerUpdate(newCliTool as CliToolImpl, updater);
+      await expect(cliToolRegistry.selectCliToolVersionToUpdate(newCliTool.id)).rejects.toThrowError(
+        `No updater registered for ${newCliTool.id}`,
+      );
+    });
+
+    test('throw if there is no updater registered', async () => {
+      const updateMock = vi.fn();
+      const selectVersionMock = vi.fn();
+      const updater: CliToolSelectUpdate = {
+        doUpdate: updateMock,
+        selectVersion: selectVersionMock,
+      };
+      const options: CliToolOptions = {
+        name: 'tool-name',
+        displayName: 'tool-display-name',
+        markdownDescription: 'markdown description',
+        images: {},
+        version: '1.0.1',
+        path: 'path/to/tool-name',
+      };
+      const newCliTool = cliToolRegistry.createCliTool(extensionInfo, options);
+      // register the updater and call the selectCliTool
+      cliToolRegistry.registerUpdate(newCliTool as CliToolImpl, updater);
+      await cliToolRegistry.selectCliToolVersionToUpdate(newCliTool.id);
+      expect(selectVersionMock).toBeCalled();
+    });
+  });
+
+  suite('isUpdaterToPredefinedVersion', () => {
+    test('return true if item is instance of CliToolUpdate', () => {
+      const updater: CliToolUpdate = {
+        doUpdate: vi.fn(),
+        version: '1.1.1',
+      };
+      const isCliToolUpdate = cliToolRegistry.isUpdaterToPredefinedVersion(updater);
+      expect(isCliToolUpdate).toBeTruthy();
+    });
+
+    test('return false if item is NOT instance of CliToolUpdate', () => {
+      const updater: CliToolSelectUpdate = {
+        doUpdate: vi.fn(),
+        selectVersion: vi.fn(),
+      };
+      const isCliToolUpdate = cliToolRegistry.isUpdaterToPredefinedVersion(updater);
+      expect(isCliToolUpdate).toBeFalsy();
     });
   });
 });

--- a/packages/main/src/plugin/cli-tool-registry.ts
+++ b/packages/main/src/plugin/cli-tool-registry.ts
@@ -16,13 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { CliTool, CliToolOptions, CliToolUpdate, Logger } from '@podman-desktop/api';
+import type { CliTool, CliToolOptions, CliToolSelectUpdate, CliToolUpdate, Logger } from '@podman-desktop/api';
 
 import type { CliToolExtensionInfo, CliToolInfo } from '/@api/cli-tool-info.js';
 
 import type { ApiSenderType } from './api.js';
 import { CliToolImpl } from './cli-tool-impl.js';
-import type { Telemetry } from './telemetry/telemetry.js';
 import { Disposable } from './types/disposable.js';
 import type { Exec } from './util/exec.js';
 
@@ -30,11 +29,10 @@ export class CliToolRegistry {
   constructor(
     private apiSender: ApiSenderType,
     private exec: Exec,
-    private telemetryService: Telemetry,
   ) {}
 
   private cliTools = new Map<string, CliToolImpl>();
-  private cliToolsUpdater = new Map<string, CliToolUpdate>();
+  private cliToolsUpdater = new Map<string, CliToolUpdate | CliToolSelectUpdate>();
 
   createCliTool(extensionInfo: CliToolExtensionInfo, options: CliToolOptions): CliTool {
     const cliTool = new CliToolImpl(this.apiSender, this.exec, extensionInfo, this, options);
@@ -44,7 +42,7 @@ export class CliToolRegistry {
     return cliTool;
   }
 
-  registerUpdate(cliTool: CliToolImpl, updater: CliToolUpdate): Disposable {
+  registerUpdate(cliTool: CliToolImpl, updater: CliToolUpdate | CliToolSelectUpdate): Disposable {
     this.cliToolsUpdater.set(cliTool.id, updater);
 
     return Disposable.create(() => {
@@ -60,6 +58,18 @@ export class CliToolRegistry {
     }
   }
 
+  async selectCliToolVersionToUpdate(id: string): Promise<string> {
+    const cliToolUpdater = this.cliToolsUpdater.get(id);
+    if (!cliToolUpdater || this.isUpdaterToPredefinedVersion(cliToolUpdater)) {
+      throw new Error(`No updater registered for ${id}`);
+    }
+    return cliToolUpdater.selectVersion();
+  }
+
+  isUpdaterToPredefinedVersion(update: CliToolUpdate | CliToolSelectUpdate): update is CliToolUpdate {
+    return (update as CliToolUpdate).version !== undefined;
+  }
+
   disposeCliTool(cliTool: CliToolImpl): void {
     this.cliTools.delete(cliTool.id);
     this.cliToolsUpdater.delete(cliTool.id);
@@ -68,6 +78,12 @@ export class CliToolRegistry {
 
   getCliToolInfos(): CliToolInfo[] {
     return Array.from(this.cliTools.values()).map(cliTool => {
+      const updater = this.cliToolsUpdater.get(cliTool.id);
+      // if updater is the one with a default version that the tool will use to get updated we use it
+      const newVersion = updater && this.isUpdaterToPredefinedVersion(updater) ? updater.version : undefined;
+      // if the cli tool has an updater registered and its binary has been installed by podman desktop, it can be updated
+      const canUpdate = !!updater && cliTool.installationSource === 'appInstalled';
+
       return {
         id: cliTool.id,
         name: cliTool.name,
@@ -78,7 +94,8 @@ export class CliToolRegistry {
         extensionInfo: cliTool.extensionInfo,
         version: cliTool.version,
         path: cliTool.path,
-        newVersion: this.cliToolsUpdater.get(cliTool.id)?.version,
+        newVersion,
+        canUpdate,
       };
     });
   }

--- a/packages/main/src/plugin/cli-tool-registry.ts
+++ b/packages/main/src/plugin/cli-tool-registry.ts
@@ -82,7 +82,7 @@ export class CliToolRegistry {
       // if updater is the one with a default version that the tool will use to get updated we use it
       const newVersion = updater && this.isUpdaterToPredefinedVersion(updater) ? updater.version : undefined;
       // if the cli tool has an updater registered and its binary has been installed by podman desktop, it can be updated
-      const canUpdate = !!updater && cliTool.installationSource === 'appInstalled';
+      const canUpdate = !!updater && cliTool.installationSource === 'extension';
 
       return {
         id: cliTool.id,

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -593,7 +593,7 @@ export class PluginSystem {
 
     const authentication = new AuthenticationImpl(apiSender, messageBox);
 
-    const cliToolRegistry = new CliToolRegistry(apiSender, exec, telemetry);
+    const cliToolRegistry = new CliToolRegistry(apiSender, exec);
 
     const imageChecker = new ImageCheckerImpl(apiSender);
 
@@ -1239,6 +1239,10 @@ export class PluginSystem {
         return troubleshooting.generateLogFileName(filename, prefix);
       },
     );
+
+    this.ipcHandle('cli-tool-registry:selectCliToolVersionToUpdate', async (_listener, id: string): Promise<string> => {
+      return cliToolRegistry.selectCliToolVersionToUpdate(id);
+    });
 
     this.ipcHandle(
       'cli-tool-registry:updateCliTool',

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1126,6 +1126,10 @@ export function initExposure(): void {
     return ipcInvoke('cli-tool-registry:getCliToolInfos');
   });
 
+  contextBridge.exposeInMainWorld('selectCliToolVersionToUpdate', async (id: string): Promise<string> => {
+    return ipcInvoke('cli-tool-registry:selectCliToolVersionToUpdate', id);
+  });
+
   contextBridge.exposeInMainWorld(
     'updateCliTool',
     async (

--- a/packages/renderer/src/lib/preferences/PreferencesCliTool.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesCliTool.spec.ts
@@ -41,6 +41,7 @@ const cliToolInfoItem1: CliToolInfo = {
     label: 'ext-label1',
   },
   path: 'path/to/tool-name-1',
+  canUpdate: false,
 };
 
 const cliToolInfoItem2: CliToolInfo = {
@@ -55,6 +56,7 @@ const cliToolInfoItem2: CliToolInfo = {
   },
   version: '1.0.1',
   path: 'path/to/tool-name-2',
+  canUpdate: false,
 };
 
 const cliToolInfoItem3: CliToolInfo = {
@@ -70,6 +72,22 @@ const cliToolInfoItem3: CliToolInfo = {
   version: '1.0.1',
   path: 'path/to/tool-name-3',
   newVersion: '2.0.1',
+  canUpdate: true,
+};
+
+const cliToolInfoItem4: CliToolInfo = {
+  id: 'ext-id.tool-name4',
+  name: 'tool-name4',
+  description: 'markdown description4',
+  displayName: 'tools-display-name4',
+  state: 'registered',
+  extensionInfo: {
+    id: 'ext-id4',
+    label: 'ext-label4',
+  },
+  version: '1.0.1',
+  path: 'path/to/tool-name-4',
+  canUpdate: true,
 };
 
 const updateCliToolMock = vi.fn();
@@ -119,9 +137,8 @@ suite('CLI Tool item', () => {
     expect(versionElement.textContent).equal(`${cliToolInfoItem2.name} v${cliToolInfoItem2.version}`);
     const displayFullPathElement = screen.getByText('Path: path/to/tool-name-2');
     expect(displayFullPathElement).toBeInTheDocument();
-    const updateLoadingButton = screen.getByRole('button', { name: 'Update' });
-    expect(updateLoadingButton).toBeInTheDocument();
-    expect(updateLoadingButton).toBeDisabled();
+    const updateLoadingButton = screen.queryByRole('button', { name: 'Update' });
+    expect(updateLoadingButton).not.toBeInTheDocument();
   });
 
   test('check tool infos are displayed as expected and there is a new version available', () => {
@@ -164,5 +181,30 @@ suite('CLI Tool item', () => {
 
     const failedErrorButton2 = screen.getByRole('button', { name: `${cliToolInfoItem3.displayName} failed` });
     expect(failedErrorButton2).toBeInTheDocument();
+  });
+
+  test('check tool infos are displayed as expected and without a new version', async () => {
+    updateCliToolMock.mockRejectedValue('');
+    render(PreferencesCliTool, {
+      cliTool: cliToolInfoItem4,
+    });
+    const nameElement = screen.getByLabelText('cli-name');
+    expect(nameElement).toBeDefined();
+    expect(nameElement.textContent).equal(cliToolInfoItem4.name);
+    const registeredByElement = screen.getByLabelText('cli-registered-by');
+    expect(registeredByElement).toBeDefined();
+    expect(registeredByElement.textContent).equal(`Registered by ${cliToolInfoItem4.extensionInfo.label}`);
+    const displayNameElement = screen.getByLabelText('cli-display-name');
+    expect(displayNameElement).toBeDefined();
+    expect(displayNameElement.textContent).equal(cliToolInfoItem4.displayName);
+    const versionElement = screen.getByLabelText('cli-version');
+    expect(versionElement).toBeDefined();
+    expect(versionElement.textContent).equal(`${cliToolInfoItem4.name} v${cliToolInfoItem4.version}`);
+    const updateAvailableElement = screen.getByRole('button', { name: 'Update available' });
+    expect(updateAvailableElement).toBeDefined();
+    expect(updateAvailableElement.textContent).toBe('Upgrade/Downgrade');
+    const updateLoadingButton = screen.getByRole('button', { name: 'Update' });
+    expect(updateLoadingButton).toBeInTheDocument();
+    expect(updateLoadingButton).toBeEnabled();
   });
 });

--- a/packages/renderer/src/lib/preferences/PreferencesCliToolsRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesCliToolsRendering.spec.ts
@@ -45,6 +45,7 @@ const cliToolInfoItem1: CliToolInfo = {
   },
   version: '1.0.1',
   path: 'path/to/tool-name-1',
+  canUpdate: false,
 };
 
 const cliToolInfoItem2: CliToolInfo = {
@@ -60,6 +61,7 @@ const cliToolInfoItem2: CliToolInfo = {
   images: {},
   version: '1.0.2',
   path: 'path/to/tool-name-2',
+  canUpdate: false,
 };
 
 const cliToolInfoItem3: CliToolInfo = {
@@ -77,6 +79,7 @@ const cliToolInfoItem3: CliToolInfo = {
   },
   version: '1.0.3',
   path: 'path/to/tool-name-3',
+  canUpdate: false,
 };
 
 const cliToolInfoItem4: CliToolInfo = {
@@ -92,6 +95,7 @@ const cliToolInfoItem4: CliToolInfo = {
   images: {},
   version: '', // version is empty, so it should be showing the error
   path: '',
+  canUpdate: false,
 };
 
 suite('CLI Tool Prefernces page shows', () => {


### PR DESCRIPTION
### What does this PR do?

This PR is just a part of https://github.com/containers/podman-desktop/issues/8003 
It enhances the update process to allow upgrading/downgrading to a specific version.
If the cli tool has been installed by the user (it is in a path different from the one used by desktop), the update is not allowed.

The PR is splitted in 2 commits: the first is about the core, the second is about the extensions. I can also split them in 2 PRs if you prefer

### Screenshot / video of UI

![upgrade_downgrade_cli](https://github.com/user-attachments/assets/368e80d5-35e4-43ac-aaf5-f4a18d05e5d1)

### What issues does this PR fix or reference?

it is part of #8003 

### How to test this PR?

1. try to upgrade/downgrade compose or kubectl

- [x] Tests are covering the bug fix or the new feature
