### PR TITLE
feat: allow to uninstall cli tool

### DIFF
--- a/extensions/compose/src/extension.spec.ts
+++ b/extensions/compose/src/extension.spec.ts
@@ -353,7 +353,7 @@ describe('registerCLITool', () => {
     });
 
     await expect(() => installer?.doInstall({} as unknown as Logger)).rejects.toThrowError(
-      `Cannot install docker-compose. Version 0.0.0 is already installed.`,
+      `Cannot install docker-compose. Version 0.0.0 in system-wide-path is already installed.`,
     );
   });
 
@@ -437,5 +437,37 @@ describe('registerCLITool', () => {
     await installer?.doUninstall({} as unknown as Logger);
     expect(fs.promises.unlink).toHaveBeenNthCalledWith(1, 'storage-path');
     expect(fs.promises.unlink).toHaveBeenNthCalledWith(2, 'system-wide-path');
+  });
+
+  test('if unlink fails because of a permission issue, it should delete all binaries as admin', async () => {
+    vi.mocked(detectMock.checkSystemWideDockerCompose).mockResolvedValue(true);
+    vi.mocked(detectMock.getDockerComposeBinaryInfo).mockResolvedValue({
+      version: 'v0.0.0',
+      path: 'system-wide-path',
+      updatable: false, // not updatable as unknown location
+    });
+    vi.spyOn(cliRun, 'getSystemBinaryPath').mockReturnValue('system-wide-path');
+    vi.mocked(detectMock.getStoragePath).mockResolvedValue('storage-path');
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    vi.mocked(fs.promises.unlink).mockRejectedValue({
+      code: 'EACCES',
+    } as unknown as Error);
+    const command = process.platform === 'win32' ? 'del' : 'rm';
+
+    let installer: extensionApi.CliToolInstaller | undefined;
+    vi.mocked(cliToolMock.registerInstaller).mockImplementation(mInstaller => {
+      installer = mInstaller;
+      return { dispose: vi.fn() };
+    });
+
+    await activate(extensionContextMock);
+
+    await vi.waitFor(() => {
+      expect(installer).toBeDefined();
+    });
+
+    await installer?.doUninstall({} as unknown as Logger);
+    expect(extensionApi.process.exec).toHaveBeenNthCalledWith(1, command, ['storage-path'], { isAdmin: true });
+    expect(extensionApi.process.exec).toHaveBeenNthCalledWith(2, command, ['system-wide-path'], { isAdmin: true });
   });
 });

--- a/extensions/compose/src/extension.spec.ts
+++ b/extensions/compose/src/extension.spec.ts
@@ -15,6 +15,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
+import * as fs from 'node:fs';
 
 import type { CliTool, Logger } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
@@ -62,6 +63,9 @@ vi.mock('@podman-desktop/api', async () => {
 });
 
 vi.mock('node:fs', () => ({
+  promises: {
+    unlink: vi.fn(),
+  },
   existsSync: vi.fn(),
 }));
 
