### PR TITLE
feat: optional display name container connection

### DIFF
--- a/extensions/podman/src/extension.spec.ts
+++ b/extensions/podman/src/extension.spec.ts
@@ -1227,6 +1227,31 @@ test('provider is registered with edit capabilities on MacOS', async () => {
   expect(registeredConnection?.lifecycle?.edit).toBeDefined();
 });
 
+test('display name is beautified version of the name', async () => {
+  extension.initExtensionContext({ subscriptions: [] } as unknown as extensionApi.ExtensionContext);
+  const spyExecPromise = vi.spyOn(extensionApi.process, 'exec');
+  spyExecPromise.mockImplementation(() => {
+    return Promise.reject(new Error('wsl bootstrap script failed: exit status 0xffffffff'));
+  });
+  let registeredConnection: ContainerProviderConnection | undefined;
+  vi.mocked(provider.registerContainerProviderConnection).mockImplementation(connection => {
+    registeredConnection = connection;
+    return Disposable.from({ dispose: () => {} });
+  });
+  await extension.registerProviderFor(
+    provider,
+    podmanConfiguration,
+    {
+      ...machineInfo,
+      name: machineDefaultName,
+    },
+    'socket',
+  );
+  expect(registeredConnection).toBeDefined();
+  expect(registeredConnection?.displayName).toBe('Podman Machine');
+  expect(registeredConnection?.name).toBe(machineDefaultName);
+});
+
 test('provider is registered without edit capabilities on Windows', async () => {
   vi.mocked(isMac).mockReturnValue(false);
   extension.initExtensionContext({ subscriptions: [] } as unknown as extensionApi.ExtensionContext);

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -793,7 +793,8 @@ export async function registerProviderFor(
   }
 
   const containerProviderConnection: extensionApi.ContainerProviderConnection = {
-    name: prettyMachineName(machineInfo.name),
+    name: machineInfo.name,
+    displayName: prettyMachineName(machineInfo.name),
     type: 'podman',
     status: () => podmanMachinesStatuses.get(machineInfo.name) ?? 'unknown',
     lifecycle,

--- a/packages/api/src/provider-info.ts
+++ b/packages/api/src/provider-info.ts
@@ -31,6 +31,7 @@ export type LifecycleMethod = 'start' | 'stop' | 'delete' | 'edit';
 
 export interface ProviderContainerConnectionInfo {
   name: string;
+  displayName?: string;
   status: ProviderConnectionStatus;
   endpoint: {
     socketPath: string;

--- a/packages/api/src/provider-info.ts
+++ b/packages/api/src/provider-info.ts
@@ -31,7 +31,7 @@ export type LifecycleMethod = 'start' | 'stop' | 'delete' | 'edit';
 
 export interface ProviderContainerConnectionInfo {
   name: string;
-  displayName?: string;
+  displayName: string;
   status: ProviderConnectionStatus;
   endpoint: {
     socketPath: string;

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -483,7 +483,6 @@ declare module '@podman-desktop/api' {
   }
   export interface KubernetesProviderConnection {
     name: string;
-    displayName?: string;
     endpoint: KubernetesProviderConnectionEndpoint;
     lifecycle?: ProviderConnectionLifecycle;
     status(): ProviderConnectionStatus;

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -358,6 +358,7 @@ declare module '@podman-desktop/api' {
 
   export interface ContainerProviderConnection {
     name: string;
+    displayName?: string;
     type: 'docker' | 'podman';
     endpoint: ContainerProviderConnectionEndpoint;
     lifecycle?: ProviderConnectionLifecycle;
@@ -482,6 +483,7 @@ declare module '@podman-desktop/api' {
   }
   export interface KubernetesProviderConnection {
     name: string;
+    displayName?: string;
     endpoint: KubernetesProviderConnectionEndpoint;
     lifecycle?: ProviderConnectionLifecycle;
     status(): ProviderConnectionStatus;

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -1280,6 +1280,7 @@ describe('buildImage', () => {
 
     const connection: ProviderContainerConnectionInfo = {
       name: 'connection',
+      displayName: 'podman',
       type: 'docker',
       endpoint: {
         socketPath: '/endpoint1.sock',
@@ -1325,6 +1326,7 @@ describe('buildImage', () => {
 
     const connection: podmanDesktopAPI.ContainerProviderConnection = {
       name: 'connection',
+      displayName: 'podman',
       type: 'docker',
       endpoint: {
         socketPath: '/endpoint1.sock',
@@ -1361,6 +1363,7 @@ describe('buildImage', () => {
 
     const connection: ProviderContainerConnectionInfo = {
       name: 'podman',
+      displayName: 'podman',
       type: 'podman',
       endpoint: {
         socketPath: '/endpoint1.sock',
@@ -1403,6 +1406,7 @@ describe('buildImage', () => {
 
     const connection: podmanDesktopAPI.ContainerProviderConnection = {
       name: 'podman',
+      displayName: 'podman',
       type: 'podman',
       endpoint: {
         socketPath: '/endpoint1.sock',
@@ -1444,6 +1448,7 @@ describe('buildImage', () => {
 
     const connection: ProviderContainerConnectionInfo = {
       name: 'podman',
+      displayName: 'podman',
       type: 'podman',
       endpoint: {
         socketPath: '/endpoint1.sock',
@@ -1480,6 +1485,7 @@ describe('buildImage', () => {
     // set providers with docker being first
     containerRegistry.addInternalProvider('podman1', {
       name: 'podman',
+      displayName: 'podman',
       id: 'podman1',
       api: dockerAPI,
       libpodApi: dockerAPI,
@@ -1494,6 +1500,7 @@ describe('buildImage', () => {
 
     const connection: podmanDesktopAPI.ContainerProviderConnection = {
       name: 'podman',
+      displayName: 'podman',
       type: 'podman',
       endpoint: {
         socketPath: '/endpoint1.sock',
@@ -1543,6 +1550,7 @@ describe('buildImage', () => {
 
     const connection: ProviderContainerConnectionInfo = {
       name: 'podman',
+      displayName: 'podman',
       type: 'podman',
       endpoint: {
         socketPath: '/endpoint1.sock',
@@ -2174,6 +2182,7 @@ describe('listNetworks', () => {
     containerRegistry.addInternalProvider('podman', {
       name: 'podman',
       id: 'podman1',
+      displayName: 'podman',
       api,
       connection: {
         type: 'podman',
@@ -2207,6 +2216,7 @@ describe('createVolume', () => {
       connection: {
         type: 'podman',
         name: 'podman',
+        displayName: 'podman',
         endpoint: {
           socketPath: '/endpoint1.sock',
         },
@@ -2242,6 +2252,7 @@ describe('createVolume', () => {
       connection: {
         type: 'podman',
         name: 'podman',
+        displayName: 'podman',
         endpoint: {
           socketPath: '/endpoint1.sock',
         },
@@ -2277,6 +2288,7 @@ describe('createVolume', () => {
       connection: {
         type: 'podman',
         name: 'podman',
+        displayName: 'podman',
         endpoint: {
           socketPath: '/endpoint1.sock',
         },
@@ -2312,6 +2324,7 @@ describe('createVolume', () => {
       connection: {
         type: 'podman',
         name: 'podman',
+        displayName: 'podman',
         endpoint: {
           socketPath: '/endpoint1.sock',
         },
@@ -2324,6 +2337,7 @@ describe('createVolume', () => {
     const containerProviderConnection: podmanDesktopAPI.ContainerProviderConnection = {
       name: 'podman',
       type: 'podman',
+      displayName: 'podman',
       endpoint: {
         socketPath: '/endpoint1.sock',
       },
@@ -2360,6 +2374,7 @@ describe('deleteVolume', () => {
       connection: {
         type: 'podman',
         name: 'podman',
+        displayName: 'podman',
         endpoint: {
           socketPath: '/endpoint1.sock',
         },
@@ -2406,6 +2421,7 @@ describe('deleteVolume', () => {
       connection: {
         type: 'podman',
         name: 'podman',
+        displayName: 'podman',
         endpoint: {
           socketPath: '/endpoint1.sock',
         },
@@ -3054,6 +3070,7 @@ test('createNetwork', async () => {
     api,
     connection: {
       type: 'podman',
+      displayName: 'podman',
       name: 'podman',
       endpoint: {
         socketPath: '/endpoint1.sock',
@@ -3089,6 +3106,7 @@ test('setupConnectionAPI with errors', async () => {
     id: 'podman1',
     connection: {
       type: 'podman',
+      displayName: 'podman',
       name: 'podman',
       endpoint: {
         socketPath: 'http://localhost',
@@ -3099,6 +3117,7 @@ test('setupConnectionAPI with errors', async () => {
 
   const providerConnectionInfo: podmanDesktopAPI.ContainerProviderConnection = {
     name: 'podman',
+    displayName: 'podman',
     type: 'podman',
     endpoint: {
       socketPath: '/endpoint1.sock',
@@ -3172,6 +3191,7 @@ test('setupConnectionAPI with errors after machine being removed', async () => {
     connection: {
       type: 'podman',
       name: 'podman',
+      displayName: 'podman',
       endpoint: {
         socketPath: 'http://localhost',
       },
@@ -3184,6 +3204,7 @@ test('setupConnectionAPI with errors after machine being removed', async () => {
 
   const providerConnectionInfo: podmanDesktopAPI.ContainerProviderConnection = {
     name: 'podman',
+    displayName: 'podman',
     type: 'podman',
     endpoint: {
       socketPath: '/endpoint1.sock',
@@ -3422,6 +3443,7 @@ test('check that createManifest errors with The matching provider does not suppo
 
   const containerProviderConnection: podmanDesktopAPI.ContainerProviderConnection = {
     name: 'podman1',
+    displayName: 'podman',
     endpoint: {
       socketPath: 'podman.sock',
     },
@@ -3490,6 +3512,7 @@ test('check createPod uses running podman connection if ContainerProviderConnect
 
   const containerProviderConnection: podmanDesktopAPI.ContainerProviderConnection = {
     name: 'podman1',
+    displayName: 'podman',
     endpoint: {
       socketPath: 'podman.sock',
     },
@@ -3531,6 +3554,7 @@ test('check createPod uses running podman connection if ProviderContainerConnect
 
   const containerProviderConnection: ProviderContainerConnectionInfo = {
     name: 'podman1',
+    displayName: 'podman1',
     endpoint: {
       socketPath: 'podman.sock',
     },
@@ -5127,6 +5151,7 @@ describe('provider update', () => {
       connection: {
         type: 'podman',
         name: 'podman',
+        displayName: 'podman',
         endpoint: {
           socketPath: '/endpoint1.sock',
         },
@@ -5199,6 +5224,7 @@ describe('provider update', () => {
       connection: {
         type: 'podman',
         name: 'podman',
+        displayName: 'podman',
         endpoint: {
           socketPath: '/endpoint1.sock',
         },

--- a/packages/main/src/plugin/provider-registry.spec.ts
+++ b/packages/main/src/plugin/provider-registry.spec.ts
@@ -177,6 +177,32 @@ test('should initialize provider if there is container connection provider', asy
   expect(apiSenderSendMock).toBeCalled();
 });
 
+test('connections should contain the display name provided when registering', async () => {
+  const provider = providerRegistry.createProvider('id', 'name', {
+    id: 'internal',
+    name: 'internal',
+    status: 'installed',
+  });
+
+  expect(providerRegistry.getContainerConnections().length).toBe(0);
+
+  const displayName = 'Podman Display Name';
+  provider.registerContainerProviderConnection({
+    name: 'podman-machine-default',
+    displayName: displayName,
+    type: 'podman',
+    lifecycle: {},
+    status: () => 'stopped',
+    endpoint: {
+      socketPath: 'dummy',
+    },
+  });
+
+  const connections = providerRegistry.getContainerConnections();
+  expect(connections.length).toBe(1);
+  expect(connections[0]?.connection.displayName).toBe(displayName);
+});
+
 test('should reset state if initialization fails', async () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let providerInternalId: any;

--- a/packages/main/src/plugin/provider-registry.spec.ts
+++ b/packages/main/src/plugin/provider-registry.spec.ts
@@ -237,6 +237,7 @@ test('should reset state if initialization fails', async () => {
 test('expect isContainerConnection returns true with a ContainerConnection', async () => {
   const connection: ContainerProviderConnection = {
     name: 'connection',
+    displayName: 'connection',
     type: 'docker',
     endpoint: {
       socketPath: '/endpoint1.sock',
@@ -264,6 +265,7 @@ test('expect isContainerConnection returns false with a KubernetesConnection', a
 test('expect isProviderContainerConnection returns true with a ProviderContainerConnection', async () => {
   const connection: ProviderContainerConnectionInfo = {
     name: 'connection',
+    displayName: 'connection',
     type: 'docker',
     endpoint: {
       socketPath: '/endpoint1.sock',
@@ -319,6 +321,7 @@ test('should send events when starting a container connection', async () => {
   });
   const connection: ProviderContainerConnectionInfo = {
     name: 'connection',
+    displayName: 'connection',
     type: 'docker',
     endpoint: {
       socketPath: '/endpoint1.sock',
@@ -331,6 +334,7 @@ test('should send events when starting a container connection', async () => {
   const stopMock = vi.fn();
   provider.registerContainerProviderConnection({
     name: 'connection',
+    displayName: 'connection',
     type: 'docker',
     lifecycle: {
       start: startMock,
@@ -384,6 +388,7 @@ test('should send events when stopping a container connection', async () => {
   });
   const connection: ProviderContainerConnectionInfo = {
     name: 'connection',
+    displayName: 'connection',
     type: 'docker',
     endpoint: {
       socketPath: '/endpoint1.sock',
@@ -396,6 +401,7 @@ test('should send events when stopping a container connection', async () => {
   const stopMock = vi.fn();
   provider.registerContainerProviderConnection({
     name: 'connection',
+    displayName: 'connection',
     type: 'docker',
     lifecycle: {
       start: startMock,
@@ -496,6 +502,7 @@ test('should retrieve context of container provider', async () => {
   });
   const connection: ProviderContainerConnectionInfo = {
     name: 'connection',
+    displayName: 'connection',
     type: 'docker',
     endpoint: {
       socketPath: '/endpoint1.sock',
@@ -507,6 +514,7 @@ test('should retrieve context of container provider', async () => {
   const stopMock = vi.fn();
   provider.registerContainerProviderConnection({
     name: 'connection',
+    displayName: 'connection',
     type: 'docker',
     lifecycle: {
       start: startMock,
@@ -590,6 +598,7 @@ test('should retrieve provider internal id from id', async () => {
   const stopMock = vi.fn();
   provider.registerContainerProviderConnection({
     name: 'connection',
+    displayName: 'connection',
     type: 'docker',
     lifecycle: {
       start: startMock,
@@ -1063,6 +1072,7 @@ describe('startProvider', () => {
     });
     provider.registerContainerProviderConnection({
       name: 'connection',
+      displayName: 'connection',
       type: 'podman',
       endpoint: {
         socketPath: '/endpoint1.sock',
@@ -1085,6 +1095,7 @@ describe('startProvider', () => {
     const startMock = vi.fn();
     provider.registerContainerProviderConnection({
       name: 'connection',
+      displayName: 'connection',
       type: 'podman',
       lifecycle: {
         start: startMock,

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -640,6 +640,7 @@ export class ProviderRegistry {
     if (this.isContainerConnection(connection)) {
       providerConnection = {
         name: connection.name,
+        displayName: connection.displayName,
         status: connection.status(),
         type: connection.type,
         endpoint: {
@@ -1000,6 +1001,7 @@ export class ProviderRegistry {
         const event = {
           providerId: provider.id,
           connection: {
+            displayName: providerConnectionInfo.displayName,
             name: providerConnectionInfo.name,
             type: providerConnectionInfo.type,
             endpoint: providerConnectionInfo.endpoint,
@@ -1090,6 +1092,7 @@ export class ProviderRegistry {
         const event = {
           providerId: provider.id,
           connection: {
+            displayName: providerConnectionInfo.displayName,
             name: providerConnectionInfo.name,
             type: providerConnectionInfo.type,
             endpoint: providerConnectionInfo.endpoint,

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -640,7 +640,7 @@ export class ProviderRegistry {
     if (this.isContainerConnection(connection)) {
       providerConnection = {
         name: connection.name,
-        displayName: connection.displayName,
+        displayName: connection.displayName ?? connection.name,
         status: connection.status(),
         type: connection.type,
         endpoint: {

--- a/packages/renderer/src/lib/dashboard/NewContentOnDashboardBadge.spec.ts
+++ b/packages/renderer/src/lib/dashboard/NewContentOnDashboardBadge.spec.ts
@@ -47,6 +47,7 @@ const notification1: NotificationCard = {
 const pStatus: ProviderStatus = 'started';
 const pInfo: ProviderContainerConnectionInfo = {
   name: 'test',
+  displayName: 'test',
   status: 'started',
   endpoint: {
     socketPath: '',

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
@@ -83,6 +83,7 @@ function setup() {
   const pStatus: ProviderStatus = 'started';
   const pInfo: ProviderContainerConnectionInfo = {
     name: 'test',
+    displayName: 'test',
     status: 'started',
     endpoint: {
       socketPath: '',

--- a/packages/renderer/src/lib/image/ImportContainersImages.spec.ts
+++ b/packages/renderer/src/lib/image/ImportContainersImages.spec.ts
@@ -37,6 +37,7 @@ const importContainerMock = vi.fn();
 const pStatus: ProviderStatus = 'started';
 const pInfo: ProviderContainerConnectionInfo = {
   name: 'test',
+  displayName: 'test',
   status: 'started',
   endpoint: {
     socketPath: '',

--- a/packages/renderer/src/lib/image/LoadImages.spec.ts
+++ b/packages/renderer/src/lib/image/LoadImages.spec.ts
@@ -37,6 +37,7 @@ const loadImagesMock = vi.fn();
 const pStatus: ProviderStatus = 'started';
 const pInfo: ProviderContainerConnectionInfo = {
   name: 'test',
+  displayName: 'test',
   status: 'started',
   endpoint: {
     socketPath: '',

--- a/packages/renderer/src/lib/image/PullImage.spec.ts
+++ b/packages/renderer/src/lib/image/PullImage.spec.ts
@@ -71,6 +71,7 @@ function setup() {
   const pStatus: ProviderStatus = 'started';
   const pInfo: ProviderContainerConnectionInfo = {
     name: 'test',
+    displayName: 'test',
     status: 'started',
     endpoint: {
       socketPath: '',

--- a/packages/renderer/src/lib/kube/KubePlayYAML.spec.ts
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.spec.ts
@@ -91,6 +91,7 @@ function setup() {
   const pStatus: ProviderStatus = 'started';
   const pInfo: ProviderContainerConnectionInfo = {
     name: 'test',
+    displayName: 'test',
     status: 'started',
     endpoint: {
       socketPath: '',

--- a/packages/renderer/src/lib/onboarding/OnboardingComponent.spec.ts
+++ b/packages/renderer/src/lib/onboarding/OnboardingComponent.spec.ts
@@ -40,6 +40,7 @@ const providerInfo: ProviderInfo = {
   containerConnections: [
     {
       name: 'machine',
+      displayName: 'machine',
       status: 'started',
       endpoint: {
         socketPath: 'socket',

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.spec.ts
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.spec.ts
@@ -41,6 +41,7 @@ const providerInfo: ProviderInfo = {
   containerConnections: [
     {
       name: 'machine',
+      displayName: 'machine',
       status: 'started',
       endpoint: {
         socketPath: 'socket',

--- a/packages/renderer/src/lib/pod/PodsList.spec.ts
+++ b/packages/renderer/src/lib/pod/PodsList.spec.ts
@@ -47,6 +47,7 @@ const provider: ProviderInfo = {
   containerConnections: [
     {
       name: 'MyConnection',
+      displayName: 'MyConnection',
       status: 'started',
       endpoint: { socketPath: 'dummy' },
       type: 'podman',

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionActions.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionActions.spec.ts
@@ -54,6 +54,7 @@ const containerProviderInfo: ProviderInfo = {
 
 const containerConnection: ProviderContainerConnectionInfo = {
   name: 'machine',
+  displayName: 'machine',
   status: 'started',
   endpoint: {
     socketPath: 'socket',

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsLogs.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsLogs.spec.ts
@@ -37,6 +37,7 @@ global.ResizeObserver = vi.fn().mockImplementation(() => ({
 
 const containerConnection: ProviderContainerConnectionInfo = {
   name: 'connection',
+  displayName: 'connection',
   endpoint: {
     socketPath: 'socket',
   },

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionDetailsSummary.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionDetailsSummary.spec.ts
@@ -31,6 +31,7 @@ import PreferencesContainerConnectionDetailsSummary from './PreferencesContainer
 
 const podmanContainerConnection: ProviderContainerConnectionInfo = {
   name: 'connection',
+  displayName: 'connection',
   endpoint: {
     socketPath: 'socket',
   },
@@ -40,6 +41,7 @@ const podmanContainerConnection: ProviderContainerConnectionInfo = {
 
 const dockerContainerConnection: ProviderContainerConnectionInfo = {
   name: 'connection',
+  displayName: 'connection',
   endpoint: {
     socketPath: 'socket',
   },

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.spec.ts
@@ -52,6 +52,7 @@ test('Expect that the right machine is displayed', async () => {
     containerConnections: [
       {
         name: podmanMachineName1,
+        displayName: podmanMachineName1,
         status: 'started',
         endpoint: {
           socketPath,
@@ -60,6 +61,7 @@ test('Expect that the right machine is displayed', async () => {
       },
       {
         name: podmanMachineName2,
+        displayName: podmanMachineName2,
         status: 'started',
         endpoint: {
           socketPath,
@@ -68,6 +70,7 @@ test('Expect that the right machine is displayed', async () => {
       },
       {
         name: podmanMachineName3,
+        displayName: podmanMachineName3,
         status: 'started',
         endpoint: {
           socketPath,
@@ -130,6 +133,7 @@ test('Expect that removing the connection is going back to the previous page', a
     containerConnections: [
       {
         name: podmanMachineName1,
+        displayName: podmanMachineName1,
         status: 'started',
         endpoint: {
           socketPath,
@@ -138,6 +142,7 @@ test('Expect that removing the connection is going back to the previous page', a
       },
       {
         name: podmanMachineName2,
+        displayName: podmanMachineName2,
         status: 'stopped',
         endpoint: {
           socketPath,
@@ -147,6 +152,7 @@ test('Expect that removing the connection is going back to the previous page', a
       },
       {
         name: podmanMachineName3,
+        displayName: podmanMachineName3,
         status: 'started',
         endpoint: {
           socketPath,
@@ -238,6 +244,7 @@ test('Expect to see error message if action fails', async () => {
     containerConnections: [
       {
         name: podmanMachineName,
+        displayName: podmanMachineName,
         status: 'stopped',
         endpoint: {
           socketPath,
@@ -317,6 +324,7 @@ test('Expect startContainerProvider to only be called once when restarting', asy
     containerConnections: [
       {
         name: podmanMachineName,
+        displayName: podmanMachineName,
         status: 'started',
         endpoint: {
           socketPath,

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.spec.ts
@@ -372,3 +372,66 @@ test('Expect startContainerProvider to only be called once when restarting', asy
 
   expect(startConnectionMock).toBeCalledTimes(1);
 });
+
+test('Expect display name to be used in favor of name for page title', async () => {
+  const socketPath = '/my/common-socket-path';
+  const podmanMachineName = 'podman-machine-default';
+  const podmanMachineDisplayName = 'Dummy Podman Display Name';
+
+  const stopConnectionMock = vi.fn();
+  const startConnectionMock = vi.fn();
+  (window as any).stopProviderConnectionLifecycle = stopConnectionMock;
+  (window as any).startProviderConnectionLifecycle = startConnectionMock;
+
+  const providerInfo: ProviderInfo = {
+    id: 'podman',
+    name: 'podman',
+    images: {
+      icon: 'img',
+    },
+    status: 'started',
+    warnings: [],
+    containerProviderConnectionCreation: true,
+    detectionChecks: [],
+    containerConnections: [
+      {
+        name: podmanMachineName,
+        displayName: podmanMachineDisplayName,
+        status: 'started',
+        endpoint: {
+          socketPath,
+        },
+        type: 'podman',
+        lifecycleMethods: ['start', 'stop'],
+      },
+    ],
+    installationSupport: false,
+    internalId: '0',
+    kubernetesConnections: [],
+    kubernetesProviderConnectionCreation: true,
+    links: [],
+    containerProviderConnectionInitialization: false,
+    containerProviderConnectionCreationDisplayName: 'Podman machine',
+    kubernetesProviderConnectionInitialization: false,
+    extensionId: '',
+    cleanupSupport: false,
+  };
+
+  providerInfos.set([providerInfo]);
+
+  // encode name with base64 of the second machine
+  const name = Buffer.from(podmanMachineName).toString('base64');
+
+  const connection = Buffer.from(socketPath).toString('base64');
+
+  const { getByLabelText } = render(PreferencesContainerConnectionRendering, {
+    name,
+    connection,
+    providerInternalId: '0',
+  });
+
+  const header = getByLabelText(podmanMachineDisplayName);
+  expect(header).toBeDefined();
+  expect(header instanceof HTMLHeadingElement).toBeTruthy();
+  expect(header.textContent).toBe(podmanMachineDisplayName);
+});

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
@@ -136,7 +136,7 @@ function setNoLogs() {
 </script>
 
 {#if connectionInfo}
-  <DetailsPage title={connectionInfo.displayName ?? connectionInfo.name} bind:this={detailsPage}>
+  <DetailsPage title={connectionInfo.displayName} bind:this={detailsPage}>
     <svelte:fragment slot="subtitle">
       <div class="flex flex-row">
         <ConnectionStatus status={connectionInfo.status} />

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
@@ -136,7 +136,7 @@ function setNoLogs() {
 </script>
 
 {#if connectionInfo}
-  <DetailsPage title={connectionInfo.name} bind:this={detailsPage}>
+  <DetailsPage title={connectionInfo.displayName ?? connectionInfo.name} bind:this={detailsPage}>
     <svelte:fragment slot="subtitle">
       <div class="flex flex-row">
         <ConnectionStatus status={connectionInfo.status} />

--- a/packages/renderer/src/lib/preferences/PreferencesProviderInstallationModal.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesProviderInstallationModal.spec.ts
@@ -39,6 +39,7 @@ const providerInfo: ProviderInfo = {
   containerConnections: [
     {
       name: 'machine',
+      displayName: 'podman',
       status: 'started',
       endpoint: {
         socketPath: 'socket',

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
@@ -59,7 +59,6 @@ const providerInfo: ProviderInfo = {
     },
     {
       name: secondaryContainerConnectionName,
-      displayName: 'Dummy Podman Machine Display Name',
       status: 'stopped',
       endpoint: {
         socketPath: 'socket',

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
@@ -59,6 +59,7 @@ const providerInfo: ProviderInfo = {
     },
     {
       name: secondaryContainerConnectionName,
+      displayName: 'Dummy Podman Machine Display Name',
       status: 'stopped',
       endpoint: {
         socketPath: 'socket',

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
@@ -49,6 +49,7 @@ const providerInfo: ProviderInfo = {
   containerConnections: [
     {
       name: defaultContainerConnectionName,
+      displayName: defaultContainerConnectionName,
       status: 'started',
       endpoint: {
         socketPath: 'socket',

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
@@ -59,6 +59,7 @@ const providerInfo: ProviderInfo = {
     },
     {
       name: secondaryContainerConnectionName,
+      displayName: 'Dummy Secondary Connection',
       status: 'stopped',
       endpoint: {
         socketPath: 'socket',
@@ -219,6 +220,18 @@ describe('provider connections', () => {
     expect(typeDiv.textContent).toBe('Docker endpoint');
     const endpointSpan = await vi.waitFor(() => within(region).getByTitle('unix://socket'));
     expect(endpointSpan.textContent).toBe('unix://socket');
+  });
+
+  test('Expect display name to be used in favor of name when available', async () => {
+    providerInfos.set([providerInfo]);
+
+    const { getByRole } = render(PreferencesResourcesRendering, {});
+
+    // get the region containing the content for the default connection
+    const region = getByRole('region', { name: secondaryContainerConnectionName });
+
+    const text = within(region).getByText('Dummy Secondary Connection');
+    expect(text).toBeDefined();
   });
 });
 

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -471,7 +471,7 @@ function hasAnyConfiguration(provider: ProviderInfo) {
                 </Tooltip>
               </div>
               <div class="{container.status !== 'started' ? 'text-gray-900' : ''} font-semibold">
-                {container.name}
+                {container.displayName ?? container.name}
               </div>
               <div class="flex" aria-label="Connection Status">
                 <ConnectionStatus status={container.status} />

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -471,7 +471,7 @@ function hasAnyConfiguration(provider: ProviderInfo) {
                 </Tooltip>
               </div>
               <div class="{container.status !== 'started' ? 'text-gray-900' : ''} font-semibold">
-                {container.displayName ?? container.name}
+                {container.displayName}
               </div>
               <div class="flex" aria-label="Connection Status">
                 <ConnectionStatus status={container.status} />


### PR DESCRIPTION
### What does this PR do?

Adding an optional `displayName` when registering connections. Allowing user friendly name.

E.g. podman extension register `Podman Machine` as display name, and keep `podman-machine-default` as name (real name).

ℹ️ The name will always be the fallback if the display name is not available
### Screenshot / video of UI

Places where the `displayName` is used

![image](https://github.com/user-attachments/assets/e055e385-5845-4ef4-bcb9-7bacffd95487)

![image](https://github.com/user-attachments/assets/23efb504-f583-48d9-a202-c4649b9912aa)


### What issues does this PR fix or reference?

Need rebase after https://github.com/containers/podman-desktop/pull/8689

First part of https://github.com/containers/podman-desktop/issues/8484

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature

