### PR TITLE
Pretty display command in image layer

### DIFF
--- a/packages/renderer/src/lib/image/ImageDetailsFilesExpandableCommand.spec.ts
+++ b/packages/renderer/src/lib/image/ImageDetailsFilesExpandableCommand.spec.ts
@@ -1,0 +1,77 @@
+/**********************************************************************
+ * Copyright (C) 2023-2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { expect, test } from 'vitest';
+
+import ImageDetailsFilesExpandableCommand from './ImageDetailsFilesExpandableCommand.svelte';
+
+test('command with more than 2 lines', async () => {
+  render(ImageDetailsFilesExpandableCommand, {
+    command: `RUN command1    command2\tcommand3\ncommand4`,
+  });
+
+  // Initial display
+  let text = screen.getByText(/RUN command1/);
+  expect(text).toBeInTheDocument();
+  expect(text.innerHTML).toEqual(`RUN command1\n    command2`);
+
+  let more = screen.queryByText('show more');
+  let less = screen.queryByText('show less');
+  expect(more).toBeInTheDocument();
+  expect(less).not.toBeInTheDocument();
+
+  // Display more
+  await userEvent.click(more!);
+  less = screen.queryByText('show less');
+  more = screen.queryByText('show more');
+  expect(more).not.toBeInTheDocument();
+  expect(less).toBeInTheDocument();
+
+  text = screen.getByText(/RUN command1/);
+  expect(text).toBeInTheDocument();
+  expect(text.innerHTML).toEqual(`RUN command1\n    command2\n\tcommand3\ncommand4`);
+
+  // Display less
+  await userEvent.click(less!);
+  less = screen.queryByText('show less');
+  more = screen.queryByText('show more');
+  expect(more).toBeInTheDocument();
+  expect(less).not.toBeInTheDocument();
+
+  text = screen.getByText(/RUN command1/);
+  expect(text).toBeInTheDocument();
+  expect(text.innerHTML).toEqual(`RUN command1\n    command2`);
+});
+
+test('command with 2 lines', async () => {
+  render(ImageDetailsFilesExpandableCommand, {
+    command: `RUN command1  command2`,
+  });
+  const text = screen.getByText(/RUN command1/);
+  expect(text).toBeInTheDocument();
+  expect(text.innerHTML).toEqual(`RUN command1\n  command2`);
+
+  const more = screen.queryByText('show more');
+  const less = screen.queryByText('show less');
+  expect(more).not.toBeInTheDocument();
+  expect(less).not.toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/image/ImageDetailsFilesExpandableCommand.svelte
+++ b/packages/renderer/src/lib/image/ImageDetailsFilesExpandableCommand.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+import { onMount } from 'svelte';
+
+export let command: string = '';
+
+let formatted: string = '';
+let header: string = '';
+let short: boolean = false;
+let moreDisplayed: boolean = false;
+
+onMount(() => {
+  // add a newline before a tab or several spaces
+  formatted = command.replaceAll(/(  +|\t+)/g, '\n$1') || '';
+  const lines = formatted.split('\n');
+  const headerLines = lines.slice(0, 2);
+  header = headerLines.join('\n');
+  short = headerLines.length < lines.length;
+});
+</script>
+
+<div class="font-mono whitespace-pre-wrap break-all">{moreDisplayed ? formatted : header}</div>
+{#if short}
+  <button
+    class="text-xs underline decoration-dashed"
+    on:click={() => {
+      moreDisplayed = !moreDisplayed;
+    }}>{moreDisplayed ? 'show less' : 'show more'}</button>
+{/if}

--- a/packages/renderer/src/lib/image/ImageDetailsFilesLayers.svelte
+++ b/packages/renderer/src/lib/image/ImageDetailsFilesLayers.svelte
@@ -3,6 +3,7 @@ import { createEventDispatcher } from 'svelte';
 
 import { ImageUtils } from './image-utils';
 import type { ImageFilesystemLayerUI } from './imageDetailsFiles';
+import ImageDetailsFilesExpandableCommand from './ImageDetailsFilesExpandableCommand.svelte';
 
 const dispatch = createEventDispatcher();
 
@@ -20,11 +21,11 @@ function onLayerSelected(layer: ImageFilesystemLayerUI) {
     on:click={() => onLayerSelected(layer)}
     role="row"
     aria-label={layer.id}
-    class="rounded-lg mb-4 p-4 flex flex-col w-full text-left truncate hover:bg-[var(--pd-content-card-hover-bg)]"
+    class="rounded-lg mb-4 p-4 flex flex-col w-full text-left hover:bg-[var(--pd-content-card-hover-bg)]"
     class:bg-[var(--pd-content-card-bg)]={layer.id !== currentLayerId}
     class:bg-[var(--pd-content-card-selected-bg)]={layer.id === currentLayerId}>
     <div>
-      <div>{layer.createdBy}</div>
+      <ImageDetailsFilesExpandableCommand command={layer.createdBy} />
       <div class="text-sm opacity-70">{layer.id}</div>
       <div class="text-sm opacity-70">
         <span>{new ImageUtils().getHumanSize(layer.sizeInArchive)}</span>


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Display the command used to create an image layer with formatting, and displaying only the first 2 lines, with a `show more`/`show less` link helping displaying the full command 
 
### Screenshot / video of UI

https://github.com/user-attachments/assets/3ea1fe1a-b1e2-4975-abf9-008decf81c45

### What issues does this PR fix or reference?

Fixes #8156 

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