@@ -279,6 +283,7 @@ describe('registerCLITool', () => {
       expect(cliToolMock.registerInstaller).toHaveBeenCalledWith({
         selectVersion: expect.any(Function),
         doInstall: expect.any(Function),
+        doUninstall: expect.any(Function),
       });
       expect(cliToolMock.registerUpdate).toHaveBeenCalledWith({
         selectVersion: expect.any(Function),
@@ -403,6 +408,38 @@ describe('registerCLITool', () => {
     expect(cliToolMock.updateVersion).toHaveBeenCalledWith({
       installationSource: 'extension',
       version: '1.0.0',
+    });
+  });
+
+  test('by uninstalling it should delete all executables', async () => {
+    vi.mocked(detectMock.checkSystemWideDockerCompose).mockResolvedValue(true);
+    vi.mocked(detectMock.getDockerComposeBinaryInfo).mockResolvedValue({
+      version: 'v0.0.0',
+      path: 'system-wide-path',
+      updatable: false, // not updatable as unknown location
+    });
+    vi.spyOn(cliRun, 'getSystemBinaryPath').mockReturnValue('system-wide-path');
+    vi.mocked(detectMock.getStoragePath).mockResolvedValue('storage-path');
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+
+    let installer: extensionApi.CliToolInstaller | undefined;
+    vi.mocked(cliToolMock.registerInstaller).mockImplementation(mInstaller => {
+      installer = mInstaller;
+      return { dispose: vi.fn() };
+    });
+
+    await activate(extensionContextMock);
+
+    await vi.waitFor(() => {
+      expect(installer).toBeDefined();
+    });
+
+    await installer?.doUninstall({} as unknown as Logger);
+    expect(fs.promises.unlink).toHaveBeenNthCalledWith(1, 'storage-path');
+    expect(fs.promises.unlink).toHaveBeenNthCalledWith(2, 'system-wide-path');
+    expect(cliToolMock.updateVersion).toHaveBeenCalledWith({
+      version: undefined,
+      path: undefined,
     });
   });
 });

--- a/extensions/compose/src/extension.spec.ts
+++ b/extensions/compose/src/extension.spec.ts
@@ -437,9 +437,5 @@ describe('registerCLITool', () => {
     await installer?.doUninstall({} as unknown as Logger);
     expect(fs.promises.unlink).toHaveBeenNthCalledWith(1, 'storage-path');
     expect(fs.promises.unlink).toHaveBeenNthCalledWith(2, 'system-wide-path');
-    expect(cliToolMock.updateVersion).toHaveBeenCalledWith({
-      version: undefined,
-      path: undefined,
-    });
   });
 });

