### PR TITLE
feat: extension can define task action

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -1070,6 +1070,51 @@ declare module '@podman-desktop/api' {
      * button.
      */
     cancellable?: boolean;
+
+    /**
+     * Progress may have an associate action
+     *
+     * @example
+     * Action could be used to redirect the user to a specific page
+     * ```ts
+     * import { window, navigation } from '@podman-desktop/api';
+     *
+     * window.withProgress({
+     *   title: 'Collecting container logs',
+     *   action: {
+     *     name: 'See details',
+     *     execute: () => {
+     *       navigation.navigateToContainerLogs('container-id');
+     *     },
+     *   },
+     * }, () => {
+     *   // code to execute
+     * });
+     * ```
+     *
+     * @example
+     * Action could be used to open an external page
+     * ```ts
+     * import { window, env, Uri } from '@podman-desktop/api';
+     *
+     * window.withProgress({
+     *   title: 'Updating something',
+     *   action: {
+     *     name: 'See release notes',
+     *     execute: () => {
+     *       env.openExternal(Uri.parse("https://github.com/containers/podman/releases/tag/v5.2.2"));
+     *     },
+     *   },
+     * }, () => {
+     *   // code to execute
+     * });
+     * ```
+     *
+     */
+    action?: {
+      name: string;
+      execute: () => void;
+    };
   }
 
   /**

--- a/packages/main/src/plugin/tasks/progress-impl.ts
+++ b/packages/main/src/plugin/tasks/progress-impl.ts
@@ -84,7 +84,7 @@ export class ProgressImpl {
       token: extensionApi.CancellationToken,
     ) => Promise<R>,
   ): Promise<R> {
-    const t = this.taskManager.createTask({ title: options.title });
+    const t = this.taskManager.createTask({ title: options.title, action: options.action });
 
     return task(
       {


### PR DESCRIPTION
### What does this PR do?

Allowing extensions to define an action when calling `window.withProgress`. Backward compatible as it is an optional option. 

### Screenshot / video of UI

**Demo example**

https://github.com/user-attachments/assets/eb7ae27e-874d-441f-81a7-8874c65820fe

> This is not implemented, only demo purpose

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
