### PR TITLE
chore: publish prereleases to another repository

### DIFF
--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -67,7 +67,7 @@ jobs:
           git commit -m "chore: tag ${{ steps.TAG_UTIL.outputs.githubTag }}"
           echo "Tagging with ${{ steps.TAG_UTIL.outputs.githubTag }}"
           git tag ${{ steps.TAG_UTIL.outputs.githubTag }}
-          # push tag to the preleases repository
+          # push tag to the prereleases repository
           git remote add prereleases https://github.com/containers/podman-desktop-prereleases
           git push prereleases ${{ steps.TAG_UTIL.outputs.githubTag }}
 

--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -39,6 +39,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+         token: ${{ secrets.PODMAN_DESKTOP_BOT_TOKEN }}
+         fetch-depth: 0
       - name: Generate tag utilities
         id: TAG_UTIL
         run: |
@@ -54,24 +57,31 @@ jobs:
       - name: tag
         run: |
           git config --local user.name ${{ github.actor }}
+          git config --local user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
           sed -i  "s#version\":\ \"\(.*\)\",#version\":\ \"${{ steps.TAG_UTIL.outputs.desktopVersion }}\",#g" package.json
           find extensions/* -maxdepth 2 -name "package.json" | xargs -I {} sed -i "s#version\":\ \"\(.*\)\",#version\":\ \"${{ steps.TAG_UTIL.outputs.desktopVersion }}\",#g" {}
+          # change the repository field to be the prerelease repository in package.json file
+          sed -i "s#\"repository\":\ \"\(.*\)\",#\"repository\":\ \"https://github.com/containers/podman-desktop-prereleases\",#g" package.json
           cat package.json
           git add package.json extensions/*/package.json
           git commit -m "chore: tag ${{ steps.TAG_UTIL.outputs.githubTag }}"
           echo "Tagging with ${{ steps.TAG_UTIL.outputs.githubTag }}"
           git tag ${{ steps.TAG_UTIL.outputs.githubTag }}
-          git push origin ${{ steps.TAG_UTIL.outputs.githubTag }}
+          # push tag to the preleases repository
+          git remote add prereleases https://github.com/containers/podman-desktop-prereleases
+          git push prereleases ${{ steps.TAG_UTIL.outputs.githubTag }}
+
       - name: Create Release
         id: create_release
         uses: ncipollo/release-action@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag: ${{ steps.TAG_UTIL.outputs.githubTag }}
           name: ${{ steps.TAG_UTIL.outputs.githubTag }}
           draft: true
           prerelease: true
+          owner: containers
+          repo: podman-desktop-prereleases
+          token: ${{ secrets.PODMAN_DESKTOP_BOT_TOKEN }}
 
   build:
     name: Build / ${{ matrix.os }}
@@ -85,6 +95,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          repository: containers/podman-desktop-prereleases
           ref: ${{ needs.tag.outputs.githubTag}}
 
       - uses: pnpm/action-setup@v4
@@ -140,6 +151,8 @@ jobs:
       - name: Run Build
         timeout-minutes: 40
         run: pnpm compile:next
+        env:
+          GITHUB_TOKEN: ${{ secrets.PODMAN_DESKTOP_BOT_TOKEN }}
 
   release:
     needs: [tag, build]
@@ -152,9 +165,11 @@ jobs:
       - name: Publish release
         uses: StuYarrow/publish-release@v1.1.2
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PODMAN_DESKTOP_BOT_TOKEN }}
         with:
           id: ${{ needs.tag.outputs.releaseId}}
+          repo: podman-desktop-prereleases
+          owner: containers
 
   publish:
     needs: [tag, release]


### PR DESCRIPTION
### What does this PR do?
move post-commit/prereleases to https://github.com/containers/podman-desktop-prereleases repository
only main releases (like 1.12.0, 1.12.1, 1.13, etc will be released on podman-desktop repository)


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/8659


### How to test this PR?

hard to manually test, need to like copy the workflow to your private fork, comment out lines using the token, use another repository where you have the rights

- [ ] Tests are covering the bug fix or the new feature