--- a/extensions/compose/src/extension.ts
+++ b/extensions/compose/src/extension.ts
@@ -295,8 +295,10 @@ async function registerCLITool(composeDownload: ComposeDownload, detect: Detect)
       return releaseVersionToInstall;
     },
     doInstall: async _logger => {
-      if (binaryVersion ?? binaryPath) {
-        throw new Error(`Cannot install ${composeCliName}. Version ${binaryVersion} is already installed.`);
+      if (binaryVersion || binaryPath) {
+        throw new Error(
+          `Cannot install ${composeCliName}. Version ${binaryVersion} in ${binaryPath} is already installed.`,
+        );
       }
       if (!releaseToInstall || !releaseVersionToInstall) {
         throw new Error(`Cannot install ${composeCliName}. No release selected.`);

--- a/extensions/compose/src/extension.ts
+++ b/extensions/compose/src/extension.ts
@@ -295,7 +295,7 @@ async function registerCLITool(composeDownload: ComposeDownload, detect: Detect)
       return releaseVersionToInstall;
     },
     doInstall: async _logger => {
-      if (binaryVersion || binaryPath) {
+      if (binaryVersion ?? binaryPath) {
         throw new Error(
           `Cannot install ${composeCliName}. Version ${binaryVersion} in ${binaryPath} is already installed.`,
         );

--- a/extensions/compose/src/extension.ts
+++ b/extensions/compose/src/extension.ts
@@ -334,10 +334,6 @@ async function registerCLITool(composeDownload: ComposeDownload, detect: Detect)
 
       // update the version to undefined
       binaryVersion = undefined;
-      composeCliTool?.updateVersion({
-        version: undefined,
-        path: undefined,
-      });
     },
   });
 

--- a/extensions/kubectl-cli/src/extension.spec.ts
+++ b/extensions/kubectl-cli/src/extension.spec.ts
@@ -17,8 +17,8 @@
  ***********************************************************************/
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { tmpdir } from 'node:os';
 import * as fs from 'node:fs';
+import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import { afterEach } from 'node:test';
 

--- a/extensions/kubectl-cli/src/extension.spec.ts
+++ b/extensions/kubectl-cli/src/extension.spec.ts
@@ -649,7 +649,7 @@ describe('postActivate', () => {
     const cliInstaller = await deferredCliInstall;
     await cliInstaller.doUninstall({} as unknown as Logger);
 
-    expect(fs.promises.unlink).toHaveBeenNthCalledWith(1, path.join('/tmp/kubectl-cli', 'bin', 'kubectl'));
+    expect(fs.promises.unlink).toHaveBeenNthCalledWith(1, path.join(extensionContext.storagePath, 'bin', 'kubectl'));
     expect(fs.promises.unlink).toHaveBeenNthCalledWith(2, 'system-path');
   });
 
@@ -715,7 +715,7 @@ describe('postActivate', () => {
     expect(extensionApi.process.exec).toHaveBeenNthCalledWith(
       4,
       command,
-      [path.join('/tmp/kubectl-cli', 'bin', 'kubectl')],
+      [path.join(extensionContext.storagePath, 'bin', 'kubectl')],
       { isAdmin: true },
     );
     expect(extensionApi.process.exec).toHaveBeenNthCalledWith(5, command, ['system-path'], { isAdmin: true });

--- a/extensions/kubectl-cli/src/extension.spec.ts
+++ b/extensions/kubectl-cli/src/extension.spec.ts
@@ -652,4 +652,72 @@ describe('postActivate', () => {
     expect(fs.promises.unlink).toHaveBeenNthCalledWith(1, path.join('/tmp/kubectl-cli', 'bin', 'kubectl'));
     expect(fs.promises.unlink).toHaveBeenNthCalledWith(2, 'system-path');
   });
+
+  test('if unlink fails because of a permission issue, it should delete all binaries as admin', async () => {
+    vi.spyOn(cliRun, 'getSystemBinaryPath').mockReturnValue('system-path');
+    vi.mocked(extensionApi.process.exec).mockImplementation(
+      (_command: string, _args?: string[], _options?: extensionApi.RunOptions) =>
+        new Promise<extensionApi.RunResult>(resolve => {
+          if (_args?.[0] === 'version') {
+            resolve({
+              stderr: '',
+              stdout: JSON.stringify(jsonStdout),
+              command: 'kubectl version --client=true -o=json',
+            });
+            return;
+          }
+          resolve({
+            stderr: '',
+            stdout: 'system-path',
+            command: 'which kubectl',
+          });
+        }),
+    );
+    // mock return value bellow current
+    vi.mocked(KubectlGitHubReleases).mockReturnValue({
+      grabLatestsReleasesMetadata: vi.fn().mockResolvedValue([
+        {
+          label: 'Kubernetes v1.1.0',
+          tag: 'v1.1.0',
+          id: -1,
+        },
+      ]),
+      getReleaseAssetURL: vi.fn().mockResolvedValue('dummy download url'),
+      downloadReleaseAsset: downloadReleaseAssetMock,
+    } as unknown as KubectlGitHubReleases);
+    const deferredCliInstall: Promise<extensionApi.CliToolInstaller> = new Promise<extensionApi.CliToolInstaller>(
+      resolve => {
+        vi.mocked(extensionApi.cli.createCliTool).mockImplementation(() => {
+          return {
+            registerUpdate: vi.fn(),
+            registerInstaller: (listener: extensionApi.CliToolInstaller) => {
+              resolve(listener);
+              return {
+                dispose: vi.fn(),
+              };
+            },
+            updateVersion: vi.fn(),
+          } as unknown as extensionApi.CliTool;
+        });
+      },
+    );
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    vi.mocked(fs.promises.unlink).mockRejectedValue({
+      code: 'EACCES',
+    } as unknown as Error);
+    const command = process.platform === 'win32' ? 'del' : 'rm';
+
+    await KubectlExtension.activate(extensionContext);
+
+    const cliInstaller = await deferredCliInstall;
+    await cliInstaller.doUninstall({} as unknown as Logger);
+
+    expect(extensionApi.process.exec).toHaveBeenNthCalledWith(
+      4,
+      command,
+      [path.join('/tmp/kubectl-cli', 'bin', 'kubectl')],
+      { isAdmin: true },
+    );
+    expect(extensionApi.process.exec).toHaveBeenNthCalledWith(5, command, ['system-path'], { isAdmin: true });
+  });
 });

--- a/extensions/kubectl-cli/src/extension.spec.ts
+++ b/extensions/kubectl-cli/src/extension.spec.ts
@@ -18,6 +18,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { tmpdir } from 'node:os';
+import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { afterEach } from 'node:test';
 
@@ -48,6 +49,7 @@ vi.mock('node:fs', () => ({
   promises: {
     chmod: vi.fn(),
     mkdir: vi.fn(),
+    unlink: vi.fn(),
   },
   existsSync: vi.fn(),
 }));
@@ -590,5 +592,64 @@ describe('postActivate', () => {
     expect(vi.mocked(cliRun.installBinaryToSystem).mock.calls[0][0]).toContain(
       path.resolve(extensionContext.storagePath, 'bin', 'kubectl'),
     );
+  });
+
+  test('doUninstall should delete all binaries', async () => {
+    vi.spyOn(cliRun, 'getSystemBinaryPath').mockReturnValue('system-path');
+    vi.mocked(extensionApi.process.exec).mockImplementation(
+      (_command: string, _args?: string[], _options?: extensionApi.RunOptions) =>
+        new Promise<extensionApi.RunResult>(resolve => {
+          if (_args?.[0] === 'version') {
+            resolve({
+              stderr: '',
+              stdout: JSON.stringify(jsonStdout),
+              command: 'kubectl version --client=true -o=json',
+            });
+            return;
+          }
+          resolve({
+            stderr: '',
+            stdout: 'system-path',
+            command: 'which kubectl',
+          });
+        }),
+    );
+    // mock return value bellow current
+    vi.mocked(KubectlGitHubReleases).mockReturnValue({
+      grabLatestsReleasesMetadata: vi.fn().mockResolvedValue([
+        {
+          label: 'Kubernetes v1.1.0',
+          tag: 'v1.1.0',
+          id: -1,
+        },
+      ]),
+      getReleaseAssetURL: vi.fn().mockResolvedValue('dummy download url'),
+      downloadReleaseAsset: downloadReleaseAssetMock,
+    } as unknown as KubectlGitHubReleases);
+    const deferredCliInstall: Promise<extensionApi.CliToolInstaller> = new Promise<extensionApi.CliToolInstaller>(
+      resolve => {
+        vi.mocked(extensionApi.cli.createCliTool).mockImplementation(() => {
+          return {
+            registerUpdate: vi.fn(),
+            registerInstaller: (listener: extensionApi.CliToolInstaller) => {
+              resolve(listener);
+              return {
+                dispose: vi.fn(),
+              };
+            },
+            updateVersion: vi.fn(),
+          } as unknown as extensionApi.CliTool;
+        });
+      },
+    );
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+
+    await KubectlExtension.activate(extensionContext);
+
+    const cliInstaller = await deferredCliInstall;
+    await cliInstaller.doUninstall({} as unknown as Logger);
+
+    expect(fs.promises.unlink).toHaveBeenNthCalledWith(1, path.join('/tmp/kubectl-cli', 'bin', 'kubectl'));
+    expect(fs.promises.unlink).toHaveBeenNthCalledWith(2, 'system-path');
   });
 });

