### PR TITLE
chore: split checks in smaller chunks

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -194,14 +194,10 @@ jobs:
             PR_NUMBER
             PR_SHA
 
-  lint-format-unit:
-    name: linter, formatters and unit tests / ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+  lint-format:
+    name: linter, formatters
+    runs-on: ubuntu-24.04
     timeout-minutes: 40
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [windows-2022, ubuntu-24.04]
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -223,8 +219,32 @@ jobs:
       - name: Run formatter
         run: pnpm format:check
 
-      - name: Run unit tests
-        run: pnpm test:unit
+      # Check we don't have changes in git
+      - name: Check no changes in git
+        run: |
+          if ! git diff --exit-code; then
+            echo "Found changes in git"
+            exit 1
+          fi
+
+  tpecheck:
+    name: typecheck
+    runs-on: ubuntu-24.04
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Execute pnpm
+        run: pnpm install
 
       - name: Run typecheck
         run: pnpm typecheck
@@ -232,14 +252,31 @@ jobs:
       - name: Run svelte check
         run: pnpm svelte:check
 
-      # Check we don't have changes in git
-      - name: Check no changes in git
-        if: ${{ matrix.os=='ubuntu-24.04'}}
-        run: |
-          if ! git diff --exit-code; then
-            echo "Found changes in git"
-            exit 1
-          fi
+  unit-tests:
+    name: unit tests / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-2022, ubuntu-24.04]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Execute pnpm
+        run: pnpm install
+
+      - name: Run unit tests
+        run: pnpm test:unit
 
   smoke-e2e-tests:
     name: smoke e2e tests

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -227,7 +227,7 @@ jobs:
             exit 1
           fi
 
-  tpecheck:
+  typecheck:
     name: typecheck
     runs-on: ubuntu-24.04
     timeout-minutes: 40

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "typecheck:preload-dd-extension": "tsc --noEmit -p packages/preload-docker-extension/tsconfig.json",
     "typecheck:preload-webview": "tsc --noEmit -p packages/preload-webview/tsconfig.json",
     "typecheck:renderer": "npm run build:preload:types && tsc --noEmit -p packages/renderer/tsconfig.json",
-    "typecheck:ui": "npm run build:preload:types && tsc --noEmit -p packages/ui/tsconfig.json",
+    "typecheck:ui": "npm run build:ui && npm run build:preload:types && tsc --noEmit -p packages/ui/tsconfig.json",
     "typecheck:extensions": "npm run typecheck:extensions:compose && npm run typecheck:extensions:kind && npm run typecheck:extensions:docker && npm run typecheck:extensions:lima && npm run typecheck:extensions:kube-context && npm run typecheck:extensions:podman && npm run typecheck:extensions:registries && npm run typecheck:extensions:kubectl-cli",
     "typecheck:extensions:kind": "tsc --noEmit --project extensions/kind",
     "typecheck:extensions:compose": "tsc --noEmit --project extensions/compose",


### PR DESCRIPTION
### What does this PR do?
- move typecheck/svelte to a dedicated job (Linux only)
- move linter/formatter to a dedicated job (Linux only)
- keep unit tests in a dedicated job (Windows & Linux)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/8660

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
