### PR TITLE
feat: allow to set a zoom level

### DIFF
--- a/packages/main/src/application-menu-builder.ts
+++ b/packages/main/src/application-menu-builder.ts
@@ -16,28 +16,116 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { MenuItemConstructorOptions } from 'electron';
 import { Menu } from 'electron';
 import { aboutMenuItem } from 'electron-util/main';
 
+import type { ZoomLevelHandler } from './plugin/zoom-level-handler.js';
+
 export class ApplicationMenuBuilder {
+  #zoomLevelHandler: ZoomLevelHandler;
+
+  constructor(zoomLevelHandler: ZoomLevelHandler) {
+    this.#zoomLevelHandler = zoomLevelHandler;
+  }
+
   build(): Electron.Menu | undefined {
     const menu = Menu.getApplicationMenu(); // get default menu
     if (!menu) {
       return undefined;
     }
-    // Add help/about menu entry
-    menu.items.forEach(i => {
-      // add the About entry only in the help menu
-      if (i.role === 'help' && i.submenu) {
-        const aboutMenuSubItem = aboutMenuItem({});
-        aboutMenuSubItem.label = 'About';
 
-        // create new submenu
-        // also add a separator before the About entry
-        const newSubMenu = Menu.buildFromTemplate([...i.submenu.items, { type: 'separator' }, aboutMenuSubItem]);
-        i.submenu = newSubMenu;
-      }
-    });
-    return menu;
+    return Menu.buildFromTemplate(
+      menu.items.map(i => {
+        // add the About entry only in the help menu
+        if (i.role === 'help' && i.submenu) {
+          const aboutMenuSubItem = aboutMenuItem({});
+          aboutMenuSubItem.label = 'About';
+
+          // create new submenu
+          // also add a separator before the About entry
+          const newSubMenu = Menu.buildFromTemplate([...i.submenu.items, { type: 'separator' }, aboutMenuSubItem]);
+          return { ...i, submenu: newSubMenu };
+        } else if (i.role?.toLocaleLowerCase() === 'viewmenu' && i.submenu) {
+          // replace the Zoom In item by a new custom item
+          const newZoomInMenuItem: MenuItemConstructorOptions = {
+            label: 'Zoom In',
+            accelerator: 'CommandOrControl+Plus',
+            click: () => {
+              this.#zoomLevelHandler.zoomIn();
+            },
+          };
+          // hidden entry to register a shortcut
+          const newZoomInMenuItemAlt: MenuItemConstructorOptions = {
+            label: 'Zoom In alt',
+            visible: false,
+            accelerator: 'CommandOrControl+numadd',
+            click: () => {
+              this.#zoomLevelHandler.zoomIn();
+            },
+          };
+
+          // replace the Zoom Out item by a new custom item
+          const newZoomOutMenuItem: MenuItemConstructorOptions = {
+            label: 'Zoom Out',
+            accelerator: 'CommandOrControl+-',
+            click: () => {
+              this.#zoomLevelHandler.zoomOut();
+            },
+          };
+          // hidden entry to register a shortcut
+          const newZoomOutMenuItemAlt: MenuItemConstructorOptions = {
+            label: 'Zoom Out alt',
+            visible: false,
+            accelerator: 'CommandOrControl+numsub',
+            click: () => {
+              this.#zoomLevelHandler.zoomOut();
+            },
+          };
+
+          // replace the Actual item by a new custom item
+          const newZoomResetMenuItem: MenuItemConstructorOptions = {
+            label: 'Actual Size',
+            accelerator: 'CommandOrControl+0',
+            click: () => {
+              this.#zoomLevelHandler.resetZoom();
+            },
+          };
+          // hidden entry to register a shortcut
+          const newZoomOResetMenuItemAlt: MenuItemConstructorOptions = {
+            label: 'Actual Size alt',
+            visible: false,
+            accelerator: 'CommandOrControl+num0',
+            click: () => {
+              this.#zoomLevelHandler.resetZoom();
+            },
+          };
+
+          const items = Menu.buildFromTemplate([newZoomInMenuItemAlt, newZoomOutMenuItemAlt, newZoomOResetMenuItemAlt]);
+          for (const item of items.items) {
+            i.submenu.items.push(item);
+          }
+
+          // replace the "Zoom In" item stored inside the submenu by this one
+          const newSubMenu = Menu.buildFromTemplate(
+            i.submenu.items.map(item => {
+              if (item.label === 'Zoom In') {
+                return newZoomInMenuItem;
+              } else if (item.label === 'Zoom Out') {
+                return newZoomOutMenuItem;
+              } else if (item.label === 'Actual Size') {
+                return newZoomResetMenuItem;
+              } else {
+                return item;
+              }
+            }),
+          );
+
+          return { ...i, submenu: newSubMenu };
+        }
+
+        return i;
+      }),
+    );
   }
 }

