### PR TITLE
chore: migrate the types for vitest

### DIFF
--- a/extensions/compose/src/detect.spec.ts
+++ b/extensions/compose/src/detect.spec.ts
@@ -25,7 +25,7 @@ import * as path from 'node:path';
 
 import * as extensionApi from '@podman-desktop/api';
 import * as shellPath from 'shell-path';
-import type { Mock, SpyInstance } from 'vitest';
+import type { Mock, MockInstance } from 'vitest';
 import { afterEach, beforeEach, describe, expect, test, vi, vitest } from 'vitest';
 
 import { Detect } from './detect';
@@ -246,7 +246,7 @@ describe('Check docker socket', async () => {
       };
     });
 
-    const spyGet = vi.spyOn(http, 'get') as unknown as SpyInstance;
+    const spyGet = vi.spyOn(http, 'get') as unknown as MockInstance;
     const clientRequestEmitter = new EventEmitter();
     const myRequest = clientRequestEmitter as unknown as http.ClientRequest;
 
@@ -279,7 +279,7 @@ describe('Check docker socket', async () => {
       };
     });
 
-    const spyGet = vi.spyOn(http, 'get') as unknown as SpyInstance;
+    const spyGet = vi.spyOn(http, 'get') as unknown as MockInstance;
     const clientRequestEmitter = new EventEmitter();
     const myRequest = clientRequestEmitter as unknown as http.ClientRequest;
 
@@ -309,7 +309,7 @@ describe('Check docker socket', async () => {
       };
     });
 
-    const spyGet = vi.spyOn(http, 'get') as unknown as SpyInstance;
+    const spyGet = vi.spyOn(http, 'get') as unknown as MockInstance;
     const clientRequestEmitter = new EventEmitter();
     const myRequest = clientRequestEmitter as unknown as http.ClientRequest;
     const spyOnce = vi.spyOn(clientRequestEmitter, 'once');

--- a/packages/main/src/plugin/module-loader.spec.ts
+++ b/packages/main/src/plugin/module-loader.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import type * as PodmanDesktop from '@podman-desktop/api';
-import type { SpyInstance } from 'vitest';
+import type { MockInstance } from 'vitest';
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
 import type { ExtensionModule } from './module-loader.js';
@@ -35,7 +35,7 @@ const fakeModule1 = {
 };
 const fakeApi = {} as typeof PodmanDesktop;
 
