### PR TITLE
feat: adding open release note to update confirmation dialog

### DIFF
--- a/extensions/podman/src/podman-install.spec.ts
+++ b/extensions/podman/src/podman-install.spec.ts
@@ -23,8 +23,14 @@ import * as extensionApi from '@podman-desktop/api';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { InstalledPodman } from './podman-cli';
-import type { Installer, UpdateCheck } from './podman-install';
-import { getBundledPodmanVersion, PodmanInstall, WinInstaller } from './podman-install';
+import type {
+  getBundledPodmanVersion,
+  Installer,
+  PodmanInfo,
+  PodmanInstall,
+  UpdateCheck,
+  WinInstaller,
+} from './podman-install';
 import * as podmanInstallObj from './podman-install';
 import * as utils from './util';
 
@@ -60,12 +66,14 @@ vi.mock('@podman-desktop/api', async () => {
     },
     env: {
       isMac: true,
+      openExternal: vi.fn(),
     },
     window: {
       withProgress: vi.fn(),
       showNotification: vi.fn(),
       showErrorMessage: vi.fn(),
       showInformationMessage: vi.fn(),
+      showWarningMessage: vi.fn(),
     },
     ProgressLocation: {},
     process: {
@@ -73,6 +81,9 @@ vi.mock('@podman-desktop/api', async () => {
     },
     configuration: {
       getConfiguration: vi.fn(),
+    },
+    Uri: {
+      parse: vi.fn(),
     },
   };
 });
@@ -815,5 +826,90 @@ test('checkForUpdate should return installed version and update if the installed
     installedVersion: '1.1',
     hasUpdate: true,
     bundledVersion: podmanInstallObj.getBundledPodmanVersion(),
+  });
+});
+
+const providerMock: extensionApi.Provider = {} as unknown as extensionApi.Provider;
+
+describe('performUpdate', () => {
+  test('should raise an error if no podmanInfo provided', async () => {
+    const podmanInstall: TestPodmanInstall = new TestPodmanInstall(extensionContext);
+
+    await expect(() => {
+      return podmanInstall.performUpdate(providerMock, undefined);
+    }).rejects.toThrowError('The podman extension has not been successfully initialized');
+  });
+
+  test('should call showWarningMessage if stopPodmanMachinesIfAnyBeforeUpdating resolve false', async () => {
+    const podmanInstall: TestPodmanInstall = new TestPodmanInstall(extensionContext);
+    // mock initialized
+    podmanInstall['podmanInfo'] = {} as unknown as PodmanInfo;
+    // mock checkForUpdate
+    vi.spyOn(podmanInstall, 'checkForUpdate').mockResolvedValue({
+      hasUpdate: true,
+      installedVersion: '1.0.0',
+      bundledVersion: '0.9.8',
+    });
+    // E.g. user cancel stop
+    vi.spyOn(podmanInstall, 'stopPodmanMachinesIfAnyBeforeUpdating').mockResolvedValue(false);
+
+    await podmanInstall.performUpdate(providerMock, undefined);
+
+    expect(extensionApi.window.showWarningMessage).toHaveBeenCalledWith('Podman update has been canceled.', 'OK');
+  });
+
+  test('should call showInformationMessage ', async () => {
+    vi.mocked(extensionApi.window.showInformationMessage).mockResolvedValue(undefined);
+
+    const podmanInstall: TestPodmanInstall = new TestPodmanInstall(extensionContext);
+    // mock initialized
+    podmanInstall['podmanInfo'] = {} as unknown as PodmanInfo;
+
+    // all podman machine are stopped
+    vi.spyOn(podmanInstall, 'stopPodmanMachinesIfAnyBeforeUpdating').mockResolvedValue(true);
+    // return true if data have been cleaned or if user skip it
+    vi.spyOn(podmanInstall, 'wipeAllDataBeforeUpdatingToV5').mockResolvedValue(true);
+
+    // mock checkForUpdate
+    vi.spyOn(podmanInstall, 'checkForUpdate').mockResolvedValue({
+      hasUpdate: true,
+      installedVersion: '1.0.0',
+      bundledVersion: '0.9.8',
+    });
+
+    await podmanInstall.performUpdate(providerMock, undefined);
+
+    expect(extensionApi.window.showInformationMessage).toHaveBeenCalledWith(
+      'You have Podman 1.0.0.\nDo you want to update to 0.9.8?',
+      'Yes',
+      'No',
+      'Ignore',
+      'Open release note',
+    );
+  });
+
+  test('user clicking on Open release note should open external link', async () => {
+    vi.mocked(extensionApi.window.showInformationMessage).mockResolvedValue('Open release note');
+
+    const podmanInstall: TestPodmanInstall = new TestPodmanInstall(extensionContext);
+    // mock initialized
+    podmanInstall['podmanInfo'] = {} as unknown as PodmanInfo;
+
+    // all podman machine are stopped
+    vi.spyOn(podmanInstall, 'stopPodmanMachinesIfAnyBeforeUpdating').mockResolvedValue(true);
+    // return true if data have been cleaned or if user skip it
+    vi.spyOn(podmanInstall, 'wipeAllDataBeforeUpdatingToV5').mockResolvedValue(true);
+
+    // mock checkForUpdate
+    vi.spyOn(podmanInstall, 'checkForUpdate').mockResolvedValue({
+      hasUpdate: true,
+      installedVersion: '1.0.0',
+      bundledVersion: '0.9.8',
+    });
+
+    await podmanInstall.performUpdate(providerMock, undefined);
+
+    expect(extensionApi.Uri.parse).toHaveBeenCalledWith('https://github.com/containers/podman/releases/tag/v0.9.8');
+    expect(extensionApi.env.openExternal).toHaveBeenCalled();
   });
 });

