### PR TITLE
fix: delay onChange callback after the result of the validation

### DIFF
--- a/packages/renderer/src/lib/preferences/item-formats/NumberItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/NumberItem.spec.ts
@@ -152,3 +152,41 @@ test('Expect zero value set correctly', async () => {
   vi.advanceTimersByTime(510);
   expect(onChange).toHaveBeenCalledWith('record', 0);
 });
+
+test('Expect onChange is not triggered in case of error on validation', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'number',
+    minimum: 1,
+    maximum: 20,
+  };
+  const onChange = vi.fn();
+  const value = 1;
+  render(NumberItem, { record, value, onChange });
+
+  const input = screen.getByRole('textbox', { name: 'record-description' });
+  expect(input).toBeInTheDocument();
+
+  // enter the text 0
+  await userEvent.type(input, '0');
+
+  // 10 is a valid value, so the onChange should be called
+  await vi.waitFor(() => expect(onChange).toHaveBeenCalledWith('record', 10));
+
+  // reset the number of calls
+  onChange.mockClear();
+
+  // enter again 0, it will be 100 and outside of the scope
+  await userEvent.type(input, '0');
+  // then we should not have any onChange call
+  await vi.waitFor(() => expect(onChange).not.toHaveBeenCalled());
+
+  // remove the 00 by sending delete 2 times backspace key
+  await userEvent.keyboard('{backspace}{backspace}');
+
+  // then we should have the onChange call to be 1
+  await vi.waitFor(() => expect(onChange).toHaveBeenCalledWith('record', 1));
+});

--- a/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
@@ -17,8 +17,10 @@ let error: string | undefined = undefined;
 
 $: recordValue = value ?? 0;
 
-$: {
-  const newValue = Number(recordValue);
+function onValidation(newValue: number, validationError?: string) {
+  if (validationError) {
+    invalidRecord(validationError);
+  }
   // if the value is different from the original update
   if (record.id && newValue !== lastValue && !error) {
     // clear the timeout so if there was an old call to onChange pending is deleted. We will create a new one soon
@@ -31,16 +33,13 @@ $: {
     }, 500);
   }
 }
-
-$: if (error) {
-  invalidRecord(error);
-}
 </script>
 
 <Tooltip topLeft tip={error}>
   <NumberInput
     class="w-24"
     name={record.id}
+    onValidation={onValidation}
     bind:value={recordValue}
     bind:error={error}
     aria-label={record.description}

--- a/packages/renderer/src/lib/ui/NumberInput.svelte
+++ b/packages/renderer/src/lib/ui/NumberInput.svelte
@@ -11,6 +11,9 @@ export let error: string | undefined = undefined;
 export let showError: boolean = true;
 export let type: 'number' | 'integer';
 
+// callback after validation occurs
+export let onValidation = (_value: number, _error?: string) => {};
+
 let minimumEnabled: boolean;
 let maximumEnabled: boolean;
 
@@ -19,15 +22,19 @@ $: if (value !== undefined || disabled) {
 }
 
 function validateNumber() {
-  if (maximum !== undefined && value > maximum) {
+  const numberToValidate = Number(value);
+  if (maximum !== undefined && numberToValidate > maximum) {
     error = `The value cannot be greater than ${maximum}`;
-  } else if (minimum !== undefined && value < minimum) {
+  } else if (minimum !== undefined && numberToValidate < minimum) {
     error = `The value cannot be less than ${minimum}`;
   } else {
     error = undefined;
   }
-  minimumEnabled = !disabled && (minimum === undefined || minimum < value);
-  maximumEnabled = !disabled && (maximum === undefined || maximum > value);
+  minimumEnabled = !disabled && (minimum === undefined || minimum < numberToValidate);
+  maximumEnabled = !disabled && (maximum === undefined || maximum > numberToValidate);
+
+  // send the callback
+  onValidation(numberToValidate, error);
 }
 
 function onKeyPress(event: any) {


### PR DESCRIPTION
### What does this PR do?
currently, the onChange event is triggered as soon as the value is modified but we need to delay the change only after the validation is occuring

it means then we can decide to do stuff based on both the value and the error after validating the value


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/8661


### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
