### PR TITLE
chore: upgrade kubernetes client library

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
   },
   "dependencies": {
     "@docker/extension-api-client-types": "0.3.4",
-    "@kubernetes/client-node": "^0.21.0",
+    "@kubernetes/client-node": "^1.0.0-rc6",
     "@segment/analytics-node": "^2.1.2",
     "@types/semver": "^7.5.8",
     "@types/stream-json": "^1.7.7",

--- a/packages/main/src/plugin/kubernetes-client-kubeconfig.spec.ts
+++ b/packages/main/src/plugin/kubernetes-client-kubeconfig.spec.ts
@@ -49,8 +49,8 @@ class TestKubernetesClient extends KubernetesClient {
 describe('context tests', () => {
   const originalUsers = [{ name: 'user1' }, { name: 'user2' }];
   const originalClusters = [
-    { name: 'cluster1', server: 'server1' },
-    { name: 'cluster2', server: 'server2' },
+    { name: 'cluster1', server: 'server1' } as Cluster,
+    { name: 'cluster2', server: 'server2' } as Cluster,
   ];
   const originalContexts = [
     { name: 'ctx1', user: 'user1', cluster: 'cluster1', currentContext: true },

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -27,6 +27,8 @@ import type {
   Context,
   KubernetesListObject,
   KubernetesObject,
+  RequestContext,
+  ResponseContext,
   V1APIGroup,
   V1APIResource,
   V1ConfigMap,
@@ -49,9 +51,10 @@ import {
   AppsV1Api,
   BatchV1Api,
   CoreV1Api,
+  createConfiguration,
   CustomObjectsApi,
   Exec,
-  HttpError,
+  FetchError,
   KubeConfig,
   KubernetesObjectApi,
   Log,
@@ -59,6 +62,7 @@ import {
   VersionApi,
   Watch,
 } from '@kubernetes/client-node';
+import { PromiseMiddlewareWrapper } from '@kubernetes/client-node/dist/gen/middleware.js';
 import type * as containerDesktopAPI from '@podman-desktop/api';
 import * as jsYaml from 'js-yaml';
 import { parseAllDocuments } from 'yaml';
@@ -297,7 +301,7 @@ export class KubernetesClient {
     try {
       if (this.kubeConfig) {
         const result = await this.kubeConfig.makeApiClient(ApisApi).getAPIVersions();
-        this.apiGroups = result?.body.groups;
+        this.apiGroups = result?.groups;
       }
     } catch (err) {
       console.log(`Error while fetching API groups: ${err}`);
@@ -433,7 +437,7 @@ export class KubernetesClient {
       if (projectGroupSupported) {
         const projects = await ctx
           .makeApiClient(CustomObjectsApi)
-          .listClusterCustomObject(OPENSHIFT_PROJECT_API_GROUP, 'v1', 'projects');
+          .listClusterCustomObject({ group: OPENSHIFT_PROJECT_API_GROUP, version: 'v1', plural: 'projects' });
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         if ((projects?.body as any)?.items.length > 0) {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -443,8 +447,8 @@ export class KubernetesClient {
     } catch (err) {
       try {
         const namespaces = await ctx.makeApiClient(CoreV1Api).listNamespace();
-        if (namespaces?.body?.items.length > 0) {
-          namespace = namespaces?.body?.items[0].metadata?.name;
+        if (namespaces?.items.length > 0) {
+          namespace = namespaces?.items[0].metadata?.name;
         }
       } catch (error) {
         // unable to list namespaces, can be due to a connection refused (cluster not up)
@@ -502,8 +506,7 @@ export class KubernetesClient {
     const k8sCoreApi = this.kubeConfig.makeApiClient(CoreV1Api);
 
     try {
-      const createdPodData = await k8sCoreApi.createNamespacedPod(namespace, body);
-      return createdPodData.body;
+      return await k8sCoreApi.createNamespacedPod({ namespace, body });
     } catch (error) {
       telemetryOptions = { error: error };
       throw this.wrapK8sClientError(error);
@@ -517,8 +520,7 @@ export class KubernetesClient {
     const k8sCoreApi = this.kubeConfig.makeApiClient(CoreV1Api);
 
     try {
-      const createdPodData = await k8sCoreApi.createNamespacedService(namespace, body);
-      return createdPodData.body;
+      return await k8sCoreApi.createNamespacedService({ namespace, body });
     } catch (error) {
       telemetryOptions = { error: error };
       throw this.wrapK8sClientError(error);
@@ -532,8 +534,7 @@ export class KubernetesClient {
     const k8sCoreApi = this.kubeConfig.makeApiClient(NetworkingV1Api);
 
     try {
-      const createdIngressData = await k8sCoreApi.createNamespacedIngress(namespace, body);
-      return createdIngressData.body;
+      return await k8sCoreApi.createNamespacedIngress({ namespace, body });
     } catch (error) {
       telemetryOptions = { error: error };
       throw this.wrapK8sClientError(error);
@@ -547,14 +548,13 @@ export class KubernetesClient {
     const k8sCustomObjectsApi = this.kubeConfig.makeApiClient(CustomObjectsApi);
 
     try {
-      const createdPodData = await k8sCustomObjectsApi.createNamespacedCustomObject(
-        'route.openshift.io',
-        'v1',
+      return await k8sCustomObjectsApi.createNamespacedCustomObject({
+        group: 'route.openshift.io',
+        version: 'v1',
         namespace,
-        'routes',
+        plural: 'routes',
         body,
-      );
-      return createdPodData.body as V1Route;
+      });
     } catch (error) {
       telemetryOptions = { error: error };
       throw this.wrapK8sClientError(error);
@@ -566,21 +566,11 @@ export class KubernetesClient {
   async listNamespacedPod(namespace: string, fieldSelector?: string, labelSelector?: string): Promise<V1PodList> {
     const k8sApi = this.kubeConfig.makeApiClient(CoreV1Api);
     try {
-      const res = await k8sApi.listNamespacedPod(
+      return await k8sApi.listNamespacedPod({
         namespace,
-        undefined,
-        undefined,
-        undefined,
         fieldSelector,
         labelSelector,
-      );
-      if (res?.body) {
-        return res.body;
-      } else {
-        return {
-          items: [],
-        };
-      }
+      });
     } catch (error) {
       throw this.wrapK8sClientError(error);
     }
@@ -599,15 +589,15 @@ export class KubernetesClient {
 
   // List all deployments
   async listDeployments(): Promise<V1Deployment[]> {
-    const ns = this.getCurrentNamespace();
+    const namespace = this.getCurrentNamespace();
     // Only retrieve deployments if valid namespace && valid connection, otherwise we will return an empty array
     const connected = await this.checkConnection();
-    if (ns && connected) {
+    if (namespace && connected) {
       // Get the deployments via the kubernetes api
       try {
         const k8sAppsApi = this.kubeConfig.makeApiClient(AppsV1Api);
-        const deployments = await k8sAppsApi.listNamespacedDeployment(ns);
-        return deployments.body.items;
+        const deployments = await k8sAppsApi.listNamespacedDeployment({ namespace });
+        return deployments.items;
       } catch (_) {
         // do nothing
       }
@@ -617,15 +607,15 @@ export class KubernetesClient {
 
   // List all ingresses
   async listIngresses(): Promise<V1Ingress[]> {
-    const ns = this.getCurrentNamespace();
+    const namespace = this.getCurrentNamespace();
     // Only retrieve ingresses if valid namespace && valid connection, otherwise we will return an empty array
     const connected = await this.checkConnection();
-    if (ns && connected) {
+    if (namespace && connected) {
       // Get the ingresses via the kubernetes api
       try {
         const k8sNetworkingApi = this.kubeConfig.makeApiClient(NetworkingV1Api);
-        const ingresses = await k8sNetworkingApi.listNamespacedIngress(ns);
-        return ingresses.body.items;
+        const ingresses = await k8sNetworkingApi.listNamespacedIngress({ namespace });
+        return ingresses.items;
       } catch (_) {
         // do nothing
       }
@@ -635,15 +625,20 @@ export class KubernetesClient {
 
   // List all routes
   async listRoutes(): Promise<V1Route[]> {
-    const ns = this.getCurrentNamespace();
+    const namespace = this.getCurrentNamespace();
     // Only retrieve routes if valid namespace && valid connection, otherwise we will return an empty array
     const connected = await this.checkConnection();
-    if (ns && connected) {
+    if (namespace && connected) {
       try {
         // Get the routes via the kubernetes api
         const customObjectsApi = this.kubeConfig.makeApiClient(CustomObjectsApi);
-        const routes = await customObjectsApi.listNamespacedCustomObject('route.openshift.io', 'v1', ns, 'routes');
-        const body = routes.body as KubernetesListObject<V1Route>;
+        const routes = await customObjectsApi.listNamespacedCustomObject({
+          group: 'route.openshift.io',
+          version: 'v1',
+          namespace,
+          plural: 'routes',
+        });
+        const body = routes as KubernetesListObject<V1Route>;
         return body.items;
       } catch (_) {
         // catch 404 error
@@ -655,15 +650,15 @@ export class KubernetesClient {
 
   // List all services
   async listServices(): Promise<V1Service[]> {
-    const ns = this.getCurrentNamespace();
+    const namespace = this.getCurrentNamespace();
     // Only retrieve services if valid namespace && valid connection, otherwise we will return an empty array
     const connected = await this.checkConnection();
-    if (ns && connected) {
+    if (namespace && connected) {
       // Get the services via the kubernetes api
       try {
         const k8sApi = this.kubeConfig.makeApiClient(CoreV1Api);
-        const services = await k8sApi.listNamespacedService(ns);
-        return services.body.items;
+        const services = await k8sApi.listNamespacedService({ namespace });
+        return services.items;
       } catch (_) {
         // do nothing
       }
@@ -691,10 +686,10 @@ export class KubernetesClient {
   async deletePod(name: string): Promise<void> {
     let telemetryOptions = {};
     try {
-      const ns = this.currentNamespace;
-      if (ns) {
+      const namespace = this.currentNamespace;
+      if (namespace) {
         const k8sApi = this.kubeConfig.makeApiClient(CoreV1Api);
-        await k8sApi.deleteNamespacedPod(name, ns);
+        await k8sApi.deleteNamespacedPod({ name, namespace });
       }
     } catch (error) {
       telemetryOptions = { error: error };
@@ -707,12 +702,12 @@ export class KubernetesClient {
   async deleteDeployment(name: string): Promise<void> {
     let telemetryOptions = {};
     try {
-      const ns = this.getCurrentNamespace();
+      const namespace = this.getCurrentNamespace();
       // Only delete deployment if valid namespace && valid connection
       const connected = await this.checkConnection();
-      if (ns && connected) {
+      if (namespace && connected) {
         const k8sAppsApi = this.kubeConfig.makeApiClient(AppsV1Api);
-        await k8sAppsApi.deleteNamespacedDeployment(name, ns);
+        await k8sAppsApi.deleteNamespacedDeployment({ name, namespace });
       }
     } catch (error) {
       telemetryOptions = { error: error };
@@ -725,12 +720,12 @@ export class KubernetesClient {
   async deleteConfigMap(name: string): Promise<void> {
     let telemetryOptions = {};
     try {
-      const ns = this.getCurrentNamespace();
+      const namespace = this.getCurrentNamespace();
       // Only delete config map if valid namespace && valid connection
       const connected = await this.checkConnection();
-      if (ns && connected) {
+      if (namespace && connected) {
         const k8sApi = this.kubeConfig.makeApiClient(CoreV1Api);
-        await k8sApi.deleteNamespacedConfigMap(name, ns);
+        await k8sApi.deleteNamespacedConfigMap({ name, namespace });
       }
     } catch (error) {
       telemetryOptions = { error: error };
@@ -743,12 +738,12 @@ export class KubernetesClient {
   async deleteSecret(name: string): Promise<void> {
     let telemetryOptions = {};
     try {
-      const ns = this.getCurrentNamespace();
+      const namespace = this.getCurrentNamespace();
       // Only delete secret if valid namespace && valid connection
       const connected = await this.checkConnection();
-      if (ns && connected) {
+      if (namespace && connected) {
         const k8sApi = this.kubeConfig.makeApiClient(CoreV1Api);
-        await k8sApi.deleteNamespacedSecret(name, ns);
+        await k8sApi.deleteNamespacedSecret({ name, namespace });
       }
     } catch (error) {
       telemetryOptions = { error: error };
@@ -761,12 +756,12 @@ export class KubernetesClient {
   async deletePersistentVolumeClaim(name: string): Promise<void> {
     let telemetryOptions = {};
     try {
-      const ns = this.getCurrentNamespace();
+      const namespace = this.getCurrentNamespace();
       // Only delete PVC if valid namespace && valid connection
       const connected = await this.checkConnection();
-      if (ns && connected) {
+      if (namespace && connected) {
         const k8sApi = this.kubeConfig.makeApiClient(CoreV1Api);
-        await k8sApi.deleteNamespacedPersistentVolumeClaim(name, ns);
+        await k8sApi.deleteNamespacedPersistentVolumeClaim({ name, namespace });
       }
     } catch (error) {
       telemetryOptions = { error: error };
@@ -779,12 +774,12 @@ export class KubernetesClient {
   async deleteIngress(name: string): Promise<void> {
     let telemetryOptions = {};
     try {
-      const ns = this.getCurrentNamespace();
+      const namespace = this.getCurrentNamespace();
       // Only delete ingress if valid namespace && valid connection
       const connected = await this.checkConnection();
-      if (ns && connected) {
+      if (namespace && connected) {
         const networkingK8sApi = this.kubeConfig.makeApiClient(NetworkingV1Api);
-        await networkingK8sApi.deleteNamespacedIngress(name, ns);
+        await networkingK8sApi.deleteNamespacedIngress({ name, namespace });
       }
     } catch (error) {
       telemetryOptions = { error: error };
@@ -797,12 +792,18 @@ export class KubernetesClient {
   async deleteRoute(name: string): Promise<void> {
     let telemetryOptions = {};
     try {
-      const ns = this.getCurrentNamespace();
+      const namespace = this.getCurrentNamespace();
       // Only delete route if valid namespace && valid connection
       const connected = await this.checkConnection();
-      if (ns && connected) {
+      if (namespace && connected) {
         const customObjectsApi = this.kubeConfig.makeApiClient(CustomObjectsApi);
-        await customObjectsApi.deleteNamespacedCustomObject('route.openshift.io', 'v1', ns, 'routes', name);
+        await customObjectsApi.deleteNamespacedCustomObject({
+          group: 'route.openshift.io',
+          version: 'v1',
+          namespace,
+          plural: 'routes',
+          name,
+        });
       }
     } catch (error) {
       telemetryOptions = { error: error };
@@ -815,12 +816,12 @@ export class KubernetesClient {
   async deleteService(name: string): Promise<void> {
     let telemetryOptions = {};
     try {
-      const ns = this.getCurrentNamespace();
+      const namespace = this.getCurrentNamespace();
       // Only delete service if valid namespace && valid connection
       const connected = await this.checkConnection();
-      if (ns && connected) {
+      if (namespace && connected) {
         const k8sApi = this.kubeConfig.makeApiClient(CoreV1Api);
-        await k8sApi.deleteNamespacedService(name, ns);
+        await k8sApi.deleteNamespacedService({ name, namespace });
       }
     } catch (error) {
       telemetryOptions = { error: error };
@@ -833,11 +834,11 @@ export class KubernetesClient {
   async readNamespacedPod(name: string, namespace: string): Promise<V1Pod | undefined> {
     const k8sApi = this.kubeConfig.makeApiClient(CoreV1Api);
     try {
-      const res = await k8sApi.readNamespacedPod(name, namespace);
-      if (res.body?.metadata?.managedFields) {
-        delete res.body.metadata.managedFields;
+      const res = await k8sApi.readNamespacedPod({ name, namespace });
+      if (res?.metadata?.managedFields) {
+        delete res.metadata.managedFields;
       }
-      return res?.body;
+      return res;
     } catch (error) {
       this.telemetry.track('kubernetesReadNamespacedPod.error', error);
       throw this.wrapK8sClientError(error);
@@ -847,11 +848,11 @@ export class KubernetesClient {
   async readNamespacedDeployment(name: string, namespace: string): Promise<V1Deployment | undefined> {
     const k8sAppsApi = this.kubeConfig.makeApiClient(AppsV1Api);
     try {
-      const res = await k8sAppsApi.readNamespacedDeployment(name, namespace);
-      if (res.body?.metadata?.managedFields) {
-        delete res.body.metadata.managedFields;
+      const res = await k8sAppsApi.readNamespacedDeployment({ name, namespace });
+      if (res?.metadata?.managedFields) {
+        delete res.metadata.managedFields;
       }
-      return res?.body;
+      return res;
     } catch (error) {
       this.telemetry.track('kubernetesReadNamespacedDeployment.error', error);
       throw this.wrapK8sClientError(error);
@@ -864,11 +865,11 @@ export class KubernetesClient {
   ): Promise<V1PersistentVolumeClaim | undefined> {
     const k8sApi = this.kubeConfig.makeApiClient(CoreV1Api);
     try {
-      const res = await k8sApi.readNamespacedPersistentVolumeClaim(name, namespace);
-      if (res?.body?.metadata?.managedFields) {
-        delete res?.body.metadata?.managedFields;
+      const res = await k8sApi.readNamespacedPersistentVolumeClaim({ name, namespace });
+      if (res?.metadata?.managedFields) {
+        delete res?.metadata?.managedFields;
       }
-      return res?.body;
+      return res;
     } catch (error) {
       this.telemetry.track('kubernetesReadNamespacedPersistentVolumeClaim.error', error);
       throw this.wrapK8sClientError(error);
@@ -878,11 +879,11 @@ export class KubernetesClient {
   async readNode(name: string): Promise<V1Node | undefined> {
     const k8sApi = this.kubeConfig.makeApiClient(CoreV1Api);
     try {
-      const res = await k8sApi.readNode(name);
-      if (res.body?.metadata?.managedFields) {
-        delete res.body.metadata.managedFields;
+      const res = await k8sApi.readNode({ name });
+      if (res?.metadata?.managedFields) {
+        delete res.metadata.managedFields;
       }
-      return res?.body;
+      return res;
     } catch (error) {
       this.telemetry.track('kubernetesReadNode.error', error);
       throw this.wrapK8sClientError(error);
@@ -892,11 +893,11 @@ export class KubernetesClient {
   async readNamespacedIngress(name: string, namespace: string): Promise<V1Ingress | undefined> {
     const k8sNetworkingApi = this.kubeConfig.makeApiClient(NetworkingV1Api);
     try {
-      const res = await k8sNetworkingApi.readNamespacedIngress(name, namespace);
-      if (res.body?.metadata?.managedFields) {
-        delete res.body.metadata.managedFields;
+      const res = await k8sNetworkingApi.readNamespacedIngress({ name, namespace });
+      if (res?.metadata?.managedFields) {
+        delete res.metadata.managedFields;
       }
-      return res?.body;
+      return res;
     } catch (error) {
       this.telemetry.track('kubernetesReadNamespacedIngress.error', error);
       throw this.wrapK8sClientError(error);
@@ -906,13 +907,13 @@ export class KubernetesClient {
   async readNamespacedRoute(name: string, namespace: string): Promise<V1Route | undefined> {
     const k8sCustomObjectsApi = this.kubeConfig.makeApiClient(CustomObjectsApi);
     try {
-      const res = await k8sCustomObjectsApi.getNamespacedCustomObject(
-        'route.openshift.io',
-        'v1',
+      const res = await k8sCustomObjectsApi.getNamespacedCustomObject({
+        group: 'route.openshift.io',
+        version: 'v1',
         namespace,
-        'routes',
+        plural: 'routes',
         name,
-      );
+      });
       const route = res?.body as V1Route;
       if (route?.metadata?.managedFields) {
         delete route.metadata.managedFields;
@@ -927,11 +928,11 @@ export class KubernetesClient {
   async readNamespacedService(name: string, namespace: string): Promise<V1Service | undefined> {
     const k8sApi = this.kubeConfig.makeApiClient(CoreV1Api);
     try {
-      const res = await k8sApi.readNamespacedService(name, namespace);
-      if (res.body?.metadata?.managedFields) {
-        delete res.body.metadata.managedFields;
+      const res = await k8sApi.readNamespacedService({ name, namespace });
+      if (res?.metadata?.managedFields) {
+        delete res.metadata.managedFields;
       }
-      return res?.body;
+      return res;
     } catch (error) {
       this.telemetry.track('kubernetesReadNamespacedService.error', error);
       throw this.wrapK8sClientError(error);
@@ -941,11 +942,11 @@ export class KubernetesClient {
   async readNamespacedConfigMap(name: string, namespace: string): Promise<V1ConfigMap | undefined> {
     const k8sApi = this.kubeConfig.makeApiClient(CoreV1Api);
     try {
-      const res = await k8sApi.readNamespacedConfigMap(name, namespace);
-      if (res.body?.metadata?.managedFields) {
-        delete res.body.metadata.managedFields;
+      const res = await k8sApi.readNamespacedConfigMap({ name, namespace });
+      if (res?.metadata?.managedFields) {
+        delete res.metadata.managedFields;
       }
-      return res?.body;
+      return res;
     } catch (error) {
       this.telemetry.track('kubernetesReadNamespacedConfigMap.error', error);
       throw this.wrapK8sClientError(error);
@@ -955,11 +956,11 @@ export class KubernetesClient {
   async readNamespacedSecret(name: string, namespace: string): Promise<V1Secret | undefined> {
     const k8sApi = this.kubeConfig.makeApiClient(CoreV1Api);
     try {
-      const res = await k8sApi.readNamespacedSecret(name, namespace);
-      if (res.body?.metadata?.managedFields) {
-        delete res.body.metadata.managedFields;
+      const res = await k8sApi.readNamespacedSecret({ name, namespace });
+      if (res?.metadata?.managedFields) {
+        delete res.metadata.managedFields;
       }
-      return res?.body;
+      return res;
     } catch (error) {
       this.telemetry.track('kubernetesReadNamespacedSecret.error', error);
       throw this.wrapK8sClientError(error);
@@ -969,14 +970,7 @@ export class KubernetesClient {
   async listNamespaces(): Promise<V1NamespaceList> {
     try {
       const k8sApi = this.kubeConfig.makeApiClient(CoreV1Api);
-      const res = await k8sApi.listNamespace();
-      if (res?.body) {
-        return res.body;
-      } else {
-        return {
-          items: [],
-        };
-      }
+      return await k8sApi.listNamespace();
     } catch (error) {
       throw this.wrapK8sClientError(error);
     }
@@ -1056,17 +1050,17 @@ export class KubernetesClient {
     } else if (manifest.kind === 'PersistentVolumeClaim') {
       return client.createNamespacedPersistentVolumeClaim(optionalNamespace ?? manifest.metadata.namespace, manifest);
     } else if (manifest.kind === 'PodBinding') {
-      return client.createNamespacedPodBinding(
-        manifest.metadata.name,
-        optionalNamespace ?? manifest.metadata.namespace,
-        manifest,
-      );
+      return client.createNamespacedPodBinding({
+        name: manifest.metadata.name,
+        namespace: optionalNamespace ?? manifest.metadata.namespace,
+        body: manifest,
+      });
     } else if (manifest.kind === 'PodEviction') {
-      return client.createNamespacedPodEviction(
-        manifest.metadata.name,
-        optionalNamespace ?? manifest.metadata.namespace,
-        manifest,
-      );
+      return client.createNamespacedPodEviction({
+        name: manifest.metadata.name,
+        namespace: optionalNamespace ?? manifest.metadata.namespace,
+        body: manifest,
+      });
     } else if (manifest.kind === 'PodTemplate') {
       return client.createNamespacedPodTemplate(optionalNamespace ?? manifest.metadata.namespace, manifest);
     } else if (manifest.kind === 'ReplicationController') {
@@ -1078,11 +1072,11 @@ export class KubernetesClient {
     } else if (manifest.kind === 'ServiceAccount') {
       return client.createNamespacedServiceAccount(optionalNamespace ?? manifest.metadata.namespace, manifest);
     } else if (manifest.kind === 'ServiceAccountToken') {
-      return client.createNamespacedServiceAccountToken(
-        manifest.metadata.name,
-        optionalNamespace ?? manifest.metadata.namespace,
-        manifest,
-      );
+      return client.createNamespacedServiceAccountToken({
+        name: manifest.metadata.name,
+        namespace: optionalNamespace ?? manifest.metadata.namespace,
+        body: manifest,
+      });
     }
     return Promise.reject(new Error(`Unsupported kind ${manifest.kind}`));
   }
@@ -1098,9 +1092,14 @@ export class KubernetesClient {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ): Promise<any> {
     if (namespace) {
-      return client.createNamespacedCustomObject(group, version, namespace, plural, manifest);
+      return client.createNamespacedCustomObject({ group, version, namespace, plural, body: manifest });
     } else {
-      return client.createClusterCustomObject(group, version, manifest.kind.toLowerCase() + 's', manifest);
+      return client.createClusterCustomObject({
+        group,
+        version,
+        plural: manifest.kind.toLowerCase() + 's',
+        body: manifest,
+      });
     }
   }
 
@@ -1126,7 +1125,11 @@ export class KubernetesClient {
   ): Promise<V1APIResource> {
     let apiResources = this.apiResources.get(apiGroup.group + '/' + apiGroup.version);
     if (!apiResources) {
-      const response = await client.listClusterCustomObject(apiGroup.group, apiGroup.version, '');
+      const response = await client.listClusterCustomObject({
+        group: apiGroup.group,
+        version: apiGroup.version,
+        plural: '',
+      });
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       apiResources = (response.body as any).resources;
       this.apiResources.set(apiGroup.group + '/' + apiGroup.version, apiResources as V1APIResource[]);
@@ -1317,24 +1320,24 @@ export class KubernetesClient {
               undefined /* dryRun */,
               FIELD_MANAGER /* fieldManager */,
             );
-            created.push(response.body);
+            created.push(response);
           }
         } catch (error) {
           // we did not get the resource, so it does not exist: create it
           const response = await client.create(spec);
-          created.push(response.body);
+          created.push(response);
         }
       }
       return created;
     } catch (error: unknown) {
       telemetryOptions.error = error;
-      if (error instanceof HttpError) {
-        const httpError = error as HttpError;
+      if (error instanceof FetchError) {
+        const httpError = error as FetchError;
 
         // If there is a "message" in the body of the http error, throw that
         // as that's where Kubernetes tends to put the error message
-        if (httpError.body?.message) {
-          throw new Error(httpError.body.message);
+        if (httpError.message) {
+          throw new Error(httpError.message);
         }
 
         // Otherwise, throw the "generic" HTTP error message
@@ -1343,7 +1346,7 @@ export class KubernetesClient {
         }
 
         // If all else fails, throw the body of the error
-        throw new Error(httpError.body);
+        throw new Error(httpError.message);
       }
       throw error;
     } finally {
@@ -1481,7 +1484,7 @@ export class KubernetesClient {
 
   protected async restartManuallyCreatedPod(name: string, namespace: string, pod: V1Pod): Promise<void> {
     const coreApi = this.kubeConfig.makeApiClient(CoreV1Api);
-    await coreApi.deleteNamespacedPod(name, namespace);
+    await coreApi.deleteNamespacedPod({ name, namespace });
 
     const isDeleted = await this.waitForPodDeletion(coreApi, name, namespace);
     if (!isDeleted) {
@@ -1495,7 +1498,7 @@ export class KubernetesClient {
     delete pod.status;
 
     const newPod: V1Pod = { ...pod };
-    await coreApi.createNamespacedPod(namespace, newPod);
+    await coreApi.createNamespacedPod({ namespace, body: newPod });
   }
 
   protected async waitForPodDeletion(
@@ -1508,7 +1511,7 @@ export class KubernetesClient {
 
     while (Date.now() - startTime < timeout) {
       try {
-        await coreApi.readNamespacedPodStatus(name, namespace);
+        await coreApi.readNamespacedPodStatus({ name, namespace });
         await new Promise(resolve => setTimeout(resolve, 1000));
       } catch (e) {
         const error = e ?? {};
@@ -1535,13 +1538,13 @@ export class KubernetesClient {
 
     let currentReplicas = 0;
     if (controllerType === 'Deployment') {
-      const { body: currentDeployment } = await appsApi.readNamespacedDeployment(controllerName, namespace);
+      const currentDeployment = await appsApi.readNamespacedDeployment({ name: controllerName, namespace });
       currentReplicas = currentDeployment.spec?.replicas ?? 1;
     } else if (controllerType === 'ReplicaSet') {
-      const { body: currentReplicaSet } = await appsApi.readNamespacedReplicaSet(controllerName, namespace);
+      const currentReplicaSet = await appsApi.readNamespacedReplicaSet({ name: controllerName, namespace });
       currentReplicas = currentReplicaSet.spec?.replicas ?? 1;
     } else if (controllerType === 'StatefulSet') {
-      const { body: currentStatefulSet } = await appsApi.readNamespacedStatefulSet(controllerName, namespace);
+      const currentStatefulSet = await appsApi.readNamespacedStatefulSet({ name: controllerName, namespace });
       currentReplicas = currentStatefulSet.spec?.replicas ?? 1;
     }
 
@@ -1559,41 +1562,36 @@ export class KubernetesClient {
     controllerType: ScalableControllerType,
     replicas: number,
   ): Promise<void> {
+    const headerPatchMiddleware = new PromiseMiddlewareWrapper({
+      pre: async (requestContext: RequestContext): Promise<RequestContext> => {
+        requestContext.setHeaderParam('Content-type', 'application/json-patch+json');
+        return requestContext;
+      },
+      post: async (context: ResponseContext): Promise<ResponseContext> => {
+        return context;
+      },
+    });
+
+    const configuration = createConfiguration({ middleware: [headerPatchMiddleware] });
+
     if (controllerType === 'Deployment') {
       await appsApi.patchNamespacedDeploymentScale(
-        controllerName,
-        namespace,
-        { spec: { replicas } },
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        { headers: { 'Content-Type': 'application/strategic-merge-patch+json' } },
+        { name: controllerName, namespace, body: { spec: { replicas } } },
+        configuration,
       );
     } else if (controllerType === 'ReplicaSet') {
       await appsApi.patchNamespacedReplicaSetScale(
-        controllerName,
-        namespace,
-        { spec: { replicas } },
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        { headers: { 'Content-Type': 'application/strategic-merge-patch+json' } },
+        {
+          name: controllerName,
+          namespace,
+          body: { spec: { replicas } },
+        },
+        configuration,
       );
     } else if (controllerType === 'StatefulSet') {
       await appsApi.patchNamespacedStatefulSetScale(
-        controllerName,
-        namespace,
-        { spec: { replicas } },
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        { headers: { 'Content-Type': 'application/strategic-merge-patch+json' } },
+        { name: controllerName, namespace, body: { spec: { replicas } } },
+        configuration,
       );
     }
   }
@@ -1602,8 +1600,13 @@ export class KubernetesClient {
     const batchApi = this.kubeConfig.makeApiClient(BatchV1Api);
     const coreApi = this.kubeConfig.makeApiClient(CoreV1Api);
 
-    const { body: existingJob } = await batchApi.readNamespacedJob(name, namespace);
-    await batchApi.deleteNamespacedJob(name, namespace, 'true', undefined, undefined, undefined, 'Background');
+    const existingJob = await batchApi.readNamespacedJob({ name, namespace });
+    await batchApi.deleteNamespacedJob({
+      name,
+      namespace,
+      pretty: 'true',
+      propagationPolicy: 'Background',
+    });
 
     const isJobDeleted = await this.waitForJobDeletion(batchApi, name, namespace);
     if (!isJobDeleted) {
@@ -1617,7 +1620,6 @@ export class KubernetesClient {
         `not all pods with selector "${labelSelector}" in namespace "${namespace}" were deleted within the expected timeframe`,
       );
     }
-
     delete existingJob.metadata!.creationTimestamp;
     delete existingJob.metadata!.resourceVersion;
     delete existingJob.metadata!.selfLink;
@@ -1638,7 +1640,7 @@ export class KubernetesClient {
       delete existingJob.metadata.labels['job-name'];
     }
 
-    await batchApi.createNamespacedJob(namespace, existingJob);
+    await batchApi.createNamespacedJob({ namespace, body: existingJob });
   }
 
   protected async waitForJobDeletion(
@@ -1651,7 +1653,7 @@ export class KubernetesClient {
 
     while (Date.now() - startTime < timeout) {
       try {
-        await batchApi.readNamespacedJobStatus(name, namespace);
+        await batchApi.readNamespacedJobStatus({ name, namespace });
         await new Promise(resolve => setTimeout(resolve, 1000));
       } catch (e) {
         const error = e ?? {};
@@ -1677,14 +1679,7 @@ export class KubernetesClient {
     const startTime = Date.now();
 
     while (Date.now() - startTime < timeout) {
-      const { body: podList } = await coreApi.listNamespacedPod(
-        namespace,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        selector,
-      );
+      const podList = await coreApi.listNamespacedPod({ namespace, labelSelector: selector });
       if (podList.items.length === 0) {
         return true;
       }

--- a/packages/main/src/plugin/kubernetes-context-state.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.ts
@@ -16,8 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { IncomingMessage } from 'node:http';
-
 import type {
   Cluster,
   Context,
@@ -25,7 +23,6 @@ import type {
   KubernetesListObject,
   KubernetesObject,
   ListPromise,
-  ObjectCache,
   User,
   V1ConfigMap,
   V1ConfigMapList,
@@ -71,7 +68,7 @@ import {
 const MAX_NON_CURRENT_CONTEXTS_TO_CHECK = 10;
 
 // ContextInternalState stores informers for a kube context
-type ContextInternalState = Map<ResourceName, Informer<KubernetesObject> & ObjectCache<KubernetesObject>>;
+type ContextInternalState = Map<ResourceName, Informer<KubernetesObject>>;
 
 // CheckingState indicates the state of the check for a context
 export interface CheckingState {
@@ -223,11 +220,7 @@ export class ContextsStates {
     }
   }
 
-  setResourceInformer(
-    contextName: string,
-    resourceName: ResourceName,
-    informer: Informer<KubernetesObject> & ObjectCache<KubernetesObject>,
-  ): void {
+  setResourceInformer(contextName: string, resourceName: ResourceName, informer: Informer<KubernetesObject>): void {
     const informers = this.informers.get(contextName);
     if (!informers) {
       throw new Error(`watchers for context ${contextName} not found`);
@@ -592,7 +585,7 @@ export class ContextsManager {
     });
 
     const ns = context.namespace ?? 'default';
-    const result = new Map<ResourceName, Informer<KubernetesObject> & ObjectCache<KubernetesObject>>();
+    const result = new Map<ResourceName, Informer<KubernetesObject>>();
     result.set('pods', this.createPodInformer(kc, ns, context));
     result.set('deployments', this.createDeploymentInformer(kc, ns, context));
     return result;
@@ -605,7 +598,7 @@ export class ContextsManager {
     }
     const kubeContext: KubeContext = this.getKubeContext(context);
     const ns = context.namespace ?? 'default';
-    let informer: Informer<KubernetesObject> & ObjectCache<KubernetesObject>;
+    let informer: Informer<KubernetesObject>;
     switch (resourceName) {
       case 'services':
         informer = this.createServiceInformer(this.kubeConfig, ns, kubeContext);
@@ -646,10 +639,10 @@ export class ContextsManager {
     };
   }
 
-  private createPodInformer(kc: KubeConfig, ns: string, context: KubeContext): Informer<V1Pod> & ObjectCache<V1Pod> {
+  private createPodInformer(kc: KubeConfig, namespace: string, context: KubeContext): Informer<V1Pod> {
     const k8sApi = kc.makeApiClient(CoreV1Api);
-    const listFn = (): Promise<{ response: IncomingMessage; body: V1PodList }> => k8sApi.listNamespacedPod(ns);
-    const path = `/api/v1/namespaces/${ns}/pods`;
+    const listFn = (): Promise<V1PodList> => k8sApi.listNamespacedPod({ namespace });
+    const path = `/api/v1/namespaces/${namespace}/pods`;
     let timer: NodeJS.Timeout | undefined;
     let connectionDelay: NodeJS.Timeout | undefined;
     this.setConnectionTimers('pods', timer, connectionDelay);
@@ -698,17 +691,10 @@ export class ContextsManager {
     });
   }
 
-  private createDeploymentInformer(
-    kc: KubeConfig,
-    ns: string,
-    context: KubeContext,
-  ): Informer<V1Deployment> & ObjectCache<V1Deployment> {
+  private createDeploymentInformer(kc: KubeConfig, namespace: string, context: KubeContext): Informer<V1Deployment> {
     const k8sApi = kc.makeApiClient(AppsV1Api);
-    const listFn = (): Promise<{
-      response: IncomingMessage;
-      body: V1DeploymentList;
-    }> => k8sApi.listNamespacedDeployment(ns);
-    const path = `/apis/apps/v1/namespaces/${ns}/deployments`;
+    const listFn = (): Promise<V1DeploymentList> => k8sApi.listNamespacedDeployment({ namespace });
+    const path = `/apis/apps/v1/namespaces/${namespace}/deployments`;
     let timer: NodeJS.Timeout | undefined;
     let connectionDelay: NodeJS.Timeout | undefined;
     this.setConnectionTimers('deployments', timer, connectionDelay);
@@ -743,15 +729,10 @@ export class ContextsManager {
     });
   }
 
-  public createConfigMapInformer(
-    kc: KubeConfig,
-    ns: string,
-    context: KubeContext,
-  ): Informer<V1ConfigMap> & ObjectCache<V1ConfigMap> {
+  public createConfigMapInformer(kc: KubeConfig, namespace: string, context: KubeContext): Informer<V1ConfigMap> {
     const k8sApi = kc.makeApiClient(CoreV1Api);
-    const listFn = (): Promise<{ response: IncomingMessage; body: V1ConfigMapList }> =>
-      k8sApi.listNamespacedConfigMap(ns);
-    const path = `/api/v1/namespaces/${ns}/configmaps`;
+    const listFn = (): Promise<V1ConfigMapList> => k8sApi.listNamespacedConfigMap({ namespace });
+    const path = `/api/v1/namespaces/${namespace}/configmaps`;
     let timer: NodeJS.Timeout | undefined;
     let connectionDelay: NodeJS.Timeout | undefined;
     this.setConnectionTimers('configmaps', timer, connectionDelay);
@@ -786,14 +767,10 @@ export class ContextsManager {
     });
   }
 
-  public createSecretInformer(
-    kc: KubeConfig,
-    ns: string,
-    context: KubeContext,
-  ): Informer<V1Secret> & ObjectCache<V1Secret> {
+  public createSecretInformer(kc: KubeConfig, namespace: string, context: KubeContext): Informer<V1Secret> {
     const k8sApi = kc.makeApiClient(CoreV1Api);
-    const listFn = (): Promise<{ response: IncomingMessage; body: V1SecretList }> => k8sApi.listNamespacedSecret(ns);
-    const path = `/api/v1/namespaces/${ns}/secrets`;
+    const listFn = (): Promise<V1SecretList> => k8sApi.listNamespacedSecret({ namespace });
+    const path = `/api/v1/namespaces/${namespace}/secrets`;
     let timer: NodeJS.Timeout | undefined;
     let connectionDelay: NodeJS.Timeout | undefined;
     this.setConnectionTimers('secrets', timer, connectionDelay);
@@ -828,13 +805,13 @@ export class ContextsManager {
 
   public createPersistentVolumeClaimInformer(
     kc: KubeConfig,
-    ns: string,
+    namespace: string,
     context: KubeContext,
-  ): Informer<V1PersistentVolumeClaim> & ObjectCache<V1PersistentVolumeClaim> {
+  ): Informer<V1PersistentVolumeClaim> {
     const k8sApi = kc.makeApiClient(CoreV1Api);
-    const listFn = (): Promise<{ response: IncomingMessage; body: V1PersistentVolumeClaimList }> =>
-      k8sApi.listNamespacedPersistentVolumeClaim(ns);
-    const path = `/api/v1/namespaces/${ns}/persistentvolumeclaims`;
+    const listFn = (): Promise<V1PersistentVolumeClaimList> =>
+      k8sApi.listNamespacedPersistentVolumeClaim({ namespace });
+    const path = `/api/v1/namespaces/${namespace}/persistentvolumeclaims`;
     let timer: NodeJS.Timeout | undefined;
     let connectionDelay: NodeJS.Timeout | undefined;
     this.setConnectionTimers('persistentvolumeclaims', timer, connectionDelay);
@@ -871,9 +848,9 @@ export class ContextsManager {
     });
   }
 
-  public createNodeInformer(kc: KubeConfig, ns: string, context: KubeContext): Informer<V1Node> & ObjectCache<V1Node> {
+  public createNodeInformer(kc: KubeConfig, ns: string, context: KubeContext): Informer<V1Node> {
     const k8sApi = kc.makeApiClient(CoreV1Api);
-    const listFn = (): Promise<{ response: IncomingMessage; body: V1NodeList }> => k8sApi.listNode();
+    const listFn = (): Promise<V1NodeList> => k8sApi.listNode();
     const path = '/api/v1/nodes';
     let timer: NodeJS.Timeout | undefined;
     let connectionDelay: NodeJS.Timeout | undefined;
@@ -904,17 +881,10 @@ export class ContextsManager {
     });
   }
 
-  public createServiceInformer(
-    kc: KubeConfig,
-    ns: string,
-    context: KubeContext,
-  ): Informer<V1Service> & ObjectCache<V1Service> {
+  public createServiceInformer(kc: KubeConfig, namespace: string, context: KubeContext): Informer<V1Service> {
     const k8sApi = kc.makeApiClient(CoreV1Api);
-    const listFn = (): Promise<{
-      response: IncomingMessage;
-      body: V1ServiceList;
-    }> => k8sApi.listNamespacedService(ns);
-    const path = `/api/v1/namespaces/${ns}/services`;
+    const listFn = (): Promise<V1ServiceList> => k8sApi.listNamespacedService({ namespace });
+    const path = `/api/v1/namespaces/${namespace}/services`;
     let timer: NodeJS.Timeout | undefined;
     let connectionDelay: NodeJS.Timeout | undefined;
     this.setConnectionTimers('services', timer, connectionDelay);
@@ -947,17 +917,10 @@ export class ContextsManager {
     });
   }
 
-  public createIngressInformer(
-    kc: KubeConfig,
-    ns: string,
-    context: KubeContext,
-  ): Informer<V1Ingress> & ObjectCache<V1Ingress> {
+  public createIngressInformer(kc: KubeConfig, namespace: string, context: KubeContext): Informer<V1Ingress> {
     const k8sNetworkingApi = this.kubeConfig.makeApiClient(NetworkingV1Api);
-    const listFn = (): Promise<{
-      response: IncomingMessage;
-      body: V1IngressList;
-    }> => k8sNetworkingApi.listNamespacedIngress(ns);
-    const path = `/apis/networking.k8s.io/v1/namespaces/${ns}/ingresses`;
+    const listFn = (): Promise<V1IngressList> => k8sNetworkingApi.listNamespacedIngress({ namespace });
+    const path = `/apis/networking.k8s.io/v1/namespaces/${namespace}/ingresses`;
     let timer: NodeJS.Timeout | undefined;
     let connectionDelay: NodeJS.Timeout | undefined;
     this.setConnectionTimers('ingresses', timer, connectionDelay);
@@ -990,21 +953,16 @@ export class ContextsManager {
     });
   }
 
-  public createRouteInformer(
-    kc: KubeConfig,
-    ns: string,
-    context: KubeContext,
-  ): Informer<V1Route> & ObjectCache<V1Route> {
+  public createRouteInformer(kc: KubeConfig, namespace: string, context: KubeContext): Informer<V1Route> {
     const customObjectsApi = this.kubeConfig.makeApiClient(CustomObjectsApi);
-    const listFn = (): Promise<{
-      response: IncomingMessage;
-      body: KubernetesListObject<V1Route>;
-    }> =>
-      customObjectsApi.listNamespacedCustomObject('route.openshift.io', 'v1', ns, 'routes') as Promise<{
-        response: IncomingMessage;
-        body: KubernetesListObject<V1Route>;
-      }>;
-    const path = `/apis/route.openshift.io/v1/namespaces/${ns}/routes`;
+    const listFn = (): Promise<KubernetesListObject<V1Route>> =>
+      customObjectsApi.listNamespacedCustomObject({
+        group: 'route.openshift.io',
+        version: 'v1',
+        namespace,
+        plural: 'routes',
+      }) as Promise<KubernetesListObject<V1Route>>;
+    const path = `/apis/route.openshift.io/v1/namespaces/${namespace}/routes`;
     let timer: NodeJS.Timeout | undefined;
     let connectionDelay: NodeJS.Timeout | undefined;
     this.setConnectionTimers('routes', timer, connectionDelay);
@@ -1047,7 +1005,7 @@ export class ContextsManager {
     path: string,
     listPromiseFn: ListPromise<T>,
     options: CreateInformerOptions<T>,
-  ): Informer<T> & ObjectCache<T> {
+  ): Informer<T> {
     const informer = makeInformer(kc, path, listPromiseFn);
 
     informer.on('add', (obj: T) => {
@@ -1133,7 +1091,7 @@ export class ContextsManager {
   }
 
   private restartInformer<T extends KubernetesObject>(
-    informer: Informer<KubernetesObject> & ObjectCache<KubernetesObject>,
+    informer: Informer<T>,
     context: KubeContext,
     options: CreateInformerOptions<T>,
   ): void {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4385,27 +4385,43 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@kubernetes/client-node@^0.21.0":
-  version "0.21.0"
-  resolved "https://registry.yarnpkg.com/@kubernetes/client-node/-/client-node-0.21.0.tgz#c807af50e5d4ecbbaa571087636d79cd71a7d9cc"
-  integrity sha512-yYRbgMeyQbvZDHt/ZqsW3m4lRefzhbbJEuj8sVXM+bufKrgmzriA2oq7lWPH/k/LQIicAME9ixPUadTrxIF6dQ==
+"@jsep-plugin/assignment@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@jsep-plugin/assignment/-/assignment-1.2.1.tgz#07277bdd7862451a865d391e2142efba33f46c9b"
+  integrity sha512-gaHqbubTi29aZpVbBlECRpmdia+L5/lh2BwtIJTmtxdbecEyyX/ejAOg7eQDGNvGOUmPY7Z2Yxdy9ioyH/VJeA==
+
+"@jsep-plugin/regex@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@jsep-plugin/regex/-/regex-1.0.3.tgz#3aeaa2e5fa45d89de116aeafbfa41c95935b7f6d"
+  integrity sha512-XfZgry4DwEZvSFtS/6Y+R48D7qJYJK6R9/yJFyUFHCIUMEEHuJ4X95TDgJp5QkmzfLYvapMPzskV5HpIDrREug==
+
+"@kubernetes/client-node@^1.0.0-rc6":
+  version "1.0.0-rc6"
+  resolved "https://registry.yarnpkg.com/@kubernetes/client-node/-/client-node-1.0.0-rc6.tgz#522568568ea07b9c5e06bbb73e56fea6c91bd89f"
+  integrity sha512-CBNOZ0rrGc2NKx3/1Bu4Be6DLPbNWDDLmjgZ0DmIWOpEye/kyVf4vKqOCwfm+eM//reebW8DLxGZUsrrXETkEA==
   dependencies:
     "@types/js-yaml" "^4.0.1"
-    "@types/node" "^20.1.1"
-    "@types/request" "^2.47.1"
-    "@types/ws" "^8.5.3"
+    "@types/node" "^20.3.1"
+    "@types/node-fetch" "^2.6.9"
+    "@types/stream-buffers" "^3.0.3"
+    "@types/tar" "^6.1.1"
+    "@types/underscore" "^1.8.9"
+    "@types/ws" "^8.5.4"
     byline "^5.0.0"
+    form-data "^4.0.0"
     isomorphic-ws "^5.0.0"
     js-yaml "^4.1.0"
-    jsonpath-plus "^8.0.0"
-    request "^2.88.0"
+    jsonpath-plus "^9.0.0"
+    node-fetch "^2.6.9"
+    openid-client "^5.6.5"
     rfc4648 "^1.3.0"
     stream-buffers "^3.0.2"
     tar "^7.0.0"
-    tslib "^2.4.1"
-    ws "^8.11.0"
-  optionalDependencies:
-    openid-client "^5.3.0"
+    tmp-promise "^3.0.2"
+    tslib "^2.5.0"
+    underscore "^1.9.1"
+    url-parse "^1.4.3"
+    ws "^8.13.0"
 
 "@leichtgewicht/ip-codec@^2.0.1":
   version "2.0.4"
@@ -5857,11 +5873,6 @@
     "@types/node" "*"
     "@types/responselike" "^1.0.0"
 
-"@types/caseless@*":
-  version "0.12.2"
-  resolved "https://registry.yarnpkg.com/@types/caseless/-/caseless-0.12.2.tgz#f65d3d6389e01eeb458bd54dc8f52b95a9463bc8"
-  integrity sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==
-
 "@types/connect-history-api-fallback@^1.3.5":
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.3.5.tgz#d1f7a8a09d0ed5a57aee5ae9c18ab9b803205dae"
@@ -6155,6 +6166,14 @@
   resolved "https://registry.yarnpkg.com/@types/mustache/-/mustache-4.2.5.tgz#9129f0d6857f976e00e171bbb3460e4b702f84ef"
   integrity sha512-PLwiVvTBg59tGFL/8VpcGvqOu3L4OuveNvPi0EYbWchRdEVP++yRUXJPFl+CApKEq13017/4Nf7aQ5lTtHUNsA==
 
+"@types/node-fetch@^2.6.9":
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.11.tgz#9b39b78665dae0e82a08f02f4967d62c66f95d24"
+  integrity sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==
+  dependencies:
+    "@types/node" "*"
+    form-data "^4.0.0"
+
 "@types/node-forge@^1.3.0":
   version "1.3.10"
   resolved "https://registry.yarnpkg.com/@types/node-forge/-/node-forge-1.3.10.tgz#62a19d4f75a8b03290578c2b04f294b1a5a71b07"
@@ -6162,7 +6181,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@^17.0.5", "@types/node@^18.0.0", "@types/node@^18.11.18", "@types/node@^20", "@types/node@^20.1.1", "@types/node@^20.9.0":
+"@types/node@*", "@types/node@^17.0.5", "@types/node@^18.0.0", "@types/node@^18.11.18", "@types/node@^20", "@types/node@^20.3.1", "@types/node@^20.9.0":
   version "20.16.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.16.1.tgz#0b44b15271d0e2191ca68faf1fbe506e06aed732"
   integrity sha512-zJDo7wEadFtSyNz5QITDfRcrhqDvQI1xQNQ0VoizPjM/dVAODqqIUWbJPkvsxmTI0MYRGRikcdjMPhOssnPejQ==
@@ -6277,16 +6296,6 @@
     "@types/prop-types" "*"
     csstype "^3.0.2"
 
-"@types/request@^2.47.1":
-  version "2.48.8"
-  resolved "https://registry.yarnpkg.com/@types/request/-/request-2.48.8.tgz#0b90fde3b655ab50976cb8c5ac00faca22f5a82c"
-  integrity sha512-whjk1EDJPcAR2kYHRbFl/lKeeKYTi05A15K9bnLInCVroNDCtXce57xKdI0/rQaA3K+6q0eFyUBPmqfSndUZdQ==
-  dependencies:
-    "@types/caseless" "*"
-    "@types/node" "*"
-    "@types/tough-cookie" "*"
-    form-data "^2.5.0"
-
 "@types/resolve@1.20.2":
   version "1.20.2"
   resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.20.2.tgz#97d26e00cd4a0423b4af620abecf3e6f442b7975"
@@ -6399,6 +6408,13 @@
     "@types/asn1" "*"
     "@types/node" "*"
 
+"@types/stream-buffers@^3.0.3":
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/@types/stream-buffers/-/stream-buffers-3.0.7.tgz#0b719fa1bd2ca2cc0908205a440e5e569e1aa21e"
+  integrity sha512-azOCy05sXVXrO+qklf0c/B07H/oHaIuDDAiHPVwlk3A9Ek+ksHyTeMajLZl3r76FxpPpxem//4Te61G1iW3Giw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/stream-chain@*":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/stream-chain/-/stream-chain-2.0.1.tgz#4d3cc47a32609878bc188de0bae420bcfd3bf1f5"
@@ -6429,7 +6445,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/tar@^6.1.13":
+"@types/tar@^6.1.1", "@types/tar@^6.1.13":
   version "6.1.13"
   resolved "https://registry.yarnpkg.com/@types/tar/-/tar-6.1.13.tgz#9b5801c02175344101b4b91086ab2bbc8e93a9b6"
   integrity sha512-IznnlmU5f4WcGTh2ltRu/Ijpmk8wiWXfF0VA4s+HPjHZgvFggk1YaIkbo5krX/zUCzWF8N/l4+W/LNxnvAJ8nw==
@@ -6437,10 +6453,10 @@
     "@types/node" "*"
     minipass "^4.0.0"
 
-"@types/tough-cookie@*":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.2.tgz#6286b4c7228d58ab7866d19716f3696e03a09397"
-  integrity sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==
+"@types/underscore@^1.8.9":
+  version "1.11.15"
+  resolved "https://registry.yarnpkg.com/@types/underscore/-/underscore-1.11.15.tgz#29c776daecf6f1935da9adda17509686bf979947"
+  integrity sha512-HP38xE+GuWGlbSRq9WrZkousaQ7dragtZCruBVMi0oX1migFZavZ3OROKHSkNp/9ouq82zrWtZpg18jFnVN96g==
 
 "@types/unist@*", "@types/unist@^2.0.0":
   version "2.0.6"
@@ -6467,7 +6483,14 @@
   resolved "https://registry.npmjs.org/@types/verror/-/verror-1.10.5.tgz"
   integrity sha512-9UjMCHK5GPgQRoNbqdLIAvAy0EInuiqbW0PBMtVP6B5B2HQJlvoJHM+KodPZMEjOa5VkSc+5LH7xy+cUzQdmHw==
 
-"@types/ws@^8.5.3", "@types/ws@^8.5.5":
+"@types/ws@^8.5.4":
+  version "8.5.12"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.12.tgz#619475fe98f35ccca2a2f6c137702d85ec247b7e"
+  integrity sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ==
+  dependencies:
+    "@types/node" "*"
+
+"@types/ws@^8.5.5":
   version "8.5.10"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.10.tgz#4acfb517970853fa6574a3a6886791d04a396787"
   integrity sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==
@@ -7009,7 +7032,7 @@ ajv-keywords@^5.0.0, ajv-keywords@^5.1.0:
   dependencies:
     fast-deep-equal "^3.1.3"
 
-ajv@^6.10.0, ajv@^6.12.0, ajv@^6.12.2, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.12.5:
+ajv@^6.10.0, ajv@^6.12.0, ajv@^6.12.2, ajv@^6.12.4, ajv@^6.12.5:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -7311,7 +7334,7 @@ asn1@^0.2.4, asn1@~0.2.3:
   dependencies:
     safer-buffer "~2.1.0"
 
-assert-plus@1.0.0, assert-plus@^1.0.0:
+assert-plus@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
   integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
@@ -7386,16 +7409,6 @@ available-typed-arrays@^1.0.7:
   integrity sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==
   dependencies:
     possible-typed-array-names "^1.0.0"
-
-aws-sign2@~0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
-  integrity sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==
-
-aws4@^1.8.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
-  integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
 axios@^1.6.8:
   version "1.7.4"
@@ -7913,11 +7926,6 @@ caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001646:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001649.tgz#3ec700309ca0da2b0d3d5fb03c411b191761c992"
   integrity sha512-fJegqZZ0ZX8HOWr6rcafGr72+xcgJKI9oWfDW5DrD7ExUtgZC7a7R7ZYmZqplh7XDocFdGeIFn7roAxhOeYrPQ==
 
-caseless@~0.12.0:
-  version "0.12.0"
-  resolved "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
-  integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
-
 ccount@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-2.0.1.tgz#17a3bf82302e0870d6da43a01311a8bc02a3ecf5"
@@ -8311,7 +8319,7 @@ combine-promises@^1.1.0:
   resolved "https://registry.yarnpkg.com/combine-promises/-/combine-promises-1.1.0.tgz#72db90743c0ca7aab7d0d8d2052fd7b0f674de71"
   integrity sha512-ZI9jvcLDxqwaXEixOhArm3r7ReIivsXkpbyEWyeOhzz1QS0iSgBPnWvEqvIQtYyamGCYA88gFhmUrs9hrrQ0pg==
 
-combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
+combined-stream@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -10731,7 +10739,7 @@ extend-shallow@^2.0.1:
   dependencies:
     is-extendable "^0.1.0"
 
-extend@^3.0.0, extend@~3.0.2:
+extend@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
@@ -10746,11 +10754,6 @@ extract-zip@^2.0.1:
     yauzl "^2.10.0"
   optionalDependencies:
     "@types/yauzl" "^2.9.1"
-
-extsprintf@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
-  integrity sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==
 
 extsprintf@^1.2.0:
   version "1.4.1"
@@ -11031,11 +11034,6 @@ foreground-child@^3.1.0:
     cross-spawn "^7.0.0"
     signal-exit "^4.0.1"
 
-forever-agent@~0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
-  integrity sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==
-
 fork-ts-checker-webpack-plugin@^6.5.0:
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-6.5.0.tgz#0282b335fa495a97e167f69018f566ea7d2a2b5e"
@@ -11065,15 +11063,6 @@ form-data-encoder@^4.0.2:
   resolved "https://registry.yarnpkg.com/form-data-encoder/-/form-data-encoder-4.0.2.tgz#dd286fd5f9049e8ded1d44ce427f5e29185c7c12"
   integrity sha512-KQVhvhK8ZkWzxKxOr56CPulAhH3dobtuQ4+hNQ+HekH/Wp5gSOafqRAeTphQUJAIk0GBvHZgJ2ZGRWd5kphMuw==
 
-form-data@^2.5.0:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
-  integrity sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.6"
-    mime-types "^2.1.12"
-
 form-data@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz"
@@ -11081,15 +11070,6 @@ form-data@^4.0.0:
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
-    mime-types "^2.1.12"
-
-form-data@~2.3.2:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
-  integrity sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
 format@^0.2.0:
@@ -11667,19 +11647,6 @@ handle-thing@^2.0.0:
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.1.tgz#857f79ce359580c340d43081cc648970d0bb234e"
   integrity sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==
 
-har-schema@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
-  integrity sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==
-
-har-validator@~5.1.3:
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.5.tgz#1f0803b9f8cb20c0fa13822df1ecddb36bde1efd"
-  integrity sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==
-  dependencies:
-    ajv "^6.12.3"
-    har-schema "^2.0.0"
-
 has-bigints@^1.0.1, has-bigints@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
@@ -12126,15 +12093,6 @@ http-proxy@^1.18.1:
     eventemitter3 "^4.0.0"
     follow-redirects "^1.0.0"
     requires-port "^1.0.0"
-
-http-signature@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
-  integrity sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==
-  dependencies:
-    assert-plus "^1.0.0"
-    jsprim "^1.2.2"
-    sshpk "^1.7.0"
 
 http2-wrapper@^1.0.0-beta.5.2:
   version "1.0.3"
@@ -12744,7 +12702,7 @@ is-typed-array@^1.1.3:
   dependencies:
     which-typed-array "^1.1.14"
 
-is-typedarray@^1.0.0, is-typedarray@~1.0.0:
+is-typedarray@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==
@@ -12822,11 +12780,6 @@ isomorphic-ws@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz#e5529148912ecb9b451b46ed44d53dae1ce04bbf"
   integrity sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==
-
-isstream@~0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
-  integrity sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==
 
 istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.2:
   version "3.2.2"
@@ -12925,10 +12878,10 @@ joi@^17.9.2:
     "@sideway/formula" "^3.0.1"
     "@sideway/pinpoint" "^2.0.0"
 
-jose@^4.10.0:
-  version "4.15.5"
-  resolved "https://registry.yarnpkg.com/jose/-/jose-4.15.5.tgz#6475d0f467ecd3c630a1b5dadd2735a7288df706"
-  integrity sha512-jc7BFxgKPKi94uOvEmzlSWFFe2+vASyXaKUpdQKatWAESU2MWjDfFf0fdfc83CDKcA5QecabZeNLyfhe3yKNkg==
+jose@^4.15.5:
+  version "4.15.9"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-4.15.9.tgz#9b68eda29e9a0614c042fa29387196c7dd800100"
+  integrity sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==
 
 jose@^5.1.0:
   version "5.2.3"
@@ -13018,6 +12971,11 @@ jsdom@^24.1.1:
     ws "^8.18.0"
     xml-name-validator "^5.0.0"
 
+jsep@^1.3.8:
+  version "1.3.9"
+  resolved "https://registry.yarnpkg.com/jsep/-/jsep-1.3.9.tgz#8ce42df80ee9c1b39e52d0dd062a465342f35440"
+  integrity sha512-i1rBX5N7VPl0eYb6+mHNp52sEuaS2Wi8CDYx1X5sn9naevL78+265XJqy1qENEk7mRKwS06NHpUqiBwR7qeodw==
+
 jsesc@^2.5.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
@@ -13053,17 +13011,12 @@ json-schema-traverse@^1.0.0:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
   integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
-json-schema@0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
-  integrity sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
-
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
-json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
+json-stringify-safe@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
@@ -13111,20 +13064,14 @@ jsonparse@^1.2.0:
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==
 
-jsonpath-plus@^8.0.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-8.1.0.tgz#68c92281215672d1d6c785b3c1bdc8acc097ba3f"
-  integrity sha512-qVTiuKztFGw0dGhYi3WNqvddx3/SHtyDT0xJaeyz4uP0d1tkpG+0y5uYQ4OcIo1TLAz3PE/qDOW9F0uDt3+CTw==
-
-jsprim@^1.2.2:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.2.tgz#712c65533a15c878ba59e9ed5f0e26d5b77c5feb"
-  integrity sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==
+jsonpath-plus@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-9.0.0.tgz#bb8703ee481531142bca8dee9a42fe72b8358a7f"
+  integrity sha512-bqE77VIDStrOTV/czspZhTn+o27Xx9ZJRGVkdVShEtPoqsIx5yALv3lWVU6y+PqYvWPJNWE7ORCQheQkEe0DDA==
   dependencies:
-    assert-plus "1.0.0"
-    extsprintf "1.3.0"
-    json-schema "0.4.0"
-    verror "1.10.0"
+    "@jsep-plugin/assignment" "^1.2.1"
+    "@jsep-plugin/regex" "^1.0.3"
+    jsep "^1.3.8"
 
 jszip@^3.1.0:
   version "3.10.1"
@@ -14618,7 +14565,7 @@ mime-types@^2.1.12:
   dependencies:
     mime-db "1.51.0"
 
-mime-types@^2.1.27, mime-types@^2.1.31, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24, mime-types@~2.1.34:
+mime-types@^2.1.27, mime-types@^2.1.31, mime-types@~2.1.17, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -14935,7 +14882,7 @@ node-fetch-native@^1.6.3:
   resolved "https://registry.yarnpkg.com/node-fetch-native/-/node-fetch-native-1.6.4.tgz#679fc8fd8111266d47d7e72c379f1bed9acff06e"
   integrity sha512-IhOigYzAKHd244OC0JIMIUrjzctirCmPkaIfhDeGcEETWof5zKYUW7e7MYvChGWh/4CJeXEgsRyGzuF334rOOQ==
 
-node-fetch@^2.6.7:
+node-fetch@^2.6.7, node-fetch@^2.6.9:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
@@ -15037,17 +14984,12 @@ nypm@^0.3.8:
     pathe "^1.1.2"
     ufo "^1.4.0"
 
-oauth-sign@~0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
-  integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
-
 object-assign@^4.0.1, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
-object-hash@^2.0.1:
+object-hash@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.2.0.tgz#5ad518581eefc443bd763472b8ff2e9c2c0d54a5"
   integrity sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==
@@ -15146,10 +15088,10 @@ ohash@^1.1.3:
   resolved "https://registry.yarnpkg.com/ohash/-/ohash-1.1.3.tgz#f12c3c50bfe7271ce3fd1097d42568122ccdcf07"
   integrity sha512-zuHHiGTYTA1sYJ/wZN+t5HKZaH23i4yI1HMwbuXm24Nid7Dv0KcuRlKoNKS9UNfAVSBlnGLcuQrnOKWOZoEGaw==
 
-oidc-token-hash@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/oidc-token-hash/-/oidc-token-hash-5.0.1.tgz#ae6beec3ec20f0fd885e5400d175191d6e2f10c6"
-  integrity sha512-EvoOtz6FIEBzE+9q253HsLCVRiK/0doEJ2HCvvqMQb3dHZrP3WlJKYtJ55CRTw4jmYomzH4wkPuCj/I3ZvpKxQ==
+oidc-token-hash@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/oidc-token-hash/-/oidc-token-hash-5.0.3.tgz#9a229f0a1ce9d4fc89bcaee5478c97a889e7b7b6"
+  integrity sha512-IF4PcGgzAr6XXSff26Sk/+P4KZFJVuHAJZj3wgO3vX2bMdNVp/QXTP3P7CEm9V1IdG8lDLY3HhiqpsE/nOwpPw==
 
 on-finished@2.4.1:
   version "2.4.1"
@@ -15205,15 +15147,15 @@ opener@^1.5.2:
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
   integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
 
-openid-client@^5.3.0:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/openid-client/-/openid-client-5.3.1.tgz#69a5fa7d2b5ad479032f576852d40b4d4435488a"
-  integrity sha512-RLfehQiHch9N6tRWNx68cicf3b1WR0x74bJWHRc25uYIbSRwjxYcTFaRnzbbpls5jroLAaB/bFIodTgA5LJMvw==
+openid-client@^5.6.5:
+  version "5.6.5"
+  resolved "https://registry.yarnpkg.com/openid-client/-/openid-client-5.6.5.tgz#c149ad07b9c399476dc347097e297bbe288b8b00"
+  integrity sha512-5P4qO9nGJzB5PI0LFlhj4Dzg3m4odt0qsJTfyEtZyOlkgpILwEioOhVVJOrS1iVH494S4Ee5OCjjg6Bf5WOj3w==
   dependencies:
-    jose "^4.10.0"
+    jose "^4.15.5"
     lru-cache "^6.0.0"
-    object-hash "^2.0.1"
-    oidc-token-hash "^5.0.1"
+    object-hash "^2.2.0"
+    oidc-token-hash "^5.0.3"
 
 optionator@^0.9.1:
   version "0.9.4"
@@ -15565,11 +15507,6 @@ pend@~1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz"
   integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
-
-performance-now@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
-  integrity sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==
 
 periscopic@^3.0.0:
   version "3.1.0"
@@ -16209,7 +16146,7 @@ ps-list@^8.1.1:
   resolved "https://registry.yarnpkg.com/ps-list/-/ps-list-8.1.1.tgz#9ff1952b26a9a07fcc05270407e60544237ae581"
   integrity sha512-OPS9kEJYVmiO48u/B9qneqhkMvgCxT+Tm28VCEJpheTpl8cJ0ffZRRNgS5mrQRTrX5yRTpaJ+hRDeefXYmmorQ==
 
-psl@^1.1.28, psl@^1.1.33:
+psl@^1.1.33:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.9.0.tgz#d0df2a137f00794565fcaf3b2c00cd09f8d5a5a7"
   integrity sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==
@@ -16267,11 +16204,6 @@ qs@^6.10.0:
   integrity sha512-zWmv4RSuB9r2mYQw3zxQuHWeU+42aKi1wWig/j4ele4ygELZ7PEO6MM7rim9oAQH2A5MWfsAVf/jPvTPgCbvUQ==
   dependencies:
     side-channel "^1.0.6"
-
-qs@~6.5.2:
-  version "6.5.3"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.3.tgz#3aeeffc91967ef6e35c0e488ef46fb296ab76aad"
-  integrity sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==
 
 querystringify@^2.1.1:
   version "2.2.0"
@@ -16894,32 +16826,6 @@ renderkid@^3.0.0:
     lodash "^4.17.21"
     strip-ansi "^6.0.1"
 
-request@^2.88.0:
-  version "2.88.2"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
-  integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
-  dependencies:
-    aws-sign2 "~0.7.0"
-    aws4 "^1.8.0"
-    caseless "~0.12.0"
-    combined-stream "~1.0.6"
-    extend "~3.0.2"
-    forever-agent "~0.6.1"
-    form-data "~2.3.2"
-    har-validator "~5.1.3"
-    http-signature "~1.2.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.19"
-    oauth-sign "~0.9.0"
-    performance-now "^2.1.0"
-    qs "~6.5.2"
-    safe-buffer "^5.1.2"
-    tough-cookie "~2.5.0"
-    tunnel-agent "^0.6.0"
-    uuid "^3.3.2"
-
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"
@@ -17168,7 +17074,7 @@ safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safe-buffer@5.2.1, safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
+safe-buffer@5.2.1, safe-buffer@>=5.1.0, safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -17837,21 +17743,6 @@ sshpk@^1.18.0:
   version "1.18.0"
   resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.18.0.tgz#1663e55cddf4d688b86a46b77f0d5fe363aba028"
   integrity sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==
-  dependencies:
-    asn1 "~0.2.3"
-    assert-plus "^1.0.0"
-    bcrypt-pbkdf "^1.0.0"
-    dashdash "^1.12.0"
-    ecc-jsbn "~0.1.1"
-    getpass "^0.1.1"
-    jsbn "~0.1.0"
-    safer-buffer "^2.0.2"
-    tweetnacl "~0.14.0"
-
-sshpk@^1.7.0:
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.17.0.tgz#578082d92d4fe612b13007496e543fa0fbcbe4c5"
-  integrity sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==
   dependencies:
     asn1 "~0.2.3"
     assert-plus "^1.0.0"
@@ -18642,14 +18533,6 @@ tough-cookie@^4.1.4:
     universalify "^0.2.0"
     url-parse "^1.5.3"
 
-tough-cookie@~2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
-  integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
-  dependencies:
-    psl "^1.1.28"
-    punycode "^2.1.1"
-
 tr46@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-5.0.0.tgz#3b46d583613ec7283020d79019f1335723801cec"
@@ -18727,7 +18610,7 @@ tslib@^1.13.0, tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.4.1, tslib@^2.6.0, tslib@^2.6.3:
+tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.4.1, tslib@^2.5.0, tslib@^2.6.0, tslib@^2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.3.tgz#0438f810ad7a9edcde7a241c3d80db693c8cbfe0"
   integrity sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==
@@ -18756,13 +18639,6 @@ tsx@^4.17.0:
     get-tsconfig "^4.7.5"
   optionalDependencies:
     fsevents "~2.3.3"
-
-tunnel-agent@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
-  integrity sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==
-  dependencies:
-    safe-buffer "^5.0.1"
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
@@ -18925,6 +18801,11 @@ unbox-primitive@^1.0.2:
     has-bigints "^1.0.2"
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
+
+underscore@^1.9.1:
+  version "1.13.7"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.7.tgz#970e33963af9a7dda228f17ebe8399e5fbe63a10"
+  integrity sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==
 
 undici-types@~6.19.2:
   version "6.19.6"
@@ -19178,7 +19059,7 @@ url-loader@^4.1.1:
     mime-types "^2.1.27"
     schema-utils "^3.0.0"
 
-url-parse@^1.5.3:
+url-parse@^1.4.3, url-parse@^1.5.3:
   version "1.5.10"
   resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
   integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
@@ -19237,11 +19118,6 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@^3.3.2:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
-  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
-
 uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
@@ -19289,15 +19165,6 @@ vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
-
-verror@1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
-  integrity sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==
-  dependencies:
-    assert-plus "^1.0.0"
-    core-util-is "1.0.2"
-    extsprintf "^1.2.0"
 
 verror@^1.10.0:
   version "1.10.1"
@@ -19763,7 +19630,7 @@ ws@^7.3.1:
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.10.tgz#58b5c20dc281633f6c19113f39b349bd8bd558d9"
   integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
 
-ws@^8.11.0, ws@^8.13.0, ws@^8.18.0, ws@^8.2.3:
+ws@^8.13.0, ws@^8.18.0, ws@^8.2.3:
   version "8.18.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
   integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==


### PR DESCRIPTION
### What does this PR do?
the current version that we are using is relying on https://www.npmjs.com/package/request that is deprecated
we've also some reports from dependabot with moderate CVE
https://github.com/request/request/issues/3442

the kubernetes client has a new version no longer relying on this package and using node-fetch

but due to the switch and the generator switch, a lot of requests have their parameters being changed so it's a deep change

I think it's easier now as instead of like sometimes 8 parameters, we only provide a complex type with only the fields we want to submit and it's avoiding the current pattern `(param1, undefined, undefined, undefined, param2)` being used.

https://github.com/kubernetes-client/javascript/issues/1828#issuecomment-2265568631


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/8516

### How to test this PR?

Test all kubernetes features

- [x] Tests are covering the bug fix or the new feature