--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -32,6 +32,7 @@ import { Emitter } from './plugin/events/emitter.js';
 import type { ExtensionLoader } from './plugin/extension-loader.js';
 import { PluginSystem } from './plugin/index.js';
 import { Deferred } from './plugin/util/deferred.js';
+import { ZoomLevelHandler } from './plugin/zoom-level-handler.js';
 import { StartupInstall } from './system/startup-install.js';
 import { WindowHandler } from './system/window/window-handler.js';
 import { AnimatedTray } from './tray-animate-icon.js';
@@ -250,8 +251,14 @@ app.whenReady().then(
         .then(browserWindow => {
           const windowHandler = new WindowHandler(configurationRegistry, browserWindow);
           windowHandler.init();
+
+          // Configure the zoom level handler
+          // handle zoom level
+          const zoomLevelHandler = new ZoomLevelHandler(browserWindow, configurationRegistry);
+          zoomLevelHandler.init();
+
           // sets the menu
-          const applicationMenuBuilder = new ApplicationMenuBuilder();
+          const applicationMenuBuilder = new ApplicationMenuBuilder(zoomLevelHandler);
           const menu = applicationMenuBuilder.build();
 
           if (menu) {

--- a/packages/main/src/plugin/appearance-init.spec.ts
+++ b/packages/main/src/plugin/appearance-init.spec.ts
@@ -114,3 +114,20 @@ test('Expect native theme to be set to system', async () => {
 
   expect(nativeTheme.themeSource).toEqual('system');
 });
+
+test('should register a configuration', async () => {
+  const appearanceInit = new AppearanceInit(configurationRegistry);
+  appearanceInit.init();
+
+  expect(configurationRegistry.registerConfigurations).toBeCalled();
+  const configurationNode = vi.mocked(configurationRegistry.registerConfigurations).mock.calls[0]?.[0][0];
+  expect(configurationNode?.id).toBe('preferences.appearance');
+  expect(configurationNode?.title).toBe('Appearance');
+  expect(configurationNode?.properties).toBeDefined();
+  expect(Object.keys(configurationNode?.properties ?? {}).length).toBe(2);
+  expect(configurationNode?.properties?.['preferences.zoomLevel']).toBeDefined();
+  expect(configurationNode?.properties?.['preferences.zoomLevel']?.markdownDescription).toBeDefined();
+  expect(configurationNode?.properties?.['preferences.zoomLevel']?.type).toBe('number');
+  expect(configurationNode?.properties?.['preferences.zoomLevel']?.default).toBe(0);
+  expect(configurationNode?.properties?.['preferences.zoomLevel']?.step).toBe(0.1);
+});

--- a/packages/main/src/plugin/appearance-init.ts
+++ b/packages/main/src/plugin/appearance-init.ts
@@ -38,6 +38,15 @@ export class AppearanceInit {
           enum: ['system', 'dark', 'light'],
           default: 'system',
         },
+        [`${AppearanceSettings.SectionName}.${AppearanceSettings.ZoomLevel}`]: {
+          markdownDescription:
+            'Select the zoom level. To **Zoom In**, set a positive value like `1` for a 20% zoom. To **Zoom Out**, use a negative value, like `-1`. Use decimals for more fine-grained zoom control.',
+          type: 'number',
+          minimum: -3,
+          maximum: 3,
+          default: 0,
+          step: 0.1,
+        },
       },
     };
 

--- a/packages/main/src/plugin/appearance-settings.ts
+++ b/packages/main/src/plugin/appearance-settings.ts
@@ -22,4 +22,5 @@ export enum AppearanceSettings {
   LightEnumValue = 'light',
   DarkEnumValue = 'dark',
   SystemEnumValue = 'system',
+  ZoomLevel = 'zoomLevel',
 }

--- a/packages/main/src/plugin/zoom-level-handler.spec.ts
+++ b/packages/main/src/plugin/zoom-level-handler.spec.ts
@@ -1,0 +1,245 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { afterEach } from 'node:test';
+
+import type { Configuration } from '@podman-desktop/api';
+import type { BrowserWindow } from 'electron';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { AppearanceSettings } from './appearance-settings.js';
+import type {
+  ConfigurationRegistry,
+  IConfigurationChangeEvent,
+  IConfigurationPropertyRecordedSchema,
+} from './configuration-registry.js';
+import { Emitter } from './events/emitter.js';
+import { ZoomLevelHandler } from './zoom-level-handler.js';
+
+let zoomLevelHandler: TestZoomLevelHandler;
+
+class TestZoomLevelHandler extends ZoomLevelHandler {
+  override saveValue(): void {
+    super.saveValue();
+  }
+}
+
+const registerConfigurationsMock = vi.fn();
+let _onDidChangeConfiguration: Emitter<IConfigurationChangeEvent>;
+
+const browserWindowMock = {
+  webContents: {},
+} as unknown as BrowserWindow;
+
+const setZoomLevelMock = vi.fn();
+const getZoomLevelMock = vi.fn();
+Object.defineProperty(browserWindowMock.webContents, 'zoomLevel', {
+  get: getZoomLevelMock,
+  set: setZoomLevelMock,
+});
+
+let configurationRegistryMock: ConfigurationRegistry;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  _onDidChangeConfiguration = new Emitter<IConfigurationChangeEvent>();
+  configurationRegistryMock = {
+    onDidChangeConfiguration: _onDidChangeConfiguration.event,
+    registerConfigurations: registerConfigurationsMock,
+    updateConfigurationValue: vi.fn().mockResolvedValue({}),
+    getConfigurationProperties: vi.fn().mockReturnValue({}),
+    getConfiguration: vi.fn().mockReturnValue({
+      get: vi.fn(),
+    }),
+  } as unknown as ConfigurationRegistry;
+  zoomLevelHandler = new TestZoomLevelHandler(browserWindowMock, configurationRegistryMock);
+});
+
+afterEach(() => {
+  _onDidChangeConfiguration.dispose();
+  zoomLevelHandler.dispose();
+});
+
+test('should set zoom selected level', async () => {
+  vi.mocked(configurationRegistryMock.getConfiguration).mockReturnValue({ get: () => 5 } as unknown as Configuration);
+
+  // register configuration
+  zoomLevelHandler.init();
+
+  // check we tried to set the zoom level to 5
+  expect(setZoomLevelMock).toBeCalledWith(5);
+});
+
+test('should set zoom selected if configuration change', async () => {
+  vi.mocked(configurationRegistryMock.getConfiguration).mockReturnValue({ get: () => 5 } as unknown as Configuration);
+
+  // register configuration
+  zoomLevelHandler.init();
+
+  // reset the call to set the zoom level
+  setZoomLevelMock.mockClear();
+
+  // throw a configuration but not with right key, nothing should happen
+  _onDidChangeConfiguration.fire({ key: 'dummy.key', value: 10, scope: 'DEFAULT' });
+  expect(setZoomLevelMock).not.toBeCalled();
+
+  // now, update the configuration and see if the zoom level is updated
+  _onDidChangeConfiguration.fire({
+    key: `${AppearanceSettings.SectionName}.${AppearanceSettings.ZoomLevel}`,
+    value: 10,
+    scope: 'DEFAULT',
+  });
+
+  // check we tried to set the zoom level to 10
+  expect(setZoomLevelMock).toBeCalledWith(10);
+});
+
+test('should zoom in and save config', async () => {
+  vi.mocked(configurationRegistryMock.getConfiguration).mockReturnValue({ get: () => 5 } as unknown as Configuration);
+  vi.spyOn(zoomLevelHandler, 'saveValue').mockReturnValue();
+
+  // init
+  zoomLevelHandler.init();
+
+  setZoomLevelMock.mockClear();
+
+  getZoomLevelMock.mockReturnValue(0);
+
+  // call zoom in
+  zoomLevelHandler.zoomIn();
+
+  // increment of 0.5 by default
+  expect(setZoomLevelMock).toBeCalledWith(0.5);
+
+  // expect we save the value once it's done
+  expect(zoomLevelHandler.saveValue).toBeCalled();
+});
+
+test('should zoom in with custom step', async () => {
+  vi.mocked(configurationRegistryMock.getConfiguration).mockReturnValue({ get: () => 5 } as unknown as Configuration);
+
+  vi.mocked(configurationRegistryMock.getConfigurationProperties).mockClear();
+  vi.mocked(configurationRegistryMock.getConfigurationProperties).mockReturnValue({
+    [`${AppearanceSettings.SectionName}.${AppearanceSettings.ZoomLevel}`]: {
+      step: 1,
+    } as unknown as IConfigurationPropertyRecordedSchema,
+  });
+
+  // init
+  zoomLevelHandler.init();
+
+  setZoomLevelMock.mockClear();
+
+  getZoomLevelMock.mockReturnValue(0);
+
+  // call zoom in
+  zoomLevelHandler.zoomIn();
+
+  // increment of 10 and not default 0.5
+  expect(setZoomLevelMock).toBeCalledWith(1);
+
+  // expect we save the value once it's done
+  expect(vi.mocked(configurationRegistryMock.updateConfigurationValue)).toBeCalledWith(
+    `${AppearanceSettings.SectionName}.${AppearanceSettings.ZoomLevel}`,
+    expect.any(Number),
+  );
+});
+
+test('should zoom out and save config', async () => {
+  vi.mocked(configurationRegistryMock.getConfiguration).mockReturnValue({ get: () => 5 } as unknown as Configuration);
+  vi.spyOn(zoomLevelHandler, 'saveValue').mockReturnValue();
+
+  // init
+  zoomLevelHandler.init();
+
+  setZoomLevelMock.mockClear();
+
+  getZoomLevelMock.mockReturnValue(0);
+
+  // call zoom in
+  zoomLevelHandler.zoomOut();
+
+  // decrement of 0.5 by default
+  expect(setZoomLevelMock).toBeCalledWith(-0.5);
+
+  // expect we save the value once it's done
+  expect(zoomLevelHandler.saveValue).toBeCalled();
+});
+
+test('should zoom reset and save config', async () => {
+  vi.mocked(configurationRegistryMock.getConfiguration).mockReturnValue({ get: () => 5 } as unknown as Configuration);
+  vi.spyOn(zoomLevelHandler, 'saveValue').mockReturnValue();
+
+  // init
+  zoomLevelHandler.init();
+
+  setZoomLevelMock.mockClear();
+
+  getZoomLevelMock.mockReturnValue(0);
+
+  // call zoom in
+  zoomLevelHandler.resetZoom();
+
+  // decrement of 0.5 by default
+  expect(setZoomLevelMock).toBeCalledWith(0);
+
+  // expect we save the value once it's done
+  expect(zoomLevelHandler.saveValue).toBeCalled();
+});
+
+test('should not zoom if > maximum', async () => {
+  vi.mocked(configurationRegistryMock.getConfiguration).mockReturnValue({ get: () => 5 } as unknown as Configuration);
+  vi.mocked(configurationRegistryMock.getConfigurationProperties).mockClear();
+  vi.mocked(configurationRegistryMock.getConfigurationProperties).mockReturnValue({
+    [`${AppearanceSettings.SectionName}.${AppearanceSettings.ZoomLevel}`]: {
+      step: 10,
+    } as unknown as IConfigurationPropertyRecordedSchema,
+  });
+
+  // init
+  zoomLevelHandler.init();
+  setZoomLevelMock.mockClear();
+  getZoomLevelMock.mockReturnValue(0);
+
+  // call zoom in
+  zoomLevelHandler.zoomIn();
+
+  // increment of 10 but no call to set the zoom level as it's outside of the range
+  expect(setZoomLevelMock).not.toBeCalled();
+});
+
+test('should not zoom if < minimum', async () => {
+  vi.mocked(configurationRegistryMock.getConfiguration).mockReturnValue({ get: () => 5 } as unknown as Configuration);
+  vi.mocked(configurationRegistryMock.getConfigurationProperties).mockClear();
+  vi.mocked(configurationRegistryMock.getConfigurationProperties).mockReturnValue({
+    [`${AppearanceSettings.SectionName}.${AppearanceSettings.ZoomLevel}`]: {
+      step: 10,
+    } as unknown as IConfigurationPropertyRecordedSchema,
+  });
+
+  // init
+  zoomLevelHandler.init();
+  setZoomLevelMock.mockClear();
+  getZoomLevelMock.mockReturnValue(0);
+
+  // call zoom out
+  zoomLevelHandler.zoomOut();
+
+  // decrement of 10 but no call to set the zoom level as it's outside of the range
+  expect(setZoomLevelMock).not.toBeCalled();
+});

