### PR TITLE
fix: send version for task title

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1362,14 +1362,14 @@ export class PluginSystem {
 
     this.ipcHandle(
       'cli-tool-registry:updateCliTool',
-      async (_listener, id: string, loggerId: string): Promise<void> => {
+      async (_listener, id: string, version: string, loggerId: string): Promise<void> => {
         const logger = this.getLogHandler('provider-registry:updateCliTool-onData', loggerId);
         const tool = cliToolRegistry.getCliToolInfos().find(tool => tool.id === id);
         if (!tool) throw new Error(`cannot find cli tool with id ${id}`);
 
         // create task
         const task = taskManager.createTask({
-          title: `Update ${tool.name} to v${tool.newVersion}`,
+          title: `Update ${tool.name} to v${version}`,
           action: {
             name: 'goto task >',
             execute: (): void => {

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1173,12 +1173,13 @@ export function initExposure(): void {
     async (
       id: string,
       key: symbol,
+      version: string,
       keyLogger: (key: symbol, eventName: 'log' | 'warn' | 'error' | 'finish', args: string[]) => void,
     ): Promise<void> => {
       onDataCallbacksTaskConnectionId++;
       onDataCallbacksTaskConnectionKeys.set(onDataCallbacksTaskConnectionId, key);
       onDataCallbacksTaskConnectionLogs.set(onDataCallbacksTaskConnectionId, keyLogger);
-      return ipcInvoke('cli-tool-registry:updateCliTool', id, onDataCallbacksTaskConnectionId);
+      return ipcInvoke('cli-tool-registry:updateCliTool', id, version, onDataCallbacksTaskConnectionId);
     },
   );
 

--- a/packages/renderer/src/lib/preferences/PreferencesCliTool.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesCliTool.spec.ts
@@ -24,7 +24,7 @@ import { beforeEach } from 'node:test';
 
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
-import { afterEach, expect, suite, test, vi } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import type { CliToolInfo } from '/@api/cli-tool-info';
 
@@ -147,7 +147,7 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-suite('CLI Tool item', () => {
+describe('CLI Tool item', () => {
   test('check tool infos are displayed as expected if version is not specified', () => {
     render(PreferencesCliTool, {
       cliTool: cliToolInfoItem1,
@@ -229,6 +229,23 @@ suite('CLI Tool item', () => {
 
     const failedErrorButton2 = screen.getByRole('button', { name: `${cliToolInfoItem3.displayName} failed` });
     expect(failedErrorButton2).toBeInTheDocument();
+  });
+
+  test('check version is sent to updateCliTool', async () => {
+    const selectCliToolVersionToUpdateMock = vi.fn().mockImplementation(() => Promise.resolve('1.1.1'));
+    (window as any).selectCliToolVersionToUpdate = selectCliToolVersionToUpdateMock;
+    (window as any).updateCliTool = updateCliToolMock;
+    render(PreferencesCliTool, {
+      cliTool: cliToolInfoItem4,
+    });
+    const updateAvailableElement = screen.getByRole('button', { name: 'Update available' });
+    expect(updateAvailableElement).toBeDefined();
+    expect(updateAvailableElement.textContent).toBe('Upgrade/Downgrade');
+
+    await userEvent.click(updateAvailableElement);
+
+    expect(selectCliToolVersionToUpdateMock).toBeCalledWith(cliToolInfoItem4.id);
+    expect(updateCliToolMock).toBeCalledWith(cliToolInfoItem4.id, expect.any(Symbol), '1.1.1', expect.any(Function));
   });
 
   test('check tool infos are displayed as expected and without a new version', async () => {

--- a/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
@@ -55,7 +55,7 @@ async function update(cliTool: CliToolInfo) {
     cliToolUpdateStatus.inProgress = true;
     cliToolUpdateStatus = cliToolUpdateStatus;
     const loggerHandlerKey = registerConnectionCallback(getLoggerHandler(cliTool.id));
-    await window.updateCliTool(cliTool.id, loggerHandlerKey, eventCollect);
+    await window.updateCliTool(cliTool.id, loggerHandlerKey, newVersion, eventCollect);
     showError = false;
   } catch (e) {
     errorMessage = `Unable to update ${cliTool.displayName} to version ${newVersion}.`;


### PR DESCRIPTION
### What does this PR do?

When mobing the task manager to the main, i forgot to send the version selected by the user to update the task title

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

it is part of cli refactoring https://github.com/containers/podman-desktop/issues/8003

### How to test this PR?

1. update a cli and see that the task title is correct

- [x] Tests are covering the bug fix or the new feature