-let loadSpy: SpyInstance;
+let loadSpy: MockInstance;
 
 beforeEach(() => {
   loadSpy = vi.spyOn(fakeModule, '_load');

--- a/packages/main/src/plugin/webview/webview-registry.spec.ts
+++ b/packages/main/src/plugin/webview/webview-registry.spec.ts
@@ -75,7 +75,7 @@ const fakeRouter = {
   get: getRouterMock,
 } as unknown as Router;
 
-let spyRouter: MockInstance<[], Router>;
+let spyRouter: MockInstance<() => Router>;
 
 const currentConsoleLog = console.log;
 beforeEach(() => {

--- a/packages/preload-webview/src/webview-preload.spec.ts
+++ b/packages/preload-webview/src/webview-preload.spec.ts
@@ -94,10 +94,9 @@ vi.mock('electron', async () => {
 });
 
 let spyIpcRendererOn: MockInstance<
-  [channel: string, listener: (event: IpcRendererEvent, ...args: unknown[]) => void],
-  void
+  (channel: string, listener: (event: IpcRendererEvent, ...args: unknown[]) => void) => void
 >;
-let spyBuildApi: MockInstance<[], WebviewApi>;
+let spyBuildApi: MockInstance<() => WebviewApi>;
 beforeEach(() => {
   vi.resetAllMocks();
   webviewPreload = new TestWebwiewPreload('123');

--- a/packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.spec.ts
+++ b/packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.spec.ts
@@ -85,8 +85,8 @@ function mockExtensionInstallFromImage(): {
 } {
   const resolve = vi.fn();
   const reject = vi.fn();
-  const logCallback = vi.fn<[string], void>();
-  const errorCallback = vi.fn<[string], void>();
+  const logCallback = vi.fn<(data: string) => void>();
+  const errorCallback = vi.fn<(data: string) => void>();
   vi.mocked(window.extensionInstallFromImage).mockImplementation((_image, mLogCallback, mErrorCallback) => {
     logCallback.mockImplementation((content: string) => mLogCallback(content));
     errorCallback.mockImplementation((content: string) => mErrorCallback(content));

--- a/packages/renderer/src/stores/catalog-extensions.spec.ts
+++ b/packages/renderer/src/stores/catalog-extensions.spec.ts
@@ -37,7 +37,7 @@ const eventEmitter = {
   },
 };
 
-const getCatalogExtensionsMock: Mock<any, Promise<CatalogExtension[]>> = vi.fn();
+const getCatalogExtensionsMock: Mock<() => Promise<CatalogExtension[]>> = vi.fn();
 
 Object.defineProperty(global, 'window', {
   value: {

--- a/packages/renderer/src/stores/colors.spec.ts
+++ b/packages/renderer/src/stores/colors.spec.ts
@@ -41,7 +41,7 @@ vi.mock('../lib/appearance/appearance-util', () => {
   };
 });
 
-const listColorsMock: Mock<any, Promise<ColorInfo[]>> = vi.fn();
+const listColorsMock: Mock<() => Promise<ColorInfo[]>> = vi.fn();
 
 Object.defineProperty(global, 'window', {
   value: {

--- a/packages/renderer/src/stores/commands.spec.ts
+++ b/packages/renderer/src/stores/commands.spec.ts
@@ -34,7 +34,7 @@ const eventEmitter = {
   },
 };
 
-const getCommandPaletteCommandsMock: Mock<any, Promise<CommandInfo[]>> = vi.fn();
+const getCommandPaletteCommandsMock: Mock<() => Promise<CommandInfo[]>> = vi.fn();
 
 Object.defineProperty(global, 'window', {
   value: {

--- a/packages/renderer/src/stores/containers.spec.ts
+++ b/packages/renderer/src/stores/containers.spec.ts
@@ -34,7 +34,7 @@ const eventEmitter = {
   },
 };
 
-const listContainersMock: Mock<any, Promise<ContainerInfo[]>> = vi.fn();
+const listContainersMock: Mock<() => Promise<ContainerInfo[]>> = vi.fn();
 
 Object.defineProperty(global, 'window', {
   value: {

--- a/packages/renderer/src/stores/images.spec.ts
+++ b/packages/renderer/src/stores/images.spec.ts
@@ -34,7 +34,7 @@ const eventEmitter = {
   },
 };
 
-const listImagesMock: Mock<any, Promise<ImageInfo[]>> = vi.fn();
+const listImagesMock: Mock<() => Promise<ImageInfo[]>> = vi.fn();
 
 Object.defineProperty(global, 'window', {
   value: {

--- a/packages/renderer/src/stores/notifications.spec.ts
+++ b/packages/renderer/src/stores/notifications.spec.ts
@@ -34,7 +34,7 @@ const eventEmitter = {
   },
 };
 
-const listNotificationsMock: Mock<any, Promise<NotificationCard[]>> = vi.fn();
+const listNotificationsMock: Mock<() => Promise<NotificationCard[]>> = vi.fn();
 
 Object.defineProperty(global, 'window', {
   value: {

--- a/packages/renderer/src/stores/onboarding.spec.ts
+++ b/packages/renderer/src/stores/onboarding.spec.ts
@@ -34,7 +34,7 @@ const eventEmitter = {
   },
 };
 
-const listOnboardingMock: Mock<any, Promise<OnboardingInfo[]>> = vi.fn();
+const listOnboardingMock: Mock<() => Promise<OnboardingInfo[]>> = vi.fn();
 
 Object.defineProperty(global, 'window', {
   value: {

--- a/packages/renderer/src/stores/pods.spec.ts
+++ b/packages/renderer/src/stores/pods.spec.ts
@@ -33,7 +33,7 @@ const eventEmitter = {
   },
 };
 
-const listPodsMock: Mock<any, Promise<PodInfo[]>> = vi.fn();
+const listPodsMock: Mock<() => Promise<PodInfo[]>> = vi.fn();
 
 Object.defineProperty(global, 'window', {
   value: {

--- a/packages/renderer/src/stores/recommendedRegistries.spec.ts
+++ b/packages/renderer/src/stores/recommendedRegistries.spec.ts
@@ -37,7 +37,7 @@ const eventEmitter = {
   },
 };
 
-const getRecommendedRegistriesMock: Mock<any, Promise<RecommendedRegistry[]>> = vi.fn();
+const getRecommendedRegistriesMock: Mock<() => Promise<RecommendedRegistry[]>> = vi.fn();
 
 Object.defineProperty(global, 'window', {
   value: {

--- a/packages/renderer/src/stores/view.spec.ts
+++ b/packages/renderer/src/stores/view.spec.ts
@@ -34,7 +34,7 @@ const eventEmitter = {
   },
 };
 
-const listViewsMock: Mock<any, Promise<ViewInfoUI[]>> = vi.fn();
+const listViewsMock: Mock<() => Promise<ViewInfoUI[]>> = vi.fn();
 
 Object.defineProperty(global, 'window', {
   value: {

--- a/packages/renderer/src/stores/views.spec.ts
+++ b/packages/renderer/src/stores/views.spec.ts
@@ -34,7 +34,7 @@ const eventEmitter = {
   },
 };
 
-const listViewsMock: Mock<any, Promise<ViewInfoUI[]>> = vi.fn();
+const listViewsMock: Mock<() => Promise<ViewInfoUI[]>> = vi.fn();
 
 Object.defineProperty(global, 'window', {
   value: {

--- a/packages/renderer/src/stores/volumes.spec.ts
+++ b/packages/renderer/src/stores/volumes.spec.ts
@@ -34,7 +34,7 @@ const eventEmitter = {
   },
 };
 
-const listVolumesMock: Mock<any, Promise<VolumeInspectInfo[]>> = vi.fn();
+const listVolumesMock: Mock<() => Promise<VolumeInspectInfo[]>> = vi.fn();
 
 Object.defineProperty(global, 'window', {
   value: {


### PR DESCRIPTION
### What does this PR do?
fix code to use newer vitest

- SpyInstance is now MockInstance
- MockInstance generic is different

see https://vitest.dev/guide/migration

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