--- a/packages/main/src/plugin/zoom-level-handler.ts
+++ b/packages/main/src/plugin/zoom-level-handler.ts
@@ -1,0 +1,121 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { BrowserWindow } from 'electron';
+
+import { AppearanceSettings } from './appearance-settings.js';
+import type { ConfigurationRegistry } from './configuration-registry.js';
+import type { IDisposable } from './types/disposable.js';
+
+export class ZoomLevelHandler {
+  #browserWindow: BrowserWindow;
+  #configurationRegistry: ConfigurationRegistry;
+  #disposable: IDisposable | undefined;
+  #stepValue = 0.5;
+  #maximumZoomLevel = 3;
+  #minimumZoomLevel = -3;
+
+  constructor(browserWindow: BrowserWindow, configurationRegistry: ConfigurationRegistry) {
+    this.#browserWindow = browserWindow;
+    this.#configurationRegistry = configurationRegistry;
+  }
+
+  init(): void {
+    // restore the zoom level from the configuration
+    const configuration = this.#configurationRegistry.getConfiguration(AppearanceSettings.SectionName);
+
+    // zoom level is a number, so we need to cast it to a number
+    const zoomLevel = configuration.get<number>(AppearanceSettings.ZoomLevel, 0);
+
+    this.#browserWindow.webContents.zoomLevel = zoomLevel;
+
+    // now subscribe to the zoom level changes
+    this.#disposable = this.#configurationRegistry.onDidChangeConfiguration(e => {
+      if (e.key === `${AppearanceSettings.SectionName}.${AppearanceSettings.ZoomLevel}`) {
+        const val = e.value as number;
+        this.#browserWindow.webContents.zoomLevel = val;
+      }
+    });
+
+    // grab the current step to increase/decrease the zoom level
+    const allProperties = this.#configurationRegistry.getConfigurationProperties();
+    const record = allProperties[`${AppearanceSettings.SectionName}.${AppearanceSettings.ZoomLevel}`];
+    if (record?.step) {
+      this.#stepValue = record.step;
+    }
+    if (record?.maximum) {
+      this.#maximumZoomLevel = Number(record.maximum);
+    }
+    if (record?.minimum) {
+      this.#minimumZoomLevel = Number(record.minimum);
+    }
+  }
+
+  // save the value of the current zoom level into the configuration
+  saveValue(): void {
+    this.#configurationRegistry
+      .updateConfigurationValue(
+        `${AppearanceSettings.SectionName}.${AppearanceSettings.ZoomLevel}`,
+        this.#browserWindow.webContents.zoomLevel,
+      )
+      .catch((error: unknown) => {
+        console.error('Error saving zoom level', error);
+      });
+  }
+
+  zoomIn(): void {
+    // can't zoom more than the maximum zoom level
+    const newZoomLevel = this.precision(this.#browserWindow.webContents.zoomLevel, this.#stepValue);
+
+    if (newZoomLevel > this.#maximumZoomLevel) {
+      return;
+    }
+    this.#browserWindow.webContents.zoomLevel = newZoomLevel;
+    this.saveValue();
+  }
+
+  zoomOut(): void {
+    // can't zoom less than the minimum zoom level
+    const newZoomLevel = this.precision(this.#browserWindow.webContents.zoomLevel, -this.#stepValue);
+    if (newZoomLevel < this.#minimumZoomLevel) {
+      return;
+    }
+    this.#browserWindow.webContents.zoomLevel = newZoomLevel;
+
+    this.saveValue();
+  }
+
+  resetZoom(): void {
+    this.#browserWindow.webContents.zoomLevel = 0;
+    this.saveValue();
+  }
+
+  dispose(): void {
+    this.#disposable?.dispose();
+  }
+
+  precision(value: number, incrementOrDecrement: number): number {
+    const valuePrecisionDigits = value.toString().split('.')[1]?.length ?? 0;
+    const stepPrecisionDigits = incrementOrDecrement.toString().split('.')[1]?.length ?? 0;
+    // take the maximum of the two
+    const precisionDigits = Math.max(valuePrecisionDigits, stepPrecisionDigits);
+
+    // if incrementOrDecrement is negative, it will decrement
+    return Number((Number(value) + incrementOrDecrement).toFixed(precisionDigits));
+  }
+}


### PR DESCRIPTION
### What does this PR do?
user can define a zoom to get bigger fonts/UI elements inside Podman Desktop

### Screenshot / video of UI


https://github.com/user-attachments/assets/4b0ef3e0-5a36-4219-aff2-e28ada06f8ec


### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/8640
fixes https://github.com/containers/podman-desktop/issues/1660


### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
