### PR TITLE
fix: remove state from CliToolInfo

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -4361,6 +4361,7 @@ declare module '@podman-desktop/api' {
   export type CliToolState = 'registered';
 
   export interface CliTool extends CliToolInfo, Disposable {
+    state: CliToolState;
     updateVersion(version: CliToolUpdateOptions): void;
     onDidUpdateVersion: Event<string>;
 
@@ -4376,7 +4377,6 @@ declare module '@podman-desktop/api' {
     name: string;
     displayName: string;
     markdownDescription: string;
-    state: CliToolState;
     images: ProviderImages;
     version?: string;
     extensionInfo: {

--- a/packages/main/src/plugin/cli-tool-registry.ts
+++ b/packages/main/src/plugin/cli-tool-registry.ts
@@ -162,7 +162,6 @@ export class CliToolRegistry {
       name: cliTool.name,
       displayName: cliTool.displayName,
       markdownDescription: cliTool.markdownDescription,
-      state: cliTool.state,
       images: cliTool.images,
       version: cliTool.version,
       extensionInfo: {


### PR DESCRIPTION
### What does this PR do?

As discussed in https://github.com/containers/podman-desktop/issues/8599 moving the state to CliTool for backward compliance.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/8599

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
