### PR TITLE
fix: isContextChanges when there is no kube context

### DIFF
--- a/packages/main/src/plugin/kubernetes-context-state.ts
+++ b/packages/main/src/plugin/kubernetes-context-state.ts
@@ -436,7 +436,7 @@ export class ContextsManager {
     }
 
     const ns = kubeconfig.getContexts()?.find(c => c.name === kubeconfig.currentContext)?.namespace;
-    if (ns !== this.currentContext.namespace) {
+    if (ns !== this.currentContext?.namespace) {
       return true;
     }
 


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

fix isContextChanges when there is no kube context


### What issues does this PR fix or reference?

Fixes #8654 

### How to test this PR?

Rename ~/.kube/config and start Podman Desktop. No error should appear in the logs

- [x] Tests are covering the bug fix or the new feature
