### PR TITLE
fix: handle undefined installationSource

### DIFF
--- a/packages/main/src/plugin/cli-tool-impl.ts
+++ b/packages/main/src/plugin/cli-tool-impl.ts
@@ -79,9 +79,9 @@ export class CliToolImpl implements CliTool, Disposable {
     return Object.freeze(this._options.images);
   }
 
-  // it returns the installation source of the cli tool. If not specified, we default to user which is the most restrictive way (prevent to update it)
-  get installationSource(): CliToolInstallationSource {
-    return this._options.installationSource ?? 'external';
+  // it returns the installation source of the cli tool. If not specified, there is no tool installed
+  get installationSource(): CliToolInstallationSource | undefined {
+    return this._options.installationSource;
   }
 
   dispose(): void {

--- a/packages/main/src/plugin/cli-tool-registry.spec.ts
+++ b/packages/main/src/plugin/cli-tool-registry.spec.ts
@@ -117,8 +117,14 @@ suite('cli module', () => {
         doUpdate: vi.fn(),
         selectVersion: vi.fn(),
       };
+      const installer: CliToolInstaller = {
+        doInstall: vi.fn(),
+        selectVersion: vi.fn(),
+        doUninstall: vi.fn(),
+      };
       const newCliTool = cliToolRegistry.createCliTool(extensionInfo, options);
       cliToolRegistry.registerUpdate(newCliTool as CliToolImpl, updater);
+      cliToolRegistry.registerInstaller(newCliTool as CliToolImpl, installer);
       const infoList = cliToolRegistry.getCliToolInfos();
       expect(infoList.length).equals(1);
       expect(infoList[0]).toMatchObject({
@@ -130,6 +136,7 @@ suite('cli module', () => {
         images: newCliTool.images,
         extensionInfo: newCliTool.extensionInfo,
         canUpdate: true,
+        canInstall: true,
       });
     });
 
@@ -147,8 +154,14 @@ suite('cli module', () => {
         doUpdate: vi.fn(),
         selectVersion: vi.fn(),
       };
+      const installer: CliToolInstaller = {
+        doInstall: vi.fn(),
+        selectVersion: vi.fn(),
+        doUninstall: vi.fn(),
+      };
       const newCliTool = cliToolRegistry.createCliTool(extensionInfo, options);
       cliToolRegistry.registerUpdate(newCliTool as CliToolImpl, updater);
+      cliToolRegistry.registerInstaller(newCliTool as CliToolImpl, installer);
       const infoList = cliToolRegistry.getCliToolInfos();
       expect(infoList.length).equals(1);
       expect(infoList[0]).toMatchObject({
@@ -160,6 +173,7 @@ suite('cli module', () => {
         images: newCliTool.images,
         extensionInfo: newCliTool.extensionInfo,
         canUpdate: false,
+        canInstall: false,
         version: newCliTool.version,
       });
     });

--- a/packages/main/src/plugin/cli-tool-registry.ts
+++ b/packages/main/src/plugin/cli-tool-registry.ts
@@ -126,8 +126,8 @@ export class CliToolRegistry {
   getCliToolInfos(): CliToolInfo[] {
     return Array.from(this.cliTools.values()).map(cliTool => {
       const installer = this.cliToolsInstaller.get(cliTool.id);
-      // if the installer has been registered, enable install
-      const canInstall = !!installer;
+      // if the installer has been registered and the source is different from external enable install/uninstall
+      const canInstall = !!installer && cliTool.installationSource !== 'external';
 
       const updater = this.cliToolsUpdater.get(cliTool.id);
       // if updater is the one with a default version that the tool will use to get updated we use it


### PR DESCRIPTION
### What does this PR do?

It prevents from returning 'external' when there is no installationSource defined. When the cli binary is not installed and the installationSource is undefined the installer must be active. However if the function returns external when its value is undefined, we cannot know if the clitool is really installed or not. 

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

part of the refactoring with #8003 

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
