### PR TITLE
chore: fix unit tests to make them more reliable

### DIFF
--- a/packages/main/src/plugin/onboarding-registry.spec.ts
+++ b/packages/main/src/plugin/onboarding-registry.spec.ts
@@ -45,7 +45,6 @@ const configurationRegistry = {
 } as unknown as ConfigurationRegistry;
 
 const readFileSync = vi.spyOn(fs, 'readFileSync');
-const bufferFrom = vi.spyOn(Buffer, 'from');
 const apiSender: ApiSenderType = { send: vi.fn() } as unknown as ApiSenderType;
 const context = new Context(apiSender);
 
@@ -84,7 +83,6 @@ describe('an OnboardingRegistry instance exists', () => {
 
     vi.mock('node:fs');
     readFileSync.mockReturnValue(JSON.stringify({}));
-    bufferFrom.mockReturnValue(Buffer.from(''));
   });
 
   test('Should always return onboarding', async () => {

--- a/packages/main/src/util.spec.ts
+++ b/packages/main/src/util.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,12 +42,9 @@ test('getBase64Image - return undefined if erroring durin execution', () => {
 });
 
 test('getBase64Image - return base64 image', () => {
-  const buffer: Buffer = {} as Buffer;
   vi.spyOn(fs, 'existsSync').mockReturnValue(true);
-  vi.spyOn(fs, 'readFileSync').mockReturnValue('file');
-  vi.spyOn(Buffer, 'from').mockReturnValue(buffer);
-  vi.spyOn(buffer, 'toString').mockReturnValue('image');
+  vi.spyOn(fs, 'readFileSync').mockReturnValue('image');
 
   const result = getBase64Image('path');
-  expect(result).toBe('data:image/png;base64,image');
+  expect(result).toBe('data:image/png;base64,aW1hZ2U=');
 });

--- a/packages/main/src/util.ts
+++ b/packages/main/src/util.ts
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { Buffer } from 'node:buffer';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 

--- a/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretList.spec.ts
+++ b/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretList.spec.ts
@@ -91,15 +91,15 @@ test('Expect configmap and secrets list', async () => {
 
   await waitRender({});
 
-  const configMapName = screen.getByRole('cell', { name: 'my-configmap my-namespace' });
-  expect(configMapName).toBeInTheDocument();
+  const configMapNames = screen.getAllByRole('cell', { name: 'my-configmap my-namespace' });
+  expect(configMapNames.length).toBeGreaterThan(0);
   // Expect ConfigMap type
-  const configMapType = screen.getByRole('cell', { name: 'ConfigMap' });
-  expect(configMapType).toBeInTheDocument();
+  const configMapTypes = screen.getAllByRole('cell', { name: 'ConfigMap' });
+  expect(configMapTypes.length).toBeGreaterThan(0);
 
-  const secretName = screen.getByRole('cell', { name: 'my-secret my-namespace' });
-  expect(secretName).toBeInTheDocument();
+  const secretNames = screen.getAllByRole('cell', { name: 'my-secret my-namespace' });
+  expect(secretNames.length).toBeGreaterThan(0);
   // Expect Opaque type
-  const secretType = screen.getByRole('cell', { name: 'Opaque' });
-  expect(secretType).toBeInTheDocument();
+  const secretTypes = screen.getAllByRole('cell', { name: 'Opaque' });
+  expect(secretTypes.length).toBeGreaterThan(0);
 });

--- a/packages/renderer/src/lib/learning-center/GuideCard.spec.ts
+++ b/packages/renderer/src/lib/learning-center/GuideCard.spec.ts
@@ -25,19 +25,20 @@ import { afterEach, beforeEach, expect, suite, test, vi } from 'vitest';
 
 import GuideCard from './GuideCard.svelte';
 
+beforeEach(() => {
+  (window as any).openExternal = vi.fn();
+  (window as any).telemetryTrack = vi.fn();
+});
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
 suite('Guide card', () => {
   beforeEach(() => {
     render(GuideCard, {
       guide: { id: 'id', url: 'url', title: 'title', description: 'description', categories: [], icon: 'icon' },
       width: 300,
       height: 300,
-    });
-    beforeEach(() => {
-      (window as any).openExternal = vi.fn();
-      (window as any).telemetryTrack = vi.fn();
-    });
-    afterEach(() => {
-      vi.resetAllMocks();
     });
   });
 

--- a/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -245,6 +245,8 @@ test('Expect to create routes with OpenShift and open Link', async () => {
       },
     },
   });
+
+  await tick();
 
   // now, grab the link 'openRoute' with name 'hello-8080'
   const openRouteButton = screen.getByRole('link', { name: 'hello-8080' });

--- a/packages/renderer/src/stores/event-store.spec.ts
+++ b/packages/renderer/src/stores/event-store.spec.ts
@@ -91,19 +91,15 @@ test('should call fetch method using window event', async () => {
 
   await callback();
 
-  // wait updater method being called
-  while (updater.mock.calls.length === 0) {
-    await new Promise(resolve => setTimeout(resolve, 100));
-  }
-
   // check the updater is called
-  expect(updater).toHaveBeenCalled();
+  await vi.waitFor(() => {
+    expect(updater).toHaveBeenCalled();
+  });
 
   // check the store is updated
-  expect(get(myStoreInfo)).toStrictEqual([myCustomTypeInfo]);
-
-  // check the store is updated
-  expect(get(myStoreInfo)).toStrictEqual([myCustomTypeInfo]);
+  await vi.waitFor(() => {
+    expect(get(myStoreInfo)).toStrictEqual([myCustomTypeInfo]);
+  });
 
   // check buffer events
   expect(eventStoreInfo.bufferEvents.length).toBe(1);
@@ -154,16 +150,15 @@ test('should call fetch method using listener event', async () => {
 
   await callback();
 
-  // wait updater being called
-  while (updater.mock.calls.length === 0) {
-    await new Promise(resolve => setTimeout(resolve, 100));
-  }
-
   // check the updater is called
-  expect(updater).toHaveBeenCalled();
+  await vi.waitFor(() => {
+    expect(updater).toHaveBeenCalled();
+  });
 
   // check the store is updated
-  expect(get(myStoreInfo)).toStrictEqual([myCustomTypeInfo]);
+  await vi.waitFor(() => {
+    expect(get(myStoreInfo)).toStrictEqual([myCustomTypeInfo]);
+  });
 
   // check buffer events
   expect(eventStoreInfo.bufferEvents.length).toBe(1);


### PR DESCRIPTION
### What does this PR do?
with the new vitest version, mocking Buffer is for example hanging all the processes for other tests, some ticks are missing
or some wait

it's mainly due on how the pooling is used (vitest 2 change the pool/fork/thread usage)

Here there is no update to vitest component but it should ensure tests are still passing with the current vitest

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