--- a/extensions/podman/src/podman-install.spec.ts
+++ b/extensions/podman/src/podman-install.spec.ts
@@ -23,15 +23,10 @@ import * as extensionApi from '@podman-desktop/api';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { InstalledPodman } from './podman-cli';
-import type {
-  getBundledPodmanVersion,
-  Installer,
-  PodmanInfo,
-  PodmanInstall,
-  UpdateCheck,
-  WinInstaller,
-} from './podman-install';
+import type { Installer, PodmanInfo, UpdateCheck } from './podman-install';
+import { getBundledPodmanVersion, PodmanInstall, WinInstaller } from './podman-install';
 import * as podmanInstallObj from './podman-install';
+import { releaseNotes } from './podman5.json';
 import * as utils from './util';
 
 const originalConsoleError = console.error;
@@ -884,12 +879,12 @@ describe('performUpdate', () => {
       'Yes',
       'No',
       'Ignore',
-      'Open release note',
+      'Open release notes',
     );
   });
 
   test('user clicking on Open release note should open external link', async () => {
-    vi.mocked(extensionApi.window.showInformationMessage).mockResolvedValue('Open release note');
+    vi.mocked(extensionApi.window.showInformationMessage).mockResolvedValue('Open release notes');
 
     const podmanInstall: TestPodmanInstall = new TestPodmanInstall(extensionContext);
     // mock initialized
@@ -909,7 +904,7 @@ describe('performUpdate', () => {
 
     await podmanInstall.performUpdate(providerMock, undefined);
 
-    expect(extensionApi.Uri.parse).toHaveBeenCalledWith('https://github.com/containers/podman/releases/tag/v0.9.8');
+    expect(extensionApi.Uri.parse).toHaveBeenCalledWith(releaseNotes.href);
     expect(extensionApi.env.openExternal).toHaveBeenCalled();
   });
 });

--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -340,6 +340,7 @@ export class PodmanInstall {
         'Yes',
         'No',
         'Ignore',
+        'Open release note',
       );
       if (answer === 'Yes') {
         await this.getInstaller()?.update();
@@ -367,6 +368,10 @@ export class PodmanInstall {
         }
       } else if (answer === 'Ignore') {
         this.podmanInfo.ignoreVersionUpdate = updateInfo.bundledVersion;
+      } else if (answer === 'Open release note') {
+        await extensionApi.env.openExternal(
+          extensionApi.Uri.parse(`https://github.com/containers/podman/releases/tag/v${updateInfo.bundledVersion}`),
+        );
       }
     }
   }

--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -340,7 +340,7 @@ export class PodmanInstall {
         'Yes',
         'No',
         'Ignore',
-        'Open release note',
+        'Open release notes',
       );
       if (answer === 'Yes') {
         await this.getInstaller()?.update();
@@ -368,10 +368,8 @@ export class PodmanInstall {
         }
       } else if (answer === 'Ignore') {
         this.podmanInfo.ignoreVersionUpdate = updateInfo.bundledVersion;
-      } else if (answer === 'Open release note') {
-        await extensionApi.env.openExternal(
-          extensionApi.Uri.parse(`https://github.com/containers/podman/releases/tag/v${updateInfo.bundledVersion}`),
-        );
+      } else if (answer === 'Open release notes') {
+        await extensionApi.env.openExternal(extensionApi.Uri.parse(podman5JSON.releaseNotes.href));
       }
     }
   }

--- a/extensions/podman/src/podman5.json
+++ b/extensions/podman/src/podman5.json
@@ -1,5 +1,8 @@
 {
   "version": "5.2.0",
+  "releaseNotes": {
+    "href": "https://github.com/containers/podman/releases/tag/v5.2.0"
+  },
   "platform": {
     "win32": {
       "version": "v5.2.0",


### PR DESCRIPTION
### What does this PR do?

Add a `Open release note` action to the confirmation dialog for updating podman desktop.

When clicking on `Open release note` the following link will be open `https://github.com/containers/podman/releases/tag/v{VERSION}`.

### Screenshot / video of UI

https://github.com/user-attachments/assets/f8aad1ca-a932-498a-9631-212964c7abf4

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/7880

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
**Manually**

Replicate video provided above
