### PR TITLE
chore: use stricter typescript rules on the main package

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-typescript": "^11.1.6",
+    "@tsconfig/strictest": "^2.0.5",
     "@types/adm-zip": "^0.5.5",
     "@types/dockerode": "^3.3.31",
     "@types/express": "^4.17.21",

--- a/packages/main/src/index.spec.ts
+++ b/packages/main/src/index.spec.ts
@@ -304,6 +304,9 @@ test('app-ready event with activate event', async () => {
   expect(windows).toHaveLength(1);
 
   const window = windows[0];
+  if (!window) {
+    assert.fail('window is undefined');
+  }
   const spyShow = vi.spyOn(window, 'show');
   const spyFocus = vi.spyOn(window, 'focus');
 

--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -192,18 +192,23 @@ async function createWindow(): Promise<BrowserWindow> {
       if (import.meta.env.DEV) {
         let extensionId = '';
         if (parameters?.linkURL?.includes('/contribs')) {
-          extensionId = parameters.linkURL.split('/contribs/')[1];
-          return [
-            {
-              label: `Open DevTools of ${decodeURI(extensionId)} Extension`,
-              // make it visible when link contains contribs and we're inside the extension
-              visible:
-                parameters.linkURL.includes('/contribs/') && parameters.pageURL.includes(`/contribs/${extensionId}`),
-              click: (): void => {
-                browserWindow.webContents.send('dev-tools:open-extension', extensionId.replaceAll('%20', '-'));
+          const extensionIdVal = parameters.linkURL.split('/contribs/')[1];
+          if (extensionIdVal) {
+            extensionId = extensionIdVal;
+            return [
+              {
+                label: `Open DevTools of ${decodeURI(extensionId)} Extension`,
+                // make it visible when link contains contribs and we're inside the extension
+                visible:
+                  parameters.linkURL.includes('/contribs/') && parameters.pageURL.includes(`/contribs/${extensionId}`),
+                click: (): void => {
+                  browserWindow.webContents.send('dev-tools:open-extension', extensionId.replaceAll('%20', '-'));
+                },
               },
-            },
-          ];
+            ];
+          } else {
+            return [];
+          }
         } else if (parameters?.linkURL?.includes('/webviews/')) {
           const webviewId = parameters.linkURL.split('/webviews/')[1];
           return [

--- a/packages/main/src/navigation-items-menu-builder.spec.ts
+++ b/packages/main/src/navigation-items-menu-builder.spec.ts
@@ -35,10 +35,10 @@ const browserWindowMock = {
 } as unknown as BrowserWindow;
 
 class TestNavigationItemsMenuBuilder extends NavigationItemsMenuBuilder {
-  buildHideMenuItem(linkText: string): MenuItemConstructorOptions | undefined {
+  override buildHideMenuItem(linkText: string): MenuItemConstructorOptions | undefined {
     return super.buildHideMenuItem(linkText);
   }
-  buildNavigationToggleMenuItems(): MenuItemConstructorOptions[] {
+  override buildNavigationToggleMenuItems(): MenuItemConstructorOptions[] {
     return super.buildNavigationToggleMenuItems();
   }
 }
@@ -94,18 +94,18 @@ describe('buildNavigationToggleMenuItems', async () => {
     expect(menu.length).toBe(4);
 
     // check the first item is a separator
-    expect(menu[0].type).toBe('separator');
+    expect(menu[0]?.type).toBe('separator');
 
     // label should be escaped as we have an &
-    expect(menu[1].label).toBe('A && A');
-    expect(menu[1].checked).toBe(true);
-    expect(menu[2].label).toBe('B');
-    expect(menu[2].checked).toBe(false);
-    expect(menu[3].label).toBe('C');
-    expect(menu[3].checked).toBe(true);
+    expect(menu[1]?.label).toBe('A && A');
+    expect(menu[1]?.checked).toBe(true);
+    expect(menu[2]?.label).toBe('B');
+    expect(menu[2]?.checked).toBe(false);
+    expect(menu[3]?.label).toBe('C');
+    expect(menu[3]?.checked).toBe(true);
 
     // click on the A item
-    menu[1].click?.({} as MenuItem, browserWindowMock, {} as unknown as KeyboardEvent);
+    menu[1]?.click?.({} as MenuItem, browserWindowMock, {} as unknown as KeyboardEvent);
 
     expect(getConfigurationMock).toBeCalled();
     // if clicking it should send the item to the configuration as being disabled
@@ -120,7 +120,7 @@ describe('buildNavigationToggleMenuItems', async () => {
     vi.mocked(configurationRegistryMock.updateConfigurationValue).mockClear();
 
     // click on the B item should unhide it so disabled items should be empty
-    menu[2].click?.({} as MenuItem, browserWindowMock, {} as unknown as KeyboardEvent);
+    menu[2]?.click?.({} as MenuItem, browserWindowMock, {} as unknown as KeyboardEvent);
     expect(configurationRegistryMock.updateConfigurationValue).toBeCalledWith(
       'navbar.disabledItems',
       ['existing'],

--- a/packages/main/src/plugin/authentication.spec.ts
+++ b/packages/main/src/plugin/authentication.spec.ts
@@ -226,6 +226,9 @@ test('Authentication provider creates session when session request is executed',
   expect(authModule.getSessionRequests()).length(1);
 
   const [signInRequest] = authModule.getSessionRequests();
+  if (!signInRequest) {
+    throw new Error('Sign in request is not defined');
+  }
   await authModule.executeSessionRequest(signInRequest.id);
   expect(createSessionSpy).toBeCalledTimes(1);
 });

--- a/packages/main/src/plugin/authentication.ts
+++ b/packages/main/src/plugin/authentication.ts
@@ -237,16 +237,16 @@ export class AuthenticationImpl {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  readAllowedExtensions(providerId: string, accountName: string): AllowedExtension[] {
+  readAllowedExtensions(_providerId: string, _accountName: string): AllowedExtension[] {
     throw new Error('The method is not implemented!');
   }
 
   updateAllowedExtension(
-    providerId: string, // eslint-disable-line @typescript-eslint/no-unused-vars
-    accountName: string, // eslint-disable-line @typescript-eslint/no-unused-vars
-    extensionId: string, // eslint-disable-line @typescript-eslint/no-unused-vars
-    extensionName: string, // eslint-disable-line @typescript-eslint/no-unused-vars
-    isAllowed: boolean, // eslint-disable-line @typescript-eslint/no-unused-vars
+    _providerId: string, // eslint-disable-line @typescript-eslint/no-unused-vars
+    _accountName: string, // eslint-disable-line @typescript-eslint/no-unused-vars
+    _extensionId: string, // eslint-disable-line @typescript-eslint/no-unused-vars
+    _extensionName: string, // eslint-disable-line @typescript-eslint/no-unused-vars
+    _isAllowed: boolean, // eslint-disable-line @typescript-eslint/no-unused-vars
   ): void {
     throw new Error('The method is not implemented!');
   }
@@ -260,7 +260,7 @@ export class AuthenticationImpl {
    * if they haven't made a choice yet
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  isAccessAllowed(providerId: string, accountName: string, extensionId: string): boolean | undefined {
+  isAccessAllowed(_providerId: string, _accountName: string, _extensionId: string): boolean | undefined {
     return true; // To be implemented later
   }
 
@@ -298,7 +298,11 @@ export class AuthenticationImpl {
 
     const sessions = providerData ? await providerData.provider.getSessions(sortedScopes) : [];
 
-    if (sessions.length && this.isAccessAllowed(providerId, sessions[0].account.label, requestingExtension.id)) {
+    if (
+      sessions.length &&
+      sessions[0]?.account.label &&
+      this.isAccessAllowed(providerId, sessions[0].account.label, requestingExtension.id)
+    ) {
       // add account usage to show confirmation on sign out request
       this.addAccountUsage(providerId, sessions[0].id, requestingExtension.id, requestingExtension.label);
       return sessions[0];
@@ -348,13 +352,14 @@ export class AuthenticationImpl {
       });
 
       if (providerRequests) {
-        const existingRequests = providerRequests[scopesList] || [];
+        const existingRequests = providerRequests[scopesList] ?? [];
         providerRequests[scopesList] = [...existingRequests, requestingExtension.id];
       } else {
         this._signInRequests.set(providerId, { [scopesList]: [requestingExtension.id] });
       }
       this.apiSender.send('authentication-provider-update', { id: providerId });
     }
+    return undefined;
   }
 
   getSessionRequests(): SessionRequestInfo[] {

--- a/packages/main/src/plugin/cli-tool-impl.spec.ts
+++ b/packages/main/src/plugin/cli-tool-impl.spec.ts
@@ -21,10 +21,8 @@ import { expect, test, vi } from 'vitest';
 
 import type { CliToolExtensionInfo } from '/@api/cli-tool-info.js';
 
-import type { ApiSenderType } from './api.js';
 import { CliToolImpl } from './cli-tool-impl.js';
 import type { CliToolRegistry } from './cli-tool-registry.js';
-import type { Exec } from './util/exec.js';
 
 test('check updateVersion updates CliTool', () => {
   const options: CliToolOptions = {
@@ -36,8 +34,6 @@ test('check updateVersion updates CliTool', () => {
     path: 'path/to/tool-name',
   };
   const newCliTool = new CliToolImpl(
-    vi.fn() as unknown as ApiSenderType,
-    vi.fn() as unknown as Exec,
     vi.fn() as unknown as CliToolExtensionInfo,
     vi.fn() as unknown as CliToolRegistry,
     options,

--- a/packages/main/src/plugin/cli-tool-impl.ts
+++ b/packages/main/src/plugin/cli-tool-impl.ts
@@ -32,10 +32,8 @@ import type {
 
 import type { CliToolExtensionInfo } from '/@api/cli-tool-info.js';
 
-import type { ApiSenderType } from './api.js';
 import type { CliToolRegistry } from './cli-tool-registry.js';
 import { Emitter } from './events/emitter.js';
-import type { Exec } from './util/exec.js';
 
 export class CliToolImpl implements CliTool, Disposable {
   readonly id: string;
@@ -44,8 +42,6 @@ export class CliToolImpl implements CliTool, Disposable {
   readonly onDidUpdateVersion: Event<string> = this._onDidUpdateVersion.event;
 
   constructor(
-    private _apiSender: ApiSenderType,
-    private _exec: Exec,
     readonly extensionInfo: CliToolExtensionInfo,
     readonly registry: CliToolRegistry,
     private _options: CliToolOptions,

--- a/packages/main/src/plugin/cli-tool-registry.spec.ts
+++ b/packages/main/src/plugin/cli-tool-registry.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,6 @@ import type { CliToolExtensionInfo } from '/@api/cli-tool-info.js';
 import type { ApiSenderType } from './api.js';
 import type { CliToolImpl } from './cli-tool-impl.js';
 import { CliToolRegistry } from './cli-tool-registry.js';
-import type { Exec } from './util/exec.js';
 
 const apiSender: ApiSenderType = {
   send: vi.fn(),
@@ -36,7 +35,7 @@ const apiSender: ApiSenderType = {
 let cliToolRegistry: CliToolRegistry;
 suite('cli module', () => {
   beforeEach(() => {
-    cliToolRegistry = new CliToolRegistry(apiSender, vi.fn() as unknown as Exec);
+    cliToolRegistry = new CliToolRegistry(apiSender);
   });
 
   afterEach(() => {

--- a/packages/main/src/plugin/cli-tool-registry.ts
+++ b/packages/main/src/plugin/cli-tool-registry.ts
@@ -30,20 +30,16 @@ import type { CliToolExtensionInfo, CliToolInfo } from '/@api/cli-tool-info.js';
 import type { ApiSenderType } from './api.js';
 import { CliToolImpl } from './cli-tool-impl.js';
 import { Disposable } from './types/disposable.js';
-import type { Exec } from './util/exec.js';
 
 export class CliToolRegistry {
-  constructor(
-    private apiSender: ApiSenderType,
-    private exec: Exec,
-  ) {}
+  constructor(private apiSender: ApiSenderType) {}
 
   private cliTools = new Map<string, CliToolImpl>();
   private cliToolsUpdater = new Map<string, CliToolUpdate | CliToolSelectUpdate>();
   private cliToolsInstaller = new Map<string, CliToolInstaller>();
 
   createCliTool(extensionInfo: CliToolExtensionInfo, options: CliToolOptions): CliTool {
-    const cliTool = new CliToolImpl(this.apiSender, this.exec, extensionInfo, this, options);
+    const cliTool = new CliToolImpl(extensionInfo, this, options);
     this.cliTools.set(cliTool.id, cliTool);
     this.apiSender.send('cli-tool-create');
     cliTool.onDidUpdateVersion(() => this.apiSender.send('cli-tool-change', cliTool.id));

--- a/packages/main/src/plugin/close-behavior.spec.ts
+++ b/packages/main/src/plugin/close-behavior.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,11 +49,11 @@ test('should register a configuration', async () => {
 test('should set default value of configuraton registry on Linux to true', async () => {
   vi.spyOn(util, 'isLinux').mockImplementation(() => true);
   await closeBehavior.init();
-  expect(configurationRegistry.getConfigurationProperties()['preferences.ExitOnClose'].default).toBeTruthy();
+  expect(configurationRegistry.getConfigurationProperties()['preferences.ExitOnClose']?.default).toBeTruthy();
 });
 
 test('should set default value of configuraton registry if not Linux', async () => {
   vi.spyOn(util, 'isLinux').mockImplementation(() => false);
   await closeBehavior.init();
-  expect(configurationRegistry.getConfigurationProperties()['preferences.ExitOnClose'].default).toBeFalsy();
+  expect(configurationRegistry.getConfigurationProperties()['preferences.ExitOnClose']?.default).toBeFalsy();
 });

--- a/packages/main/src/plugin/color-registry.spec.ts
+++ b/packages/main/src/plugin/color-registry.spec.ts
@@ -33,34 +33,34 @@ import colorPalette from '../../../../tailwind-color-palette.json';
 import { ColorRegistry } from './color-registry.js';
 
 class TestColorRegistry extends ColorRegistry {
-  notifyUpdate(): void {
+  override notifyUpdate(): void {
     super.notifyUpdate();
   }
-  initColors(): void {
+  override initColors(): void {
     super.initColors();
   }
 
-  trackChanges(): void {
+  override trackChanges(): void {
     super.trackChanges();
   }
 
-  setDone(): void {
+  override setDone(): void {
     super.setDone();
   }
 
-  registerColor(colorId: string, definition: ColorDefinition): void {
+  override registerColor(colorId: string, definition: ColorDefinition): void {
     super.registerColor(colorId, definition);
   }
 
-  initTitlebar(): void {
+  override initTitlebar(): void {
     super.initTitlebar();
   }
 
-  initCardContent(): void {
+  override initCardContent(): void {
     super.initCardContent();
   }
 
-  initContent(): void {
+  override initContent(): void {
     super.initContent();
   }
 }
@@ -96,7 +96,7 @@ describe('trackChanges', () => {
 
     expect(spyOnDidChange).toHaveBeenCalled();
     // grab the anonymous function that is the first argument of the first call
-    const callback = spyOnDidChange.mock.calls[0][0];
+    const callback = spyOnDidChange.mock.calls[0]?.[0];
     expect(callback).toBeDefined();
 
     // call the callback
@@ -117,7 +117,7 @@ describe('trackChanges', () => {
 
     expect(spyOnDidChange).toHaveBeenCalled();
     // grab the anonymous function that is the first argument of the first call
-    const callback = spyOnDidChange.mock.calls[0][0];
+    const callback = spyOnDidChange.mock.calls[0]?.[0];
     expect(callback).toBeDefined();
 
     // call the callback
@@ -195,9 +195,9 @@ test('initTitlebar', async () => {
   expect(spyOnRegisterColor.mock.calls.length).toBeGreaterThanOrEqual(3);
 
   // check the first call
-  expect(spyOnRegisterColor.mock.calls[0][0]).toStrictEqual('titlebar-bg');
-  expect(spyOnRegisterColor.mock.calls[0][1].light).toBe('#f9fafb');
-  expect(spyOnRegisterColor.mock.calls[0][1].dark).toBe('#0f0f11');
+  expect(spyOnRegisterColor.mock.calls[0]?.[0]).toStrictEqual('titlebar-bg');
+  expect(spyOnRegisterColor.mock.calls[0]?.[1].light).toBe('#f9fafb');
+  expect(spyOnRegisterColor.mock.calls[0]?.[1].dark).toBe('#0f0f11');
 });
 
 test('initCardContent', async () => {
@@ -213,9 +213,9 @@ test('initCardContent', async () => {
   expect(spyOnRegisterColor.mock.calls.length).toBeGreaterThanOrEqual(3);
 
   // check the first call
-  expect(spyOnRegisterColor.mock.calls[0][0]).toStrictEqual('card-bg');
-  expect(spyOnRegisterColor.mock.calls[0][1].light).toBe(colorPalette.gray[300]);
-  expect(spyOnRegisterColor.mock.calls[0][1].dark).toBe(colorPalette.charcoal[800]);
+  expect(spyOnRegisterColor.mock.calls[0]?.[0]).toStrictEqual('card-bg');
+  expect(spyOnRegisterColor.mock.calls[0]?.[1].light).toBe(colorPalette.gray[300]);
+  expect(spyOnRegisterColor.mock.calls[0]?.[1].dark).toBe(colorPalette.charcoal[800]);
 });
 
 test('initContent', async () => {
@@ -231,9 +231,9 @@ test('initContent', async () => {
   expect(spyOnRegisterColor.mock.calls.length).toBeGreaterThanOrEqual(10);
 
   // check the first call
-  expect(spyOnRegisterColor.mock.calls[0][0]).toStrictEqual('content-breadcrumb');
-  expect(spyOnRegisterColor.mock.calls[0][1].light).toBe(colorPalette.purple[900]);
-  expect(spyOnRegisterColor.mock.calls[0][1].dark).toBe(colorPalette.gray[600]);
+  expect(spyOnRegisterColor.mock.calls[0]?.[0]).toStrictEqual('content-breadcrumb');
+  expect(spyOnRegisterColor.mock.calls[0]?.[1].light).toBe(colorPalette.purple[900]);
+  expect(spyOnRegisterColor.mock.calls[0]?.[1].dark).toBe(colorPalette.gray[600]);
 });
 
 describe('registerColor', () => {
@@ -251,14 +251,14 @@ describe('registerColor', () => {
     const lightColors = colorRegistry.listColors('light');
     expect(lightColors).toBeDefined();
     expect(lightColors).toHaveLength(1);
-    expect(lightColors[0].id).toBe('dummyColor');
-    expect(lightColors[0].value).toBe('lightColor');
+    expect(lightColors[0]?.id).toBe('dummyColor');
+    expect(lightColors[0]?.value).toBe('lightColor');
 
     const darkColors = colorRegistry.listColors('dark');
     expect(darkColors).toBeDefined();
     expect(darkColors).toHaveLength(1);
-    expect(darkColors[0].id).toBe('dummyColor');
-    expect(darkColors[0].value).toBe('darkColor');
+    expect(darkColors[0]?.id).toBe('dummyColor');
+    expect(darkColors[0]?.value).toBe('darkColor');
   });
 
   test('registerColor already defined', async () => {
@@ -285,9 +285,9 @@ describe('listColors', () => {
     const colors = colorRegistry.listColors('unknownTheme');
     expect(colors).toBeDefined();
     expect(colors).toHaveLength(1);
-    expect(colors[0].id).toBe('dummy-color');
-    expect(colors[0].cssVar).toBe('--pd-dummy-color');
-    expect(colors[0].value).toBe('darkColor');
+    expect(colors[0]?.id).toBe('dummy-color');
+    expect(colors[0]?.cssVar).toBe('--pd-dummy-color');
+    expect(colors[0]?.value).toBe('darkColor');
   });
 });
 

--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -96,7 +96,7 @@ export class ColorRegistry {
       for (const colorDefinitionId of this.#definitions.keys()) {
         // get the color from the theme
         // need to convert kebab-case to camelCase as in json it's contributed with camelCase
-        const camelCaseColorDefinitionId = colorDefinitionId.replace(/-([a-z])/g, g => g[1].toUpperCase());
+        const camelCaseColorDefinitionId = colorDefinitionId.replace(/-([a-z])/g, g => (g[1] ?? '').toUpperCase());
         let color: string | undefined = theme.colors[camelCaseColorDefinitionId];
         if (!color) {
           color = parentTheme?.get(colorDefinitionId);

--- a/packages/main/src/plugin/configuration-registry.spec.ts
+++ b/packages/main/src/plugin/configuration-registry.spec.ts
@@ -226,7 +226,7 @@ test('addConfigurationEnum', async () => {
   const records = configurationRegistry.getConfigurationProperties();
   const record = records['my.fake.enum.property'];
   expect(record).toBeDefined();
-  expect(record.enum).toEqual(['myValue1', 'myValue2', 'myValue3']);
+  expect(record?.enum).toEqual(['myValue1', 'myValue2', 'myValue3']);
 
   // now call the dispose
   disposable.dispose();
@@ -235,7 +235,7 @@ test('addConfigurationEnum', async () => {
 
   const afterDisposeRecord = records['my.fake.enum.property'];
   expect(afterDisposeRecord).toBeDefined();
-  expect(afterDisposeRecord.enum).toEqual(['myValue1', 'myValue2']);
+  expect(afterDisposeRecord?.enum).toEqual(['myValue1', 'myValue2']);
 });
 
 test('addConfigurationEnum with a previous default value', async () => {
@@ -264,7 +264,7 @@ test('addConfigurationEnum with a previous default value', async () => {
   const records = configurationRegistry.getConfigurationProperties();
   const record = records['my.fake.enum.property'];
   expect(record).toBeDefined();
-  expect(record.enum).toEqual(['myValue1', 'myValue2', 'myValue3']);
+  expect(record?.enum).toEqual(['myValue1', 'myValue2', 'myValue3']);
 
   // now call the dispose
   disposable.dispose();

--- a/packages/main/src/plugin/confirmation-init.spec.ts
+++ b/packages/main/src/plugin/confirmation-init.spec.ts
@@ -36,15 +36,15 @@ test('should register a configuration', async () => {
 
   expect(configurationRegistryMock.registerConfigurations).toBeCalled();
 
-  const configurationNode = vi.mocked(configurationRegistryMock.registerConfigurations).mock.calls[0][0][0];
-  expect(configurationNode.id).toBe('preferences.userConfirmation');
-  expect(configurationNode.title).toBe('User Confirmation');
-  expect(configurationNode.properties).toBeDefined();
-  expect(Object.keys(configurationNode.properties ?? {}).length).toBe(1);
-  expect(configurationNode.properties?.['userConfirmation.bulk']).toBeDefined();
-  expect(configurationNode.properties?.['userConfirmation.bulk'].description).toBe(
+  const configurationNode = vi.mocked(configurationRegistryMock.registerConfigurations).mock.calls[0]?.[0][0];
+  expect(configurationNode?.id).toBe('preferences.userConfirmation');
+  expect(configurationNode?.title).toBe('User Confirmation');
+  expect(configurationNode?.properties).toBeDefined();
+  expect(Object.keys(configurationNode?.properties ?? {}).length).toBe(1);
+  expect(configurationNode?.properties?.['userConfirmation.bulk']).toBeDefined();
+  expect(configurationNode?.properties?.['userConfirmation.bulk']?.description).toBe(
     'Require user confirmation for bulk actions',
   );
-  expect(configurationNode.properties?.['userConfirmation.bulk'].type).toBe('boolean');
-  expect(configurationNode.properties?.['userConfirmation.bulk'].default).toBe(true);
+  expect(configurationNode?.properties?.['userConfirmation.bulk']?.type).toBe('boolean');
+  expect(configurationNode?.properties?.['userConfirmation.bulk']?.default).toBe(true);
 });

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -313,27 +313,27 @@ const fakeContainerInspectInfoWithVolume = {
 };
 
 class TestContainerProviderRegistry extends ContainerProviderRegistry {
-  public extractContainerEnvironment(container: ContainerInspectInfo): { [key: string]: string } {
+  public override extractContainerEnvironment(container: ContainerInspectInfo): { [key: string]: string } {
     return super.extractContainerEnvironment(container);
   }
 
-  public getMatchingEngine(engineId: string): Dockerode {
+  public override getMatchingEngine(engineId: string): Dockerode {
     return super.getMatchingEngine(engineId);
   }
 
-  public getMatchingContainer(engineId: string, containerId: string): Dockerode.Container {
+  public override getMatchingContainer(engineId: string, containerId: string): Dockerode.Container {
     return super.getMatchingContainer(engineId, containerId);
   }
 
-  public getMatchingPodmanEngine(engineId: string): InternalContainerProvider {
+  public override getMatchingPodmanEngine(engineId: string): InternalContainerProvider {
     return super.getMatchingPodmanEngine(engineId);
   }
 
-  public getMatchingPodmanEngineLibPod(engineId: string): LibPod {
+  public override getMatchingPodmanEngineLibPod(engineId: string): LibPod {
     return super.getMatchingPodmanEngineLibPod(engineId);
   }
 
-  public getMatchingContainerProvider(
+  public override getMatchingContainerProvider(
     providerContainerConnectionInfo: ProviderContainerConnectionInfo | podmanDesktopAPI.ContainerProviderConnection,
   ): InternalContainerProvider {
     return super.getMatchingContainerProvider(providerContainerConnectionInfo);
@@ -347,7 +347,9 @@ class TestContainerProviderRegistry extends ContainerProviderRegistry {
     this.containerProviders.set(name, provider);
   }
 
-  getMatchingEngineFromConnection(providerContainerConnectionInfo: ProviderContainerConnectionInfo): Dockerode {
+  override getMatchingEngineFromConnection(
+    providerContainerConnectionInfo: ProviderContainerConnectionInfo,
+  ): Dockerode {
     return super.getMatchingEngineFromConnection(providerContainerConnectionInfo);
   }
 
@@ -940,19 +942,19 @@ describe('listContainers', () => {
     expect(containers).toBeDefined();
     expect(containers).toHaveLength(1);
     const container = containers[0];
-    expect(container.engineId).toBe('podman1');
-    expect(container.engineName).toBe('podman');
-    expect(container.engineType).toBe('podman');
-    expect(container.StartedAt).toBe('2023-08-10T13:37:44.000Z');
-    expect(container.pod).toBeUndefined();
-    expect(container.Id).toBe('31a4b282691420be2611817f203765402d8da7e13cd530f80a6ddd1bb4aa63b4');
-    expect(container.Command).toBe('httpd-foreground');
-    expect(container.Names).toStrictEqual(['/admiring_wing']);
-    expect(container.Image).toBe('docker.io/library/httpd:latest');
-    expect(container.ImageID).toBe('sha256:911d72fc5020723f0c003a134a8d2f062b4aea884474a11d1db7dcd28ce61d6a');
-    expect(container.Created).toBe(1691674664);
-    expect(container.ImageBase64RepoTag).toBe('ZG9ja2VyLmlvL2xpYnJhcnkvaHR0cGQ6bGF0ZXN0');
-    expect(container.Ports).toStrictEqual([
+    expect(container?.engineId).toBe('podman1');
+    expect(container?.engineName).toBe('podman');
+    expect(container?.engineType).toBe('podman');
+    expect(container?.StartedAt).toBe('2023-08-10T13:37:44.000Z');
+    expect(container?.pod).toBeUndefined();
+    expect(container?.Id).toBe('31a4b282691420be2611817f203765402d8da7e13cd530f80a6ddd1bb4aa63b4');
+    expect(container?.Command).toBe('httpd-foreground');
+    expect(container?.Names).toStrictEqual(['/admiring_wing']);
+    expect(container?.Image).toBe('docker.io/library/httpd:latest');
+    expect(container?.ImageID).toBe('sha256:911d72fc5020723f0c003a134a8d2f062b4aea884474a11d1db7dcd28ce61d6a');
+    expect(container?.Created).toBe(1691674664);
+    expect(container?.ImageBase64RepoTag).toBe('ZG9ja2VyLmlvL2xpYnJhcnkvaHR0cGQ6bGF0ZXN0');
+    expect(container?.Ports).toStrictEqual([
       {
         IP: '',
         PrivatePort: 8080,
@@ -960,11 +962,11 @@ describe('listContainers', () => {
         Type: 'tcp',
       },
     ]);
-    expect(container.Labels).toStrictEqual({
+    expect(container?.Labels).toStrictEqual({
       'io.buildah.version': '1.30.0',
       maintainer: 'Podman Maintainers',
     });
-    expect(container.State).toBe('running');
+    expect(container?.State).toBe('running');
   });
 
   test('list containers with Docker API', async () => {
@@ -1041,12 +1043,12 @@ describe('listContainers', () => {
     expect(containers).toBeDefined();
     expect(containers).toHaveLength(1);
     const container = containers[0];
-    expect(container.engineId).toBe('docker1');
-    expect(container.engineName).toBe('docker');
-    expect(container.engineType).toBe('docker');
+    expect(container?.engineId).toBe('docker1');
+    expect(container?.engineName).toBe('docker');
+    expect(container?.engineType).toBe('docker');
 
     // grab StartedAt from the containerWithDockerAPI
-    const started = container.StartedAt;
+    const started = container?.StartedAt;
 
     //convert with moment
     const diff = moment.now() - moment(started).toDate().getTime();
@@ -1054,26 +1056,26 @@ describe('listContainers', () => {
 
     // expect delta to be 2 minutes
     expect(delta).toBe(2);
-    expect(container.pod).toBeUndefined();
+    expect(container?.pod).toBeUndefined();
 
-    expect(container.Id).toBe('31a4b282691420be2611817f203765402d8da7e13cd530f80a6ddd1bb4aa63b4');
-    expect(container.Command).toBe('httpd-foreground');
-    expect(container.Names).toStrictEqual(['/admiring_wing']);
-    expect(container.Image).toBe('docker.io/library/httpd:latest');
-    expect(container.ImageID).toBe('sha256:911d72fc5020723f0c003a134a8d2f062b4aea884474a11d1db7dcd28ce61d6a');
-    expect(container.Created).toBe(1691674664);
-    expect(container.Ports).toStrictEqual([
+    expect(container?.Id).toBe('31a4b282691420be2611817f203765402d8da7e13cd530f80a6ddd1bb4aa63b4');
+    expect(container?.Command).toBe('httpd-foreground');
+    expect(container?.Names).toStrictEqual(['/admiring_wing']);
+    expect(container?.Image).toBe('docker.io/library/httpd:latest');
+    expect(container?.ImageID).toBe('sha256:911d72fc5020723f0c003a134a8d2f062b4aea884474a11d1db7dcd28ce61d6a');
+    expect(container?.Created).toBe(1691674664);
+    expect(container?.Ports).toStrictEqual([
       {
         PrivatePort: 8080,
         PublicPort: 8080,
         Type: 'tcp',
       },
     ]);
-    expect(container.Labels).toStrictEqual({
+    expect(container?.Labels).toStrictEqual({
       'io.buildah.version': '1.30.0',
       maintainer: 'Podman Maintainers',
     });
-    expect(container.State).toBe('running');
+    expect(container?.State).toBe('running');
   });
 
   test('list containers with Podman API and null command value', async () => {
@@ -1146,18 +1148,18 @@ describe('listContainers', () => {
     expect(containers).toBeDefined();
     expect(containers).toHaveLength(1);
     const container = containers[0];
-    expect(container.engineId).toBe('podman1');
-    expect(container.engineName).toBe('podman');
-    expect(container.engineType).toBe('podman');
-    expect(container.StartedAt).toBe('2023-08-10T13:37:44.000Z');
-    expect(container.pod).toBeUndefined();
-    expect(container.Id).toBe('31a4b282691420be2611817f203765402d8da7e13cd530f80a6ddd1bb4aa63b4');
-    expect(container.Command).toBe(undefined);
-    expect(container.Names).toStrictEqual(['/admiring_wing']);
-    expect(container.Image).toBe('docker.io/library/httpd:latest');
-    expect(container.ImageID).toBe('sha256:911d72fc5020723f0c003a134a8d2f062b4aea884474a11d1db7dcd28ce61d6a');
-    expect(container.Created).toBe(1691674664);
-    expect(container.Ports).toStrictEqual([
+    expect(container?.engineId).toBe('podman1');
+    expect(container?.engineName).toBe('podman');
+    expect(container?.engineType).toBe('podman');
+    expect(container?.StartedAt).toBe('2023-08-10T13:37:44.000Z');
+    expect(container?.pod).toBeUndefined();
+    expect(container?.Id).toBe('31a4b282691420be2611817f203765402d8da7e13cd530f80a6ddd1bb4aa63b4');
+    expect(container?.Command).toBe(undefined);
+    expect(container?.Names).toStrictEqual(['/admiring_wing']);
+    expect(container?.Image).toBe('docker.io/library/httpd:latest');
+    expect(container?.ImageID).toBe('sha256:911d72fc5020723f0c003a134a8d2f062b4aea884474a11d1db7dcd28ce61d6a');
+    expect(container?.Created).toBe(1691674664);
+    expect(container?.Ports).toStrictEqual([
       {
         IP: '',
         PrivatePort: 8080,
@@ -1165,11 +1167,11 @@ describe('listContainers', () => {
         Type: 'tcp',
       },
     ]);
-    expect(container.Labels).toStrictEqual({
+    expect(container?.Labels).toStrictEqual({
       'io.buildah.version': '1.30.0',
       maintainer: 'Podman Maintainers',
     });
-    expect(container.State).toBe('running');
+    expect(container?.State).toBe('running');
   });
 });
 
@@ -1897,17 +1899,17 @@ describe('listVolumes', () => {
     expect(volumes).toBeDefined();
     expect(volumes).toHaveLength(1);
     const volume = volumes[0];
-    expect(volume.engineId).toBe('podman1');
-    expect(volume.engineName).toBe('podman');
-    expect(volume.Volumes).toHaveLength(3);
+    expect(volume?.engineId).toBe('podman1');
+    expect(volume?.engineName).toBe('podman');
+    expect(volume?.Volumes).toHaveLength(3);
 
-    const volumeData = volume.Volumes[2];
+    const volumeData = volume?.Volumes[2];
 
-    expect(volumeData.Name).toBe('myFirstVolume');
+    expect(volumeData?.Name).toBe('myFirstVolume');
 
     // check UsageData is set (provided by system/df)
     // refcount is 1 as one container is using it
-    expect(volumeData.UsageData).toStrictEqual({
+    expect(volumeData?.UsageData).toStrictEqual({
       RefCount: 1,
       Size: 83990640,
     });
@@ -2018,18 +2020,18 @@ describe('listVolumes', () => {
     expect(volumes).toBeDefined();
     expect(volumes).toHaveLength(1);
     const volume = volumes[0];
-    expect(volume.engineId).toBe('podman1');
-    expect(volume.engineName).toBe('podman');
-    expect(volume.Volumes).toHaveLength(3);
+    expect(volume?.engineId).toBe('podman1');
+    expect(volume?.engineName).toBe('podman');
+    expect(volume?.Volumes).toHaveLength(3);
 
-    const volumeData = volume.Volumes[2];
+    const volumeData = volume?.Volumes[2];
 
-    expect(volumeData.Name).toBe('myFirstVolume');
+    expect(volumeData?.Name).toBe('myFirstVolume');
 
     // check UsageData is set (provided by system/df)
     // refcount is 1 as one container is using it
     // but size is -1 as we skip system df call
-    expect(volumeData.UsageData).toStrictEqual({
+    expect(volumeData?.UsageData).toStrictEqual({
       RefCount: 1,
       Size: -1,
     });
@@ -2091,9 +2093,9 @@ describe('listVolumes', () => {
     expect(volumes).toBeDefined();
     expect(volumes).toHaveLength(1);
     const volume = volumes[0];
-    expect(volume.engineId).toBe('podman1');
-    expect(volume.engineName).toBe('podman');
-    expect(volume.Volumes).toHaveLength(1);
+    expect(volume?.engineId).toBe('podman1');
+    expect(volume?.engineName).toBe('podman');
+    expect(volume?.Volumes).toHaveLength(1);
   });
 });
 
@@ -2185,10 +2187,10 @@ describe('listNetworks', () => {
     expect(networks).toBeDefined();
     expect(networks).toHaveLength(2);
     const network = networks[0];
-    expect(network.engineId).toBe('podman1');
-    expect(network.engineName).toBe('podman');
+    expect(network?.engineId).toBe('podman1');
+    expect(network?.engineName).toBe('podman');
 
-    expect(network.Name).toBe('podify');
+    expect(network?.Name).toBe('podify');
   });
 });
 
@@ -3155,7 +3157,7 @@ test('setupConnectionAPI with errors', async () => {
   // filter calls to find the one with container-started-event
   const containerStartedEventCalls = allCalls.filter(call => call[0] === 'container-started-event');
   expect(containerStartedEventCalls).toHaveLength(1);
-  expect(containerStartedEventCalls[0][1]).toBe(fakeId);
+  expect(containerStartedEventCalls[0]?.[1]).toBe(fakeId);
 
   stream2.end();
 
@@ -3618,10 +3620,10 @@ test('list pods', async () => {
   expect(pods).toBeDefined();
   expect(pods).toHaveLength(1);
   const pod = pods[0];
-  expect(pod.engineId).toBe('podman1');
-  expect(pod.engineName).toBe('podman');
-  expect(pod.kind).toBe('podman');
-  expect(pod.Labels).toStrictEqual({
+  expect(pod?.engineId).toBe('podman1');
+  expect(pod?.engineName).toBe('podman');
+  expect(pod?.kind).toBe('podman');
+  expect(pod?.Labels).toStrictEqual({
     key1: 'value1',
     key2: 'value2',
   });
@@ -4021,9 +4023,9 @@ test('list images with podmanListImages correctly', async () => {
   expect(images).toBeDefined();
   expect(images).toHaveLength(1);
   const image = images[0];
-  expect(image.engineId).toBe('podman1');
-  expect(image.engineName).toBe('podman');
-  expect(image.Id).toBe('sha256:dummyImageId');
+  expect(image?.engineId).toBe('podman1');
+  expect(image?.engineName).toBe('podman');
+  expect(image?.Id).toBe('sha256:dummyImageId');
 });
 
 test('expect images with podmanListImages to also include History as well as engineId and engineName', async () => {
@@ -4054,9 +4056,9 @@ test('expect images with podmanListImages to also include History as well as eng
   expect(images).toBeDefined();
   expect(images).toHaveLength(1);
   const image = images[0];
-  expect(image.engineId).toBe('podman1');
-  expect(image.engineName).toBe('podman');
-  expect(image.History).toStrictEqual(['history1', 'history2']);
+  expect(image?.engineId).toBe('podman1');
+  expect(image?.engineName).toBe('podman');
+  expect(image?.History).toStrictEqual(['history1', 'history2']);
 });
 
 test('expect images with podmanListImages to also include Digest as engineId and engineName', async () => {
@@ -4087,9 +4089,9 @@ test('expect images with podmanListImages to also include Digest as engineId and
   expect(images).toBeDefined();
   expect(images).toHaveLength(1);
   const image = images[0];
-  expect(image.engineId).toBe('podman1');
-  expect(image.engineName).toBe('podman');
-  expect(image.Digest).toBe('dummyDigest');
+  expect(image?.engineId).toBe('podman1');
+  expect(image?.engineName).toBe('podman');
+  expect(image?.Digest).toBe('dummyDigest');
 });
 
 test('If image does not have Digest in list images, expect the Digest to be sha256:ID', async () => {
@@ -4122,9 +4124,9 @@ test('If image does not have Digest in list images, expect the Digest to be sha2
   expect(images).toBeDefined();
   expect(images).toHaveLength(1);
   const image = images[0];
-  expect(image.engineId).toBe('podman1');
-  expect(image.engineName).toBe('podman');
-  expect(image.Digest).toBe('sha256:c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2');
+  expect(image?.engineId).toBe('podman1');
+  expect(image?.engineName).toBe('podman');
+  expect(image?.Digest).toBe('sha256:c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2');
 });
 
 test('expect to fall back to compat api images if podman provider does not have libpodApi', async () => {
@@ -4160,7 +4162,7 @@ test('expect to fall back to compat api images if podman provider does not have 
   // ensure the field are correct
   expect(images).toBeDefined();
   expect(images).toHaveLength(1);
-  expect(images[0].Id).toBe('dummyImageId2');
+  expect(images[0]?.Id).toBe('dummyImageId2');
 });
 
 test('expect a blank array if there is no api or libpod API when doing podmanListImages', async () => {
@@ -4800,32 +4802,32 @@ test('manifest is listed as true with podmanListImages correctly', async () => {
 
   // Check the first image
   const image = images[0];
-  expect(image.engineId).toBe('podman1');
-  expect(image.engineName).toBe('podman');
-  expect(image.Id).toBe('manifestImage');
-  expect(image.isManifest).toBe(true);
+  expect(image?.engineId).toBe('podman1');
+  expect(image?.engineName).toBe('podman');
+  expect(image?.Id).toBe('manifestImage');
+  expect(image?.isManifest).toBe(true);
 
   // Check that the manifest returned sha:256:digest123
-  expect(image.manifests).toBeDefined();
-  expect(image.manifests).toHaveLength(1);
-  if (image.manifests) {
-    expect(image.manifests[0].digest).toBe('sha256:digest123');
+  expect(image?.manifests).toBeDefined();
+  expect(image?.manifests).toHaveLength(1);
+  if (image?.manifests) {
+    expect(image?.manifests[0]?.digest).toBe('sha256:digest123');
   }
 
   // Check the second image
   const image2 = images[1];
-  expect(image2.engineId).toBe('podman1');
-  expect(image2.engineName).toBe('podman');
-  expect(image2.Id).toBe('ee301c921b8aadc002973b2e0c3da17d701dcd994b606769a7e6eaa100b81d44');
-  expect(image2.isManifest).toBe(false);
+  expect(image2?.engineId).toBe('podman1');
+  expect(image2?.engineName).toBe('podman');
+  expect(image2?.Id).toBe('ee301c921b8aadc002973b2e0c3da17d701dcd994b606769a7e6eaa100b81d44');
+  expect(image2?.isManifest).toBe(false);
 
   // Check the third image manifest is false due to isManifestList despite all the "guesses" that it should be a manifest
   const image3 = images[2];
-  expect(image3.isManifest).toBe(false);
+  expect(image3?.isManifest).toBe(false);
 
   // Check the fourth image manifest is true due to isManifestList being true
   const image4 = images[3];
-  expect(image4.isManifest).toBe(true);
+  expect(image4?.isManifest).toBe(true);
 });
 
 test('if configuration setting is disabled for using libpodApi, it should fall back to compat api', async () => {
@@ -4860,8 +4862,8 @@ test('if configuration setting is disabled for using libpodApi, it should fall b
   expect(images).toBeDefined();
   expect(images).toHaveLength(1);
   const image = images[0];
-  expect(image.engineId).toBe('podman1');
-  expect(image.engineName).toBe('podman');
+  expect(image?.engineId).toBe('podman1');
+  expect(image?.engineName).toBe('podman');
 });
 
 test('check that inspectManifest returns information from libPod.podmanInspectManifest', async () => {

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -453,7 +453,9 @@ export class ContainerProviderRegistry {
               if (podmanContainer.Labels) {
                 // copy all labels
                 for (const label of Object.keys(podmanContainer.Labels)) {
-                  Labels[label] = podmanContainer.Labels[label];
+                  if (podmanContainer.Labels[label]) {
+                    Labels[label] = podmanContainer.Labels[label];
+                  }
                 }
               }
 
@@ -970,7 +972,7 @@ export class ContainerProviderRegistry {
     });
 
     const matchingConnection = matchingContainerProviders[0];
-    if (!matchingConnection[1].api) {
+    if (!matchingConnection?.[1].api) {
       throw new Error('No provider with a running engine');
     }
 
@@ -1070,7 +1072,7 @@ export class ContainerProviderRegistry {
 
   getImageName(inspectInfo: Dockerode.ImageInspectInfo): string {
     const tags = inspectInfo.RepoTags;
-    if (!tags) {
+    if (!tags?.[0]) {
       throw new Error('Cannot push an image without a tag');
     }
     // take the first tag
@@ -1407,7 +1409,9 @@ export class ContainerProviderRegistry {
     return container.Config.Env.reduce((acc: { [key: string]: string }, env) => {
       // should handle multiple values after the = sign
       const [key, ...values] = env.split('=');
-      acc[key] = values.join('=');
+      if (key) {
+        acc[key] = values.join('=');
+      }
       return acc;
     }, {});
   }
@@ -2009,7 +2013,9 @@ export class ContainerProviderRegistry {
     // convert env from array of string to an object with key being the env name
     const updatedEnv = options.Env?.reduce((acc: { [key: string]: string }, env) => {
       const [key, value] = env.split('=');
-      acc[key] = value;
+      if (key && value) {
+        acc[key] = value;
+      }
       return acc;
     }, {});
 
@@ -2076,7 +2082,7 @@ export class ContainerProviderRegistry {
         if (hostItems.length !== 2) {
           continue;
         }
-        dns_server.push(hostItems[1].split('.').map(v => parseInt(v)));
+        dns_server.push((hostItems[1]?.split('.') ?? []).map(v => parseInt(v)));
       }
     }
 
@@ -2122,7 +2128,7 @@ export class ContainerProviderRegistry {
     const options = ['rbind'];
     let propagation = 'rprivate';
     if (bindItems.length === 3) {
-      const flags = bindItems[2].split(',');
+      const flags = bindItems[2]?.split(',') ?? [];
       for (const flag of flags) {
         switch (flag) {
           case 'Z':
@@ -2139,6 +2145,10 @@ export class ContainerProviderRegistry {
             break;
         }
       }
+    }
+
+    if (bindItems[0] === undefined || bindItems[1] === undefined) {
+      return undefined;
     }
 
     return {

--- a/packages/main/src/plugin/context/context.ts
+++ b/packages/main/src/plugin/context/context.ts
@@ -84,6 +84,9 @@ export class Context implements IContext {
       return undefined;
     }
     const bits = key.split('.');
+    if (!bits[0]) {
+      return undefined;
+    }
     let contextValue = this.getValue<T>(bits[0]);
     if (contextValue === undefined) {
       return undefined;

--- a/packages/main/src/plugin/contribution-manager.spec.ts
+++ b/packages/main/src/plugin/contribution-manager.spec.ts
@@ -145,13 +145,13 @@ test('Should interpret ${DESKTOP_PLUGIN_IMAGE}', async () => {
   };
   const result = await contributionManager.doEnhanceCompose(ociImage, extensionName, portNumber, composeFile);
 
-  expect(result.services['devenv-volumes'].image).toBe(ociImage);
+  expect(result.services['devenv-volumes']?.image).toBe(ociImage);
 });
 
 test('Should add custom labels', async () => {
   const result = await contributionManager.doEnhanceCompose(ociImage, extensionName, portNumber, composeFileExample);
 
-  expect(result.services['devenv-volumes'].labels).toStrictEqual({
+  expect(result.services['devenv-volumes']?.labels).toStrictEqual({
     'com.docker.desktop.extension': 'true',
     'com.docker.desktop.extension.name': 'my-extension',
     'io.podman_desktop.PodmanDesktop.extension': 'true',
@@ -162,16 +162,16 @@ test('Should add custom labels', async () => {
 test('Should add restart policy', async () => {
   const result = await contributionManager.doEnhanceCompose(ociImage, extensionName, portNumber, composeFileExample);
 
-  expect(result.services['devenv-volumes'].deploy?.restart_policy?.condition).toBe('always');
+  expect(result.services['devenv-volumes']?.deploy?.restart_policy?.condition).toBe('always');
 });
 
 test('Should add volumes from', async () => {
   const result = await contributionManager.doEnhanceCompose(ociImage, extensionName, portNumber, composeFileExample);
 
-  expect(result.services['devenv-volumes'].volumes_from).toStrictEqual(['podman-desktop-socket']);
+  expect(result.services['devenv-volumes']?.volumes_from).toStrictEqual(['podman-desktop-socket']);
 
   // check the volume is not added on the podman-desktop-socket service
-  expect(result.services['podman-desktop-socket'].volumes_from).toBeUndefined();
+  expect(result.services['podman-desktop-socket']?.volumes_from).toBeUndefined();
 });
 
 test('Should not add a service to expose port if no socket', async () => {
@@ -182,13 +182,13 @@ test('Should not add a service to expose port if no socket', async () => {
   expect(podmanDesktopService).toBeDefined();
 
   // check new service is exposing the port
-  expect(podmanDesktopService.ports).toBeUndefined();
+  expect(podmanDesktopService?.ports).toBeUndefined();
 
   // check the volumes is mounted
-  expect(podmanDesktopService.volumes).toStrictEqual(['/run/guest-services']);
+  expect(podmanDesktopService?.volumes).toStrictEqual(['/run/guest-services']);
 
   // no socket exposure
-  expect(podmanDesktopService.command).not.toContain('socat');
+  expect(podmanDesktopService?.command).not.toContain('socat');
 });
 
 test('Should add a service to expose port if socket', async () => {
@@ -206,15 +206,15 @@ test('Should add a service to expose port if socket', async () => {
   expect(podmanDesktopService).toBeDefined();
 
   // check new service is exposing the port
-  expect(podmanDesktopService.ports).toStrictEqual(['10000:10000']);
+  expect(podmanDesktopService?.ports).toStrictEqual(['10000:10000']);
 
   // check the volumes is mounted
-  expect(podmanDesktopService.volumes).toStrictEqual(['/run/guest-services']);
+  expect(podmanDesktopService?.volumes).toStrictEqual(['/run/guest-services']);
 
   // socket exposure
-  expect(podmanDesktopService.command).toContain('socat');
+  expect(podmanDesktopService?.command).toContain('socat');
   // socket exposure
-  expect(podmanDesktopService.command).toContain(`/run/guest-services/${socketPath}`);
+  expect(podmanDesktopService?.command).toContain(`/run/guest-services/${socketPath}`);
 });
 
 test('Check invalid port file', async () => {

--- a/packages/main/src/plugin/dialog-registry.ts
+++ b/packages/main/src/plugin/dialog-registry.ts
@@ -87,6 +87,8 @@ export class DialogRegistry {
       // return the URIs if dialogId is not provided (call from main process)
       return paths;
     }
+
+    return undefined;
   }
 
   async saveDialog(options?: SaveDialogOptions, dialogId?: string): Promise<APIUri | undefined> {
@@ -123,5 +125,6 @@ export class DialogRegistry {
     } else {
       return fileUri;
     }
+    return undefined;
   }
 }

--- a/packages/main/src/plugin/docker-extension/docker-desktop-installation.spec.ts
+++ b/packages/main/src/plugin/docker-extension/docker-desktop-installation.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,19 +69,19 @@ const apiSender: ApiSenderType = {
 
 class TestDockerDesktopInstallation extends DockerDesktopInstallation {
   // transform the method name to a got method
-  isGotMethod(methodName: string): methodName is Method {
+  override isGotMethod(methodName: string): methodName is Method {
     return super.isGotMethod(methodName);
   }
 
-  asGotMethod(methodName: string): Method {
+  override asGotMethod(methodName: string): Method {
     return super.asGotMethod(methodName);
   }
 
-  async handleExtensionVMServiceRequest(port: string, config: RequestConfig): Promise<unknown> {
+  override async handleExtensionVMServiceRequest(port: string, config: RequestConfig): Promise<unknown> {
     return super.handleExtensionVMServiceRequest(port, config);
   }
 
-  async handlePluginInstall(event: IpcMainEvent, imageName: string, logCallbackId: number): Promise<void> {
+  override async handlePluginInstall(event: IpcMainEvent, imageName: string, logCallbackId: number): Promise<void> {
     return super.handlePluginInstall(event, imageName, logCallbackId);
   }
 }

--- a/packages/main/src/plugin/docker-extension/docker-desktop-installation.ts
+++ b/packages/main/src/plugin/docker-extension/docker-desktop-installation.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022-2023 Red Hat, Inc.
+ * Copyright (C) 2022-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -204,7 +204,7 @@ export class DockerDesktopInstallation {
 
     this.ipcHandle(
       'docker-desktop-plugin:delete',
-      async (event: IpcMainInvokeEvent, extensionId: string): Promise<void> => {
+      async (_event: IpcMainInvokeEvent, extensionId: string): Promise<void> => {
         return this.contributionManager.deleteExtension(extensionId);
       },
     );
@@ -373,7 +373,16 @@ export class DockerDesktopInstallation {
     // strip the tag (ending with :something) from the image name if any
     let imageNameWithoutTag: string;
     if (imageName.includes(':')) {
-      imageNameWithoutTag = imageName.split(':')[0];
+      const splitVal = imageName.split(':')[0];
+      if (!splitVal) {
+        event.reply(
+          'docker-desktop-plugin:install-error',
+          logCallbackId,
+          `Invalid image name ${imageName}. Please provide a valid image name.`,
+        );
+        return;
+      }
+      imageNameWithoutTag = splitVal;
     } else {
       imageNameWithoutTag = imageName;
     }

--- a/packages/main/src/plugin/docker-extension/docker-desktop-installer.ts
+++ b/packages/main/src/plugin/docker-extension/docker-desktop-installer.ts
@@ -93,7 +93,7 @@ export class DockerDesktopInstaller {
       // do we have binaries ?
       if (metadata.host.binaries) {
         metadata.host.binaries.forEach((binary: { [key: string]: { path: string }[] }) => {
-          binary[platform].forEach(binaryPlatform => {
+          binary[platform]?.forEach(binaryPlatform => {
             hostFiles.push(binaryPlatform.path);
           });
         });

--- a/packages/main/src/plugin/docker-extension/docker-plugin-adapter.spec.ts
+++ b/packages/main/src/plugin/docker-extension/docker-plugin-adapter.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ vi.mock('electron', () => {
 const contributionManager = {} as unknown as ContributionManager;
 
 class TestDockerPluginAdapter extends DockerPluginAdapter {
-  async getVmServiceContainer(contributionId: string): Promise<SimpleContainerInfo> {
+  override async getVmServiceContainer(contributionId: string): Promise<SimpleContainerInfo> {
     return super.getVmServiceContainer(contributionId);
   }
 }

--- a/packages/main/src/plugin/docker-extension/docker-plugin-adapter.ts
+++ b/packages/main/src/plugin/docker-extension/docker-plugin-adapter.ts
@@ -49,10 +49,11 @@ export class DockerPluginAdapter {
     let result: string[] = [];
     for (let i = args.length - 1; i >= 0; i--) {
       const j = i - 1;
+      const value = args[i];
       if (j >= 0 && args[j] === '-v' && args[i] === '/var/run/docker.sock:/var/run/docker.sock') {
         i--;
-      } else {
-        result = [args[i], ...result];
+      } else if (value) {
+        result = [value, ...result];
       }
     }
     return [cmd, ...result];
@@ -63,13 +64,13 @@ export class DockerPluginAdapter {
     const contributionPath = this.contributionManager.getExtensionPath(extensionId);
     if (contributionPath) {
       if (os.platform() === 'win32') {
-        if (process.env.Path) {
-          env.Path = `${contributionPath};${process.env.Path}`;
+        if (process.env['Path']) {
+          env['Path'] = `${contributionPath};${process.env['Path']}`;
         } else {
-          env.Path = `${contributionPath}`;
+          env['Path'] = `${contributionPath}`;
         }
       } else {
-        env.PATH = `${contributionPath}:${env.PATH}`;
+        env['PATH'] = `${contributionPath}:${env['PATH']}`;
       }
     }
   }
@@ -149,8 +150,8 @@ export class DockerPluginAdapter {
     }
 
     const env = process.env;
-    if (os.platform() === 'darwin' && env.PATH) {
-      env.PATH = env.PATH.concat(':').concat(DockerPluginAdapter.MACOS_EXTRA_PATH);
+    if (os.platform() === 'darwin' && env['PATH']) {
+      env['PATH'] = env['PATH'].concat(':').concat(DockerPluginAdapter.MACOS_EXTRA_PATH);
     }
 
     // In production mode, applications don't have access to the 'user' path like brew
@@ -241,8 +242,8 @@ export class DockerPluginAdapter {
     let updatedCommand;
     let updatedArgs;
     const env = process.env;
-    if (os.platform() === 'darwin' && env.PATH) {
-      env.PATH = env.PATH.concat(':').concat(DockerPluginAdapter.MACOS_EXTRA_PATH);
+    if (os.platform() === 'darwin' && env['PATH']) {
+      env['PATH'] = env['PATH'].concat(':').concat(DockerPluginAdapter.MACOS_EXTRA_PATH);
     }
     if (launcher) {
       updatedCommand = launcher;
@@ -302,7 +303,7 @@ export class DockerPluginAdapter {
     ipcMain.handle(
       'docker-plugin-adapter:exec',
       async (
-        event: IpcMainInvokeEvent,
+        _event: IpcMainInvokeEvent,
         contributionId: string,
         launcher: string | undefined,
         cmd: string,

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.spec.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ beforeAll(() => {
 test('Check force is not given with default remove pod options', async () => {
   nock('http://localhost')
     .delete('/v4.2.0/libpod/pods/dummy')
-    .query(query => !query.force)
+    .query(query => !query['force'])
     .reply(200);
   const api = new Dockerode({ protocol: 'http', host: 'localhost' });
   await (api as unknown as LibPod).removePod('dummy');
@@ -45,7 +45,7 @@ test('Check force is not given with default remove pod options', async () => {
 test('Check force is given with remove pod options', async () => {
   nock('http://localhost')
     .delete('/v4.2.0/libpod/pods/dummy')
-    .query(query => query.force === 'true')
+    .query(query => query['force'] === 'true')
     .reply(200);
   const api = new Dockerode({ protocol: 'http', host: 'localhost' });
   await (api as unknown as LibPod).removePod('dummy', { force: true });
@@ -72,7 +72,7 @@ test('Check list of images using Podman API', async () => {
   const listOfImages = await (api as unknown as LibPod).podmanListImages({} as PodmanListImagesOptions);
   expect(listOfImages.length).toBe(1);
   const firstImage = listOfImages[0];
-  expect(firstImage.Id).toBe('sha256:1234567890');
+  expect(firstImage?.Id).toBe('sha256:1234567890');
 });
 
 test('Check list of containers using Podman API', async () => {
@@ -118,7 +118,7 @@ test('Check list of containers using Podman API', async () => {
   const listOfContainers = await (api as unknown as LibPod).listPodmanContainers();
   expect(listOfContainers.length).toBe(1);
   const firstContainer = listOfContainers[0];
-  expect(firstContainer.Id).toBe('37a54a845ef27a212634ef00c994c0793b5f19ec16853d606beb1c929461c1cd');
+  expect(firstContainer?.Id).toBe('37a54a845ef27a212634ef00c994c0793b5f19ec16853d606beb1c929461c1cd');
 });
 
 test('Check list of containers using Podman API and all true options', async () => {
@@ -164,7 +164,7 @@ test('Check list of containers using Podman API and all true options', async () 
   const listOfContainers = await (api as unknown as LibPod).listPodmanContainers({ all: true });
   expect(listOfContainers.length).toBe(1);
   const firstContainer = listOfContainers[0];
-  expect(firstContainer.Id).toBe('37a54a845ef27a212634ef00c994c0793b5f19ec16853d606beb1c929461c1cd');
+  expect(firstContainer?.Id).toBe('37a54a845ef27a212634ef00c994c0793b5f19ec16853d606beb1c929461c1cd');
 });
 
 test('Check attach API', async () => {
@@ -253,11 +253,11 @@ test('Check using libpod/manifests/{name}/json endpoint', async () => {
   expect(manifest.manifests.length).toBe(1);
 
   // Check manifest.manifests
-  expect(manifest.manifests[0].mediaType).toBe('application/vnd.docker.distribution.manifest.v2+json');
-  expect(manifest.manifests[0].platform.architecture).toBe('amd64');
-  expect(manifest.manifests[0].platform.os).toBe('linux');
-  expect(manifest.manifests[0].size).toBe(0);
-  expect(manifest.manifests[0].urls).toEqual([]);
+  expect(manifest.manifests[0]?.mediaType).toBe('application/vnd.docker.distribution.manifest.v2+json');
+  expect(manifest.manifests[0]?.platform.architecture).toBe('amd64');
+  expect(manifest.manifests[0]?.platform.os).toBe('linux');
+  expect(manifest.manifests[0]?.size).toBe(0);
+  expect(manifest.manifests[0]?.urls).toEqual([]);
 });
 
 test('Check create volume', async () => {

--- a/packages/main/src/plugin/env-file-parser.spec.ts
+++ b/packages/main/src/plugin/env-file-parser.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,11 +32,11 @@ beforeAll(() => {
 });
 
 class TestEnvfileParser extends EnvfileParser {
-  public async parseEnvFile(envFile: string): Promise<string[]> {
+  public override async parseEnvFile(envFile: string): Promise<string[]> {
     return super.parseEnvFile(envFile);
   }
 
-  public envFileCleanEntry(entry: string): { key: string | undefined; value: string | undefined } {
+  public override envFileCleanEntry(entry: string): { key: string | undefined; value: string | undefined } {
     return super.envFileCleanEntry(entry);
   }
 }

--- a/packages/main/src/plugin/env-file-parser.ts
+++ b/packages/main/src/plugin/env-file-parser.ts
@@ -110,7 +110,7 @@ export class EnvfileParser {
     }
 
     return {
-      key: key.trim(),
+      key: key?.trim(),
       value: updatedValue?.replace(/\\"/g, '"'),
     };
   }

--- a/packages/main/src/plugin/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension-loader.spec.ts
@@ -73,7 +73,7 @@ import { Exec } from './util/exec.js';
 import type { ViewRegistry } from './view-registry.js';
 
 class TestExtensionLoader extends ExtensionLoader {
-  public async setupScanningDirectory(): Promise<void> {
+  public override async setupScanningDirectory(): Promise<void> {
     return super.setupScanningDirectory();
   }
 
@@ -96,7 +96,7 @@ class TestExtensionLoader extends ExtensionLoader {
     return this.extensionStateErrors;
   }
 
-  doRequire(module: string): NodeRequire {
+  override doRequire(module: string): NodeRequire {
     return super.doRequire(module);
   }
 
@@ -593,10 +593,10 @@ test('Verify setExtensionsUpdates', async () => {
 
   // check we have our extension
   expect(extensions.length).toBe(1);
-  expect(extensions[0].id).toBe(extensionId);
+  expect(extensions[0]?.id).toBe(extensionId);
 
   // check that update field is empty
-  expect(extensions[0].update).toBeUndefined();
+  expect(extensions[0]?.update).toBeUndefined();
 
   // now call the update
 
@@ -614,10 +614,10 @@ test('Verify setExtensionsUpdates', async () => {
   const extensionsAfterUpdate = await extensionLoader.listExtensions();
   // check we have our extension
   expect(extensionsAfterUpdate.length).toBe(1);
-  expect(extensionsAfterUpdate[0].id).toBe(extensionId);
+  expect(extensionsAfterUpdate[0]?.id).toBe(extensionId);
 
   // check that update field is set
-  expect(extensionsAfterUpdate[0].update).toStrictEqual({
+  expect(extensionsAfterUpdate[0]?.update).toStrictEqual({
     ociUri: 'quay.io/extension',
     version: newVersion,
   });
@@ -1093,7 +1093,7 @@ test('Verify extension uri', async () => {
   expect(activateMethod).toBeCalled();
 
   // check extensionUri
-  const grabUri: containerDesktopAPI.Uri = activateMethod.mock.calls[0][0].extensionUri;
+  const grabUri: containerDesktopAPI.Uri = activateMethod.mock.calls[0]?.[0].extensionUri;
   expect(grabUri).toBeDefined();
   expect(grabUri.fsPath).toBe('dummy');
 });
@@ -1145,7 +1145,7 @@ test('Verify exports and packageJSON', async () => {
   expect(allExtensions).toBeDefined();
   // 1 item
   expect(allExtensions.length).toBe(1);
-  expect(allExtensions[0].exports.hello()).toBe('world');
+  expect(allExtensions[0]?.exports.hello()).toBe('world');
   expect((allExtensions[0] as any).packageJSON.foo).toBe('bar');
 });
 
@@ -1719,12 +1719,12 @@ test('check listWebviews', async () => {
   // esnure we got result
   expect(result).toBeDefined();
   expect(result.length).toBe(2);
-  expect(result[0].id).toBe('123');
-  expect(result[0].viewType).toBe('customView');
-  expect(result[0].title).toBe('customTitle1');
-  expect(result[1].id).toBe('456');
-  expect(result[1].viewType).toBe('anotherView');
-  expect(result[1].title).toBe('customTitle2');
+  expect(result[0]?.id).toBe('123');
+  expect(result[0]?.viewType).toBe('customView');
+  expect(result[0]?.title).toBe('customTitle1');
+  expect(result[1]?.id).toBe('456');
+  expect(result[1]?.viewType).toBe('anotherView');
+  expect(result[1]?.title).toBe('customTitle2');
 });
 
 test('check version', async () => {
@@ -1852,7 +1852,7 @@ describe('authentication Provider', async () => {
     const call = vi.mocked(authenticationProviderRegistry.registerAuthenticationProvider).mock.calls[0];
 
     // get options from the call
-    const options = call[3];
+    const options = call?.[3];
 
     expect(options?.images?.logo).toBeUndefined();
     expect(options?.images?.icon).toBeUndefined();
@@ -1875,7 +1875,7 @@ describe('authentication Provider', async () => {
     const call = vi.mocked(authenticationProviderRegistry.registerAuthenticationProvider).mock.calls[0];
 
     // get options from the call
-    const options = call[3];
+    const options = call?.[3];
 
     expect(options?.images?.logo).equals(BASE64ENCODEDIMAGE);
     expect(options?.images?.icon).equals(BASE64ENCODEDIMAGE);
@@ -1904,7 +1904,7 @@ describe('authentication Provider', async () => {
     const call = vi.mocked(authenticationProviderRegistry.registerAuthenticationProvider).mock.calls[0];
 
     // get options from the call
-    const options = call[3];
+    const options = call?.[3];
 
     const themeIcon = typeof options?.images?.icon === 'string' ? undefined : options?.images?.icon;
     expect(themeIcon).toBeDefined();
@@ -2016,8 +2016,8 @@ describe('window', async () => {
     const urisArray = uris as containerDesktopAPI.Uri[];
 
     expect(dialogRegistry.openDialog).toBeCalled();
-    expect(urisArray[0].fsPath).toContain('path-to-file1');
-    expect(urisArray[1].fsPath).toContain('path-to-file2');
+    expect(urisArray[0]?.fsPath).toContain('path-to-file1');
+    expect(urisArray[1]?.fsPath).toContain('path-to-file2');
   });
 
   test('showSaveDialog ', async () => {
@@ -2245,9 +2245,9 @@ test('load extensions sequentially', async () => {
 
   // check if loadExtension is called in order
   expect(loadExtensionMock).toBeCalledTimes(3);
-  expect(loadExtensionMock.mock.calls[0][0]).toBe(analyzedExtension1);
-  expect(loadExtensionMock.mock.calls[1][0]).toBe(analyzedExtension2);
-  expect(loadExtensionMock.mock.calls[2][0]).toBe(analyzedExtension3);
+  expect(loadExtensionMock.mock.calls[0]?.[0]).toBe(analyzedExtension1);
+  expect(loadExtensionMock.mock.calls[1]?.[0]).toBe(analyzedExtension2);
+  expect(loadExtensionMock.mock.calls[2]?.[0]).toBe(analyzedExtension3);
 });
 
 test('when loading registry registerRegistry, do not push to disposables', async () => {

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -133,8 +133,6 @@ export interface RequireCacheDict {
 }
 
 export class ExtensionLoader {
-  private overrideRequireDone = false;
-
   private moduleLoader: ModuleLoader;
 
   protected activatedExtensions = new Map<string, ActivatedExtension>();
@@ -248,6 +246,7 @@ export class ExtensionLoader {
     if (activatedExtension) {
       return this.transformActivatedExtensionToExposedExtension(activatedExtension);
     }
+    return undefined;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -590,7 +589,8 @@ export class ExtensionLoader {
         pathes.push(process.argv[++index]);
       }
     }
-    return pathes;
+    // filter all undefined values
+    return pathes.filter(path => path !== undefined);
   }
 
   async readProductionFolders(folderPath: string): Promise<string[]> {
@@ -1026,6 +1026,7 @@ export class ExtensionLoader {
         if (result) {
           return result.map(uri => Uri.file(uri));
         }
+        return undefined;
       },
       showSaveDialog: async (
         options?: containerDesktopAPI.SaveDialogOptions,
@@ -1480,6 +1481,8 @@ export class ExtensionLoader {
     if (extension.mainPath) {
       return this.doRequire(extension.mainPath);
     }
+
+    return undefined;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/main/src/plugin/extensions-catalog/extensions-catalog.spec.ts
+++ b/packages/main/src/plugin/extensions-catalog/extensions-catalog.spec.ts
@@ -156,8 +156,8 @@ test('should fetch fetchable extensions', async () => {
 
   // check data
   const extension = fetchableExtensions[0];
-  expect(extension.extensionId).toBe('foo.fooName');
-  expect(extension.link).toBe('oci-registry.foo/foo/bar');
+  expect(extension?.extensionId).toBe('foo.fooName');
+  expect(extension?.link).toBe('oci-registry.foo/foo/bar');
   // no error
   expect(console.error).not.toBeCalled();
 });
@@ -232,14 +232,14 @@ test('should get all extensions', async () => {
 
   // check data
   const extension = allExtensions[0];
-  expect(extension.id).toBe('foo.fooName');
-  expect(extension.publisherName).toBe('foo');
-  expect(extension.displayName).toBe(fakePublishedExtension1.displayName);
-  expect(extension.categories).toStrictEqual(['Kubernetes']);
-  expect(extension.publisherDisplayName).toBe('Foo publisher display name');
-  expect(extension.shortDescription).toBe('Foo extension short description');
+  expect(extension?.id).toBe('foo.fooName');
+  expect(extension?.publisherName).toBe('foo');
+  expect(extension?.displayName).toBe(fakePublishedExtension1.displayName);
+  expect(extension?.categories).toStrictEqual(['Kubernetes']);
+  expect(extension?.publisherDisplayName).toBe('Foo publisher display name');
+  expect(extension?.shortDescription).toBe('Foo extension short description');
 
-  expect(extension.versions[0]).toStrictEqual({
+  expect(extension?.versions[0]).toStrictEqual({
     ociUri: 'oci-registry.foo/foo/bar',
     lastUpdated: expect.any(Date),
     preview: false,
@@ -305,8 +305,8 @@ test('should fetch alternate link', async () => {
 
   // check data
   const extension = fetchableExtensions[0];
-  expect(extension.extensionId).toBe('foo.fooName');
-  expect(extension.link).toBe('oci-registry.foo/foo/bar');
+  expect(extension?.extensionId).toBe('foo.fooName');
+  expect(extension?.link).toBe('oci-registry.foo/foo/bar');
   // no error
   expect(console.error).not.toBeCalled();
 });

--- a/packages/main/src/plugin/extensions-catalog/extensions-catalog.ts
+++ b/packages/main/src/plugin/extensions-catalog/extensions-catalog.ts
@@ -156,7 +156,7 @@ export class ExtensionsCatalog {
       // we have a list of extensions
       catalogJSON.extensions.forEach(extension => {
         const notPreviewVersions = extension.versions.filter(v => v.preview !== true);
-        if (notPreviewVersions.length > 0) {
+        if (notPreviewVersions.length > 0 && notPreviewVersions[0]) {
           // take the first version
           fetchableExtensions.push({
             extensionId: `${extension.publisher.publisherName}.${extension.extensionName}`,

--- a/packages/main/src/plugin/extensions-updater/extensions-updater.spec.ts
+++ b/packages/main/src/plugin/extensions-updater/extensions-updater.spec.ts
@@ -179,6 +179,10 @@ test('should check for updates if podman desktop version mistmatch and try to up
   // mock current version being 1.0.0
   vi.mocked(app.getVersion).mockReturnValue('1.0.0');
 
+  if (!catalogExtension1.versions[0]) {
+    throw new Error('No version');
+  }
+
   // change the catalog to include a podmanDesktopVersion minimum of 2.0.0 for the latest but ok for 1.5
   const catalogExtension1WithVersion: CatalogExtension = {
     ...catalogExtension1,

--- a/packages/main/src/plugin/icon-registry.spec.ts
+++ b/packages/main/src/plugin/icon-registry.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022 Red Hat, Inc.
+ * Copyright (C) 2022-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,16 +75,16 @@ test('should register icon contribution', async () => {
   const allIcons = iconRegistry.listIcons();
   expect(allIcons).toHaveLength(1);
   const icon = allIcons[0];
-  expect(icon.id).toBe('my-icon-id');
-  expect(icon.definition.fontCharacter).toBe(fontCharacter);
-  expect(icon.definition.description).toBe(iconDescription);
-  expect(icon.definition.font).toBeDefined();
-  expect(icon.definition.font?.src).toStrictEqual([
+  expect(icon?.id).toBe('my-icon-id');
+  expect(icon?.definition.fontCharacter).toBe(fontCharacter);
+  expect(icon?.definition.description).toBe(iconDescription);
+  expect(icon?.definition.font).toBeDefined();
+  expect(icon?.definition.font?.src).toStrictEqual([
     {
       format: 'woff2',
       location: `${extensionPath}${path.sep}${fontPath}`,
       browserURL: `url('file://${extensionPath}${path.sep}${fontPath}')`,
     },
   ]);
-  expect(icon.definition.font?.fontId).toBe(`${extensionId}-${fontPath}`);
+  expect(icon?.definition.font?.fontId).toBe(`${extensionId}-${fontPath}`);
 });

--- a/packages/main/src/plugin/image-checker.spec.ts
+++ b/packages/main/src/plugin/image-checker.spec.ts
@@ -65,11 +65,11 @@ suite('image checker module', () => {
       const providers = imageChecker.getImageCheckerProviders();
       expect(providers.length).toBe(2);
 
-      expect(providers[0].id).equals(`${extensionInfo.id}-0`);
-      expect(providers[0].label).equals('Provider label');
+      expect(providers[0]?.id).equals(`${extensionInfo.id}-0`);
+      expect(providers[0]?.label).equals('Provider label');
 
-      expect(providers[1].id).equals(`${extensionInfo.id}-1`);
-      expect(providers[1].label).equals(extensionInfo.label);
+      expect(providers[1]?.id).equals(`${extensionInfo.id}-1`);
+      expect(providers[1]?.label).equals(extensionInfo.label);
     });
 
     test('Image checker sends "image-checker-provider-update" event when new provider is added', () => {
@@ -150,11 +150,15 @@ suite('image checker module', () => {
         Containers: 1,
         Digest: 'sha256:id',
       };
-      const result = await imageChecker.check(providers[0].id, imageInfo);
+      const providerGet = providers[0];
+      if (!providerGet) {
+        throw new Error('Provider not found');
+      }
+      const result = await imageChecker.check(providerGet.id, imageInfo);
       expect(result).toBeDefined();
       expect(result!.checks.length).toBe(1);
-      expect(result!.checks[0].name).toBe('check1');
-      expect(result!.checks[0].status).toBe('failed');
+      expect(result!.checks[0]?.name).toBe('check1');
+      expect(result!.checks[0]?.status).toBe('failed');
     });
 
     test('check method throws an error if provider is unknown', async () => {

--- a/packages/main/src/plugin/image-files-registry.spec.ts
+++ b/packages/main/src/plugin/image-files-registry.spec.ts
@@ -72,11 +72,11 @@ suite('image files module', () => {
       const providers = imageFiles.getImageFilesProviders();
       expect(providers.length).toBe(2);
 
-      expect(providers[0].id).equals(`${extensionInfo.id}-0`);
-      expect(providers[0].label).equals('Provider label');
+      expect(providers[0]?.id).equals(`${extensionInfo.id}-0`);
+      expect(providers[0]?.label).equals('Provider label');
 
-      expect(providers[1].id).equals(`${extensionInfo.id}-1`);
-      expect(providers[1].label).equals(extensionInfo.label);
+      expect(providers[1]?.id).equals(`${extensionInfo.id}-1`);
+      expect(providers[1]?.label).equals(extensionInfo.label);
     });
 
     test('Image files sends "image-files-provider-update" event when new provider is added', () => {
@@ -169,16 +169,19 @@ suite('image files module', () => {
         Containers: 1,
         Digest: 'sha256:id',
       };
+      if (!providers[0]) {
+        throw new Error('Provider not found');
+      }
       const result = await imageFiles.getFilesystemLayers(providers[0].id, imageInfo);
       console.log('result', result);
       expect(result).toBeDefined();
       expect(result!.layers.length).toBe(1);
-      expect(result!.layers[0].files!.length).toBe(1);
-      expect(result!.layers[0].files![0]).toEqual(file);
-      expect(result!.layers[0].whiteouts!.length).toBe(1);
-      expect(result!.layers[0].whiteouts![0]).toBe('to-be-deleted');
-      expect(result!.layers[0].opaqueWhiteouts!.length).toBe(1);
-      expect(result!.layers[0].opaqueWhiteouts![0]).toBe('dir-to-be-deleted');
+      expect(result!.layers[0]?.files!.length).toBe(1);
+      expect(result!.layers[0]?.files![0]).toEqual(file);
+      expect(result!.layers[0]?.whiteouts!.length).toBe(1);
+      expect(result!.layers[0]?.whiteouts![0]).toBe('to-be-deleted');
+      expect(result!.layers[0]?.opaqueWhiteouts!.length).toBe(1);
+      expect(result!.layers[0]?.opaqueWhiteouts![0]).toBe('dir-to-be-deleted');
     });
 
     test('check method throws an error if provider is unknown', async () => {

--- a/packages/main/src/plugin/image-registry.spec.ts
+++ b/packages/main/src/plugin/image-registry.spec.ts
@@ -27,7 +27,7 @@ import type { Registry } from '@podman-desktop/api';
 import * as fzstd from 'fzstd';
 import nock from 'nock';
 import * as nodeTar from 'tar';
-import { beforeAll, beforeEach, describe, expect, expectTypeOf, test, vi, vitest } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, expectTypeOf, test, vi } from 'vitest';
 
 import * as imageRegistryConfigJson from '../../tests/resources/data/plugin/image-registry-config.json';
 import * as imageRegistryManifestJson from '../../tests/resources/data/plugin/image-registry-manifest-index.json';
@@ -46,7 +46,7 @@ const pxoxyIsEnabledMock = vi.fn();
 const proxyGetProxyMock = vi.fn();
 
 const telemetry: Telemetry = {
-  track(event: EventType, eventProperties?: any): void {},
+  track(_event: EventType, _eventProperties?: any): void {},
 } as Telemetry;
 const certificates: Certificates = {
   init: vi.fn(),
@@ -62,7 +62,7 @@ Object.defineProperty(proxy, 'proxy', {
   get: proxyGetProxyMock,
 });
 const apiSender: ApiSenderType = {
-  send(channel: string, data?: any): void {},
+  send(_channel: string, _data?: any): void {},
 } as ApiSenderType;
 
 beforeAll(async () => {
@@ -834,7 +834,7 @@ test('getManifestFromUrl returns the expected manifest with docker manifest v2',
   expect(manifest).toHaveProperty('endManifest', true);
   expect(spyGetBestManifest).toHaveBeenCalled();
   // check first item of the call and first element of the array
-  expect(spyGetBestManifest.mock.calls[0][0][0]).contains({ name: 'docker-manifest' });
+  expect(spyGetBestManifest.mock.calls[0]?.[0][0]).contains({ name: 'docker-manifest' });
 });
 
 test('getAuthconfigForServer returns the expected authconfig', async () => {

--- a/packages/main/src/plugin/image-registry.ts
+++ b/packages/main/src/plugin/image-registry.ts
@@ -93,7 +93,7 @@ export class ImageRegistry {
     const splitParts = imageName.split('/');
     if (
       splitParts.length === 1 ||
-      (!splitParts[0].includes('.') && !splitParts[0].includes(':') && splitParts[0] !== 'localhost')
+      (!splitParts[0]?.includes('.') && !splitParts[0]?.includes(':') && splitParts[0] !== 'localhost')
     ) {
       return 'docker.io';
     } else {
@@ -130,6 +130,7 @@ export class ImageRegistry {
         serveraddress,
       };
     }
+    return undefined;
   }
 
   /**
@@ -312,7 +313,9 @@ export class ImageRegistry {
     const parsed = WWW_AUTH_REGEXP.exec(wwwAuthenticate);
     if (parsed?.groups) {
       const { realm, service, scope, scheme } = parsed.groups;
-      return { authUrl: realm, service, scope, scheme };
+      if (realm && scheme) {
+        return { authUrl: realm, service, scope, scheme };
+      }
     }
     return undefined;
   }
@@ -409,7 +412,7 @@ export class ImageRegistry {
       name = `library/${slashes[0]}`;
       valid = true;
     } else if (slashes.length === 2) {
-      if (slashes[0].startsWith('localhost')) {
+      if (slashes[0]?.startsWith('localhost') && slashes[1]) {
         registry = slashes[0];
         name = slashes[1];
       } else {
@@ -417,7 +420,7 @@ export class ImageRegistry {
         name = `${slashes[0]}/${slashes[1]}`;
       }
       valid = true;
-    } else if (slashes.length > 2) {
+    } else if (slashes.length > 2 && slashes[0]) {
       registry = slashes[0];
       name = `${slashes[1]}/${slashes[2]}`;
       valid = true;
@@ -552,7 +555,7 @@ export class ImageRegistry {
     options.headers = options.headers ?? {};
 
     // add the Bearer token
-    options.headers.Authorization = `Bearer ${token}`;
+    options.headers['Authorization'] = `Bearer ${token}`;
 
     // replace all special characters with _ in digest
     const digestWithoutSpecialChars = digest.replace(/[^a-zA-Z0-9]/g, '_');
@@ -601,7 +604,7 @@ export class ImageRegistry {
     const options = this.getOptions();
     options.headers = options.headers ?? {};
     // add the Bearer token
-    options.headers.Authorization = `Bearer ${token}`;
+    options.headers['Authorization'] = `Bearer ${token}`;
 
     // say we want to return JSON from got
     const blobURL = `${imageData.registryURL}/${imageData.name}/blobs/${digest}`;
@@ -633,15 +636,15 @@ export class ImageRegistry {
     options.headers = options.headers ?? {};
 
     // add the Bearer token
-    options.headers.Authorization = `Bearer ${token}`;
+    options.headers['Authorization'] = `Bearer ${token}`;
 
     // add the manifest accept headers
     const acceptHeaders = [];
-    if (options.headers.Accept) {
-      if (typeof options.headers.Accept === 'string') {
-        acceptHeaders.push(options.headers.Accept);
-      } else if (Array.isArray(options.headers.Accept)) {
-        acceptHeaders.push(...options.headers.Accept);
+    if (options.headers['Accept']) {
+      if (typeof options.headers['Accept'] === 'string') {
+        acceptHeaders.push(options.headers['Accept']);
+      } else if (Array.isArray(options.headers['Accept'])) {
+        acceptHeaders.push(...options.headers['Accept']);
       }
     }
     acceptHeaders.push('application/vnd.oci.image.manifest.v1+json');
@@ -651,7 +654,7 @@ export class ImageRegistry {
     acceptHeaders.push('application/vnd.docker.distribution.manifest.list.v2+json');
     acceptHeaders.push('application/vnd.oci.image.index.v1+json');
 
-    options.headers.Accept = acceptHeaders;
+    options.headers['Accept'] = acceptHeaders;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let parsedManifest: any;
@@ -854,7 +857,7 @@ export class ImageRegistry {
     if (authServer) {
       options.headers = options.headers ?? {};
       const loginAndPassWord = `${authServer.username}:${authServer.password}`;
-      options.headers.Authorization = `Basic ${Buffer.from(loginAndPassWord).toString('base64')}`;
+      options.headers['Authorization'] = `Basic ${Buffer.from(loginAndPassWord).toString('base64')}`;
     }
     // need to replace repository%3Auser with repository:user coming from imageData
     let tokenUrl = authInfo.authUrl.replace('user%2Fimage', imageData.name.replaceAll('/', '%2F'));
@@ -953,7 +956,7 @@ export class ImageRegistry {
     const opts = this.getOptions();
     opts.headers = opts.headers ?? {};
     // add the Bearer token
-    opts.headers.Authorization = `Bearer ${token}`;
+    opts.headers['Authorization'] = `Bearer ${token}`;
 
     try {
       const catalog = await got.get(`${imageData.registryURL}/${imageData.name}/tags/list`, opts);

--- a/packages/main/src/plugin/index.spec.ts
+++ b/packages/main/src/plugin/index.spec.ts
@@ -40,7 +40,7 @@ import { Deferred } from './util/deferred.js';
 let pluginSystem: TestPluginSystem;
 
 class TestPluginSystem extends PluginSystem {
-  initConfigurationRegistry(
+  override initConfigurationRegistry(
     apiSender: ApiSenderType,
     directories: Directories,
     notifications: NotificationCardOptions[],

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -284,6 +284,7 @@ export class PluginSystem {
 
       if (toAppend !== '') return `[${toAppend}]`;
     }
+    return undefined;
   }
 
   // log locally and also send it to the renderer process
@@ -458,7 +459,7 @@ export class PluginSystem {
     const proxy = new Proxy(configurationRegistry);
     await proxy.init();
 
-    const telemetry = new Telemetry(configurationRegistry, proxy);
+    const telemetry = new Telemetry(configurationRegistry);
     await telemetry.init();
 
     const exec = new Exec(proxy);
@@ -487,7 +488,7 @@ export class PluginSystem {
     const inputQuickPickRegistry = new InputQuickPickRegistry(apiSender);
     const fileSystemMonitoring = new FilesystemMonitoring();
     const customPickRegistry = new CustomPickRegistry(apiSender);
-    const onboardingRegistry = new OnboardingRegistry(configurationRegistry, context);
+    const onboardingRegistry = new OnboardingRegistry(context);
     const kubernetesClient = new KubernetesClient(apiSender, configurationRegistry, fileSystemMonitoring, telemetry);
     await kubernetesClient.init();
     const closeBehaviorConfiguration = new CloseBehavior(configurationRegistry);
@@ -497,7 +498,7 @@ export class PluginSystem {
 
     // Don't show the tray icon options on Mac
     if (!isMac()) {
-      const trayIconColor = new TrayIconColor(configurationRegistry, providerRegistry);
+      const trayIconColor = new TrayIconColor(configurationRegistry);
       await trayIconColor.init();
     }
 
@@ -610,13 +611,13 @@ export class PluginSystem {
 
     const authentication = new AuthenticationImpl(apiSender, messageBox);
 
-    const cliToolRegistry = new CliToolRegistry(apiSender, exec);
+    const cliToolRegistry = new CliToolRegistry(apiSender);
 
     const imageChecker = new ImageCheckerImpl(apiSender);
 
     const imageFiles = new ImageFilesRegistry(apiSender);
 
-    const troubleshooting = new Troubleshooting(apiSender);
+    const troubleshooting = new Troubleshooting();
 
     const contributionManager = new ContributionManager(apiSender, directories, containerProviderRegistry, exec);
 

--- a/packages/main/src/plugin/input-quickpick/input-quickpick-registry.ts
+++ b/packages/main/src/plugin/input-quickpick/input-quickpick-registry.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -120,12 +120,15 @@ export class InputQuickPickRegistry {
         const allItems = indexes.map(index => callback.items[index]);
         // resolve the promise
         callback.deferred.resolve(allItems);
-      } else {
+      } else if (indexes[0]) {
         // grab item
         const item = callback.items[indexes[0]];
 
         // resolve the promise
         callback.deferred.resolve(item);
+      } else {
+        // error
+        callback.deferred.reject('no item');
       }
 
       // remove the callback

--- a/packages/main/src/plugin/install/extension-installer.spec.ts
+++ b/packages/main/src/plugin/install/extension-installer.spec.ts
@@ -101,7 +101,7 @@ vi.mock('./../docker-extension/docker-desktop-installer', async () => {
         setupContribution: vi.fn(),
       };
     }),
-    DockerDesktopContribution: ddInstallerReal.DockerDesktopContribution,
+    DockerDesktopContribution: ddInstallerReal['DockerDesktopContribution'],
   };
 });
 

--- a/packages/main/src/plugin/install/extension-installer.ts
+++ b/packages/main/src/plugin/install/extension-installer.ts
@@ -45,7 +45,7 @@ export class ExtensionInstaller {
     private extensionCatalog: ExtensionsCatalog,
     private telemetry: Telemetry,
     private directories: Directories,
-    private contributionManager: ContributionManager,
+    contributionManager: ContributionManager,
   ) {
     this.#dockerDesktopInstaller = new DockerDesktopInstaller(contributionManager);
   }
@@ -154,7 +154,12 @@ export class ExtensionInstaller {
     // strip the tag (ending with :something) from the image name if any
     let imageNameWithoutTag: string;
     if (imageName.includes(':')) {
-      imageNameWithoutTag = imageName.split(':')[0];
+      const splitten = imageName.split(':')[0];
+      if (!splitten) {
+        sendError(`Image ${imageName} is not a Podman Desktop Extension`);
+        return;
+      }
+      imageNameWithoutTag = splitten;
     } else {
       imageNameWithoutTag = imageName;
     }
@@ -209,6 +214,7 @@ export class ExtensionInstaller {
     } else if (isDDExtension) {
       return this.#dockerDesktopInstaller.setupContribution(titleLabel, imageName, finalFolderPath, sendLog, sendError);
     }
+    return undefined;
   }
 
   async analyzeTransitiveDependencies(

--- a/packages/main/src/plugin/kubernetes-client-kubeconfig.spec.ts
+++ b/packages/main/src/plugin/kubernetes-client-kubeconfig.spec.ts
@@ -97,6 +97,10 @@ describe('context tests', () => {
   test('should delete context from config', async () => {
     client.saveKubeConfig = vi.fn().mockImplementation((_config: KubeConfig) => {});
 
+    if (!originalContexts[1]?.name) {
+      throw new Error('originalContexts[1].name should be defined');
+    }
+
     const contexts = await client.deleteContext(originalContexts[1].name);
     expect(contexts.length).toBe(1);
     expect(contexts[0]).toStrictEqual(originalContexts[0]);
@@ -109,7 +113,16 @@ describe('context tests', () => {
   test('should delete context from config and related user and cluster not referenced anymore', async () => {
     client.saveKubeConfig = vi.fn().mockImplementation((_config: KubeConfig) => {});
 
+    if (!originalContexts[0]?.name) {
+      throw new Error('originalContexts[0].name should be defined');
+    }
+
     await client.deleteContext(originalContexts[0].name);
+
+    if (!originalContexts[1]?.name) {
+      throw new Error('originalContexts[0].name should be defined');
+    }
+
     const contexts = await client.deleteContext(originalContexts[1].name);
     expect(contexts.length).toBe(0);
     expect(client.getContexts().length).toBe(0);
@@ -126,7 +139,12 @@ describe('context tests', () => {
       throw 'an error';
     });
 
-    await expect(async () => await client.deleteContext(originalContexts[0].name)).rejects.toThrow('an error');
+    const originalContextName = originalContexts[0]?.name;
+    if (!originalContextName) {
+      throw new Error('originalContexts[0].name should be defined');
+    }
+
+    await expect(async () => await client.deleteContext(originalContextName)).rejects.toThrow('an error');
     expect(client.getContexts().length).toBe(2);
     expect(client.getUsers().length).toBe(2);
     expect(client.getClusters().length).toBe(2);
@@ -143,6 +161,14 @@ describe('context tests', () => {
 
   test('should keep the current context name when we delete the context (if not current)', async () => {
     client.saveKubeConfig = vi.fn().mockImplementation((_config: KubeConfig) => {});
+
+    if (!originalContexts[0]?.name) {
+      throw new Error('originalContexts[0].name should be defined');
+    }
+    if (!originalContexts[1]?.name) {
+      throw new Error('originalContexts[1].name should be defined');
+    }
+
     client.setCurrentContext(originalContexts[0].name);
 
     await client.deleteContext(originalContexts[1].name);
@@ -152,6 +178,10 @@ describe('context tests', () => {
   test('test that setContext updates the current context since it also modified the .kube/config file', async () => {
     client.saveKubeConfig = vi.fn().mockImplementation((_config: KubeConfig) => {});
 
+    if (!originalContexts[1]) {
+      throw new Error('originalContexts[1] should be defined');
+    }
+
     // Set the current context to something else and then check that it is the current context via getCurrentContextName
     await client.setContext(originalContexts[1].name);
     expect(client.getCurrentContextName()).toBe(originalContexts[1].name);
@@ -159,9 +189,9 @@ describe('context tests', () => {
     // We also want to check that it has also been set for currentContext in the detailed contexts retrieval
     const contexts = client.getDetailedContexts();
     // The first context should be false since it is not the current context anymore
-    expect(contexts[0].currentContext).toBe(false);
+    expect(contexts[0]?.currentContext).toBe(false);
     // The second context should be true since it is the current context
-    expect(contexts[1].currentContext).toBe(true);
+    expect(contexts[1]?.currentContext).toBe(true);
 
     expect(apiSendMock).toHaveBeenCalledTimes(1);
     expect(apiSendMock).toHaveBeenCalledWith('kubernetes-context-update');

--- a/packages/main/src/plugin/kubernetes-client-kubeconfig.spec.ts
+++ b/packages/main/src/plugin/kubernetes-client-kubeconfig.spec.ts
@@ -120,7 +120,7 @@ describe('context tests', () => {
     await client.deleteContext(originalContexts[0].name);
 
     if (!originalContexts[1]?.name) {
-      throw new Error('originalContexts[0].name should be defined');
+      throw new Error('originalContexts[1].name should be defined');
     }
 
     const contexts = await client.deleteContext(originalContexts[1].name);

--- a/packages/main/src/plugin/kubernetes-client.spec.ts
+++ b/packages/main/src/plugin/kubernetes-client.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,7 +95,7 @@ class TestKubernetesClient extends KubernetesClient {
 
   public declare currentNamespace: string | undefined;
 
-  public createWatchObject(): Watch {
+  public override createWatchObject(): Watch {
     return super.createWatchObject();
   }
 
@@ -166,7 +166,7 @@ class TestKubernetesClient extends KubernetesClient {
   }
 
   // need only to be mocked in several test methods
-  public waitForPodDeletion(
+  public override waitForPodDeletion(
     coreApi: CoreV1Api,
     name: string,
     namespace: string,
@@ -176,7 +176,7 @@ class TestKubernetesClient extends KubernetesClient {
   }
 
   // need only to be mocked in several test methods
-  public waitForPodsDeletion(
+  public override waitForPodsDeletion(
     coreApi: CoreV1Api,
     namespace: string,
     selector: string,
@@ -186,7 +186,7 @@ class TestKubernetesClient extends KubernetesClient {
   }
 
   // need only to be mocked in several test methods
-  public waitForJobDeletion(
+  public override waitForJobDeletion(
     batchApi: BatchV1Api,
     name: string,
     namespace: string,
@@ -196,7 +196,7 @@ class TestKubernetesClient extends KubernetesClient {
   }
 
   // need only to be mocked in several test methods
-  public scaleController(
+  public override scaleController(
     appsApi: AppsV1Api,
     namespace: string,
     controllerName: string,
@@ -207,17 +207,17 @@ class TestKubernetesClient extends KubernetesClient {
   }
 
   // need only to be mocked in several test methods
-  public checkPodCreationSource(podMetadata: V1ObjectMeta): PodCreationSource {
+  public override checkPodCreationSource(podMetadata: V1ObjectMeta): PodCreationSource {
     return super.checkPodCreationSource(podMetadata);
   }
 
   // need only to be mocked in several test methods
-  public restartManuallyCreatedPod(name: string, namespace: string, pod: V1Pod): Promise<void> {
+  public override restartManuallyCreatedPod(name: string, namespace: string, pod: V1Pod): Promise<void> {
     return super.restartManuallyCreatedPod(name, namespace, pod);
   }
 
   // need only to be mocked in several test methods
-  public scaleControllerToRestartPods(
+  public override scaleControllerToRestartPods(
     namespace: string,
     controllerName: string,
     controllerType: ScalableControllerType,
@@ -227,12 +227,12 @@ class TestKubernetesClient extends KubernetesClient {
   }
 
   // need only to be mocked in several test methods
-  public getPodController(podMetadata: V1ObjectMeta): V1OwnerReference | undefined {
+  public override getPodController(podMetadata: V1ObjectMeta): V1OwnerReference | undefined {
     return super.getPodController(podMetadata);
   }
 
   // need only to be mocked in several test methods
-  public restartJob(name: string, namespace: string): Promise<void> {
+  public override restartJob(name: string, namespace: string): Promise<void> {
     return super.restartJob(name, namespace);
   }
 }
@@ -600,7 +600,7 @@ test('should return deployment list if connection to cluster is ok', async () =>
 
   const list = await client.listDeployments();
   expect(list.length).toBe(1);
-  expect(list[0].metadata?.name).toEqual('deployment');
+  expect(list[0]?.metadata?.name).toEqual('deployment');
 });
 
 test('should throw error if cannot call the cluster', async () => {
@@ -697,7 +697,7 @@ test('should return ingress list if connection to cluster is ok', async () => {
 
   const list = await client.listIngresses();
   expect(list.length).toBe(1);
-  expect(list[0].metadata?.name).toEqual('ingress');
+  expect(list[0]?.metadata?.name).toEqual('ingress');
 });
 
 test('should throw error if cannot call the cluster', async () => {
@@ -811,7 +811,7 @@ test('should return route list if connection to cluster is ok', async () => {
 
   const list = await client.listRoutes();
   expect(list.length).toBe(1);
-  expect(list[0].metadata?.name).toEqual('route');
+  expect(list[0]?.metadata?.name).toEqual('route');
 });
 
 test('should throw error if cannot call the cluster', async () => {
@@ -999,7 +999,7 @@ test('should return service list if connection to cluster is ok', async () => {
 
   const list = await client.listServices();
   expect(list.length).toBe(1);
-  expect(list[0].metadata?.name).toEqual('service');
+  expect(list[0]?.metadata?.name).toEqual('service');
 });
 
 test('should throw error if cannot call the cluster', async () => {
@@ -2023,7 +2023,7 @@ test('Should correctly calls scale API for Deployments', async () => {
 
   // check header is customized
   expect(clientNode.createConfiguration).toHaveBeenCalled();
-  const config = vi.mocked(clientNode.createConfiguration).mock.calls[0][0];
+  const config = vi.mocked(clientNode.createConfiguration).mock.calls[0]?.[0];
   expect(config?.middleware?.length).toBe(1);
 });
 
@@ -2049,7 +2049,7 @@ test('correctly calls scale API for ReplicaSets', async () => {
 
   // check header is customized
   expect(clientNode.createConfiguration).toHaveBeenCalled();
-  const config = vi.mocked(clientNode.createConfiguration).mock.calls[0][0];
+  const config = vi.mocked(clientNode.createConfiguration).mock.calls[0]?.[0];
   expect(config?.middleware?.length).toBe(1);
 });
 
@@ -2075,7 +2075,7 @@ test('correctly calls scale API for StatefulSets', async () => {
 
   // check header is customized
   expect(clientNode.createConfiguration).toHaveBeenCalled();
-  const config = vi.mocked(clientNode.createConfiguration).mock.calls[0][0];
+  const config = vi.mocked(clientNode.createConfiguration).mock.calls[0]?.[0];
   expect(config?.middleware?.length).toBe(1);
 });
 

--- a/packages/main/src/plugin/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes-client.ts
@@ -448,7 +448,7 @@ export class KubernetesClient {
       try {
         const namespaces = await ctx.makeApiClient(CoreV1Api).listNamespace();
         if (namespaces?.items.length > 0) {
-          namespace = namespaces?.items[0].metadata?.name;
+          namespace = namespaces?.items[0]?.metadata?.name;
         }
       } catch (error) {
         // unable to list namespaces, can be due to a connection refused (cluster not up)
@@ -1022,11 +1022,12 @@ export class KubernetesClient {
    */
   groupAndVersion(apiVersion: string): { group: string; version: string } {
     const v = apiVersion.split('/');
-    if (v.length === 1) {
+    if (v.length === 1 && v[0]) {
       return { group: '', version: v[0] };
-    } else {
+    } else if (v.length > 1 && v[0] && v[1]) {
       return { group: v[0], version: v[1] };
     }
+    throw new Error(`Invalid apiVersion: ${apiVersion}`);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1279,7 +1280,7 @@ export class KubernetesClient {
       action: action,
     };
     if (namespace) {
-      telemetryOptions.namespace = namespace;
+      telemetryOptions['namespace'] = namespace;
     }
 
     try {
@@ -1330,7 +1331,7 @@ export class KubernetesClient {
       }
       return created;
     } catch (error: unknown) {
-      telemetryOptions.error = error;
+      telemetryOptions['error'] = error;
       if (error instanceof FetchError) {
         const httpError = error as FetchError;
 

--- a/packages/main/src/plugin/kubernetes-context-state.spec.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.spec.ts
@@ -1821,8 +1821,9 @@ describe('update', async () => {
     );
 
     makeInformerMock.mockClear();
-
-    config.contexts[0].namespace = 'other-ns';
+    if (config.contexts[0]) {
+      config.contexts[0].namespace = 'other-ns';
+    }
     kubeConfig.loadFromOptions(config);
 
     expect(informerStopMock).not.toHaveBeenCalled();
@@ -2061,7 +2062,7 @@ describe('update', async () => {
       const makeInformerMock = vi.mocked(makeInformer);
       makeInformerMock.mockImplementation(
         (
-          kubeconfig: kubeclient.KubeConfig,
+          _kubeconfig: kubeclient.KubeConfig,
           path: string,
           _listPromiseFn: kubeclient.ListPromise<kubeclient.KubernetesObject>,
         ) => {
@@ -2091,12 +2092,12 @@ describe('update', async () => {
         expect(informerStopMock).toHaveBeenNthCalledWith(
           1,
           'context2',
-          `/api/v1/namespaces/${initialConfig.contexts[1].namespace}/pods`,
+          `/api/v1/namespaces/${initialConfig.contexts[1]?.namespace}/pods`,
         );
         expect(informerStopMock).toHaveBeenNthCalledWith(
           2,
           'context2',
-          `/apis/apps/v1/namespaces/${initialConfig.contexts[1].namespace}/deployments`,
+          `/apis/apps/v1/namespaces/${initialConfig.contexts[1]?.namespace}/deployments`,
         );
       }
 
@@ -2105,13 +2106,13 @@ describe('update', async () => {
         expect(makeInformerMock).toHaveBeenNthCalledWith(
           1,
           expect.any(KubeConfig),
-          `/api/v1/namespaces/${updateConfig.contexts[1].namespace}/pods`,
+          `/api/v1/namespaces/${updateConfig.contexts[1]?.namespace}/pods`,
           expect.anything(),
         );
         expect(makeInformerMock).toHaveBeenNthCalledWith(
           2,
           expect.any(KubeConfig),
-          `/apis/apps/v1/namespaces/${updateConfig.contexts[1].namespace}/deployments`,
+          `/apis/apps/v1/namespaces/${updateConfig.contexts[1]?.namespace}/deployments`,
           expect.anything(),
         );
       }

--- a/packages/main/src/plugin/kubernetes-context-state.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.ts
@@ -848,7 +848,7 @@ export class ContextsManager {
     });
   }
 
-  public createNodeInformer(kc: KubeConfig, ns: string, context: KubeContext): Informer<V1Node> {
+  public createNodeInformer(kc: KubeConfig, _ns: string, context: KubeContext): Informer<V1Node> {
     const k8sApi = kc.makeApiClient(CoreV1Api);
     const listFn = (): Promise<V1NodeList> => k8sApi.listNode();
     const path = '/api/v1/nodes';

--- a/packages/main/src/plugin/kubernetes-exec-transmitter.ts
+++ b/packages/main/src/plugin/kubernetes-exec-transmitter.ts
@@ -35,7 +35,7 @@ export class ExecStreamWriter extends Writable {
     this.transmitter = transmitter;
   }
 
-  _write(chunk: unknown, encoding: BufferEncoding, callback: (error?: Error | null) => void): void {
+  override _write(chunk: unknown, encoding: BufferEncoding, callback: (error?: Error | null) => void): void {
     this.transmitter._write(chunk, encoding, callback);
   }
 }
@@ -54,7 +54,7 @@ export class ResizableTerminalWriter extends ExecStreamWriter {
     this.rows = terminalSize.height;
   }
 
-  _write(chunk: unknown, encoding: BufferEncoding, callback: (error?: Error | null) => void): void {
+  override _write(chunk: unknown, encoding: BufferEncoding, callback: (error?: Error | null) => void): void {
     super._write(chunk, encoding, callback);
   }
 
@@ -81,7 +81,7 @@ export class BufferedStreamWriter extends Writable {
     this.transmitFn = transmitFn;
   }
 
-  _write(chunk: Buffer, encoding: BufferEncoding, callback: (error?: Error | null) => void): void {
+  override _write(chunk: Buffer, _encoding: BufferEncoding, callback: (error?: Error | null) => void): void {
     this.transmitFn(chunk);
     callback();
   }
@@ -102,7 +102,7 @@ export class StringLineReader extends Readable {
     }
   }
 
-  _read(): void {
+  override _read(): void {
     this.isReading = true;
     const data = this.dataQueue.shift();
 

--- a/packages/main/src/plugin/menu-registry.spec.ts
+++ b/packages/main/src/plugin/menu-registry.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,8 +89,8 @@ test('Image context should have a single entry', async () => {
   expect(menus).toBeDefined();
   expectTypeOf(menus).toBeArray();
   expect(menus.length).toBe(1);
-  expect(menus[0].command).toBe('image.command1');
-  expect(menus[0].title).toBe('Image 1');
+  expect(menus[0]?.command).toBe('image.command1');
+  expect(menus[0]?.title).toBe('Image 1');
 });
 
 test('Container context should have two entries', async () => {
@@ -98,10 +98,10 @@ test('Container context should have two entries', async () => {
   expect(menus).toBeDefined();
   expectTypeOf(menus).toBeArray();
   expect(menus.length).toBe(2);
-  expect(menus[0].command).toBe('container.command1');
-  expect(menus[0].title).toBe('Container 1');
-  expect(menus[1].command).toBe('container.command2');
-  expect(menus[1].title).toBe('Container 2');
+  expect(menus[0]?.command).toBe('container.command1');
+  expect(menus[0]?.title).toBe('Container 1');
+  expect(menus[1]?.command).toBe('container.command2');
+  expect(menus[1]?.title).toBe('Container 2');
 });
 
 test('Menus with unregistered commands should not be returned', async () => {
@@ -158,13 +158,13 @@ test('Should find icon', async () => {
   const menus = menuRegistry.getContributedMenus('dashboard/image');
 
   // icon should be set for the command
-  expect(menus[0].icon).toBe('${myIcon1}');
+  expect(menus[0]?.icon).toBe('${myIcon1}');
 
   const menus2 = menuRegistry.getContributedMenus('dashboard/container');
   // check icons
-  expect(menus2[0].icon).toBe('${myIcon2}');
+  expect(menus2[0]?.icon).toBe('${myIcon2}');
   // other one should be undefined
-  expect(menus2[1].icon).toBe(undefined);
+  expect(menus2[1]?.icon).toBe(undefined);
 
   // and now last item should be undefined as commands is not registered
   const menus3 = menuRegistry.getContributedMenus('dashboard/unregistered');

--- a/packages/main/src/plugin/menu-registry.ts
+++ b/packages/main/src/plugin/menu-registry.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ export class MenuRegistry {
   registerMenus(menus: { [key: string]: Menu[] }): Disposable {
     for (const name in menus) {
       const contextMenus = menus[name];
-      contextMenus.forEach(menu => this.registerMenu(name, menu));
+      contextMenus?.forEach(menu => this.registerMenu(name, menu));
     }
 
     return Disposable.create(() => {
@@ -52,7 +52,7 @@ export class MenuRegistry {
   unregisterMenus(menus: { [key: string]: Menu[] }): void {
     for (const name in menus) {
       const contextMenus = menus[name];
-      contextMenus.forEach(menu => this.unregisterMenu(name, menu));
+      contextMenus?.forEach(menu => this.unregisterMenu(name, menu));
     }
   }
 

--- a/packages/main/src/plugin/module-loader.ts
+++ b/packages/main/src/plugin/module-loader.ts
@@ -48,7 +48,7 @@ export class ModuleLoader {
 
   addOverride(lookup: Record<string, object | OverrideFunction>): void {
     Object.keys(lookup).forEach(entry => {
-      this._overrides.set(entry, lookup[entry]);
+      this._overrides.set(entry, lookup[entry] ?? {});
     });
   }
 

--- a/packages/main/src/plugin/navigation-items-init.spec.ts
+++ b/packages/main/src/plugin/navigation-items-init.spec.ts
@@ -36,15 +36,15 @@ test('should register a configuration', async () => {
 
   expect(configurationRegistryMock.registerConfigurations).toBeCalled();
 
-  const configurationNode = vi.mocked(configurationRegistryMock.registerConfigurations).mock.calls[0][0][0];
-  expect(configurationNode.id).toBe('preferences.navBar');
-  expect(configurationNode.title).toBe('User Confirmation');
-  expect(configurationNode.properties).toBeDefined();
-  expect(Object.keys(configurationNode.properties ?? {}).length).toBe(1);
-  expect(configurationNode.properties?.['navbar.disabledItems']).toBeDefined();
-  expect(configurationNode.properties?.['navbar.disabledItems'].description).toBe(
+  const configurationNode = vi.mocked(configurationRegistryMock.registerConfigurations).mock.calls[0]?.[0][0];
+  expect(configurationNode?.id).toBe('preferences.navBar');
+  expect(configurationNode?.title).toBe('User Confirmation');
+  expect(configurationNode?.properties).toBeDefined();
+  expect(Object.keys(configurationNode?.properties ?? {}).length).toBe(1);
+  expect(configurationNode?.properties?.['navbar.disabledItems']).toBeDefined();
+  expect(configurationNode?.properties?.['navbar.disabledItems']?.description).toBe(
     'Items being disabled in the navigation bar',
   );
-  expect(configurationNode.properties?.['navbar.disabledItems'].type).toStrictEqual(['boolean']);
-  expect(configurationNode.properties?.['navbar.disabledItems'].default).toStrictEqual([]);
+  expect(configurationNode?.properties?.['navbar.disabledItems']?.type).toStrictEqual(['boolean']);
+  expect(configurationNode?.properties?.['navbar.disabledItems']?.default).toStrictEqual([]);
 });

--- a/packages/main/src/plugin/navigation/navigation-manager.spec.ts
+++ b/packages/main/src/plugin/navigation/navigation-manager.spec.ts
@@ -32,10 +32,10 @@ import { NavigationManager } from './navigation-manager.js';
 let navigationManager: TestNavigationManager;
 
 class TestNavigationManager extends NavigationManager {
-  assertContributionExist(name: string): void {
+  override assertContributionExist(name: string): void {
     return super.assertContributionExist(name);
   }
-  assertWebviewExist(webviewId: string): void {
+  override assertWebviewExist(webviewId: string): void {
     return super.assertWebviewExist(webviewId);
   }
 }

--- a/packages/main/src/plugin/onboarding-registry.spec.ts
+++ b/packages/main/src/plugin/onboarding-registry.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ import { afterEach, beforeEach, describe, expect, expectTypeOf, test, vi } from 
 import type { OnboardingState } from '/@api/onboarding.js';
 
 import type { ApiSenderType } from './api.js';
-import type { ConfigurationRegistry } from './configuration-registry.js';
 import { Context } from './context/context.js';
 import type { AnalyzedExtension } from './extension-loader.js';
 import { OnboardingRegistry } from './onboarding-registry.js';
@@ -38,11 +37,6 @@ const getConfigurationMock = vi.fn();
 getConfigurationMock.mockReturnValue({
   get: getConfigMock,
 });
-const configurationRegistry = {
-  registerConfigurations: vi.fn(),
-  onDidChangeConfiguration: vi.fn(),
-  getConfiguration: getConfigurationMock,
-} as unknown as ConfigurationRegistry;
 
 const readFileSync = vi.spyOn(fs, 'readFileSync');
 const apiSender: ApiSenderType = { send: vi.fn() } as unknown as ApiSenderType;
@@ -54,7 +48,7 @@ describe('an OnboardingRegistry instance exists', () => {
   /* eslint-disable @typescript-eslint/no-empty-function */
   beforeEach(() => {
     vi.clearAllMocks();
-    onboardingRegistry = new OnboardingRegistry(configurationRegistry, context);
+    onboardingRegistry = new OnboardingRegistry(context);
     const manifest = {
       contributes: {
         onboarding: {
@@ -118,15 +112,15 @@ describe('an OnboardingRegistry instance exists', () => {
     expect(onboarding).toBeDefined();
     expectTypeOf(onboarding).toBeArray();
     expect(onboarding.length).toBe(1);
-    expect(onboarding[0].title).toBe('Get started with Podman Desktop');
+    expect(onboarding[0]?.title).toBe('Get started with Podman Desktop');
   });
 
   test('Should update state of step', async () => {
     onboardingRegistry.updateStepState('completed', extensionId, stepId);
     const onboarding = onboardingRegistry.getOnboarding(extensionId);
     expect(onboarding).toBeDefined();
-    expect(onboarding?.steps[0].status).toBeDefined();
-    expect(onboarding?.steps[0].status).toBe('completed');
+    expect(onboarding?.steps[0]?.status).toBeDefined();
+    expect(onboarding?.steps[0]?.status).toBe('completed');
   });
 
   test('Should update state of onboarding', async () => {
@@ -160,8 +154,8 @@ describe('an OnboardingRegistry instance exists', () => {
     expect(onboarding).toBeDefined();
     expect(onboarding?.status).toBeDefined();
     expect(onboarding?.status).toBe('completed');
-    expect(onboarding?.steps[0].status).toBeDefined();
-    expect(onboarding?.steps[0].status).toBe('completed');
+    expect(onboarding?.steps[0]?.status).toBeDefined();
+    expect(onboarding?.steps[0]?.status).toBe('completed');
     expect(context.getValue(contextKey)).toBe('test');
     // reset all states
     onboardingRegistry.resetOnboarding([extensionId]);
@@ -169,7 +163,7 @@ describe('an OnboardingRegistry instance exists', () => {
     onboarding = onboardingRegistry.getOnboarding(extensionId);
     expect(onboarding).toBeDefined();
     expect(onboarding?.status).toBe(undefined);
-    expect(onboarding?.steps[0].status).toBe(undefined);
+    expect(onboarding?.steps[0]?.status).toBe(undefined);
     expect('test' in context.collectAllValues()).toBe(false);
   });
 
@@ -194,7 +188,7 @@ describe('checkIdsReadability tests', () => {
   });
 
   test('checkIdsReadability should detect non valid ids', () => {
-    const onboardingRegistry = new OnboardingRegistry(configurationRegistry, context);
+    const onboardingRegistry = new OnboardingRegistry(context);
     const extensionPath = '/root/path';
     const extension = {
       path: extensionPath,

--- a/packages/main/src/plugin/onboarding-registry.ts
+++ b/packages/main/src/plugin/onboarding-registry.ts
@@ -22,7 +22,6 @@ import * as path from 'node:path';
 import type { Onboarding, OnboardingInfo, OnboardingStatus } from '/@api/onboarding.js';
 
 import { getBase64Image } from '../util.js';
-import type { ConfigurationRegistry } from './configuration-registry.js';
 import type { Context } from './context/context.js';
 import type { AnalyzedExtension } from './extension-loader.js';
 import { Disposable } from './types/disposable.js';
@@ -30,10 +29,7 @@ import { Disposable } from './types/disposable.js';
 export class OnboardingRegistry {
   private onboardingInfos: Map<string, OnboardingInfo> = new Map<string, OnboardingInfo>();
 
-  constructor(
-    private configurationRegistry: ConfigurationRegistry,
-    private context: Context,
-  ) {}
+  constructor(private context: Context) {}
 
   registerOnboarding(extension: AnalyzedExtension, onboarding: Onboarding): Disposable {
     const onInfo = this.createOnboardingInfo(extension, onboarding);

--- a/packages/main/src/plugin/open-devtools-init.spec.ts
+++ b/packages/main/src/plugin/open-devtools-init.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,17 +40,17 @@ test('should register a configuration', async () => {
   expect(configurationRegistryMock.registerConfigurations).toBeCalled();
 
   // take first argument of first call
-  const configurationNode = vi.mocked(configurationRegistryMock).registerConfigurations.mock.calls[0][0][0];
-  expect(configurationNode.id).toBe('preferences.OpenDevTools');
-  expect(configurationNode.title).toBe('Open Dev Tools');
-  expect(configurationNode.type).toBe('object');
-  expect(configurationNode.properties).toBeDefined();
-  expect(configurationNode.properties?.['preferences.OpenDevTools']).toBeDefined();
-  expect(configurationNode.properties?.['preferences.OpenDevTools'].description).toBe(
+  const configurationNode = vi.mocked(configurationRegistryMock).registerConfigurations.mock.calls[0]?.[0][0];
+  expect(configurationNode?.id).toBe('preferences.OpenDevTools');
+  expect(configurationNode?.title).toBe('Open Dev Tools');
+  expect(configurationNode?.type).toBe('object');
+  expect(configurationNode?.properties).toBeDefined();
+  expect(configurationNode?.properties?.['preferences.OpenDevTools']).toBeDefined();
+  expect(configurationNode?.properties?.['preferences.OpenDevTools']?.description).toBe(
     'Open DevTools when launching Podman Desktop in development mode.',
   );
-  expect(configurationNode.properties?.['preferences.OpenDevTools'].type).toBe('string');
-  expect(configurationNode.properties?.['preferences.OpenDevTools'].enum).toEqual([
+  expect(configurationNode?.properties?.['preferences.OpenDevTools']?.type).toBe('string');
+  expect(configurationNode?.properties?.['preferences.OpenDevTools']?.enum).toEqual([
     'left',
     'right',
     'bottom',
@@ -58,5 +58,5 @@ test('should register a configuration', async () => {
     'detach',
     'none',
   ]);
-  expect(configurationNode.properties?.['preferences.OpenDevTools'].default).toBe('undocked');
+  expect(configurationNode?.properties?.['preferences.OpenDevTools']?.default).toBe('undocked');
 });

--- a/packages/main/src/plugin/provider-registry.spec.ts
+++ b/packages/main/src/plugin/provider-registry.spec.ts
@@ -640,8 +640,8 @@ test('should retrieve cleanup actions without provider Id', async () => {
 
   expect(allActions).toBeDefined();
   expect(allActions).lengthOf(2);
-  expect(allActions[0].providerName).toBe('internal1');
-  expect(allActions[1].providerName).toBe('internal2');
+  expect(allActions[0]?.providerName).toBe('internal1');
+  expect(allActions[1]?.providerName).toBe('internal2');
 });
 
 test('should retrieve cleanup actions with a given provider Id', async () => {
@@ -672,7 +672,7 @@ test('should retrieve cleanup actions with a given provider Id', async () => {
 
   expect(allActions).toBeDefined();
   expect(allActions).lengthOf(1);
-  expect(allActions[0].providerName).toBe('internal1');
+  expect(allActions[0]?.providerName).toBe('internal1');
 });
 
 test('should execute actions', async () => {

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -565,9 +565,12 @@ export class ProviderRegistry {
 
     if (provider.containerConnections && provider.containerConnections.length > 0) {
       const connection = provider.containerConnections[0];
-      const lifecycle = connection.lifecycle;
+      const lifecycle = connection?.lifecycle;
       if (!lifecycle?.start) {
         throw new Error('The container connection does not support start lifecycle');
+      }
+      if (!connection) {
+        throw new Error('The provider does not have a container connection to start');
       }
 
       const context = this.connectionLifecycleContexts.get(connection);

--- a/packages/main/src/plugin/proxy-resolver.ts
+++ b/packages/main/src/plugin/proxy-resolver.ts
@@ -57,6 +57,7 @@ export function getProxyUrl(proxy: Proxy, secure: boolean): string | undefined {
   if (proxy.isEnabled()) {
     return secure ? proxy.proxy?.httpsProxy : proxy.proxy?.httpProxy;
   }
+  return undefined;
 }
 
 type ProxyOptions = { agent?: http.Agent | https.Agent };

--- a/packages/main/src/plugin/proxy.spec.ts
+++ b/packages/main/src/plugin/proxy.spec.ts
@@ -42,6 +42,8 @@ function getConfigurationRegistry(
       return https;
     } else if (name === 'no') {
       return no;
+    } else {
+      return '';
     }
   });
   return {

--- a/packages/main/src/plugin/proxy.ts
+++ b/packages/main/src/plugin/proxy.ts
@@ -35,6 +35,7 @@ export function ensureURL(urlstring: string | undefined): string | undefined {
     }
     return `http://${urlstring}`;
   }
+  return undefined;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/main/src/plugin/recommendations/recommendations-registry.spec.ts
+++ b/packages/main/src/plugin/recommendations/recommendations-registry.spec.ts
@@ -101,17 +101,17 @@ test('should register a configuration', async () => {
   expect(configurationRegistryMock.registerConfigurations).toBeCalled();
 
   // take first argument of first call
-  const configurationNode = vi.mocked(configurationRegistryMock).registerConfigurations.mock.calls[0][0][0];
-  expect(configurationNode.id).toBe('preferences.extensions');
-  expect(configurationNode.title).toBe('Extensions');
-  expect(configurationNode.type).toBe('object');
-  expect(configurationNode.properties).toBeDefined();
-  expect(configurationNode.properties?.['extensions.ignoreRecommendations']).toBeDefined();
-  expect(configurationNode.properties?.['extensions.ignoreRecommendations'].description).toBe(
+  const configurationNode = vi.mocked(configurationRegistryMock).registerConfigurations.mock.calls[0]?.[0]?.[0];
+  expect(configurationNode?.id).toBe('preferences.extensions');
+  expect(configurationNode?.title).toBe('Extensions');
+  expect(configurationNode?.type).toBe('object');
+  expect(configurationNode?.properties).toBeDefined();
+  expect(configurationNode?.properties?.['extensions.ignoreRecommendations']).toBeDefined();
+  expect(configurationNode?.properties?.['extensions.ignoreRecommendations']?.description).toBe(
     'When enabled, the notifications for extension recommendations will not be shown.',
   );
-  expect(configurationNode.properties?.['extensions.ignoreRecommendations'].type).toBe('boolean');
-  expect(configurationNode.properties?.['extensions.ignoreRecommendations'].default).toBeFalsy();
+  expect(configurationNode?.properties?.['extensions.ignoreRecommendations']?.type).toBe('boolean');
+  expect(configurationNode?.properties?.['extensions.ignoreRecommendations']?.default).toBeFalsy();
 });
 
 describe('isRecommendationEnabled', () => {
@@ -175,12 +175,12 @@ describe('getExtensionBanners', () => {
 
     const extensions = await recommendationsRegistry.getExtensionBanners();
     expect(extensions.length).toBe(1);
-    expect(extensions[0].featured).toStrictEqual(featured);
-    expect(extensions[0].extensionId).toBe('dummy.id-0');
-    expect(extensions[0].title).toBe('dummy title');
-    expect(extensions[0].description).toBe('dummy description');
-    expect(extensions[0].icon).toBe('data:image/png;base64-icon');
-    expect(extensions[0].thumbnail).toBe('data:image/png;base64-thumbnail');
+    expect(extensions[0]?.featured).toStrictEqual(featured);
+    expect(extensions[0]?.extensionId).toBe('dummy.id-0');
+    expect(extensions[0]?.title).toBe('dummy title');
+    expect(extensions[0]?.description).toBe('dummy description');
+    expect(extensions[0]?.icon).toBe('data:image/png;base64-icon');
+    expect(extensions[0]?.thumbnail).toBe('data:image/png;base64-thumbnail');
 
     expect(featuredMock.getFeaturedExtensions).toHaveBeenCalled();
   });
@@ -322,7 +322,10 @@ describe('getExtensionBanners', () => {
       const banners = await recommendationsRegistry.getExtensionBanners(1);
       expect(banners.length).toBe(1);
 
-      actualsIds.add(banners[0].extensionId);
+      const actualExtensionId = banners[0]?.extensionId;
+      expect(actualExtensionId).toBeDefined();
+      const actualExtensionIdString = actualExtensionId as string;
+      actualsIds.add(actualExtensionIdString);
     }
 
     expect(expectedIds).toStrictEqual(actualsIds);
@@ -358,7 +361,9 @@ describe('getRegistries', () => {
 
     const registries = await recommendationsRegistry.getRegistries();
     expect(registries.length).toBe(1);
-
+    if (!registries[0]) {
+      throw new Error('registry is undefined');
+    }
     expect(registries[0].extensionId).toBe('my.extensionId');
 
     expect(vi.mocked(extensionLoaderMock).listExtensions).toHaveBeenCalled();

--- a/packages/main/src/plugin/recommendations/recommendations-registry.ts
+++ b/packages/main/src/plugin/recommendations/recommendations-registry.ts
@@ -95,7 +95,7 @@ export class RecommendationsRegistry {
     // Filter and shuffle the extensions
     const extensionBanners: ExtensionBanner[] = recommendations.extensions.reduce((prev, extension) => {
       // ensure the extension is in the featured extensions and is not install
-      if (!(extension.extensionId in featuredExtensions) || featuredExtensions[extension.extensionId].installed) {
+      if (!(extension.extensionId in featuredExtensions) || featuredExtensions[extension.extensionId]?.installed) {
         return prev;
       }
 
@@ -107,10 +107,13 @@ export class RecommendationsRegistry {
         }
       }
 
-      prev.push({
-        ...extension,
-        featured: featuredExtensions[extension.extensionId],
-      });
+      const featured = featuredExtensions[extension.extensionId];
+      if (featured) {
+        prev.push({
+          ...extension,
+          featured,
+        });
+      }
 
       return prev;
     }, [] as ExtensionBanner[]);
@@ -121,7 +124,11 @@ export class RecommendationsRegistry {
       const startingIndex = new Date().getHours() % extensionBanners.length;
 
       // Let's return the subset of banners starting at the chosen index
-      return Array.from({ length: limit }, (_, i) => extensionBanners[(startingIndex + i) % extensionBanners.length]);
+      // and filter out all potential undefined items
+      return Array.from(
+        { length: limit },
+        (_, i) => extensionBanners[(startingIndex + i) % extensionBanners.length],
+      ).filter((value): value is ExtensionBanner => value !== undefined);
     }
     return extensionBanners;
   }

--- a/packages/main/src/plugin/safe-storage/safe-storage-registry.ts
+++ b/packages/main/src/plugin/safe-storage/safe-storage-registry.ts
@@ -128,6 +128,7 @@ export class SafeStorage {
     if (value) {
       return this.decrypt(value);
     }
+    return undefined;
   }
 
   set(key: string, value: string): void {

--- a/packages/main/src/plugin/tasks/notification-registry.spec.ts
+++ b/packages/main/src/plugin/tasks/notification-registry.spec.ts
@@ -66,9 +66,9 @@ test('expect notification added to the queue', async () => {
 
   queue = notificationRegistry.getNotifications();
   expect(queue.length).toEqual(1);
-  expect(queue[0].extensionId).toEqual(extensionId);
-  expect(queue[0].title).toEqual('title');
-  expect(queue[0].type).toEqual('info');
+  expect(queue[0]?.extensionId).toEqual(extensionId);
+  expect(queue[0]?.title).toEqual('title');
+  expect(queue[0]?.type).toEqual('info');
   expect(createNotificationtaskMock).toBeCalledWith({
     title: 'title',
     body: 'description',
@@ -98,9 +98,9 @@ test('expect notification is disposed correctly', async () => {
 
   queue = notificationRegistry.getNotifications();
   expect(queue.length).toEqual(1);
-  expect(queue[0].extensionId).toEqual(extensionId);
-  expect(queue[0].title).toEqual('title');
-  expect(queue[0].type).toEqual('info');
+  expect(queue[0]?.extensionId).toEqual(extensionId);
+  expect(queue[0]?.title).toEqual('title');
+  expect(queue[0]?.type).toEqual('info');
   disposable.dispose();
 
   expect(deleteTaskMock).toBeCalledWith(notificationTask);
@@ -130,17 +130,17 @@ test('expect latest added notification is in top of the queue', async () => {
 
   const queue = notificationRegistry.getNotifications();
   expect(queue.length).toEqual(3);
-  expect(queue[0].extensionId).toEqual(extensionId);
-  expect(queue[0].title).toEqual('3');
-  expect(queue[0].type).toEqual('info');
+  expect(queue[0]?.extensionId).toEqual(extensionId);
+  expect(queue[0]?.title).toEqual('3');
+  expect(queue[0]?.type).toEqual('info');
 
-  expect(queue[1].extensionId).toEqual(extensionId);
-  expect(queue[1].title).toEqual('2');
-  expect(queue[1].type).toEqual('info');
+  expect(queue[1]?.extensionId).toEqual(extensionId);
+  expect(queue[1]?.title).toEqual('2');
+  expect(queue[1]?.type).toEqual('info');
 
-  expect(queue[2].extensionId).toEqual(extensionId);
-  expect(queue[2].title).toEqual('1');
-  expect(queue[2].type).toEqual('info');
+  expect(queue[2]?.extensionId).toEqual(extensionId);
+  expect(queue[2]?.title).toEqual('1');
+  expect(queue[2]?.type).toEqual('info');
 });
 
 test('expect the queue to not have the notification after it is removed by id', async () => {
@@ -157,7 +157,9 @@ test('expect the queue to not have the notification after it is removed by id', 
   queue = notificationRegistry.getNotifications();
   expect(queue.length).toEqual(1);
 
-  notificationRegistry.removeNotificationById(queue[0].id);
+  const queueId = queue[0]?.id;
+  expect(queueId).toBeDefined();
+  notificationRegistry.removeNotificationById(queueId as number);
   queue = notificationRegistry.getNotifications();
   expect(queue.length).toEqual(0);
 });
@@ -185,7 +187,7 @@ test('expect the queue to not have the notifications after they are removed by e
   notificationRegistry.removeNotificationsByExtensionAndTitle(extensionId, 'title');
   queue = notificationRegistry.getNotifications();
   expect(queue.length).toEqual(1);
-  expect(queue[0].title).equal('title1');
+  expect(queue[0]?.title).equal('title1');
 });
 
 test('expect all notifications to be removed', async () => {
@@ -259,8 +261,8 @@ test('expect same notification to only appear once if added multiple times', asy
   });
   let queue = notificationRegistry.getNotifications();
   expect(queue.length).toEqual(2);
-  expect(queue[0].title).equal('1');
-  expect(queue[1].title).equal('2');
+  expect(queue[0]?.title).equal('1');
+  expect(queue[1]?.title).equal('2');
 
   registerNotificationDisposable.dispose();
   queue = notificationRegistry.getNotifications();

--- a/packages/main/src/plugin/tasks/progress-impl.ts
+++ b/packages/main/src/plugin/tasks/progress-impl.ts
@@ -58,7 +58,7 @@ export class ProgressImpl {
   }
 
   withApplicationIcon<R>(
-    options: extensionApi.ProgressOptions,
+    _options: extensionApi.ProgressOptions,
     task: (
       progress: extensionApi.Progress<{ message?: string; increment?: number }>,
       token: extensionApi.CancellationToken,

--- a/packages/main/src/plugin/telemetry/telemetry.spec.ts
+++ b/packages/main/src/plugin/telemetry/telemetry.spec.ts
@@ -24,7 +24,6 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import type { ExtensionInfo } from '/@api/extension-info.js';
 
 import type { ConfigurationRegistry } from '../configuration-registry.js';
-import type { Proxy } from '../proxy.js';
 import { TelemetryTrustedValue } from '../types/telemetry.js';
 import { Telemetry, TelemetryLoggerImpl } from './telemetry.js';
 import { TelemetrySettings } from './telemetry-settings.js';
@@ -52,21 +51,21 @@ vi.mock('../../../../../telemetry.json', () => ({
 
 class TelemetryTest extends Telemetry {
   constructor() {
-    super(configurationRegistryMock, {} as Proxy);
+    super(configurationRegistryMock);
   }
   public getLastTimeEvents(): Map<string, number> {
     return this.lastTimeEvents;
   }
 
-  public shouldDropEvent(eventName: string): boolean {
+  public override shouldDropEvent(eventName: string): boolean {
     return super.shouldDropEvent(eventName);
   }
 
-  public listenForTelemetryUpdates(): void {
+  public override listenForTelemetryUpdates(): void {
     super.listenForTelemetryUpdates();
   }
 
-  public createBuiltinTelemetrySender(extensionInfo: ExtensionInfo): TelemetrySender {
+  public override createBuiltinTelemetrySender(extensionInfo: ExtensionInfo): TelemetrySender {
     return super.createBuiltinTelemetrySender(extensionInfo);
   }
 }

--- a/packages/main/src/plugin/telemetry/telemetry.ts
+++ b/packages/main/src/plugin/telemetry/telemetry.ts
@@ -36,7 +36,6 @@ import { stoppedExtensions } from '../../util.js';
 import type { ConfigurationRegistry, IConfigurationNode } from '../configuration-registry.js';
 import type { Event } from '../events/emitter.js';
 import { Emitter } from '../events/emitter.js';
-import type { Proxy } from '../proxy.js';
 import { TelemetryTrustedValue as TypeTelemetryTrustedValue } from '../types/telemetry.js';
 import { Identity } from './identity.js';
 import type { TelemetryRule } from './telemetry-api.js';
@@ -84,10 +83,7 @@ export class Telemetry {
   private readonly _onDidChangeTelemetryEnabled = new Emitter<boolean>();
   readonly onDidChangeTelemetryEnabled: Event<boolean> = this._onDidChangeTelemetryEnabled.event;
 
-  constructor(
-    private configurationRegistry: ConfigurationRegistry,
-    private proxy: Proxy,
-  ) {
+  constructor(private configurationRegistry: ConfigurationRegistry) {
     this.identity = new Identity();
     this.lastTimeEvents = new Map();
   }
@@ -176,7 +172,7 @@ export class Telemetry {
       // report using the id of the extension suffixed by error
       sendErrorData(error: Error, data?: Record<string, unknown>): void {
         data = data ?? {};
-        data.sourceError = error.message;
+        data['sourceError'] = error.message;
         thisArg.track.apply(thisArg, [`${extensionInfo.id}.error`, data]);
       },
       async flush(): Promise<void> {
@@ -318,7 +314,7 @@ export class Telemetry {
           // it was not there, so we can send it
           if (!previousTime) {
             this.lastTimeEvents.set(eventName, Date.now());
-            return false;
+            return;
           } else {
             // it was there, so we check if it was more than 24h ago
             const now = Date.now();

--- a/packages/main/src/plugin/terminal-theme.spec.ts
+++ b/packages/main/src/plugin/terminal-theme.spec.ts
@@ -58,7 +58,7 @@ describe('getTerminalTheme', () => {
           '--pd-terminal-brightCyan': '#55ffff',
           '--pd-terminal-brightWhite': '#ffffff',
         };
-        return cssVariables[property] || '';
+        return cssVariables[property] ?? '';
       },
     };
 

--- a/packages/main/src/plugin/tray-icon-color.ts
+++ b/packages/main/src/plugin/tray-icon-color.ts
@@ -17,13 +17,9 @@
  ***********************************************************************/
 
 import type { ConfigurationRegistry, IConfigurationNode } from './configuration-registry.js';
-import type { ProviderRegistry } from './provider-registry.js';
 
 export class TrayIconColor {
-  constructor(
-    private configurationRegistry: ConfigurationRegistry,
-    private providerRegistry: ProviderRegistry,
-  ) {}
+  constructor(private configurationRegistry: ConfigurationRegistry) {}
 
   async init(): Promise<void> {
     // add configuration

--- a/packages/main/src/plugin/tray-menu-registry.ts
+++ b/packages/main/src/plugin/tray-menu-registry.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022-2023 Red Hat, Inc.
+ * Copyright (C) 2022-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ export class TrayMenuRegistry {
         this.trayMenu.updateProvider(providerInfo);
       }
     });
-    providerRegistry.addProviderLifecycleListener((name: string, provider: ProviderInfo) => {
+    providerRegistry.addProviderLifecycleListener((_name: string, provider: ProviderInfo) => {
       this.registerProvider(provider);
     });
 

--- a/packages/main/src/plugin/troubleshooting.spec.ts
+++ b/packages/main/src/plugin/troubleshooting.spec.ts
@@ -20,17 +20,11 @@ import * as fs from 'node:fs';
 
 import { beforeEach, expect, test, vi } from 'vitest';
 
-import type { ApiSenderType } from './api.js';
 import type { LogType, TroubleshootingFileMap } from './troubleshooting.js';
 import { Troubleshooting } from './troubleshooting.js';
 
 const writeZipMock = vi.fn();
 const addFileMock = vi.fn();
-
-const apiSender: ApiSenderType = {
-  send: vi.fn(),
-  receive: vi.fn(),
-};
 
 vi.mock('electron', () => {
   return {
@@ -56,7 +50,7 @@ beforeEach(() => {
 
 // Test the saveLogsToZip function
 test('Should save a zip file with the correct content', async () => {
-  const zipFile = new Troubleshooting(apiSender);
+  const zipFile = new Troubleshooting();
   const fileMaps = [
     {
       filename: 'file1',
@@ -78,7 +72,7 @@ test('Should save a zip file with the correct content', async () => {
 
 // Do not expect writeZipMock to have been called if fileMaps is empty
 test('Should not save a zip file if fileMaps is empty', async () => {
-  const zipFile = new Troubleshooting(apiSender);
+  const zipFile = new Troubleshooting();
   const fileMaps: TroubleshootingFileMap[] = [];
 
   const zipSpy = vi.spyOn(zipFile, 'saveLogsToZip');
@@ -91,7 +85,7 @@ test('Should not save a zip file if fileMaps is empty', async () => {
 
 // Expect the file name to have a .txt extension
 test('Should have a .txt extension in the file name', async () => {
-  const zipFile = new Troubleshooting(apiSender);
+  const zipFile = new Troubleshooting();
   const fileMaps = [
     {
       filename: 'file1',
@@ -114,7 +108,7 @@ test('Should have a .txt extension in the file name', async () => {
 
 // Expect getConsoleLogs to correctly format the console logs passed in
 test('Should correctly format console logs', async () => {
-  const zipFile = new Troubleshooting(apiSender);
+  const zipFile = new Troubleshooting();
   const consoleLogs = [
     {
       logType: 'log' as LogType,
@@ -133,9 +127,9 @@ test('Should correctly format console logs', async () => {
   const fileMaps = zipFile.getConsoleLogs(consoleLogs);
   expect(zipSpy).toHaveBeenCalledWith(consoleLogs);
 
-  expect(fileMaps[0].filename).toContain('console');
-  expect(fileMaps[0].content).toContain('log : message1');
-  expect(fileMaps[0].content).toContain('log : message2');
+  expect(fileMaps[0]?.filename).toContain('console');
+  expect(fileMaps[0]?.content).toContain('log : message1');
+  expect(fileMaps[0]?.content).toContain('log : message2');
 });
 
 // Expect getSystemLogs to return getMacSystemLogs if the platform is darwin
@@ -153,7 +147,7 @@ test('Should return getMacSystemLogs if the platform is darwin', async () => {
     return true;
   });
 
-  const zipFile = new Troubleshooting(apiSender);
+  const zipFile = new Troubleshooting();
   const getSystemLogsSpy = vi.spyOn(zipFile, 'getSystemLogs');
 
   await zipFile.getSystemLogs();
@@ -188,7 +182,7 @@ test('Should return getWindowsSystemLogs if the platform is win32', async () => 
   const readFileMock = vi.spyOn(fs.promises, 'readFile');
   readFileMock.mockResolvedValue('content');
 
-  const zipFile = new Troubleshooting(apiSender);
+  const zipFile = new Troubleshooting();
   const getSystemLogsSpy = vi.spyOn(zipFile, 'getSystemLogs');
 
   await zipFile.getSystemLogs();
@@ -205,7 +199,7 @@ test('Should return getWindowsSystemLogs if the platform is win32', async () => 
 });
 
 test('test generateLogFileName', async () => {
-  const ts = new Troubleshooting(apiSender);
+  const ts = new Troubleshooting();
   const filename = ts.generateLogFileName('test');
 
   // Simple regex to check that the file name is in the correct format (YYYMMDDHHmmss)

--- a/packages/main/src/plugin/troubleshooting.ts
+++ b/packages/main/src/plugin/troubleshooting.ts
@@ -22,8 +22,6 @@ import * as os from 'node:os';
 import AdmZip from 'adm-zip';
 import moment from 'moment';
 
-import type { ApiSenderType } from './api.js';
-
 const SYSTEM_FILENAME = 'system';
 
 export interface TroubleshootingFileMap {
@@ -34,8 +32,6 @@ export interface TroubleshootingFileMap {
 export type LogType = 'log' | 'warn' | 'trace' | 'debug' | 'error';
 
 export class Troubleshooting {
-  constructor(private apiSender: ApiSenderType) {}
-
   // The "main" function that is exposes that is used to gather
   // all the logs and save them to a zip file.
   // this also takes in the console logs and adds them to the zip file (see preload/src/index.ts) regarding memoryLogs

--- a/packages/main/src/plugin/util/exec.spec.ts
+++ b/packages/main/src/plugin/util/exec.spec.ts
@@ -563,17 +563,17 @@ describe('getInstallationPath', () => {
   let originalPath: string | undefined;
 
   beforeEach(() => {
-    originalPath = process.env.PATH;
+    originalPath = process.env['PATH'];
   });
 
   afterEach(() => {
-    process.env.PATH = originalPath;
+    process.env['PATH'] = originalPath;
   });
 
   test('should return the installation path for Windows', () => {
     vi.spyOn(util, 'isWindows').mockImplementation(() => true);
     vi.spyOn(util, 'isMac').mockImplementation(() => false);
-    process.env.PATH = '';
+    process.env['PATH'] = '';
 
     const path = getInstallationPath();
 
@@ -583,7 +583,7 @@ describe('getInstallationPath', () => {
   test('should return the installation path for Windows with pre-filled PATH', () => {
     vi.spyOn(util, 'isWindows').mockImplementation(() => true);
     vi.spyOn(util, 'isMac').mockImplementation(() => false);
-    process.env.PATH = 'c:\\Local';
+    process.env['PATH'] = 'c:\\Local';
 
     const path = getInstallationPath();
 
@@ -593,7 +593,7 @@ describe('getInstallationPath', () => {
   test('should return the installation path for Windows with defined param', () => {
     vi.spyOn(util, 'isWindows').mockImplementation(() => true);
     vi.spyOn(util, 'isMac').mockImplementation(() => false);
-    process.env.PATH = 'c:\\Local';
+    process.env['PATH'] = 'c:\\Local';
 
     const path = getInstallationPath('c:\\Directory');
 
@@ -604,7 +604,7 @@ describe('getInstallationPath', () => {
     vi.spyOn(util, 'isWindows').mockImplementation(() => false);
     vi.spyOn(util, 'isMac').mockImplementation(() => true);
 
-    process.env.PATH = '/usr/bin';
+    process.env['PATH'] = '/usr/bin';
 
     const path = getInstallationPath();
 
@@ -615,7 +615,7 @@ describe('getInstallationPath', () => {
     vi.spyOn(util, 'isWindows').mockImplementation(() => false);
     vi.spyOn(util, 'isMac').mockImplementation(() => true);
 
-    process.env.PATH = '/usr/bin';
+    process.env['PATH'] = '/usr/bin';
 
     const path = getInstallationPath('/usr/other');
 
@@ -625,7 +625,7 @@ describe('getInstallationPath', () => {
   test('should return the installation path for other platforms', () => {
     vi.spyOn(util, 'isWindows').mockImplementation(() => false);
     vi.spyOn(util, 'isMac').mockImplementation(() => false);
-    process.env.PATH = '/usr/bin'; // Example PATH for other platforms
+    process.env['PATH'] = '/usr/bin'; // Example PATH for other platforms
 
     const path = getInstallationPath();
 
@@ -635,7 +635,7 @@ describe('getInstallationPath', () => {
   test('should return the installation path for other platforms with defined param', () => {
     vi.spyOn(util, 'isWindows').mockImplementation(() => false);
     vi.spyOn(util, 'isMac').mockImplementation(() => false);
-    process.env.PATH = '/usr/bin'; // Example PATH for other platforms
+    process.env['PATH'] = '/usr/bin'; // Example PATH for other platforms
 
     const path = getInstallationPath('/usr/other');
 

--- a/packages/main/src/plugin/util/exec.ts
+++ b/packages/main/src/plugin/util/exec.ts
@@ -29,8 +29,8 @@ export const macosExtraPath = '/usr/local/bin:/opt/homebrew/bin:/opt/local/bin:/
 
 class RunErrorImpl extends Error implements RunError {
   constructor(
-    readonly name: string,
-    readonly message: string,
+    override readonly name: string,
+    override readonly message: string,
     readonly exitCode: number,
     readonly command: string,
     readonly stdout: string,
@@ -55,18 +55,18 @@ export class Exec {
 
     if (this.proxy.isEnabled()) {
       if (this.proxy.proxy?.httpsProxy) {
-        env.HTTPS_PROXY = `${this.proxy.proxy.httpsProxy}`;
+        env['HTTPS_PROXY'] = `${this.proxy.proxy.httpsProxy}`;
       }
       if (this.proxy.proxy?.httpProxy) {
-        env.HTTP_PROXY = `${this.proxy.proxy.httpProxy}`;
+        env['HTTP_PROXY'] = `${this.proxy.proxy.httpProxy}`;
       }
       if (this.proxy.proxy?.noProxy) {
-        env.NO_PROXY = this.proxy.proxy.noProxy;
+        env['NO_PROXY'] = this.proxy.proxy.noProxy;
       }
     }
 
     if (isMac() || isWindows()) {
-      env.PATH = getInstallationPath(env.PATH);
+      env['PATH'] = getInstallationPath(env['PATH']);
     }
 
     // do we have an admin task ?
@@ -136,7 +136,7 @@ export class Exec {
       }
     }
 
-    if (env.FLATPAK_ID) {
+    if (env['FLATPAK_ID']) {
       args = ['--host', command, ...(args ?? [])];
       command = 'flatpak-spawn';
     }
@@ -239,7 +239,7 @@ export class Exec {
 
 export function getInstallationPath(envPATH?: string): string {
   if (!envPATH) {
-    envPATH = process.env.PATH;
+    envPATH = process.env['PATH'];
   }
 
   if (isWindows()) {

--- a/packages/main/src/plugin/util/manifest.ts
+++ b/packages/main/src/plugin/util/manifest.ts
@@ -53,6 +53,10 @@ export function guessIsManifest(image: ImageInfo, connectionType: string): boole
   if (image.RepoDigests) {
     for (const digest of image.RepoDigests) {
       const [repo, hash] = digest.split('@');
+      if (!hash || !repo) {
+        // This is an invalid digest, skip it
+        continue;
+      }
       const tagSet = digestMap.get(hash) ?? new Set<string>();
       image?.RepoTags?.forEach(tag => {
         if (tag.includes(repo)) {

--- a/packages/main/src/plugin/util/port.spec.ts
+++ b/packages/main/src/plugin/util/port.spec.ts
@@ -25,14 +25,21 @@ import * as port from './port.js';
 
 const hosts = ['127.0.0.1', '0.0.0.0'];
 
+function getInt(val: string | undefined): number {
+  if (!val) {
+    throw new Error('Value is empty');
+  }
+  return parseInt(val);
+}
+
 test('return valid port range', async () => {
   const range = await port.getFreePortRange(3);
 
   const rangeValues = range.split('-');
   expect(rangeValues.length).toBe(2);
 
-  const startRange = parseInt(rangeValues[0]);
-  const endRange = parseInt(rangeValues[1]);
+  const startRange = getInt(rangeValues[0]);
+  const endRange = getInt(rangeValues[1]);
 
   expect(isNaN(startRange)).toBe(false);
   expect(isNaN(endRange)).toBe(false);
@@ -50,8 +57,8 @@ test.each(hosts)(
     const rangeValues = range.split('-');
     expect(rangeValues.length).toBe(2);
 
-    const startRange = parseInt(rangeValues[0]);
-    const endRange = parseInt(rangeValues[1]);
+    const startRange = getInt(rangeValues[0]);
+    const endRange = getInt(rangeValues[1]);
 
     expect(isNaN(startRange)).toBe(false);
     expect(isNaN(endRange)).toBe(false);
@@ -69,8 +76,8 @@ test.each(hosts)(
     const newRangeValues = newRange.split('-');
     expect(newRangeValues.length).toBe(2);
 
-    const startNewRange = parseInt(newRangeValues[0]);
-    const endNewRange = parseInt(newRangeValues[1]);
+    const startNewRange = getInt(newRangeValues[0]);
+    const endNewRange = getInt(newRangeValues[1]);
 
     expect(isNaN(startNewRange)).toBe(false);
     expect(isNaN(endNewRange)).toBe(false);

--- a/packages/main/src/plugin/view-registry.spec.ts
+++ b/packages/main/src/plugin/view-registry.spec.ts
@@ -61,8 +61,8 @@ test('View context should have a single entry', async () => {
   expect(views).toBeDefined();
   expectTypeOf(views).toBeArray();
   expect(views.length).toBe(1);
-  expect((views[0].value as ViewContributionIcon).when).toBe('io.x-k8s.kind.cluster in containerLabelKeys');
-  expect((views[0].value as ViewContributionIcon).icon).toBe('${kind-icon}');
+  expect((views[0]?.value as ViewContributionIcon).when).toBe('io.x-k8s.kind.cluster in containerLabelKeys');
+  expect((views[0]?.value as ViewContributionIcon).icon).toBe('${kind-icon}');
 });
 
 test('Should not find menus after dispose', async () => {

--- a/packages/main/src/plugin/webview/webview-impl.spec.ts
+++ b/packages/main/src/plugin/webview/webview-impl.spec.ts
@@ -86,7 +86,7 @@ test('allow to update options', async () => {
   expect(webviewImpl.options).toBeDefined();
   expect(webviewImpl.options.localResourceRoots).toBeDefined();
   expect(webviewImpl.options.localResourceRoots).toHaveLength(1);
-  expect(webviewImpl.options.localResourceRoots?.[0].toString()).toBe('https://www.podman-desktop.io/');
+  expect(webviewImpl.options.localResourceRoots?.[0]?.toString()).toBe('https://www.podman-desktop.io/');
 
   // expect apiSender.send has been called with correct parameters
   expect(apiSender.send).toHaveBeenCalledWith('webview-update:options', {

--- a/packages/main/src/plugin/webview/webview-registry.spec.ts
+++ b/packages/main/src/plugin/webview/webview-registry.spec.ts
@@ -39,7 +39,7 @@ vi.mock('express', () => ({
   default: (): any => {
     return {
       use: vi.fn(),
-      listen: vi.fn().mockImplementation((portNumber, func: any) => {
+      listen: vi.fn().mockImplementation((_portNumber, func: any) => {
         func();
         return { on: vi.fn() };
       }),
@@ -54,11 +54,11 @@ vi.mock('../util/port.js', () => ({
 }));
 
 class TestWebviewRegistry extends WebviewRegistry {
-  buildRouter(): Router {
+  override buildRouter(): Router {
     return super.buildRouter();
   }
 
-  configureRouter(router: express.Router): void {
+  override configureRouter(router: express.Router): void {
     super.configureRouter(router);
   }
 }
@@ -451,13 +451,13 @@ test('check listWebviews', async () => {
 
   // check
   expect(webviews.length).toBe(2);
-  expect(webviews[0].id).toBe(panelImpl1.internalId);
-  expect(webviews[0].viewType).toBe('viewTypeInfo');
-  expect(webviews[0].html).toBe('html1');
+  expect(webviews[0]?.id).toBe(panelImpl1.internalId);
+  expect(webviews[0]?.viewType).toBe('viewTypeInfo');
+  expect(webviews[0]?.html).toBe('html1');
 
-  expect(webviews[1].id).toBe(panelImpl2.internalId);
-  expect(webviews[1].viewType).toBe('viewTypeInfo');
-  expect(webviews[1].html).toBe('html2');
+  expect(webviews[1]?.id).toBe(panelImpl2.internalId);
+  expect(webviews[1]?.viewType).toBe('viewTypeInfo');
+  expect(webviews[1]?.html).toBe('html2');
 });
 
 test('check listSimpleWebviews', async () => {
@@ -481,13 +481,13 @@ test('check listSimpleWebviews', async () => {
 
   // check
   expect(webviews.length).toBe(2);
-  expect(webviews[0].id).toBe(panelImpl1.internalId);
-  expect(webviews[0].viewType).toBe('viewTypeInfo');
-  expect(webviews[0].title).toBe('customTitle1');
+  expect(webviews[0]?.id).toBe(panelImpl1.internalId);
+  expect(webviews[0]?.viewType).toBe('viewTypeInfo');
+  expect(webviews[0]?.title).toBe('customTitle1');
 
-  expect(webviews[1].id).toBe(panelImpl2.internalId);
-  expect(webviews[1].viewType).toBe('viewTypeInfo');
-  expect(webviews[1].title).toBe('customTitle2');
+  expect(webviews[1]?.id).toBe(panelImpl2.internalId);
+  expect(webviews[1]?.viewType).toBe('viewTypeInfo');
+  expect(webviews[1]?.title).toBe('customTitle2');
 });
 
 test('check disposeWebviewPanel', async () => {

--- a/packages/main/src/plugin/webview/webview-registry.ts
+++ b/packages/main/src/plugin/webview/webview-registry.ts
@@ -129,6 +129,10 @@ export class WebviewRegistry {
       // check if hostname matches uuid pattern
       const uuidPattern = new RegExp('^[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}$');
       const uuid = req.hostname.split('.')[0];
+      if (!uuid) {
+        res.status(500).send('invalid request: uuid');
+        return;
+      }
       if (!uuidPattern.test(uuid)) {
         res.status(404).send('not found');
         return;

--- a/packages/main/src/system/window/window-handler.spec.ts
+++ b/packages/main/src/system/window/window-handler.spec.ts
@@ -194,16 +194,16 @@ test('should register a configuration', async () => {
   expect(configurationRegistryMock.registerConfigurations).toBeCalled();
 
   // take first argument of first call
-  const configurationNode = vi.mocked(configurationRegistryMock).registerConfigurations.mock.calls[0][0][0];
-  expect(configurationNode.id).toBe('preferences.savePosition');
-  expect(configurationNode.title).toBe('Window');
-  expect(configurationNode.type).toBe('object');
-  expect(configurationNode.properties).toBeDefined();
-  expect(configurationNode.properties?.['window.bounds']).toBeDefined();
-  expect(configurationNode.properties?.['window.bounds'].description).toBe('bounds of the window');
-  expect(configurationNode.properties?.['window.restorePosition'].type).toBe('boolean');
-  expect(configurationNode.properties?.['window.restorePosition'].description).toBe(
+  const configurationNode = vi.mocked(configurationRegistryMock).registerConfigurations.mock.calls[0]?.[0][0];
+  expect(configurationNode?.id).toBe('preferences.savePosition');
+  expect(configurationNode?.title).toBe('Window');
+  expect(configurationNode?.type).toBe('object');
+  expect(configurationNode?.properties).toBeDefined();
+  expect(configurationNode?.properties?.['window.bounds']).toBeDefined();
+  expect(configurationNode?.properties?.['window.bounds']?.description).toBe('bounds of the window');
+  expect(configurationNode?.properties?.['window.restorePosition']?.type).toBe('boolean');
+  expect(configurationNode?.properties?.['window.restorePosition']?.description).toBe(
     'Restore position and size of the window after a restart',
   );
-  expect(configurationNode.properties?.['window.restorePosition'].default).toBeTruthy();
+  expect(configurationNode?.properties?.['window.restorePosition']?.default).toBeTruthy();
 });

--- a/packages/main/src/tray-animate-icon.spec.ts
+++ b/packages/main/src/tray-animate-icon.spec.ts
@@ -25,11 +25,11 @@ import { AnimatedTray } from './tray-animate-icon.js';
 
 // to call protected methods
 class TestAnimatedTray extends AnimatedTray {
-  getAssetsFolder(): string {
+  override getAssetsFolder(): string {
     return super.getAssetsFolder();
   }
 
-  isProd(): boolean {
+  override isProd(): boolean {
     return super.isProd();
   }
 }

--- a/packages/main/src/tray-menu.spec.ts
+++ b/packages/main/src/tray-menu.spec.ts
@@ -72,14 +72,14 @@ test('Tray delete provider item', () => {
     internalId: 'internalId',
   } as ProviderInfo);
 
-  onSpy.mock.calls[0][1](undefined as unknown as Electron.IpcMainEvent, {
+  onSpy.mock.calls[0]?.[1](undefined as unknown as Electron.IpcMainEvent, {
     providerId: 'testId',
     menuItem: { id: 'itemId', label: 'SomeLabel' },
   });
 
   trayMenu.deleteProviderItem('testId', 'itemId');
   expect(
-    (menuBuild.mock.lastCall?.[0][0].submenu as Array<MenuItemConstructorOptions>)?.filter(
+    (menuBuild.mock.lastCall?.[0]?.[0]?.submenu as Array<MenuItemConstructorOptions>)?.filter(
       it => it.label === 'SomeLabel',
     ),
   ).to.be.empty;
@@ -97,7 +97,7 @@ test('Tray update provider not delete provider items', () => {
     internalId: 'internalId',
   } as ProviderInfo);
 
-  onSpy.mock.calls[0][1](undefined as unknown as Electron.IpcMainEvent, {
+  onSpy.mock.calls[0]?.[1](undefined as unknown as Electron.IpcMainEvent, {
     providerId: 'testId',
     menuItem: { id: 'itemId', label: 'SomeLabel' },
   });
@@ -109,7 +109,7 @@ test('Tray update provider not delete provider items', () => {
   } as ProviderInfo);
 
   expect(
-    (menuBuild.mock.lastCall?.[0][0].submenu as Array<MenuItemConstructorOptions>)?.filter(
+    (menuBuild.mock.lastCall?.[0]?.[0]?.submenu as Array<MenuItemConstructorOptions>)?.filter(
       it => it.label === 'SomeLabel',
     ),
   ).to.be.not.empty;
@@ -144,7 +144,7 @@ test('Tray provider start enabled when configured state', () => {
     status: 'configured',
   } as ProviderInfo);
 
-  const startItem = (menuBuild.mock.lastCall?.[0][0].submenu as Array<MenuItemConstructorOptions>)?.find(
+  const startItem = (menuBuild.mock.lastCall?.[0]?.[0]?.submenu as Array<MenuItemConstructorOptions>)?.find(
     it => it.label === 'Start',
   );
   expect(startItem).to.be.not.undefined;

--- a/packages/main/tsconfig.json
+++ b/packages/main/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "@tsconfig/strictest/tsconfig.json",
   "compilerOptions": {
     "module": "node16",
     "target": "esnext",
@@ -9,6 +10,7 @@
     "resolveJsonModule": true,
     "strict": true,
     "isolatedModules": true,
+    "exactOptionalPropertyTypes": false,
 
     "types": ["node"],
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5843,6 +5843,11 @@
     mkdirp "^1.0.4"
     path-browserify "^1.0.1"
 
+"@tsconfig/strictest@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@tsconfig/strictest/-/strictest-2.0.5.tgz#2cbc67f207ba87fdec2a84ad79b1708cf4edd93b"
+  integrity sha512-ec4tjL2Rr0pkZ5hww65c+EEPYwxOi4Ryv+0MtjeaSQRJyq322Q27eOQiFbuNgw2hpL4hB1/W/HBGk3VKS43osg==
+
 "@tsconfig/svelte@^5.0.2", "@tsconfig/svelte@^5.0.4":
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/@tsconfig/svelte/-/svelte-5.0.4.tgz#8bd0254472bd39a5e750f1b4a05ecb18c9f3bf80"


### PR DESCRIPTION
### What does this PR do?
Enable `"@tsconfig/strictest"` typescript rule on the main package to enforce more checks int he source code

but disable for now `exactOptionalPropertyTypes` from this rule

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
