### PR TITLE
chore: close tooltip when accounts menu open

### DIFF
--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -23,6 +23,7 @@ let { exitSettingsCallback, meta = $bindable() }: { exitSettingsCallback: () => 
 
 let authActions = $state<AuthActions>();
 let outsideWindow = $state<HTMLDivElement>();
+let showAccountsTooltip = $state(true);
 
 const iconSize = '22';
 
@@ -82,10 +83,10 @@ function clickSettings(b: boolean) {
 
   <div bind:this={outsideWindow}>
     <NavItem href="/accounts" tooltip="" bind:meta={meta} onClick={event => authActions?.onButtonClick(event)}>
-      <Tooltip bottomRight tip="Accounts">
+      <Tooltip bottomRight tip={showAccountsTooltip ? 'Accounts' : ''}>
         <AccountIcon size={iconSize} />
       </Tooltip>
-      <AuthActions bind:this={authActions} outsideWindow={outsideWindow} />
+      <AuthActions bind:this={authActions} outsideWindow={outsideWindow} bind:showTooltip={showAccountsTooltip} />
     </NavItem>
   </div>
 

--- a/packages/renderer/src/lib/authentication/AuthActions.svelte
+++ b/packages/renderer/src/lib/authentication/AuthActions.svelte
@@ -9,6 +9,8 @@ import { authenticationProviders } from '../../stores/authenticationProviders';
 
 export let onBeforeToggle = (): void => {};
 let showMenu = false;
+export let showTooltip = true;
+$: showTooltip = !showMenu;
 
 let clientY: number;
 let clientX: number;


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
When the accounts menu opens, the tooltip of the buddy icon disappears and only reappears on hover when the menu is closed

### Screenshot / video of UI

[Screencast from 2024-08-27 19-57-46.webm](https://github.com/user-attachments/assets/746af548-6d9c-4c86-a3e3-ebba13f56798)


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Related to https://github.com/containers/podman-desktop/issues/8335

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->
Click on the buddy icon and check that the tooltip doesn't show when the dropdown menu is open

- [ ] Tests are covering the bug fix or the new feature
