### PR TITLE
feat: add default button action for containers empty state

### DIFF
--- a/packages/renderer/src/lib/container/ContainerEmptyScreen.svelte
+++ b/packages/renderer/src/lib/container/ContainerEmptyScreen.svelte
@@ -1,13 +1,22 @@
 <script lang="ts">
-import { EmptyScreen } from '@podman-desktop/ui-svelte';
+import { Button, EmptyScreen } from '@podman-desktop/ui-svelte';
 import { ContainerIcon } from '@podman-desktop/ui-svelte/icons';
+
+import { providerInfos } from '../../stores/providers';
 
 export let runningOnly: boolean;
 export let stoppedOnly: boolean;
+const helloImage: string = 'quay.io/podman/hello:latest';
 
+$: inProgress = false;
 $: title = getTitle(runningOnly, stoppedOnly);
-$: message = getMessage(stoppedOnly);
+$: messageCommandLine = getMessageCommandLine(stoppedOnly);
+$: messageButton = getMessageButton(stoppedOnly);
 $: commandLine = getCommandLine(stoppedOnly);
+$: selectedProviderConnection = $providerInfos
+  .map(provider => provider.containerConnections)
+  .flat()
+  .find(providerContainerConnection => providerContainerConnection.status === 'started');
 
 function getTitle(runningOnly: boolean, stoppedOnly: boolean): string {
   if (runningOnly) {
@@ -18,11 +27,18 @@ function getTitle(runningOnly: boolean, stoppedOnly: boolean): string {
     return 'No containers';
   }
 }
-function getMessage(stoppedOnly: boolean): string {
+function getMessageCommandLine(stoppedOnly: boolean): string {
   if (stoppedOnly) {
     return '';
   } else {
     return 'Run a first container using the following command line:';
+  }
+}
+function getMessageButton(stoppedOnly: boolean): string {
+  if (stoppedOnly) {
+    return '';
+  } else {
+    return 'Run a first container by clicking on this button:';
   }
 }
 function getCommandLine(stoppedOnly: boolean): string {
@@ -32,11 +48,48 @@ function getCommandLine(stoppedOnly: boolean): string {
     return 'podman run quay.io/podman/hello';
   }
 }
+async function runContainer(commandLine: string) {
+  try {
+    inProgress = true;
+    if (selectedProviderConnection) {
+      await window.pullImage(selectedProviderConnection, helloImage, () => {});
+      const listImages = await window.listImages();
+      const image = listImages.find(item => item.RepoTags?.includes(helloImage));
+      if (image) {
+        await window.createAndStartContainer(image.engineId, { Image: helloImage });
+      } else {
+        await window.showMessageBox({
+          title: `Error when running container`,
+          message: `Could not find ${helloImage} in images`,
+        });
+      }
+      window.telemetryTrack('startFirstContainerByButton');
+    }
+  } catch (err) {
+    await window.showMessageBox({
+      title: `Error when running container`,
+      message: `Error while executing ${commandLine}: ${String(err)}`,
+    });
+  }
+  inProgress = false;
+}
 </script>
 
 <EmptyScreen
   icon={ContainerIcon}
   title={title}
-  message={message}
+  message={messageCommandLine}
   commandline={commandLine}
-  on:click={() => window.clipboardWriteText(commandLine)} />
+  on:click={() => window.clipboardWriteText(commandLine)}>
+  <div slot="upperContent" hidden={stoppedOnly}>
+    <span class="text-[var(--pd-details-empty-sub-header)] max-w-[800px] text-pretty mx-2">{messageButton}</span>
+    <div class="flex gap-2 justify-center p-3">
+      <Button
+        title="Pull {helloImage} image and start container"
+        type="primary"
+        inProgress={inProgress}
+        on:click={() => runContainer(commandLine)}>Start your first container</Button>
+    </div>
+    <h1 class="text-xl text-[var(--pd-details-empty-header)]">OR</h1>
+  </div>
+</EmptyScreen>

--- a/packages/ui/src/lib/screen/EmptyScreen.svelte
+++ b/packages/ui/src/lib/screen/EmptyScreen.svelte
@@ -55,6 +55,7 @@ let copyTextDivElement: HTMLDivElement;
       {/if}
     </div>
     <h1 class="text-xl text-[var(--pd-details-empty-header)]">{title}</h1>
+    <slot name="upperContent" slot="upperContent" />
     <span class="text-[var(--pd-details-empty-sub-header)] max-w-[800px] text-pretty mx-2">{message}</span>
     {#if detail}
       <span class="text-[var(--pd-details-empty-sub-header)]">{detail}</span>


### PR DESCRIPTION
### What does this PR do?
Adds button to Container empty state screen 
=> User can use button/command to do the same action

Other pages (Image + Pods + Volumes) would probably use the same EmptyScreen slot

### Screenshot / video of UI


https://github.com/user-attachments/assets/d0f049ae-c976-4d88-8738-1e446fcae732


### What issues does this PR fix or reference?

Closes #8568 

### How to test this PR?

-Delete all Containers
-Assert that you see the button 

- [ ] Tests are covering the bug fix or the new feature
