### PR TITLE
fix: number widget should accept float value for number type

### DIFF
--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -846,6 +846,7 @@ const envDialogOptions: OpenDialogOptions = {
                 <NumberInput
                   minimum={0}
                   bind:value={restartPolicyMaxRetryCount}
+                  type="integer"
                   class="w-24 p-2"
                   disabled={restartPolicyName !== 'on-failure'} />
               </div>

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
@@ -273,3 +273,20 @@ test('Expect tooltip text shows info when input is higher than maximum', async (
   expect(tooltip).toBeInTheDocument();
   expect(tooltip.textContent).toBe('The value cannot be greater than 34');
 });
+
+test('Expect a text input when record is type integer', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'Hello',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'integer',
+    minimum: 1,
+    maximum: 15,
+  };
+  await awaitRender(record, {});
+  const inputField = screen.getByRole('textbox', { name: 'record-description' }) as HTMLInputElement;
+  expect(inputField).toBeInTheDocument();
+  expect(inputField.type).toBe('text');
+  expect(inputField.name).toBe('record');
+});

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -86,7 +86,7 @@ function ensureType(value: any): boolean {
     case 'boolean':
       return record.type === 'boolean';
     case 'number':
-      return record.type === 'number';
+      return record.type === 'number' || record.type === 'integer';
     case 'string':
       return record.type === 'string';
     default:
@@ -127,7 +127,7 @@ async function onChange(recordId: string, value: boolean | string | number): Pro
   {/if}
   {#if record.type === 'boolean'}
     <BooleanItem record={record} checked={!!recordValue} onChange={onChange} />
-  {:else if record.type === 'number'}
+  {:else if record.type === 'number' || record.type === 'integer'}
     {#if enableSlider && typeof record.maximum === 'number'}
       <SliderItem
         record={record}

--- a/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
@@ -45,6 +45,7 @@ $: if (error) {
     bind:error={error}
     aria-label={record.description}
     minimum={record.minimum}
+    type={record.type === 'integer' ? 'integer' : 'number'}
     maximum={record.maximum && typeof record.maximum === 'number' ? record.maximum : undefined}
     showError={false}>
   </NumberInput>

--- a/packages/renderer/src/lib/ui/NumberInput.spec.ts
+++ b/packages/renderer/src/lib/ui/NumberInput.spec.ts
@@ -26,13 +26,21 @@ import { expect, test } from 'vitest';
 
 import NumberInput from './NumberInput.svelte';
 
-function renderInput(name: string, value: number, disabled?: boolean, minimum?: number, maximum?: number): void {
+function renderInput(
+  name: string,
+  value: number,
+  disabled?: boolean,
+  minimum?: number,
+  maximum?: number,
+  type: 'integer' | 'number' = 'number',
+): void {
   render(NumberInput, {
     name: name,
     value: value,
     disabled: disabled,
     minimum: minimum,
     maximum: maximum,
+    type: type,
   });
 }
 
@@ -132,4 +140,67 @@ test('Expect maximum value works', async () => {
   await userEvent.click(increment);
 
   expect(increment).toBeDisabled();
+});
+
+test('Expect integer support works', async () => {
+  renderInput('test', 99, false, 10, 100, 'integer');
+
+  const input = screen.getByRole('textbox');
+  expect(input).toBeInTheDocument();
+  expect(input).toHaveValue('99');
+
+  // focus the input
+  await userEvent.click(input);
+
+  // now enter on the keyboard .0
+  await userEvent.type(input, '.0');
+
+  // the value should be 99.0
+  expect(input).toHaveValue('99.0');
+
+  // now try to enter 1
+  await userEvent.type(input, '1');
+
+  // the value should be 99.0 as we only support integers
+  expect(input).toHaveValue('99.0');
+});
+
+test('Expect number support works', async () => {
+  renderInput('test', 99, false, 10, 100, 'number');
+
+  const input = screen.getByRole('textbox');
+  expect(input).toBeInTheDocument();
+  expect(input).toHaveValue('99');
+
+  // focus the input
+  await userEvent.click(input);
+
+  // now enter on the keyboard .0
+  await userEvent.type(input, '.0');
+
+  // the value should be 99.0
+  expect(input).toHaveValue('99.0');
+
+  // now try to enter 1
+  await userEvent.type(input, '1');
+
+  // the value should be 99.01 as here we support numbers (and not integers)
+  expect(input).toHaveValue('99.01');
+});
+
+test('Expect invalid data support works', async () => {
+  renderInput('test', 99, false, 10, 100, 'number');
+
+  const input = screen.getByRole('textbox');
+  expect(input).toBeInTheDocument();
+  expect(input).toHaveValue('99');
+
+  // focus the input
+  await userEvent.click(input);
+
+  // now enter on the keyboard abcd-)à&@*.0
+  await userEvent.type(input, 'abcd-)à&@*.0');
+
+  // the value should be 99.0
+  expect(input).toHaveValue('99.0');
 });

--- a/packages/renderer/src/lib/ui/NumberInput.spec.ts
+++ b/packages/renderer/src/lib/ui/NumberInput.spec.ts
@@ -204,3 +204,20 @@ test('Expect invalid data support works', async () => {
   // the value should be 99.0
   expect(input).toHaveValue('99.0');
 });
+
+test('Expect limiting numbers for integers', async () => {
+  renderInput('test', 3, false, 10, 100, 'integer');
+
+  const input = screen.getByRole('textbox');
+  expect(input).toBeInTheDocument();
+  expect(input).toHaveValue('3');
+
+  // focus the input
+  await userEvent.click(input);
+
+  // now enter on the keyboard .1234567890
+  await userEvent.type(input, '.1234567890');
+
+  // the value should be 3.0 (as only the dot and 0 are allowed)
+  expect(input).toHaveValue('3.0');
+});

--- a/packages/renderer/src/lib/ui/NumberInput.svelte
+++ b/packages/renderer/src/lib/ui/NumberInput.svelte
@@ -31,12 +31,18 @@ function validateNumber() {
 }
 
 function onKeyPress(event: any) {
-  // if type is integer it means we can only accept nu
-  // see https://json-schema.org/understanding-json-schema/reference/numeric
   // Numbers with a zero fractional part are considered integers
+  // see https://json-schema.org/understanding-json-schema/reference/numeric
 
-  // first, add the new character to the extisting value
-  const wantedValue = `${value}${event.key}`;
+  // get cursor position
+  const cursorPosition = event.target.selectionStart;
+
+  console.log('cursorPosition', cursorPosition);
+
+  // add the new character to the cursor position
+  const wantedValue = `${event.target.value.slice(0, cursorPosition)}${event.key}${event.target.value.slice(cursorPosition)}`;
+
+  console.log('wantedValue', wantedValue);
 
   // now, check if type is integer if the value is value without digits or with zero fractional part
   if (type === 'integer' && Number.isInteger(Number(wantedValue))) {

--- a/packages/renderer/src/lib/ui/NumberInput.svelte
+++ b/packages/renderer/src/lib/ui/NumberInput.svelte
@@ -37,12 +37,8 @@ function onKeyPress(event: any) {
   // get cursor position
   const cursorPosition = event.target.selectionStart;
 
-  console.log('cursorPosition', cursorPosition);
-
   // add the new character to the cursor position
   const wantedValue = `${event.target.value.slice(0, cursorPosition)}${event.key}${event.target.value.slice(cursorPosition)}`;
-
-  console.log('wantedValue', wantedValue);
 
   // now, check if type is integer if the value is value without digits or with zero fractional part
   if (type === 'integer' && Number.isInteger(Number(wantedValue))) {

--- a/packages/renderer/src/lib/ui/NumberInput.svelte
+++ b/packages/renderer/src/lib/ui/NumberInput.svelte
@@ -9,6 +9,7 @@ export let minimum: number | undefined = undefined;
 export let maximum: number | undefined = undefined;
 export let error: string | undefined = undefined;
 export let showError: boolean = true;
+export let type: 'number' | 'integer';
 
 let minimumEnabled: boolean;
 let maximumEnabled: boolean;
@@ -30,7 +31,20 @@ function validateNumber() {
 }
 
 function onKeyPress(event: any) {
-  if (isNaN(Number(event.key))) {
+  // if type is integer it means we can only accept nu
+  // see https://json-schema.org/understanding-json-schema/reference/numeric
+  // Numbers with a zero fractional part are considered integers
+
+  // first, add the new character to the extisting value
+  const wantedValue = `${value}${event.key}`;
+
+  // now, check if type is integer if the value is value without digits or with zero fractional part
+  if (type === 'integer' && Number.isInteger(Number(wantedValue))) {
+    return;
+  } else if (type === 'number' && !isNaN(Number(wantedValue))) {
+    return;
+  } else {
+    // else prevent to use that key
     event.preventDefault();
   }
 }


### PR DESCRIPTION
### What does this PR do?
The widget Number should handle both integer and number values and validate the values as it's expected from JSON schema

Integer for example 1 and 1.0 are accepted
number: 1, 3.14 etc are valid

Today we can't use `.` character at all


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/8663

### How to test this PR?

set/edit the type of a property to `integer` or `number` and check that you can use the `.` key and only `.0` for integers

- [x] Tests are covering the bug fix or the new feature
