### PR TITLE
chore: Updated light theme item color in onboarding

### DIFF
--- a/packages/renderer/src/lib/markdown/micromark-warnings-directive.ts
+++ b/packages/renderer/src/lib/markdown/micromark-warnings-directive.ts
@@ -79,7 +79,7 @@ export function warnings(this: CompileContext, d: any) {
   const items = JSON.parse(decode(d.label) ?? '');
   for (const item of items) {
     // start the div representing one row
-    this.tag('<div class="flex flex-row space-x-3 bg-charcoal-600 p-4 rounded-md items-start">');
+    this.tag('<div class="flex flex-row space-x-3 bg-[var(--pd-invert-content-card-bg)] p-4 rounded-md items-start">');
     // add icon representing the warning status
     this.tag('<div class="mr-2 flex justify-center">');
     this.tag(item.state === 'successful' ? '✅' : '❌');


### PR DESCRIPTION
### What does this PR do?
Changes color to reflect light theme in onboarding 

### Screenshot / video of UI
Prev:

![image](https://github.com/user-attachments/assets/78900f19-b49b-4fed-bf1a-685e693bac35)

Now:
Light:
![image](https://github.com/user-attachments/assets/8868d6e2-55d7-4328-ad57-cddb361f62ab)
Dark:
![image](https://github.com/user-attachments/assets/c27249c3-d4ab-4509-8cd0-0f87023688e9)


### What issues does this PR fix or reference?
Closes #8447 

### How to test this PR?
Create a VM and run the PD 
