### PR TITLE
feat(configuration): allow to define the value of step for Input widget 

### DIFF
--- a/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
@@ -44,6 +44,7 @@ function onValidation(newValue: number, validationError?: string) {
     bind:error={error}
     aria-label={record.description}
     minimum={record.minimum}
+    step={record.step}
     type={record.type === 'integer' ? 'integer' : 'number'}
     maximum={record.maximum && typeof record.maximum === 'number' ? record.maximum : undefined}
     showError={false}>

--- a/packages/renderer/src/lib/ui/NumberInput.spec.ts
+++ b/packages/renderer/src/lib/ui/NumberInput.spec.ts
@@ -33,6 +33,7 @@ function renderInput(
   minimum?: number,
   maximum?: number,
   type: 'integer' | 'number' = 'number',
+  step?: number,
 ): void {
   render(NumberInput, {
     name: name,
@@ -41,6 +42,7 @@ function renderInput(
     minimum: minimum,
     maximum: maximum,
     type: type,
+    step: step,
   });
 }
 
@@ -220,4 +222,34 @@ test('Expect limiting numbers for integers', async () => {
 
   // the value should be 3.0 (as only the dot and 0 are allowed)
   expect(input).toHaveValue('3.0');
+});
+
+test('Expect increment works with custom step', async () => {
+  renderInput('test', 5, false, 0, 10, 'number', 0.5);
+
+  const input = screen.getByRole('textbox');
+  expect(input).toBeInTheDocument();
+  expect(input).toHaveValue('5');
+
+  const increment = screen.getByLabelText('increment');
+  expect(increment).toBeInTheDocument();
+
+  await userEvent.click(increment);
+
+  expect(input).toHaveValue('5.5');
+});
+
+test('Expect decrement works with custom step', async () => {
+  renderInput('test', 5, false, 0, 10, 'number', 0.8);
+
+  const input = screen.getByRole('textbox');
+  expect(input).toBeInTheDocument();
+  expect(input).toHaveValue('5');
+
+  const increment = screen.getByLabelText('decrement');
+  expect(increment).toBeInTheDocument();
+
+  await userEvent.click(increment);
+
+  expect(input).toHaveValue('4.2');
 });

--- a/packages/renderer/src/lib/ui/NumberInput.svelte
+++ b/packages/renderer/src/lib/ui/NumberInput.svelte
@@ -10,6 +10,7 @@ export let maximum: number | undefined = undefined;
 export let error: string | undefined = undefined;
 export let showError: boolean = true;
 export let type: 'number' | 'integer';
+export let step: number | undefined = undefined;
 
 // callback after validation occurs
 export let onValidation = (_value: number, _error?: string) => {};
@@ -59,13 +60,15 @@ function onKeyPress(event: any) {
 }
 
 function onDecrement(e: MouseEvent) {
+  const dec = step ? step : 1;
   e.preventDefault();
-  value = Number(value) - 1;
+  value = Number(value) - dec;
 }
 
 function onIncrement(e: MouseEvent) {
+  const inc = step ? step : 1;
   e.preventDefault();
-  value = Number(value) + 1;
+  value = Number(value) + inc;
 }
 </script>
 


### PR DESCRIPTION
### What does this PR do?
Allow to handle step value when doing increment/decrement in the number widget

depends on https://github.com/containers/podman-desktop/pull/8698 (will remove commits once PR is merged)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/8662

### How to test this PR?

Apply `step` configuration in JSON for a number type

- [x] Tests are covering the bug fix or the new feature
