### PR TITLE
fix: rename untagged image

### DIFF
--- a/packages/renderer/src/lib/image/RenameImageModal.svelte
+++ b/packages/renderer/src/lib/image/RenameImageModal.svelte
@@ -13,8 +13,10 @@ export let imageInfoToRename: ImageInfoUI;
 let imageName = '';
 let imageTag = '';
 onMount(async () => {
-  imageName = imageInfoToRename.name;
-  imageTag = imageInfoToRename.tag;
+  if (imageInfoToRename.name !== '<none>') {
+    imageName = imageInfoToRename.name;
+    imageTag = imageInfoToRename.tag;
+  }
 });
 
 function disableSave(name: string, tag: string): boolean {
@@ -45,11 +47,21 @@ function validateImageTag(event: any): void {
 }
 
 async function renameImage(imageName: string, imageTag: string) {
-  const currentImageNameTag = `${imageInfoToRename.name}:${imageInfoToRename.tag}`;
+  let currentImageNameTag: string;
+  let shouldDelete: boolean;
+  if (imageInfoToRename.name === '<none>') {
+    currentImageNameTag = imageInfoToRename.id;
+    shouldDelete = false;
+  } else {
+    shouldDelete = true;
+    currentImageNameTag = `${imageInfoToRename.name}:${imageInfoToRename.tag}`;
+  }
 
   try {
     await window.tagImage(imageInfoToRename.engineId, currentImageNameTag, imageName, imageTag);
-    await window.deleteImage(imageInfoToRename.engineId, currentImageNameTag);
+    if (shouldDelete) {
+      await window.deleteImage(imageInfoToRename.engineId, currentImageNameTag);
+    }
     closeCallback();
   } catch (error: any) {
     imageNameErrorMessage = error.message;


### PR DESCRIPTION
### What does this PR do?

The current rename dialog was using the `<none>` to identify the image. To explain quickly, it was similar of doing `podman tag <none> dummy-image:dummy-tag`.

This PR fixes this issue by checking for `<none>` and uses the image id instead. This PR also prevent the deletion of the image if we are renaming the image without tag (very important.)

### Screenshot / video of UI

https://github.com/user-attachments/assets/242cb53a-60a1-425a-82b0-d628fb301ec3

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/8414

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

**manually**

Rename a `<none>` image