--- a/extensions/kubectl-cli/src/extension.ts
+++ b/extensions/kubectl-cli/src/extension.ts
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 import { Octokit } from '@octokit/rest';
@@ -361,6 +362,30 @@ async function postActivate(
       currentVersion = releaseVersionToInstall;
       releaseVersionToInstall = undefined;
       releaseToInstall = undefined;
+    },
+    doUninstall: async _logger => {
+      if (!currentVersion) {
+        throw new Error(`Cannot uninstall ${kubectlCliName}. No version detected.`);
+      }
+
+      // delete the executable stored in the storage folder
+      const storagePath = getStorageKubectlPath(extensionContext);
+      if (fs.existsSync(storagePath)) {
+        await fs.promises.unlink(storagePath);
+      }
+
+      // delete the executable in the system path
+      const systemPath = getSystemBinaryPath(kubectlCliName);
+      if (fs.existsSync(systemPath)) {
+        await fs.promises.unlink(systemPath);
+      }
+
+      // update the version to undefined
+      currentVersion = undefined;
+      kubectlCliTool?.updateVersion({
+        version: undefined,
+        path: undefined,
+      });
     },
   });
 

--- a/extensions/kubectl-cli/src/extension.ts
+++ b/extensions/kubectl-cli/src/extension.ts
@@ -382,10 +382,6 @@ async function postActivate(
 
       // update the version to undefined
       currentVersion = undefined;
-      kubectlCliTool?.updateVersion({
-        version: undefined,
-        path: undefined,
-      });
     },
   });
 

