### PR TITLE
chore: always build the website on PR checks

### DIFF
--- a/.github/workflows/pr-check-website.yaml
+++ b/.github/workflows/pr-check-website.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Red Hat, Inc.
+# Copyright (C) 2022-2024 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,14 +17,7 @@
 
 name: Build website on pull request
 
-on:
-  pull_request:
-    paths:
-      - 'package.json'
-      - 'pnpm-lock.yaml'
-      - 'website/**'
-      - 'storybook/**'
-      - 'packages/extension-api/src/**'
+on: [pull_request]
 
 jobs:
   website-build:


### PR DESCRIPTION
### What does this PR do?
now, there are some scripts to generate css from color registry if this class is modified it should also triggers the website build but it may have changed in some dependencies, etc.

so might be safer to always try to run the build

ie: this morning all PRs started to fail due to a change in one color-registry dependency

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
