### PR TITLE
fix: make terminal work after stopping and starting a container

### DIFF
--- a/packages/renderer/src/lib/container/ContainerDetailsTerminal.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerDetailsTerminal.spec.ts
@@ -149,7 +149,7 @@ test('terminal active/ restarts connection after stopping and starting a contain
   onDataCallback(Buffer.from('hello\nworld'));
 
   // wait 1s
-  await new Promise(resolve => setTimeout(resolve, 1000));
+  waitFor(() => renderObject.container.querySelector('div[aria-live="assertive"]'));
 
   // search a div having aria-live="assertive" attribute
   const terminalLinesLiveRegion = renderObject.container.querySelector('div[aria-live="assertive"]');
@@ -158,34 +158,24 @@ test('terminal active/ restarts connection after stopping and starting a contain
   expect(terminalLinesLiveRegion).toHaveTextContent('hello world');
 
   container.state = 'EXITED';
-  console.log(container);
 
   await renderObject.rerender({ container: container, screenReaderMode: true });
 
   await tick();
 
-  await new Promise(resolve => setTimeout(resolve, 100));
-
-  expect(screen.queryByText('Container is not running')).toBeInTheDocument();
+  waitFor(() => expect(screen.queryByText('Container is not running')).toBeInTheDocument());
 
   container.state = 'STARTING';
-  console.log(container);
 
   await renderObject.rerender({ container: container, screenReaderMode: true });
 
   await tick();
-
-  await new Promise(resolve => setTimeout(resolve, 100));
 
   container.state = 'RUNNING';
 
-  console.log(container);
-
   await renderObject.rerender({ container: container, screenReaderMode: true });
 
   await tick();
-
-  await new Promise(resolve => setTimeout(resolve, 100));
 
   await waitFor(() => expect(shellInContainerMock).toHaveBeenCalledTimes(2), { timeout: 2000 });
 });

--- a/packages/renderer/src/lib/container/ContainerDetailsTerminal.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerDetailsTerminal.spec.ts
@@ -155,7 +155,7 @@ test('terminal active/ restarts connection after stopping and starting a contain
   const terminalLinesLiveRegion = renderObject.container.querySelector('div[aria-live="assertive"]');
 
   // check the content
-  expect(terminalLinesLiveRegion).toHaveTextContent('hello world');
+  waitFor(() => expect(terminalLinesLiveRegion).toHaveTextContent('hello world'));
 
   container.state = 'EXITED';
 

--- a/packages/renderer/src/lib/container/ContainerDetailsTerminal.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerDetailsTerminal.spec.ts
@@ -136,8 +136,9 @@ test('terminal active/ restarts connection after stopping and starting a contain
       onEnd: () => void,
     ) => {
       onDataCallback = onData;
-      await new Promise(resolve => setTimeout(resolve, 500));
-      onEnd();
+      setTimeout(() => {
+        onEnd();
+      }, 500);
       // return a callback id
       return sendCallbackId;
     },

--- a/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
@@ -17,7 +17,7 @@ import type { ContainerInfoUI } from './ContainerInfoUI';
 
 interface ContainerDetailsTerminalProps {
   container: ContainerInfoUI;
-  screenReaderMode: boolean;
+  screenReaderMode?: boolean;
 }
 
 let { container, screenReaderMode = false }: ContainerDetailsTerminalProps = $props();

--- a/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
@@ -23,6 +23,19 @@ let currentRouterPath: string;
 let sendCallbackId: number | undefined;
 let terminalContent: string = '';
 let serializeAddon: SerializeAddon;
+let lastState: string;
+
+$: {
+  if (lastState === 'STARTING' && container.state === 'RUNNING') {
+    restartTerminal();
+  }
+  lastState = container.state;
+}
+
+async function restartTerminal() {
+  await executeShellIntoContainer();
+  window.dispatchEvent(new Event('resize'));
+}
 
 // update current route scheme
 router.subscribe(route => {

--- a/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
@@ -15,22 +15,27 @@ import { getTerminalTheme } from '../../../../main/src/plugin/terminal-theme';
 import NoLogIcon from '../ui/NoLogIcon.svelte';
 import type { ContainerInfoUI } from './ContainerInfoUI';
 
-export let container: ContainerInfoUI;
-export let screenReaderMode = false;
+interface ContainerDetailsTerminalProps {
+  container: ContainerInfoUI;
+  screenReaderMode: boolean;
+}
+
+let { container, screenReaderMode = false }: ContainerDetailsTerminalProps = $props();
 let terminalXtermDiv: HTMLDivElement;
 let shellTerminal: Terminal;
 let currentRouterPath: string;
 let sendCallbackId: number | undefined;
 let terminalContent: string = '';
 let serializeAddon: SerializeAddon;
-let lastState: string;
+let lastState = $state('');
+let containerState = $state(container);
 
-$: {
-  if (lastState === 'STARTING' && container.state === 'RUNNING') {
+$effect(() => {
+  if (lastState === 'STARTING' && containerState.state === 'RUNNING') {
     restartTerminal();
   }
   lastState = container.state;
-}
+});
 
 async function restartTerminal() {
   await executeShellIntoContainer();


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Fixes container terminal to be responsive after stopping and starting a container

### Screenshot / video of UI
[Screencast from 2024-08-29 11-09-56.webm](https://github.com/user-attachments/assets/78fa006e-50d2-46cc-b082-7da29b7163a1)

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/containers/podman-desktop/issues/8363
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
