### PR TITLE
fix: configure certificates for secure proxy

### DIFF
--- a/packages/main/src/plugin/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension-loader.spec.ts
@@ -26,6 +26,7 @@ import type * as containerDesktopAPI from '@podman-desktop/api';
 import { app } from 'electron';
 import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 
+import type { Certificates } from '/@/plugin/certificates.js';
 import type { ContributionManager } from '/@/plugin/contribution-manager.js';
 import type { KubeGeneratorRegistry } from '/@/plugin/kubernetes/kube-generator-registry.js';
 import { NavigationManager } from '/@/plugin/navigation/navigation-manager.js';
@@ -241,6 +242,8 @@ const dialogRegistry: DialogRegistry = {
   saveDialog: saveDialogMock,
 } as unknown as DialogRegistry;
 
+const certificates: Certificates = {} as unknown as Certificates;
+
 vi.mock('electron', () => {
   return {
     app: {
@@ -292,6 +295,7 @@ beforeAll(() => {
     colorRegistry,
     dialogRegistry,
     safeStorageRegistry,
+    certificates,
   );
 });
 

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -41,6 +41,7 @@ import type { ApiSenderType } from './api.js';
 import type { PodInfo } from './api/pod-info.js';
 import type { AuthenticationImpl } from './authentication.js';
 import { CancellationTokenSource } from './cancellation-token.js';
+import type { Certificates } from './certificates.js';
 import type { CliToolRegistry } from './cli-tool-registry.js';
 import type { CommandRegistry } from './command-registry.js';
 import type { ConfigurationRegistry, IConfigurationNode } from './configuration-registry.js';
@@ -192,6 +193,7 @@ export class ExtensionLoader {
     private colorRegistry: ColorRegistry,
     private dialogRegistry: DialogRegistry,
     private safeStorageRegistry: SafeStorageRegistry,
+    private certificates: Certificates,
   ) {
     this.pluginsDirectory = directories.getPluginsDirectory();
     this.pluginsScanDirectory = directories.getPluginsScanDirectory();
@@ -289,7 +291,7 @@ export class ExtensionLoader {
       fs.mkdirSync(this.pluginsScanDirectory, { recursive: true });
     }
 
-    this.moduleLoader.addOverride(createHttpPatchedModules(this.proxy)); // add patched http and https
+    this.moduleLoader.addOverride(createHttpPatchedModules(this.proxy, this.certificates)); // add patched http and https
     this.moduleLoader.addOverride({ '@podman-desktop/api': ext => ext.api }); // add podman desktop API
 
     this.moduleLoader.overrideRequire();

--- a/packages/main/src/plugin/extensions-catalog/extensions-catalog.ts
+++ b/packages/main/src/plugin/extensions-catalog/extensions-catalog.ts
@@ -225,6 +225,10 @@ export class ExtensionsCatalog {
             maxFreeSockets: 256,
             scheduling: 'lifo',
             proxy: httpsProxyUrl,
+            ca: this.certificates.getAllCertificates(),
+            proxyRequestOptions: {
+              ca: this.certificates.getAllCertificates(),
+            },
           });
         } catch (error) {
           throw new Error(`Failed to create https proxy agent from ${httpsProxyUrl}: ${error}`);

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -456,7 +456,9 @@ export class PluginSystem {
     const colorRegistry = new ColorRegistry(apiSender, configurationRegistry);
     colorRegistry.init();
 
-    const proxy = new Proxy(configurationRegistry);
+    const certificates = new Certificates();
+    await certificates.init();
+    const proxy = new Proxy(configurationRegistry, certificates);
     await proxy.init();
 
     const telemetry = new Telemetry(configurationRegistry);
@@ -471,8 +473,6 @@ export class PluginSystem {
     const notificationRegistry = new NotificationRegistry(apiSender, taskManager);
     const menuRegistry = new MenuRegistry(commandRegistry);
     const kubeGeneratorRegistry = new KubeGeneratorRegistry();
-    const certificates = new Certificates();
-    await certificates.init();
     const imageRegistry = new ImageRegistry(apiSender, telemetry, certificates, proxy);
     const viewRegistry = new ViewRegistry();
     const context = new Context(apiSender);
@@ -670,6 +670,7 @@ export class PluginSystem {
       colorRegistry,
       dialogRegistry,
       safeStorageRegistry,
+      certificates,
     );
     await this.extensionLoader.init();
 

--- a/packages/main/src/plugin/proxy-resolver.spec.ts
+++ b/packages/main/src/plugin/proxy-resolver.spec.ts
@@ -27,6 +27,7 @@ import type { HttpsProxyAgentOptions } from 'hpagent';
 import { HttpsProxyAgent } from 'hpagent';
 import { beforeEach, expect, test, vi } from 'vitest';
 
+import type { Certificates } from './certificates.js';
 import type { Proxy } from './proxy.js';
 import * as ProxyResolver from './proxy-resolver.js';
 
@@ -83,40 +84,44 @@ const Http = 'http';
 const HttpProxyUrl = `${Http}://proxy.url`;
 const HttpsProxyUrl = 'https://proxy.url';
 
+const certificates: Certificates = {
+  getAllCertificates: vi.fn(),
+} as unknown as Certificates;
+
 beforeEach(() => {
   vi.clearAllMocks();
 });
 
 test('getOptions return options w/o agent if proxy not enabled', () => {
   const proxy = createProxy(false);
-  const options = ProxyResolver.getOptions(proxy, false);
+  const options = ProxyResolver.getOptions(proxy, false, certificates);
   expect(options.agent).toBeUndefined();
 });
 
 test('getOptions return options w/ agent for https proxy', () => {
   const proxy = createProxy(true, HttpsProxyUrl, HttpProxyUrl);
-  const options = ProxyResolver.getOptions(proxy, true);
+  const options = ProxyResolver.getOptions(proxy, true, certificates);
   expect(options.agent).not.toBeUndefined();
   expect((options.agent as any).https).toBeTruthy();
 });
 
 test('getOptions return options w/ https.Agent for https proxy', () => {
   const proxy = createProxy(true, undefined, HttpProxyUrl);
-  const options = ProxyResolver.getOptions(proxy, false);
+  const options = ProxyResolver.getOptions(proxy, false, certificates);
   expect(options.agent).not.toBeUndefined();
   expect((options.agent as any).https).toBeFalsy();
 });
 
 test('patched http get calls original with the original parameters when proxy is not enabled', () => {
   const proxy = createProxy(false, HttpsProxyUrl, HttpProxyUrl);
-  const patched = ProxyResolver.createHttpPatchedModules(proxy);
+  const patched = ProxyResolver.createHttpPatchedModules(proxy, certificates);
   patched.http.get(`${Http}://site.url`);
   expect(get).toBeCalledWith(`${Http}://site.url`);
 });
 
 test('patched http get calls original method with the original parameters when proxy is enabled and socketPath is requested', () => {
   const proxy = createProxy(true, HttpsProxyUrl, HttpProxyUrl);
-  const patched = ProxyResolver.createHttpPatchedModules(proxy);
+  const patched = ProxyResolver.createHttpPatchedModules(proxy, certificates);
   const socketOptions = { socketPath: '/var/socket/path' };
   patched.http.get(socketOptions);
   expect(get).toBeCalledWith(socketOptions, undefined);
@@ -124,7 +129,7 @@ test('patched http get calls original method with the original parameters when p
 
 test('patched http get when called with url and callback calls original with options and callback', () => {
   const proxy = createProxy(true, HttpsProxyUrl, HttpProxyUrl);
-  const patched = ProxyResolver.createHttpPatchedModules(proxy);
+  const patched = ProxyResolver.createHttpPatchedModules(proxy, certificates);
   const colon = ':';
   const url = `https://[fe80${colon}${colon}1802${colon}20ff${colon}fe8d${colon}d4ce]`;
   const callback = vi.fn();
@@ -145,7 +150,7 @@ test('patched http get when called with url and callback calls original with opt
 
 test('patched http get translates username@password in url to auth option', () => {
   const proxy = createProxy(true, HttpsProxyUrl, HttpProxyUrl);
-  const patched = ProxyResolver.createHttpPatchedModules(proxy);
+  const patched = ProxyResolver.createHttpPatchedModules(proxy, certificates);
   const url = 'https://usr:pass@rest.url';
   const callback = vi.fn();
   patched.http.get(url, callback);
@@ -166,7 +171,7 @@ test('patched http get translates username@password in url to auth option', () =
 
 test('patched http get works when url passed as protocol and hostname in options', () => {
   const proxy = createProxy(true, HttpsProxyUrl, HttpProxyUrl);
-  const patched = ProxyResolver.createHttpPatchedModules(proxy);
+  const patched = ProxyResolver.createHttpPatchedModules(proxy, certificates);
   const callback = vi.fn();
   const options = {
     hostname: 'rest.url',

--- a/packages/main/src/plugin/proxy.spec.ts
+++ b/packages/main/src/plugin/proxy.spec.ts
@@ -22,10 +22,15 @@ import type { AddressInfo } from 'node:net';
 import { createProxy, type ProxyServer } from 'proxy';
 import { describe, expect, test, vi } from 'vitest';
 
+import type { Certificates } from '/@/plugin/certificates.js';
 import type { ConfigurationRegistry } from '/@/plugin/configuration-registry.js';
 import { ensureURL, Proxy } from '/@/plugin/proxy.js';
 
 const URL = 'https://podman-desktop.io';
+
+const certificates: Certificates = {
+  getAllCertificates: vi.fn(),
+} as unknown as Certificates;
 
 function getConfigurationRegistry(
   enabled: boolean,
@@ -64,7 +69,7 @@ async function buildProxy(): Promise<ProxyServer> {
 
 test('fetch without proxy', async () => {
   const configurationRegistry = getConfigurationRegistry(false, undefined, undefined, undefined);
-  const proxy = new Proxy(configurationRegistry);
+  const proxy = new Proxy(configurationRegistry, certificates);
   await proxy.init();
   await fetch(URL);
 });
@@ -73,7 +78,7 @@ test('fetch with http proxy', async () => {
   const proxyServer = await buildProxy();
   const address = proxyServer.address() as AddressInfo;
   const configurationRegistry = getConfigurationRegistry(true, `127.0.0.1:${address.port}`, undefined, undefined);
-  const proxy = new Proxy(configurationRegistry);
+  const proxy = new Proxy(configurationRegistry, certificates);
   await proxy.init();
   let connectDone = false;
   proxyServer.on('connect', () => (connectDone = true));


### PR DESCRIPTION
Fixes #7683

### What does this PR do?

Configure proxy with system certificates

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

#7683

### How to test this PR?

- Install simple-proxy (https://github.com/jthomperoo/simple-proxy)
- Generate a certificate: `openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 3650 -nodes -subj "/C=XX/ST=StateName/L=CityName/O=CompanyName/OU=CompanySectionName/CN=localhost"`
- Convert for Windows certificates store import: openssl pkcs12 -inkey key.pem -in cert.pem -export -out cert.pfx
- Import the certificate in Windows: run `certmgr.msc` then right click on `Trusted root certificate authorities` then `All task ... Import` and import the pfx file
- Start the proxy server: ./simple-proxy -protocol https -key key.pem -cert cert.pem
- Configure Podman Desktop to use https://localhost:8888 for HTTP and HTTPS URLs
- Try install compose

- [x] Tests are covering the bug fix or the new feature