--- a/extensions/kubectl-cli/src/extension.ts
+++ b/extensions/kubectl-cli/src/extension.ts
@@ -370,15 +370,11 @@ async function postActivate(
 
       // delete the executable stored in the storage folder
       const storagePath = getStorageKubectlPath(extensionContext);
-      if (fs.existsSync(storagePath)) {
-        await fs.promises.unlink(storagePath);
-      }
+      await deleteFile(storagePath);
 
       // delete the executable in the system path
       const systemPath = getSystemBinaryPath(kubectlCliName);
-      if (fs.existsSync(systemPath)) {
-        await fs.promises.unlink(systemPath);
-      }
+      await deleteFile(systemPath);
 
       // update the version to undefined
       currentVersion = undefined;
@@ -430,4 +426,38 @@ function extractVersion(stdout: string): string {
     return version;
   }
   throw new Error('Cannot extract version from stdout');
+}
+
+async function deleteFile(filePath: string): Promise<void> {
+  if (filePath && fs.existsSync(filePath)) {
+    try {
+      await fs.promises.unlink(filePath);
+    } catch (error: unknown) {
+      if (
+        error &&
+        typeof error === 'object' &&
+        'code' in error &&
+        (error.code === 'EACCES' || error.code === 'EPERM')
+      ) {
+        await deleteFileAsAdmin(filePath);
+      } else {
+        throw error;
+      }
+    }
+  }
+}
+
+async function deleteFileAsAdmin(filePath: string): Promise<void> {
+  const system = process.platform;
+
+  const args: string[] = [filePath];
+  const command = system === 'win32' ? 'del' : 'rm';
+
+  try {
+    // Use admin prileges
+    await extensionApi.process.exec(command, args, { isAdmin: true });
+  } catch (error) {
+    console.error(`Failed to uninstall '${filePath}': ${error}`);
+    throw error;
+  }
 }

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -4335,7 +4335,7 @@ declare module '@podman-desktop/api' {
    * Options to update CliTool instance
    */
   export interface CliToolUpdateOptions {
-    version: string;
+    version?: string;
     displayName?: string;
     markdownDescription?: string;
     images?: ProviderImages;
@@ -4356,6 +4356,7 @@ declare module '@podman-desktop/api' {
   export interface CliToolInstaller {
     selectVersion: () => Promise<string>;
     doInstall: (logger: Logger) => Promise<void>;
+    doUninstall: (logger: Logger) => Promise<void>;
   }
 
   export type CliToolState = 'registered';

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -4335,7 +4335,7 @@ declare module '@podman-desktop/api' {
    * Options to update CliTool instance
    */
   export interface CliToolUpdateOptions {
-    version?: string;
+    version: string;
     displayName?: string;
     markdownDescription?: string;
     images?: ProviderImages;
@@ -4365,6 +4365,8 @@ declare module '@podman-desktop/api' {
     state: CliToolState;
     updateVersion(version: CliToolUpdateOptions): void;
     onDidUpdateVersion: Event<string>;
+
+    onDidUninstall: Event<void>;
 
     // register cli update flow
     registerUpdate(update: CliToolUpdate | CliToolSelectUpdate): Disposable;

--- a/packages/main/src/plugin/cli-tool-impl.ts
+++ b/packages/main/src/plugin/cli-tool-impl.ts
@@ -38,8 +38,8 @@ import { Emitter } from './events/emitter.js';
 export class CliToolImpl implements CliTool, Disposable {
   readonly id: string;
   private _state: CliToolState = 'registered';
-  private readonly _onDidUpdateVersion = new Emitter<string>();
-  readonly onDidUpdateVersion: Event<string> = this._onDidUpdateVersion.event;
+  private readonly _onDidUpdateVersion = new Emitter<string | undefined>();
+  readonly onDidUpdateVersion: Event<string | undefined> = this._onDidUpdateVersion.event;
 
   constructor(
     readonly extensionInfo: CliToolExtensionInfo,

--- a/packages/main/src/plugin/cli-tool-impl.ts
+++ b/packages/main/src/plugin/cli-tool-impl.ts
@@ -38,8 +38,10 @@ import { Emitter } from './events/emitter.js';
 export class CliToolImpl implements CliTool, Disposable {
   readonly id: string;
   private _state: CliToolState = 'registered';
-  private readonly _onDidUpdateVersion = new Emitter<string | undefined>();
-  readonly onDidUpdateVersion: Event<string | undefined> = this._onDidUpdateVersion.event;
+  private readonly _onDidUpdateVersion = new Emitter<string>();
+  readonly onDidUpdateVersion: Event<string> = this._onDidUpdateVersion.event;
+  private readonly _onDidUninstall = new Emitter<void>();
+  readonly onDidUninstall: Event<void> = this._onDidUninstall.event;
 
   constructor(
     readonly extensionInfo: CliToolExtensionInfo,
@@ -97,6 +99,15 @@ export class CliToolImpl implements CliTool, Disposable {
       installationSource: 'extension',
     };
     this._onDidUpdateVersion.fire(options.version);
+  }
+
+  uninstall(): void {
+    this._options = {
+      ...this._options,
+      path: undefined,
+      version: undefined,
+    };
+    this._onDidUninstall.fire();
   }
 
   registerUpdate(update: CliToolUpdate | CliToolSelectUpdate): Disposable {

--- a/packages/main/src/plugin/cli-tool-registry.spec.ts
+++ b/packages/main/src/plugin/cli-tool-registry.spec.ts
@@ -331,6 +331,7 @@ suite('cli module', () => {
       const installer: CliToolInstaller = {
         doInstall: installMock,
         selectVersion: selectVersionMock,
+        doUninstall: vi.fn(),
       };
       const options: CliToolOptions = {
         name: 'tool-name',
@@ -348,9 +349,11 @@ suite('cli module', () => {
 
   suite('installCliTool', () => {
     const installMock = vi.fn();
+    const uninstallMock = vi.fn();
     const selectVersionMock = vi.fn();
     const installer: CliToolInstaller = {
       doInstall: installMock,
+      doUninstall: uninstallMock,
       selectVersion: selectVersionMock,
     };
     beforeEach(() => {
@@ -396,6 +399,32 @@ suite('cli module', () => {
       cliToolRegistry.registerInstaller(newCliTool as CliToolImpl, installer);
       await cliToolRegistry.installCliTool(newCliTool.id, {} as Logger);
       expect(installMock).toBeCalled();
+    });
+
+    test('check uninstall is not called if there is no installer registered', async () => {
+      const options: CliToolOptions = {
+        name: 'tool-name',
+        displayName: 'tool-display-name',
+        markdownDescription: 'markdown description',
+        images: {},
+      };
+      const newCliTool = cliToolRegistry.createCliTool(extensionInfo, options);
+      await cliToolRegistry.uninstallCliTool(newCliTool.id, {} as Logger);
+      expect(uninstallMock).not.toBeCalled();
+    });
+
+    test('check the uninstall function of the installer is called correctly', async () => {
+      const options: CliToolOptions = {
+        name: 'tool-name',
+        displayName: 'tool-display-name',
+        markdownDescription: 'markdown description',
+        images: {},
+      };
+      const newCliTool = cliToolRegistry.createCliTool(extensionInfo, options);
+      // register the updater and call the selectCliTool
+      cliToolRegistry.registerInstaller(newCliTool as CliToolImpl, installer);
+      await cliToolRegistry.uninstallCliTool(newCliTool.id, {} as Logger);
+      expect(uninstallMock).toBeCalled();
     });
   });
 

--- a/packages/main/src/plugin/cli-tool-registry.spec.ts
+++ b/packages/main/src/plugin/cli-tool-registry.spec.ts
@@ -421,10 +421,13 @@ suite('cli module', () => {
         images: {},
       };
       const newCliTool = cliToolRegistry.createCliTool(extensionInfo, options);
+      const uninstallCliMock = vi.fn();
+      (newCliTool as CliToolImpl).uninstall = uninstallCliMock;
       // register the updater and call the selectCliTool
       cliToolRegistry.registerInstaller(newCliTool as CliToolImpl, installer);
       await cliToolRegistry.uninstallCliTool(newCliTool.id, {} as Logger);
       expect(uninstallMock).toBeCalled();
+      expect(uninstallCliMock).toBeCalled();
     });
   });
 

--- a/packages/main/src/plugin/cli-tool-registry.ts
+++ b/packages/main/src/plugin/cli-tool-registry.ts
@@ -50,6 +50,7 @@ export class CliToolRegistry {
     this.apiSender.send('cli-tool-create');
     this._onDidCliToolsChange.fire();
     cliTool.onDidUpdateVersion(() => this.apiSender.send('cli-tool-change', cliTool.id));
+    cliTool.onDidUninstall(() => this.apiSender.send('cli-tool-change', cliTool.id));
     return cliTool;
   }
 
@@ -89,6 +90,8 @@ export class CliToolRegistry {
     const cliToolInstaller = this.cliToolsInstaller.get(id);
     if (cliToolInstaller) {
       await cliToolInstaller.doUninstall(logger);
+      // notify the tool has been uninstalled
+      this.cliTools.get(id)?.uninstall();
     }
   }
 

--- a/packages/main/src/plugin/cli-tool-registry.ts
+++ b/packages/main/src/plugin/cli-tool-registry.ts
@@ -85,6 +85,13 @@ export class CliToolRegistry {
     }
   }
 
+  async uninstallCliTool(id: string, logger: Logger): Promise<void> {
+    const cliToolInstaller = this.cliToolsInstaller.get(id);
+    if (cliToolInstaller) {
+      await cliToolInstaller.doUninstall(logger);
+    }
+  }
+
   async selectCliToolVersionToUpdate(id: string): Promise<string> {
     const cliToolUpdater = this.cliToolsUpdater.get(id);
     if (!cliToolUpdater || this.isUpdaterToPredefinedVersion(cliToolUpdater)) {

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1190,13 +1190,28 @@ export function initExposure(): void {
     'installCliTool',
     async (
       id: string,
+      versionToInstall: string,
       key: symbol,
       keyLogger: (key: symbol, eventName: 'log' | 'warn' | 'error' | 'finish', args: string[]) => void,
     ): Promise<void> => {
       onDataCallbacksTaskConnectionId++;
       onDataCallbacksTaskConnectionKeys.set(onDataCallbacksTaskConnectionId, key);
       onDataCallbacksTaskConnectionLogs.set(onDataCallbacksTaskConnectionId, keyLogger);
-      return ipcInvoke('cli-tool-registry:installCliTool', id, onDataCallbacksTaskConnectionId);
+      return ipcInvoke('cli-tool-registry:installCliTool', id, versionToInstall, onDataCallbacksTaskConnectionId);
+    },
+  );
+
+  contextBridge.exposeInMainWorld(
+    'uninstallCliTool',
+    async (
+      id: string,
+      key: symbol,
+      keyLogger: (key: symbol, eventName: 'log' | 'warn' | 'error' | 'finish', args: string[]) => void,
+    ): Promise<void> => {
+      onDataCallbacksTaskConnectionId++;
+      onDataCallbacksTaskConnectionKeys.set(onDataCallbacksTaskConnectionId, key);
+      onDataCallbacksTaskConnectionLogs.set(onDataCallbacksTaskConnectionId, keyLogger);
+      return ipcInvoke('cli-tool-registry:uninstallCliTool', id, onDataCallbacksTaskConnectionId);
     },
   );
 

--- a/packages/renderer/src/lib/preferences/PreferencesCliTool.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesCliTool.spec.ts
@@ -122,6 +122,22 @@ const cliToolInfoItem6: CliToolInfo = {
   canInstall: true,
 };
 
+const cliToolInfoItem7: CliToolInfo = {
+  id: 'ext-id.tool-name7',
+  name: 'tool-name7',
+  description: 'markdown description7',
+  displayName: 'tools-display-name7',
+  state: 'registered',
+  extensionInfo: {
+    id: 'ext-id7',
+    label: 'ext-label7',
+  },
+  version: '1.0.1',
+  path: 'path/to/tool-name-7',
+  canUpdate: true,
+  canInstall: true,
+};
+
 const updateCliToolMock = vi.fn();
 beforeEach(() => {
   (window as any).updateCliTool = updateCliToolMock;
@@ -283,5 +299,51 @@ suite('CLI Tool item', () => {
     const installLoadingButton = screen.getByRole('button', { name: 'Install' });
     expect(installLoadingButton).toBeInTheDocument();
     expect(installLoadingButton).toBeEnabled();
+  });
+
+  test('check no uninstall button is displayed if there is a version and no installer registered', async () => {
+    render(PreferencesCliTool, {
+      cliTool: cliToolInfoItem4,
+    });
+    const nameElement = screen.getByLabelText('cli-name');
+    expect(nameElement).toBeDefined();
+    expect(nameElement.textContent).equal(cliToolInfoItem4.name);
+    const registeredByElement = screen.getByLabelText('cli-registered-by');
+    expect(registeredByElement).toBeDefined();
+    expect(registeredByElement.textContent).equal(`Registered by ${cliToolInfoItem4.extensionInfo.label}`);
+    const displayNameElement = screen.getByLabelText('cli-display-name');
+    expect(displayNameElement).toBeDefined();
+    expect(displayNameElement.textContent).equal(cliToolInfoItem4.displayName);
+    const versionElement = screen.getByLabelText('cli-version');
+    expect(versionElement).toBeInTheDocument();
+    expect(versionElement.textContent).equal(`${cliToolInfoItem4.name} v${cliToolInfoItem4.version}`);
+    const uninstallLoadingButton = screen.queryByRole('button', { name: 'Uninstall' });
+    expect(uninstallLoadingButton).not.toBeInTheDocument();
+  });
+
+  test('check the uninstall button is displayed if there is a version and an installer has been registered', async () => {
+    render(PreferencesCliTool, {
+      cliTool: cliToolInfoItem7,
+    });
+    const nameElement = screen.getByLabelText('cli-name');
+    expect(nameElement).toBeDefined();
+    expect(nameElement.textContent).equal(cliToolInfoItem7.name);
+    const registeredByElement = screen.getByLabelText('cli-registered-by');
+    expect(registeredByElement).toBeDefined();
+    expect(registeredByElement.textContent).equal(`Registered by ${cliToolInfoItem7.extensionInfo.label}`);
+    const displayNameElement = screen.getByLabelText('cli-display-name');
+    expect(displayNameElement).toBeDefined();
+    expect(displayNameElement.textContent).equal(cliToolInfoItem7.displayName);
+    const versionElement = screen.getByLabelText('cli-version');
+    expect(versionElement).toBeInTheDocument();
+    expect(versionElement.textContent).equal(`${cliToolInfoItem7.name} v${cliToolInfoItem7.version}`);
+    const uninstallLoadingButton = screen.getByRole('button', { name: 'Uninstall' });
+    expect(uninstallLoadingButton).toBeInTheDocument();
+    expect(uninstallLoadingButton).toBeEnabled();
+    const updateLoadingButton = screen.getByRole('button', { name: 'Update' });
+    expect(updateLoadingButton).toBeInTheDocument();
+    expect(updateLoadingButton).toBeEnabled();
+    const installLoadingButton = screen.queryByRole('button', { name: 'Install' });
+    expect(installLoadingButton).not.toBeInTheDocument();
   });
 });

--- a/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
@@ -96,6 +96,16 @@ async function install(cliTool: CliToolInfo) {
 }
 
 async function uninstall(cliTool: CliToolInfo) {
+  const result = await window.showMessageBox({
+    title: 'Uninstall',
+    message: `Uninstall ${cliTool.displayName} ${cliTool.version} ?`,
+    buttons: ['Yes', 'Cancel'],
+  });
+
+  if (!result || result.response !== 0) {
+    return;
+  }
+
   try {
     cliToolUninstallStatus.inProgress = true;
     cliToolUninstallStatus = cliToolUninstallStatus;


### PR DESCRIPTION
### What does this PR do?

It implements the logic to register the uninstall action and update the compose + kubectl extensions

### Screenshot / video of UI

![uninstall_cli_tool](https://github.com/user-attachments/assets/0db699d7-9d2e-4add-b109-814dce91271a)

### What issues does this PR fix or reference?

it is part of #8003 

### How to test this PR?

1. uninstall a cli you installed and see it is actually removed.

- [x] Tests are covering the bug fix or the new feature
