### PR TITLE
chore: split util into two files

### DIFF
--- a/packages/main/src/electron-util.spec.ts
+++ b/packages/main/src/electron-util.spec.ts
@@ -1,0 +1,77 @@
+/**********************************************************************
+ * Copyright (C) 2023-2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { BrowserWindow } from 'electron';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { findWindow } from './electron-util.js';
+
+vi.mock('electron', async () => {
+  class MyCustomWindow {
+    static readonly singleton = new MyCustomWindow();
+
+    loadURL(): void {}
+    setBounds(): void {}
+
+    on(): void {}
+
+    show(): void {}
+    focus(): void {}
+    isMinimized(): boolean {
+      return false;
+    }
+    isDestroyed(): boolean {
+      return false;
+    }
+
+    static getAllWindows(): unknown[] {
+      return [MyCustomWindow.singleton];
+    }
+  }
+
+  return {
+    BrowserWindow: MyCustomWindow,
+  };
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('findWindow - return window', () => {
+  // check findWindow function
+  const firstWindow = findWindow();
+
+  // expect to return window
+  expect(firstWindow).toBeDefined();
+
+  // check it's the MyCustomWindow
+  expect((firstWindow as any).constructor.name).toContain('MyCustomWindow');
+});
+
+test('findWindow - return undefined if none', () => {
+  // override static method getAllWindows
+  vi.spyOn(BrowserWindow, 'getAllWindows').mockReturnValue([]);
+
+  // check findWindow function
+  const firstWindow = findWindow();
+
+  // expect to return window
+  expect(firstWindow).toBeUndefined();
+});

--- a/packages/main/src/electron-util.ts
+++ b/packages/main/src/electron-util.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { BrowserWindow } from 'electron';
+
+export function findWindow(): Electron.BrowserWindow | undefined {
+  return BrowserWindow.getAllWindows().find(w => !w.isDestroyed());
+}

--- a/packages/main/src/plugin/tasks/progress-impl.ts
+++ b/packages/main/src/plugin/tasks/progress-impl.ts
@@ -17,7 +17,8 @@
  ***********************************************************************/
 import type * as extensionApi from '@podman-desktop/api';
 
-import { findWindow } from '../../util.js';
+import { findWindow } from '/@/electron-util.js';
+
 import { CancellationTokenImpl } from '../cancellation-token.js';
 import type { TaskManager } from './task-manager.js';
 

--- a/packages/main/src/tray-menu.ts
+++ b/packages/main/src/tray-menu.ts
@@ -26,8 +26,9 @@ import statusBusy from './assets/status-busy.png';
 import statusStarted from './assets/status-started.png';
 import statusStopped from './assets/status-stopped.png';
 import statusUnknown from './assets/status-unknown.png';
+import { findWindow } from './electron-util.js';
 import type { AnimatedTray, TrayIconStatus } from './tray-animate-icon.js';
-import { findWindow, isMac, isWindows } from './util.js';
+import { isMac, isWindows } from './util.js';
 
 // extends type from the plugin
 interface ProviderMenuItem extends ProviderInfo {

--- a/packages/main/src/util.ts
+++ b/packages/main/src/util.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022 Red Hat, Inc.
+ * Copyright (C) 2022-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,6 @@ import { Buffer } from 'node:buffer';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 
-import { BrowserWindow } from 'electron';
-
 const windows = os.platform() === 'win32';
 export function isWindows(): boolean {
   return windows;
@@ -33,9 +31,6 @@ export function isMac(): boolean {
 const linux = os.platform() === 'linux';
 export function isLinux(): boolean {
   return linux;
-}
-export function findWindow(): Electron.BrowserWindow | undefined {
-  return BrowserWindow.getAllWindows().find(w => !w.isDestroyed());
 }
 
 export const stoppedExtensions = { val: false };


### PR DESCRIPTION
### What does this PR do?
split util into two files
one with generic Node.js functions, another with electron dependency

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes #8675 

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
