### PR TITLE
fix: Fixed width of widget for inc/dec numbers

### DIFF
--- a/packages/ui/src/lib/inputs/Input.spec.ts
+++ b/packages/ui/src/lib/inputs/Input.spec.ts
@@ -53,7 +53,7 @@ test('Expect basic styling', async () => {
 
   const element = screen.getByPlaceholderText(value);
   expect(element).toBeInTheDocument();
-  expect(element).toHaveClass('grow');
+  expect(element).toHaveClass('w-full');
   expect(element).toHaveClass('px-0.5');
   expect(element).toHaveClass('outline-0');
   expect(element).toHaveClass('bg-[var(--pd-input-field-bg)]');
@@ -78,7 +78,7 @@ test('Expect basic readonly styling', async () => {
 
   const element = screen.getByPlaceholderText(value);
   expect(element).toBeInTheDocument();
-  expect(element).toHaveClass('grow');
+  expect(element).toHaveClass('w-full');
   expect(element).toHaveClass('px-0.5');
   expect(element).toHaveClass('outline-0');
   expect(element).toHaveClass('bg-[var(--pd-input-field-bg)]');
@@ -105,7 +105,7 @@ test('Expect basic disabled styling', async () => {
 
   const element = screen.getByPlaceholderText(value);
   expect(element).toBeInTheDocument();
-  expect(element).toHaveClass('grow');
+  expect(element).toHaveClass('w-full');
   expect(element).toHaveClass('px-0.5');
   expect(element).toHaveClass('outline-0');
   expect(element).toHaveClass('bg-[var(--pd-input-field-bg)]');

--- a/packages/ui/src/lib/inputs/Input.svelte
+++ b/packages/ui/src/lib/inputs/Input.svelte
@@ -54,7 +54,7 @@ async function onClear(): Promise<void> {
       bind:this={element}
       on:input
       on:keypress
-      class="grow px-0.5 outline-0 bg-[var(--pd-input-field-bg)] placeholder:text-[color:var(--pd-input-field-placeholder-text)] overflow-hidden {inputClass ??
+      class="w-full px-0.5 outline-0 bg-[var(--pd-input-field-bg)] placeholder:text-[color:var(--pd-input-field-placeholder-text)] overflow-hidden {inputClass ??
         ''}"
       class:text-[color:var(--pd-input-field-focused-text)]={!disabled}
       class:text-[color:var(--pd-input-field-disabled-text)]={disabled}


### PR DESCRIPTION
### What does this PR do?
Fixes width of the input element 

### Screenshot / video of UI
prev: 

![image](https://github.com/user-attachments/assets/f456d4ce-5683-4b7b-bfb6-92529416f360)

now:
![image](https://github.com/user-attachments/assets/db0e5269-a9eb-448f-8796-4d822c3224e2)

### What issues does this PR fix or reference?
Closes #8648 

### How to test this PR?
Go to settings->preferences

