### PR TITLE
feat(api): adding optional vmTypeDisplayName

### DIFF
--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -275,7 +275,7 @@ export async function updateMachines(
         machineInfo?.memory !== undefined && machineInfo?.memoryUsed !== undefined && machineInfo?.memoryUsed > 0
           ? (machineInfo?.memoryUsed * 100) / machineInfo?.memory
           : 0,
-      vmType: getProviderLabel(machine.VMType),
+      vmType: machine.VMType,
     });
 
     if (!podmanMachinesStatuses.has(machine.Name)) {
@@ -801,7 +801,8 @@ export async function registerProviderFor(
     endpoint: {
       socketPath,
     },
-    vmType: getProviderLabel(machineInfo.vmType),
+    vmType: machineInfo.vmType,
+    vmTypeDisplayName: getProviderLabel(machineInfo.vmType),
   };
 
   // Since Podman 4.5, machines are using the same path for all sockets of machines

--- a/packages/api/src/provider-info.ts
+++ b/packages/api/src/provider-info.ts
@@ -38,7 +38,7 @@ export interface ProviderContainerConnectionInfo {
   };
   lifecycleMethods?: LifecycleMethod[];
   type: 'docker' | 'podman';
-  vmType?: string;
+  vmType?: { id: string; name: string };
 }
 
 export interface ProviderKubernetesConnectionInfo {

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -364,6 +364,10 @@ declare module '@podman-desktop/api' {
     lifecycle?: ProviderConnectionLifecycle;
     status(): ProviderConnectionStatus;
     vmType?: string;
+    /**
+     * the vmTypeDisplayName property cannot be set if vmType is undefined
+     */
+    vmTypeDisplayName?: string;
   }
 
   export interface PodCreatePortOptions {

--- a/packages/main/src/plugin/provider-registry.spec.ts
+++ b/packages/main/src/plugin/provider-registry.spec.ts
@@ -327,7 +327,10 @@ test('should send events when starting a container connection', async () => {
       socketPath: '/endpoint1.sock',
     },
     status: 'started',
-    vmType: 'libkrun',
+    vmType: {
+      id: 'libkrun',
+      name: 'libkrun',
+    },
   };
 
   const startMock = vi.fn();
@@ -394,7 +397,10 @@ test('should send events when stopping a container connection', async () => {
       socketPath: '/endpoint1.sock',
     },
     status: 'stopped',
-    vmType: 'libkrun',
+    vmType: {
+      id: 'libkrun',
+      name: 'libkrun',
+    },
   };
 
   const startMock = vi.fn();

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -646,7 +646,12 @@ export class ProviderRegistry {
         endpoint: {
           socketPath: connection.endpoint.socketPath,
         },
-        vmType: connection.vmType,
+        vmType: connection.vmType
+          ? {
+              id: connection.vmType,
+              name: connection.vmTypeDisplayName ?? connection.vmType,
+            }
+          : undefined,
       };
     } else {
       providerConnection = {

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
@@ -56,7 +56,10 @@ const providerInfo: ProviderInfo = {
       },
       lifecycleMethods: ['start', 'stop', 'delete'],
       type: 'podman',
-      vmType: 'libkrun',
+      vmType: {
+        id: 'libkrun',
+        name: 'libkrun',
+      },
     },
     {
       name: secondaryContainerConnectionName,
@@ -67,7 +70,10 @@ const providerInfo: ProviderInfo = {
       },
       lifecycleMethods: ['start', 'stop', 'delete'],
       type: 'podman',
-      vmType: 'wsl',
+      vmType: {
+        id: 'wsl',
+        name: 'wsl',
+      },
     },
   ],
   installationSupport: false,

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -536,7 +536,7 @@ function hasAnyConfiguration(provider: ProviderInfo) {
                   {provider.name}
                   {provider.version ? `v${provider.version}` : ''}
                 </div>
-                <div aria-label="Connection Type">{container.vmType ? capitalize(container.vmType) : ''}</div>
+                <div aria-label="Connection Type">{container.vmType ? capitalize(container.vmType.name) : ''}</div>
               </div>
             </div>
           {/each}


### PR DESCRIPTION
### What does this PR do?

Adding an optional `vmTypeDisplayName` property to container provider connection to avoid providing user friendly value to `vmType` which should only reflect the values provided by podman.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/8484

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature

**On mac**

- assert using libkrun
- checkout / watch
- assert running
- go to resource page
- assert libkrun 
