### PR TITLE
feat(extension-api): adding version field to cli tool info

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -4378,6 +4378,7 @@ declare module '@podman-desktop/api' {
     markdownDescription: string;
     state: CliToolState;
     images: ProviderImages;
+    version?: string;
     extensionInfo: {
       id: string;
       label: string;

--- a/packages/main/src/plugin/cli-tool-registry.spec.ts
+++ b/packages/main/src/plugin/cli-tool-registry.spec.ts
@@ -160,6 +160,7 @@ suite('cli module', () => {
         images: newCliTool.images,
         extensionInfo: newCliTool.extensionInfo,
         canUpdate: false,
+        version: newCliTool.version,
       });
     });
   });
@@ -450,5 +451,6 @@ suite('cli module', () => {
     expect(cliToolInfo.name).equals(newCliTool.name);
     expect(cliToolInfo.displayName).equals(newCliTool.displayName);
     expect(cliToolInfo.markdownDescription).equals(newCliTool.markdownDescription);
+    expect(cliToolInfo.version).equals(newCliTool.version);
   });
 });

--- a/packages/main/src/plugin/cli-tool-registry.ts
+++ b/packages/main/src/plugin/cli-tool-registry.ts
@@ -164,6 +164,7 @@ export class CliToolRegistry {
       markdownDescription: cliTool.markdownDescription,
       state: cliTool.state,
       images: cliTool.images,
+      version: cliTool.version,
       extensionInfo: {
         id: cliTool.extensionInfo.id,
         label: cliTool.extensionInfo.label,


### PR DESCRIPTION
### What does this PR do?

Adding the `version` field to CliToolInfo interface. Allowing extensions to determine the version of the tool installed.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/8598

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
