### PR TITLE
feat: support cli tool installer

### DIFF
--- a/extensions/compose/src/extension.spec.ts
+++ b/extensions/compose/src/extension.spec.ts
@@ -80,6 +80,7 @@ const composeDownloadMock = {
 
 const cliToolMock = {
   registerUpdate: vi.fn(),
+  registerInstaller: vi.fn(),
   updateVersion: vi.fn(),
   dispose: vi.fn(),
 } as unknown as CliTool;
@@ -231,6 +232,7 @@ describe('registerCLITool', () => {
       });
     });
 
+    expect(cliToolMock.registerInstaller).toHaveBeenCalled();
     expect(cliToolMock.registerUpdate).toHaveBeenCalled();
   });
 
@@ -258,6 +260,7 @@ describe('registerCLITool', () => {
       });
     });
 
+    expect(cliToolMock.registerInstaller).toHaveBeenCalled();
     expect(cliToolMock.registerUpdate).not.toHaveBeenCalled();
   });
 
@@ -273,6 +276,10 @@ describe('registerCLITool', () => {
 
     await vi.waitFor(() => {
       expect(extensionApi.cli.createCliTool).toHaveBeenCalled();
+      expect(cliToolMock.registerInstaller).toHaveBeenCalledWith({
+        selectVersion: expect.any(Function),
+        doInstall: expect.any(Function),
+      });
       expect(cliToolMock.registerUpdate).toHaveBeenCalledWith({
         selectVersion: expect.any(Function),
         doUpdate: expect.any(Function),
@@ -313,6 +320,86 @@ describe('registerCLITool', () => {
     });
     expect(detectMock.getStoragePath).toHaveBeenCalled();
     expect(cliRun.installBinaryToSystem).toHaveBeenCalledWith('extension-storage-path', 'docker-compose');
+    expect(cliToolMock.updateVersion).toHaveBeenCalledWith({
+      installationSource: 'extension',
+      version: '1.0.0',
+    });
+  });
+
+  test('try to install when there is already an existing version should throw an error', async () => {
+    vi.mocked(detectMock.checkSystemWideDockerCompose).mockResolvedValue(true);
+    vi.mocked(detectMock.getDockerComposeBinaryInfo).mockResolvedValue({
+      version: 'v0.0.0',
+      path: 'system-wide-path',
+      updatable: true,
+    });
+    vi.spyOn(cliRun, 'getSystemBinaryPath').mockReturnValue('system-wide-path');
+
+    let installer: extensionApi.CliToolInstaller | undefined;
+    vi.mocked(cliToolMock.registerInstaller).mockImplementation(mInstaller => {
+      installer = mInstaller;
+      return { dispose: vi.fn() };
+    });
+
+    await activate(extensionContextMock);
+
+    await vi.waitFor(() => {
+      expect(installer).toBeDefined();
+    });
+
+    await expect(() => installer?.doInstall({} as unknown as Logger)).rejects.toThrowError(
+      `Cannot install docker-compose. Version 0.0.0 is already installed.`,
+    );
+  });
+
+  test('try to install before selecting cli tool version should throw an error', async () => {
+    vi.mocked(detectMock.checkSystemWideDockerCompose).mockResolvedValue(false);
+    vi.mocked(detectMock.getStoragePath).mockResolvedValue('');
+
+    let installer: extensionApi.CliToolInstaller | undefined;
+    vi.mocked(cliToolMock.registerInstaller).mockImplementation(mInstaller => {
+      installer = mInstaller;
+      return { dispose: vi.fn() };
+    });
+
+    await activate(extensionContextMock);
+
+    await vi.waitFor(() => {
+      expect(installer).toBeDefined();
+    });
+
+    await expect(() => installer?.doInstall({} as unknown as Logger)).rejects.toThrowError(
+      `Cannot install docker-compose. No release selected.`,
+    );
+  });
+
+  test('after selecting the version to be installed it should download compose', async () => {
+    vi.mocked(detectMock.checkSystemWideDockerCompose).mockResolvedValue(false);
+    vi.mocked(detectMock.getStoragePath).mockResolvedValue('');
+    vi.mocked(composeDownloadMock.promptUserForVersion).mockResolvedValue({
+      tag: 'v1.0.0',
+    } as unknown as ComposeGithubReleaseArtifactMetadata);
+
+    let installer: extensionApi.CliToolInstaller | undefined;
+    vi.mocked(cliToolMock.registerInstaller).mockImplementation(mInstaller => {
+      installer = mInstaller;
+      return { dispose: vi.fn() };
+    });
+
+    await activate(extensionContextMock);
+
+    await vi.waitFor(() => {
+      expect(installer).toBeDefined();
+    });
+
+    await installer?.selectVersion();
+
+    await installer?.doInstall({} as unknown as Logger);
+    expect(composeDownloadMock.download).toHaveBeenCalledWith({
+      tag: 'v1.0.0',
+    });
+    expect(detectMock.getStoragePath).toHaveBeenCalled();
+    expect(cliRun.installBinaryToSystem).toHaveBeenCalledWith('', 'docker-compose');
     expect(cliToolMock.updateVersion).toHaveBeenCalledWith({
       installationSource: 'extension',
       version: '1.0.0',

--- a/extensions/compose/src/extension.ts
+++ b/extensions/compose/src/extension.ts
@@ -262,11 +262,13 @@ async function registerCLITool(composeDownload: ComposeDownload, detect: Detect)
 
   // update existing CLI tool
   if (composeCliTool) {
-    composeCliTool.updateVersion({
-      version: binaryVersion,
-      path: binaryPath,
-      installationSource,
-    });
+    if (binaryVersion) {
+      composeCliTool.updateVersion({
+        version: binaryVersion,
+        path: binaryPath,
+        installationSource,
+      });
+    }
   } else {
     // Register the CLI tool so it appears in the preferences page.
     composeCliTool = extensionApi.cli.createCliTool({

--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -18,15 +18,7 @@
 
 import * as path from 'node:path';
 
-import type {
-  AuditRequestItems,
-  CancellationToken,
-  CliTool,
-  ExtensionContext,
-  Logger,
-  StatusBarItem,
-  TelemetryLogger,
-} from '@podman-desktop/api';
+import type { AuditRequestItems, CancellationToken, CliTool, Logger, StatusBarItem } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
 import { ProgressLocation, window } from '@podman-desktop/api';
 
@@ -357,40 +349,39 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
     }
   }
 
-  // if the binary exists (either system-wide or in extension storage)
+  // if the binary exists (either system-wide or in extension storage), we get its version/path
+  let binaryVersion: string | undefined;
+  let binaryPath: string | undefined;
+  if (binary) {
+    binaryVersion = binary.version;
+    binaryPath = binary.path;
+    kindPath = binaryPath;
+  }
   // we register it
-  if (binary && installationSource) {
-    kindPath = binary.path;
-    kindCli = extensionApi.cli.createCliTool({
-      name: 'kind',
-      images: {
-        icon: './icon.png',
-      },
-      version: binary.version,
-      path: binary.path,
-      displayName: 'kind',
-      markdownDescription: KIND_MARKDOWN,
-      installationSource,
-    });
-  }
+  kindCli = extensionApi.cli.createCliTool({
+    name: 'kind',
+    images: {
+      icon: './icon.png',
+    },
+    version: binaryVersion,
+    path: binaryPath,
+    displayName: 'kind',
+    markdownDescription: KIND_MARKDOWN,
+    installationSource,
+  });
 
-  // if the CLI tool exists, let's create a provider
-  if (kindCli) {
-    await createProvider(extensionContext, telemetryLogger);
-    return;
-  }
+  // let's create a provider
+  await createProvider(extensionContext, telemetryLogger);
 
   // if we do not have anything installed, let's add it to the status bar
-  if (await installer.isAvailable()) {
+  if (!binaryVersion && (await installer.isAvailable())) {
     const statusBarItem = extensionApi.window.createStatusBarItem();
     statusBarItem.text = 'Kind';
     statusBarItem.tooltip = 'Kind not found on your system, click to download and install it';
     statusBarItem.command = KIND_INSTALL_COMMAND;
     statusBarItem.iconClass = 'fa fa-exclamation-triangle';
     extensionContext.subscriptions.push(
-      extensionApi.commands.registerCommand(KIND_INSTALL_COMMAND, () =>
-        kindInstall(installer, statusBarItem, extensionContext, telemetryLogger),
-      ),
+      extensionApi.commands.registerCommand(KIND_INSTALL_COMMAND, () => kindInstall(installer, statusBarItem)),
       statusBarItem,
     );
     statusBarItem.show();
@@ -404,13 +395,8 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
  * @param extensionContext
  * @param telemetryLogger
  */
-async function kindInstall(
-  installer: KindInstaller,
-  statusBarItem: StatusBarItem,
-  extensionContext: ExtensionContext,
-  telemetryLogger: TelemetryLogger,
-): Promise<void> {
-  if (kindCli || kindPath) throw new Error('kind cli is already registered');
+async function kindInstall(installer: KindInstaller, statusBarItem: StatusBarItem): Promise<void> {
+  if (kindPath) throw new Error('kind cli is already registered');
 
   let path: string;
   try {
@@ -426,19 +412,10 @@ async function kindInstall(
   const binaryInfo = await getKindBinaryInfo(path);
 
   kindPath = path;
-  kindCli = extensionApi.cli.createCliTool({
-    name: 'kind',
-    images: {
-      icon: './icon.png',
-    },
+  kindCli?.updateVersion({
     version: binaryInfo.version,
     path: binaryInfo.path,
-    displayName: 'kind',
-    markdownDescription: KIND_MARKDOWN,
-    installationSource: 'extension',
   });
-
-  await createProvider(extensionContext, telemetryLogger);
 }
 
 export function deactivate(): void {

--- a/packages/api/src/cli-tool-info.ts
+++ b/packages/api/src/cli-tool-info.ts
@@ -36,4 +36,5 @@ export interface CliToolInfo {
   path?: string;
   newVersion?: string;
   canUpdate: boolean;
+  canInstall: boolean;
 }

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -4335,7 +4335,7 @@ declare module '@podman-desktop/api' {
    * Options to update CliTool instance
    */
   export interface CliToolUpdateOptions {
-    version?: string;
+    version: string;
     displayName?: string;
     markdownDescription?: string;
     images?: ProviderImages;
@@ -4373,7 +4373,7 @@ declare module '@podman-desktop/api' {
     };
 
     updateVersion(version: CliToolUpdateOptions): void;
-    onDidUpdateVersion: Event<string | undefined>;
+    onDidUpdateVersion: Event<string>;
 
     // register cli update flow
     registerUpdate(update: CliToolUpdate | CliToolSelectUpdate): Disposable;

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -4318,9 +4318,10 @@ declare module '@podman-desktop/api' {
      * Passing in path will also help to show where the CLI tool is expected to be installed.
      * This is usually the ~/.local/share/containers/podman-desktop/extensions-storage directory.
      * Note: The expected value should not include 'v'.
+     * Note: If the version and path are not defined (= the tool is not installed), the install logic should be implemented
      */
-    version: string;
-    path: string;
+    version?: string;
+    path?: string;
 
     /**
      * How the cli tool has been installed
@@ -4334,7 +4335,7 @@ declare module '@podman-desktop/api' {
    * Options to update CliTool instance
    */
   export interface CliToolUpdateOptions {
-    version: string;
+    version?: string;
     displayName?: string;
     markdownDescription?: string;
     images?: ProviderImages;
@@ -4352,6 +4353,11 @@ declare module '@podman-desktop/api' {
     doUpdate: (logger: Logger) => Promise<void>;
   }
 
+  export interface CliToolInstaller {
+    selectVersion: () => Promise<string>;
+    doInstall: (logger: Logger) => Promise<void>;
+  }
+
   export type CliToolState = 'registered';
 
   export interface CliTool extends Disposable {
@@ -4367,10 +4373,13 @@ declare module '@podman-desktop/api' {
     };
 
     updateVersion(version: CliToolUpdateOptions): void;
-    onDidUpdateVersion: Event<string>;
+    onDidUpdateVersion: Event<string | undefined>;
 
     // register cli update flow
     registerUpdate(update: CliToolUpdate | CliToolSelectUpdate): Disposable;
+
+    // register cli installer
+    registerInstaller(installer: CliToolInstaller): Disposable;
   }
 
   /**

--- a/packages/main/src/plugin/cli-tool-impl.ts
+++ b/packages/main/src/plugin/cli-tool-impl.ts
@@ -19,6 +19,7 @@
 import type {
   CliTool,
   CliToolInstallationSource,
+  CliToolInstaller,
   CliToolOptions,
   CliToolSelectUpdate,
   CliToolState,
@@ -39,8 +40,8 @@ import type { Exec } from './util/exec.js';
 export class CliToolImpl implements CliTool, Disposable {
   readonly id: string;
   private _state: CliToolState = 'registered';
-  private readonly _onDidUpdateVersion = new Emitter<string>();
-  readonly onDidUpdateVersion: Event<string> = this._onDidUpdateVersion.event;
+  private readonly _onDidUpdateVersion = new Emitter<string | undefined>();
+  readonly onDidUpdateVersion: Event<string | undefined> = this._onDidUpdateVersion.event;
 
   constructor(
     private _apiSender: ApiSenderType,
@@ -68,11 +69,11 @@ export class CliToolImpl implements CliTool, Disposable {
     return this._options.markdownDescription;
   }
 
-  get version(): string {
+  get version(): string | undefined {
     return this._options.version;
   }
 
-  get path(): string {
+  get path(): string | undefined {
     return this._options.path;
   }
 
@@ -104,5 +105,9 @@ export class CliToolImpl implements CliTool, Disposable {
 
   registerUpdate(update: CliToolUpdate | CliToolSelectUpdate): Disposable {
     return this.registry.registerUpdate(this, update);
+  }
+
+  registerInstaller(installer: CliToolInstaller): Disposable {
+    return this.registry.registerInstaller(this, installer);
   }
 }

--- a/packages/main/src/plugin/cli-tool-impl.ts
+++ b/packages/main/src/plugin/cli-tool-impl.ts
@@ -40,8 +40,8 @@ import type { Exec } from './util/exec.js';
 export class CliToolImpl implements CliTool, Disposable {
   readonly id: string;
   private _state: CliToolState = 'registered';
-  private readonly _onDidUpdateVersion = new Emitter<string | undefined>();
-  readonly onDidUpdateVersion: Event<string | undefined> = this._onDidUpdateVersion.event;
+  private readonly _onDidUpdateVersion = new Emitter<string>();
+  readonly onDidUpdateVersion: Event<string> = this._onDidUpdateVersion.event;
 
   constructor(
     private _apiSender: ApiSenderType,

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1276,6 +1276,28 @@ export class PluginSystem {
       },
     );
 
+    this.ipcHandle(
+      'cli-tool-registry:selectCliToolVersionToInstall',
+      async (_listener, id: string): Promise<string> => {
+        return cliToolRegistry.selectCliToolVersionToInstall(id);
+      },
+    );
+
+    this.ipcHandle(
+      'cli-tool-registry:installCliTool',
+      async (_listener, id: string, loggerId: string): Promise<void> => {
+        const logger = this.getLogHandler('provider-registry:installCliTool-onData', loggerId);
+        try {
+          await cliToolRegistry.installCliTool(id, logger);
+        } catch (error) {
+          logger.error(error);
+          throw error;
+        } finally {
+          logger.onEnd();
+        }
+      },
+    );
+
     this.ipcHandle('menu-registry:getContributedMenus', async (_, context: string): Promise<Menu[]> => {
       return menuRegistry.getContributedMenus(context);
     });

--- a/packages/renderer/src/lib/preferences/PreferencesCliTool.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesCliTool.spec.ts
@@ -42,6 +42,7 @@ const cliToolInfoItem1: CliToolInfo = {
   },
   path: 'path/to/tool-name-1',
   canUpdate: false,
+  canInstall: false,
 };
 
 const cliToolInfoItem2: CliToolInfo = {
@@ -57,6 +58,7 @@ const cliToolInfoItem2: CliToolInfo = {
   version: '1.0.1',
   path: 'path/to/tool-name-2',
   canUpdate: false,
+  canInstall: false,
 };
 
 const cliToolInfoItem3: CliToolInfo = {
@@ -73,6 +75,7 @@ const cliToolInfoItem3: CliToolInfo = {
   path: 'path/to/tool-name-3',
   newVersion: '2.0.1',
   canUpdate: true,
+  canInstall: false,
 };
 
 const cliToolInfoItem4: CliToolInfo = {
@@ -88,6 +91,35 @@ const cliToolInfoItem4: CliToolInfo = {
   version: '1.0.1',
   path: 'path/to/tool-name-4',
   canUpdate: true,
+  canInstall: false,
+};
+
+const cliToolInfoItem5: CliToolInfo = {
+  id: 'ext-id.tool-name4',
+  name: 'tool-name4',
+  description: 'markdown description4',
+  displayName: 'tools-display-name4',
+  state: 'registered',
+  extensionInfo: {
+    id: 'ext-id4',
+    label: 'ext-label4',
+  },
+  canUpdate: false,
+  canInstall: false,
+};
+
+const cliToolInfoItem6: CliToolInfo = {
+  id: 'ext-id.tool-name4',
+  name: 'tool-name4',
+  description: 'markdown description4',
+  displayName: 'tools-display-name4',
+  state: 'registered',
+  extensionInfo: {
+    id: 'ext-id4',
+    label: 'ext-label4',
+  },
+  canUpdate: false,
+  canInstall: true,
 };
 
 const updateCliToolMock = vi.fn();
@@ -206,5 +238,50 @@ suite('CLI Tool item', () => {
     const updateLoadingButton = screen.getByRole('button', { name: 'Update' });
     expect(updateLoadingButton).toBeInTheDocument();
     expect(updateLoadingButton).toBeEnabled();
+  });
+
+  test('check no install button is displayed if there is no version and no installer registered', async () => {
+    render(PreferencesCliTool, {
+      cliTool: cliToolInfoItem5,
+    });
+    const nameElement = screen.getByLabelText('cli-name');
+    expect(nameElement).toBeDefined();
+    expect(nameElement.textContent).equal(cliToolInfoItem4.name);
+    const registeredByElement = screen.getByLabelText('cli-registered-by');
+    expect(registeredByElement).toBeDefined();
+    expect(registeredByElement.textContent).equal(`Registered by ${cliToolInfoItem4.extensionInfo.label}`);
+    const displayNameElement = screen.getByLabelText('cli-display-name');
+    expect(displayNameElement).toBeDefined();
+    expect(displayNameElement.textContent).equal(cliToolInfoItem4.displayName);
+    const versionElement = screen.queryByLabelText('cli-version');
+    expect(versionElement).not.toBeInTheDocument();
+    const noVersionElement = screen.getByLabelText('no-cli-version');
+    expect(noVersionElement).toBeDefined();
+    expect(noVersionElement.textContent).equal('No version detected');
+    const installLoadingButton = screen.queryByRole('button', { name: 'Install' });
+    expect(installLoadingButton).not.toBeInTheDocument();
+  });
+
+  test('check the install button is displayed if there is no version and an installer has been registered', async () => {
+    render(PreferencesCliTool, {
+      cliTool: cliToolInfoItem6,
+    });
+    const nameElement = screen.getByLabelText('cli-name');
+    expect(nameElement).toBeDefined();
+    expect(nameElement.textContent).equal(cliToolInfoItem4.name);
+    const registeredByElement = screen.getByLabelText('cli-registered-by');
+    expect(registeredByElement).toBeDefined();
+    expect(registeredByElement.textContent).equal(`Registered by ${cliToolInfoItem4.extensionInfo.label}`);
+    const displayNameElement = screen.getByLabelText('cli-display-name');
+    expect(displayNameElement).toBeDefined();
+    expect(displayNameElement.textContent).equal(cliToolInfoItem4.displayName);
+    const versionElement = screen.queryByLabelText('cli-version');
+    expect(versionElement).not.toBeInTheDocument();
+    const noVersionElement = screen.getByLabelText('no-cli-version');
+    expect(noVersionElement).toBeDefined();
+    expect(noVersionElement.textContent).equal('No version detected');
+    const installLoadingButton = screen.getByRole('button', { name: 'Install' });
+    expect(installLoadingButton).toBeInTheDocument();
+    expect(installLoadingButton).toBeEnabled();
   });
 });

--- a/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
@@ -12,6 +12,7 @@ import type { ILoadingStatus } from './Util';
 
 export let cliTool: CliToolInfo;
 let showError = false;
+let errorMessage = '';
 let newVersion: string | undefined = cliTool.newVersion;
 let cliToolUpdateStatus: ILoadingStatus;
 $: cliToolUpdateStatus = {
@@ -51,6 +52,7 @@ async function update(cliTool: CliToolInfo) {
     await window.updateCliTool(cliTool.id, loggerHandlerKey, eventCollect);
     showError = false;
   } catch (e) {
+    errorMessage = `Unable to update ${cliTool.displayName} to version ${newVersion}.`;
     showError = true;
   } finally {
     cliToolUpdateStatus.inProgress = false;
@@ -65,7 +67,9 @@ async function install(cliTool: CliToolInfo) {
     versionToInstall = await window.selectCliToolVersionToInstall(cliTool.id);
   } catch (e) {
     // do nothing
-    console.log(e);
+    errorMessage = `Error when selecting a version: ${String(e)}`;
+    console.error(e);
+    showError = true;
   }
   if (!versionToInstall) {
     return;
@@ -81,6 +85,7 @@ async function install(cliTool: CliToolInfo) {
     await window.installCliTool(cliTool.id, loggerHandlerKey, eventCollect);
     showError = false;
   } catch (e) {
+    errorMessage = `Unable to install ${cliTool.displayName} to version ${versionToInstall}.`;
     showError = true;
   } finally {
     cliToolInstallStatus.inProgress = false;
@@ -240,7 +245,7 @@ function getLoggerHandler(_cliToolId: string): ConnectionCallback {
   {#if showError}
     <div class="flex flex-row items-center text-xs text-red-400 ml-[200px] mt-2">
       <Fa icon={faCircleXmark} class="mr-1 text-red-500" />
-      <span>Unable to update {cliTool.displayName} to version {cliTool.newVersion}. </span>
+      <span>{errorMessage}</span>
       <Button
         type="link"
         padding="p-0"

--- a/packages/renderer/src/lib/preferences/PreferencesCliToolsRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesCliToolsRendering.spec.ts
@@ -46,6 +46,7 @@ const cliToolInfoItem1: CliToolInfo = {
   version: '1.0.1',
   path: 'path/to/tool-name-1',
   canUpdate: false,
+  canInstall: false,
 };
 
 const cliToolInfoItem2: CliToolInfo = {
@@ -62,6 +63,7 @@ const cliToolInfoItem2: CliToolInfo = {
   version: '1.0.2',
   path: 'path/to/tool-name-2',
   canUpdate: false,
+  canInstall: false,
 };
 
 const cliToolInfoItem3: CliToolInfo = {
@@ -80,6 +82,7 @@ const cliToolInfoItem3: CliToolInfo = {
   version: '1.0.3',
   path: 'path/to/tool-name-3',
   canUpdate: false,
+  canInstall: false,
 };
 
 const cliToolInfoItem4: CliToolInfo = {
@@ -96,6 +99,7 @@ const cliToolInfoItem4: CliToolInfo = {
   version: '', // version is empty, so it should be showing the error
   path: '',
   canUpdate: false,
+  canInstall: false,
 };
 
 suite('CLI Tool Prefernces page shows', () => {


### PR DESCRIPTION
### What does this PR do?

It enables extensions to register an installer so that a cli tool can be installed from the cli tools page.

The uninstall will be added in a separate PR.
I didn't modified how the kind extension works. If not installed, there is always the item in the statusbar, but we can add an installer as the other extensions in a follow-up

### Screenshot / video of UI

![install_cli_tool](https://github.com/user-attachments/assets/1a77c72a-9c8d-4414-94fd-7f054915c112)

### What issues does this PR fix or reference?

it is part of #8003 

### How to test this PR?

1. uninstall compose, kind, kubectl
2. go to the tools page and install them

- [x] Tests are covering the bug fix or the new feature
