### PR TITLE
chore: improve colors of windows titlebar buttons

### DIFF
--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -334,12 +334,12 @@ export class ColorRegistry {
     });
 
     this.registerColor('titlebar-windows-hover-exit-bg', {
-      dark: '#be4425',
-      light: '#be4425',
+      dark: '#c42b1c',
+      light: '#c42b1c',
     });
     this.registerColor('titlebar-windows-hover-bg', {
       dark: '#2d2d2d',
-      light: '#2d2d2d',
+      light: '#dfdfdf',
     });
   }
 

--- a/packages/renderer/src/lib/window-control-buttons/WindowsControlButton.spec.ts
+++ b/packages/renderer/src/lib/window-control-buttons/WindowsControlButton.spec.ts
@@ -46,3 +46,34 @@ test('Check Maximize/Restore', async () => {
   // check the title of the button is 'Maximize'
   expect(customButton).toHaveAttribute('title', 'Maximize');
 });
+
+test('Check Windows Maximize control button colors', async () => {
+  render(WindowsControlButton, { name: 'Maximize' });
+
+  const customButton = screen.getByRole('button', { name: 'Maximize' });
+  expect(customButton).toBeInTheDocument();
+
+  expect(customButton).toHaveClass('text-[var(--pd-titlebar-icon)]');
+  expect(customButton).toHaveClass('hover:bg-[var(--pd-titlebar-windows-hover-bg)]');
+});
+
+test('Check Windows Minimize control button colors', async () => {
+  render(WindowsControlButton, { name: 'Minimize' });
+
+  const customButton = screen.getByRole('button', { name: 'Minimize' });
+  expect(customButton).toBeInTheDocument();
+
+  expect(customButton).toHaveClass('text-[var(--pd-titlebar-icon)]');
+  expect(customButton).toHaveClass('hover:bg-[var(--pd-titlebar-windows-hover-bg)]');
+});
+
+test('Check Windows Close control button colors', async () => {
+  render(WindowsControlButton, { name: 'Close' });
+
+  const customButton = screen.getByRole('button', { name: 'Close' });
+  expect(customButton).toBeInTheDocument();
+
+  expect(customButton).toHaveClass('text-[var(--pd-titlebar-icon)]');
+  expect(customButton).toHaveClass('hover:bg-[var(--pd-titlebar-windows-hover-exit-bg)]');
+  expect(customButton).toHaveClass('hover:text-white');
+});

--- a/packages/renderer/src/lib/window-control-buttons/WindowsControlButton.svelte
+++ b/packages/renderer/src/lib/window-control-buttons/WindowsControlButton.svelte
@@ -59,7 +59,7 @@ function executeAction() {
   aria-label={name}
   title={titleName}
   class="h-[32px] w-[45px] cursor-pointer {name === 'Close'
-    ? 'hover:bg-[var(--pd-titlebar-windows-hover-exit-bg)]'
+    ? 'hover:bg-[var(--pd-titlebar-windows-hover-exit-bg)] hover:text-white'
     : 'hover:bg-[var(--pd-titlebar-windows-hover-bg)]'} text-[var(--pd-titlebar-icon)] flex place-items-center justify-center">
   {#if icon}
     <svelte:component this={icon} size={iconSize} />


### PR DESCRIPTION
### What does this PR do?
Improves colors of buttons on titlebar to more reflect native colors on Windows

### Screenshot / video of UI
Top: Windows File Explorer
Bottom: PD
![image](https://github.com/user-attachments/assets/417651ac-f88f-4dee-8b10-dc61f88dc313)
![Screenshot 2024-08-29 123119](https://github.com/user-attachments/assets/1605d2f2-5bc8-496a-85c6-093395beeab2)
![Screenshot 2024-08-29 123430](https://github.com/user-attachments/assets/7bc5b2f7-922d-4176-9e85-598a95409efd)
![Screenshot 2024-08-29 123633](https://github.com/user-attachments/assets/0815a5ec-492f-4e0c-8a74-fa8465499151)


### How to test this PR?
Open PD on Windows and try to switch between light/dark theme
