### PR TITLE
fix: update binaryPath after install/uninstall on compose cli

### DIFF
--- a/extensions/compose/src/extension.ts
+++ b/extensions/compose/src/extension.ts
@@ -314,6 +314,7 @@ async function registerCLITool(composeDownload: ComposeDownload, detect: Detect)
         installationSource: 'extension',
       });
       binaryVersion = releaseVersionToInstall;
+      binaryPath = storagePath;
       releaseVersionToInstall = undefined;
       releaseToInstall = undefined;
     },
@@ -332,6 +333,7 @@ async function registerCLITool(composeDownload: ComposeDownload, detect: Detect)
 
       // update the version to undefined
       binaryVersion = undefined;
+      binaryPath = undefined;
     },
   });
 


### PR DESCRIPTION
### What does this PR do?

During the testing with the cli i noticed i missed to update the binaryPath variable when installing/uninstalling, causing some misbehavior if you uninstall/reinstall the cli.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

1. have compose installed. Uninstall it and try to install it.

- [x] Tests are covering the bug fix or the new feature
