### PR TITLE
fix: replace windows.location.href with handleNavigation call

### DIFF
--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -4,6 +4,8 @@
 import { onMount } from 'svelte';
 import type { TinroRouteMeta } from 'tinro';
 
+import { NavigationPage } from '/@api/navigation-page';
+
 import { CommandRegistry } from './lib/CommandRegistry';
 import NewContentOnDashboardBadge from './lib/dashboard/NewContentOnDashboardBadge.svelte';
 import AccountIcon from './lib/images/AccountIcon.svelte';
@@ -12,6 +14,7 @@ import SettingsIcon from './lib/images/SettingsIcon.svelte';
 import NavItem from './lib/ui/NavItem.svelte';
 import NavRegistryEntry from './lib/ui/NavRegistryEntry.svelte';
 import NavSection from './lib/ui/NavSection.svelte';
+import { handleNavigation } from './navigation';
 import { navigationRegistry } from './stores/navigation/navigation-registry';
 
 let { exitSettingsCallback, meta = $bindable() }: { exitSettingsCallback: () => void; meta: TinroRouteMeta } = $props();
@@ -27,7 +30,7 @@ function clickSettings(b: boolean) {
   if (b) {
     exitSettingsCallback();
   } else {
-    window.location.href = '#/preferences/resources';
+    handleNavigation({ page: NavigationPage.RESOURCES });
   }
 }
 </script>

--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -15,7 +15,9 @@ import { onDestroy, onMount } from 'svelte';
 import { get, type Unsubscriber } from 'svelte/store';
 import { router } from 'tinro';
 
+import { handleNavigation } from '/@/navigation';
 import type { ContainerInfo } from '/@api/container-info';
+import { NavigationPage } from '/@api/navigation-page';
 import type { ViewInfoUI } from '/@api/view-info';
 
 import type { PodInfo } from '../../../../main/src/plugin/api/pod-info';
@@ -59,7 +61,7 @@ $: updateContainers(containersInfo, globalContext, viewContributions, searchTerm
 
 function fromExistingImage(): void {
   openChoiceModal = false;
-  window.location.href = '#/images';
+  handleNavigation({ page: NavigationPage.IMAGES });
 }
 
 $: providerConnections = $providerInfos

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
@@ -9,7 +9,9 @@ import { onDestroy, onMount } from 'svelte';
 import { get } from 'svelte/store';
 
 import FileInput from '/@/lib/ui/FileInput.svelte';
+import { handleNavigation } from '/@/navigation';
 import { type BuildImageInfo, buildImagesInfo } from '/@/stores/build-images';
+import { NavigationPage } from '/@api/navigation-page';
 /* eslint-enable import/no-duplicates */
 import type { ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provider-info';
 
@@ -249,8 +251,8 @@ function cleanupBuild(): void {
     buildImageInfo = undefined;
   }
 
-  // redirect to the imlage list
-  window.location.href = '#/images';
+  // redirect to the image list
+  handleNavigation({ page: NavigationPage.IMAGES });
 }
 
 onMount(async () => {


### PR DESCRIPTION
### What does this PR do?

replaced `window.location.href = '#/location'` navigation to handleNavigation call which is using tinro router.goto() call instead.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Related to #5265.

### How to test this PR?

- [ ] Tests are covering the bug fix or the new feature
