### PR TITLE
feat: revamp Kubernetes menu

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -67,6 +67,8 @@ import Webview from './lib/webview/Webview.svelte';
 import WelcomePage from './lib/welcome/WelcomePage.svelte';
 import PreferencesNavigation from './PreferencesNavigation.svelte';
 import Route from './Route.svelte';
+import { navigationRegistry } from './stores/navigation/navigation-registry';
+import SubmenuNavigation from './SubmenuNavigation.svelte';
 
 router.mode.memory();
 
@@ -110,6 +112,11 @@ window.events?.receive('navigate', (navigationRequest: unknown) => {
       {#if meta.url.startsWith('/preferences')}
         <PreferencesNavigation meta={meta} />
       {/if}
+      {#each $navigationRegistry.filter(item => item.type === 'submenu') as navigationRegistryItem}
+        {#if meta.url.startsWith(navigationRegistryItem.link)}
+          <SubmenuNavigation meta={meta} title={navigationRegistryItem.tooltip} items={navigationRegistryItem.items} />
+        {/if}
+      {/each}
 
       <div
         class="flex flex-col w-full h-full overflow-hidden"
@@ -217,63 +224,71 @@ window.events?.receive('navigate', (navigationRequest: unknown) => {
         <Route path="/volumes/:name/:engineId/*" breadcrumb="Volume Details" let:meta navigationHint="details">
           <VolumeDetails volumeName={decodeURI(meta.params.name)} engineId={decodeURI(meta.params.engineId)} />
         </Route>
-        <Route path="/nodes" breadcrumb="Nodes" navigationHint="root">
+        <Route path="/kubernetes/nodes" breadcrumb="Nodes" navigationHint="root">
           <NodesList />
         </Route>
-        <Route path="/nodes/:name/*" breadcrumb="Node Details" let:meta navigationHint="details">
+        <Route path="/kubernetes/nodes/:name/*" breadcrumb="Node Details" let:meta navigationHint="details">
           <NodeDetails name={decodeURI(meta.params.name)} />
         </Route>
-        <Route path="/persistentvolumeclaims" breadcrumb="Persistent Volume Claims" navigationHint="root">
+        <Route path="/kubernetes/persistentvolumeclaims" breadcrumb="Persistent Volume Claims" navigationHint="root">
           <PVCList />
         </Route>
         <Route
-          path="/persistentvolumeclaims/:name/:namespace/*"
+          path="/kubernetes/persistentvolumeclaims/:name/:namespace/*"
           breadcrumb="Persistent Volume Claim Details"
           let:meta
           navigationHint="details">
           <PVCDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
         </Route>
-        <Route path="/deployments" breadcrumb="Deployments" navigationHint="root">
+        <Route path="/kubernetes/deployments" breadcrumb="Deployments" navigationHint="root">
           <DeploymentsList />
         </Route>
-        <Route path="/deployments/:name/:namespace/*" breadcrumb="Deployment Details" let:meta navigationHint="details">
+        <Route
+          path="/kubernetes/deployments/:name/:namespace/*"
+          breadcrumb="Deployment Details"
+          let:meta
+          navigationHint="details">
           <DeploymentDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
         </Route>
-        <Route path="/services" breadcrumb="Services" navigationHint="root">
+        <Route path="/kubernetes/services" breadcrumb="Services" navigationHint="root">
           <ServicesList />
         </Route>
-        <Route path="/services/:name/:namespace/*" breadcrumb="Service Details" let:meta navigationHint="details">
+        <Route
+          path="/kubernetes/services/:name/:namespace/*"
+          breadcrumb="Service Details"
+          let:meta
+          navigationHint="details">
           <ServiceDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
         </Route>
-        <Route path="/ingressesRoutes" breadcrumb="Ingresses & Routes" navigationHint="root">
+        <Route path="/kubernetes/ingressesRoutes" breadcrumb="Ingresses & Routes" navigationHint="root">
           <IngressesRoutesList />
         </Route>
         <Route
-          path="/ingressesRoutes/ingress/:name/:namespace/*"
+          path="/kubernetes/ingressesRoutes/ingress/:name/:namespace/*"
           breadcrumb="Ingress Details"
           let:meta
           navigationHint="details">
           <IngressDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
         </Route>
-        <Route path="/configmapsSecrets" breadcrumb="ConfigMaps & Secrets" navigationHint="root">
+        <Route path="/kubernetes/configmapsSecrets" breadcrumb="ConfigMaps & Secrets" navigationHint="root">
           <ConfigMapSecretList />
         </Route>
         <Route
-          path="/configmapsSecrets/configmap/:name/:namespace/*"
+          path="/kubernetes/configmapsSecrets/configmap/:name/:namespace/*"
           breadcrumb="ConfigMap Details"
           let:meta
           navigationHint="details">
           <ConfigMapDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
         </Route>
         <Route
-          path="/configmapsSecrets/secret/:name/:namespace/*"
+          path="/kubernetes/configmapsSecrets/secret/:name/:namespace/*"
           breadcrumb="Secret Details"
           let:meta
           navigationHint="details">
           <SecretDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
         </Route>
         <Route
-          path="/ingressesRoutes/route/:name/:namespace/*"
+          path="/kubernetes/ingressesRoutes/route/:name/:namespace/*"
           breadcrumb="Route Details"
           let:meta
           navigationHint="details">

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -113,7 +113,7 @@ window.events?.receive('navigate', (navigationRequest: unknown) => {
         <PreferencesNavigation meta={meta} />
       {/if}
       {#each $navigationRegistry.filter(item => item.type === 'submenu') as navigationRegistryItem}
-        {#if meta.url.startsWith(navigationRegistryItem.link)}
+        {#if meta.url.startsWith(navigationRegistryItem.link) && !meta.query['fullscreen']}
           <SubmenuNavigation meta={meta} title={navigationRegistryItem.tooltip} items={navigationRegistryItem.items} />
         {/if}
       {/each}
@@ -224,6 +224,7 @@ window.events?.receive('navigate', (navigationRequest: unknown) => {
         <Route path="/volumes/:name/:engineId/*" breadcrumb="Volume Details" let:meta navigationHint="details">
           <VolumeDetails volumeName={decodeURI(meta.params.name)} engineId={decodeURI(meta.params.engineId)} />
         </Route>
+        <Route path="/kubernetes">TODO: Kubernetes Welcome</Route>
         <Route path="/kubernetes/nodes" breadcrumb="Nodes" navigationHint="root">
           <NodesList />
         </Route>

--- a/packages/renderer/src/AppNavigation.spec.ts
+++ b/packages/renderer/src/AppNavigation.spec.ts
@@ -83,10 +83,12 @@ test('Test rendering of the navigation bar with empty items', async () => {
   const settings = screen.getByRole('link', { name: 'Settings' });
   expect(settings).toBeInTheDocument();
 
+  const kubernetes = screen.queryByRole('link', { name: 'Kubernetes' });
+  expect(kubernetes).toBeInTheDocument();
   const deployments = screen.queryByRole('link', { name: 'Deployments' });
-  expect(deployments).not.toBeInTheDocument();
+  expect(deployments).toBeInTheDocument();
   const services = screen.queryByRole('link', { name: 'Services' });
-  expect(services).not.toBeInTheDocument();
+  expect(services).toBeInTheDocument();
 });
 
 test('Test contributions', () => {

--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -75,6 +75,12 @@ function clickSettings(b: boolean) {
       {/each}
     {:else if navigationRegistryItem.type === 'entry'}
       <NavRegistryEntry entry={navigationRegistryItem} bind:meta={meta} />
+    {:else if navigationRegistryItem.type === 'submenu'}
+      {@const item = {
+        ...navigationRegistryItem,
+        link: navigationRegistryItem.items?.[0]?.link ?? navigationRegistryItem.link,
+      }}
+      <NavRegistryEntry entry={item} bind:meta={meta} />
     {/if}
   {/each}
 

--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -76,11 +76,7 @@ function clickSettings(b: boolean) {
     {:else if navigationRegistryItem.type === 'entry'}
       <NavRegistryEntry entry={navigationRegistryItem} bind:meta={meta} />
     {:else if navigationRegistryItem.type === 'submenu'}
-      {@const item = {
-        ...navigationRegistryItem,
-        link: navigationRegistryItem.items?.[0]?.link ?? navigationRegistryItem.link,
-      }}
-      <NavRegistryEntry entry={item} bind:meta={meta} />
+      <NavRegistryEntry entry={navigationRegistryItem} bind:meta={meta} />
     {/if}
   {/each}
 

--- a/packages/renderer/src/SubmenuNavigation.svelte
+++ b/packages/renderer/src/SubmenuNavigation.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+import { SettingsNavItem } from '@podman-desktop/ui-svelte';
+import type { TinroRouteMeta } from 'tinro';
+
+import type { NavigationRegistryEntry } from './stores/navigation/navigation-registry';
+
+export let title: string;
+export let items: NavigationRegistryEntry[] | undefined;
+export let meta: TinroRouteMeta;
+</script>
+
+<nav
+  class="z-1 w-leftsidebar min-w-leftsidebar flex-col justify-between flex transition-all duration-500 ease-in-out bg-[var(--pd-secondary-nav-bg)] border-[var(--pd-global-nav-bg-border)] border-r-[1px]"
+  aria-label="PreferencesNavigation">
+  <div class="flex items-center">
+    <div class="pt-4 px-3 mb-10">
+      <p
+        class="text-2xl font-semibold text-[color:var(--pd-secondary-nav-header-text)] border-l-[4px] border-transparent">
+        {title}
+      </p>
+    </div>
+  </div>
+  <div class="h-full overflow-hidden hover:overflow-y-auto" style="margin-bottom:auto">
+    {#each items ?? [] as item}
+      <SettingsNavItem title={item.tooltip} href={item.link} selected={meta.url.startsWith(item.link)}
+      ></SettingsNavItem>
+    {/each}
+  </div>
+</nav>

--- a/packages/renderer/src/lib/configmaps-secrets/ConfigMapDetails.svelte
+++ b/packages/renderer/src/lib/configmaps-secrets/ConfigMapDetails.svelte
@@ -2,9 +2,10 @@
 import type { V1ConfigMap } from '@kubernetes/client-node';
 import { StatusIcon, Tab } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
-import { router } from 'tinro';
+import { meta, router } from 'tinro';
 import { stringify } from 'yaml';
 
+import { withFullscreenParam } from '/@/navigation';
 import { kubernetesCurrentContextConfigMaps } from '/@/stores/kubernetes-contexts-state';
 
 import Route from '../../Route.svelte';
@@ -26,6 +27,8 @@ let configMap: ConfigMapSecretUI;
 let detailsPage: DetailsPage;
 let kubeConfigMap: V1ConfigMap | undefined;
 let kubeError: string;
+
+let query = meta().query;
 
 onMount(() => {
   const configMapUtils = new ConfigMapSecretUtils();
@@ -68,9 +71,18 @@ async function loadDetails() {
       <StateChange state={configMap.status} />
     </div>
     <svelte:fragment slot="tabs">
-      <Tab title="Summary" selected={isTabSelected($router.path, 'summary')} url={getTabUrl($router.path, 'summary')} />
-      <Tab title="Inspect" selected={isTabSelected($router.path, 'inspect')} url={getTabUrl($router.path, 'inspect')} />
-      <Tab title="Kube" selected={isTabSelected($router.path, 'kube')} url={getTabUrl($router.path, 'kube')} />
+      <Tab
+        title="Summary"
+        selected={isTabSelected($router.path, 'summary')}
+        url={withFullscreenParam(getTabUrl($router.path, 'summary'), !!query['fullscreen'])} />
+      <Tab
+        title="Inspect"
+        selected={isTabSelected($router.path, 'inspect')}
+        url={withFullscreenParam(getTabUrl($router.path, 'inspect'), !!query['fullscreen'])} />
+      <Tab
+        title="Kube"
+        selected={isTabSelected($router.path, 'kube')}
+        url={withFullscreenParam(getTabUrl($router.path, 'kube'), !!query['fullscreen'])} />
     </svelte:fragment>
     <svelte:fragment slot="content">
       <Route path="/summary" breadcrumb="Summary" navigationHint="tab">

--- a/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretColumnName.spec.ts
+++ b/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretColumnName.spec.ts
@@ -63,7 +63,7 @@ test('Configmap: Expect clicking works', async () => {
 
   fireEvent.click(text);
 
-  expect(routerGotoSpy).toBeCalledWith('/configmapsSecrets/configmap/my-configmap/default/summary');
+  expect(routerGotoSpy).toBeCalledWith('/kubernetes/configmapsSecrets/configmap/my-configmap/default/summary');
 });
 
 test('Secret: Expect clicking works', async () => {
@@ -77,7 +77,7 @@ test('Secret: Expect clicking works', async () => {
 
   fireEvent.click(text);
 
-  expect(routerGotoSpy).toBeCalledWith('/configmapsSecrets/secret/my-secret/default/summary');
+  expect(routerGotoSpy).toBeCalledWith('/kubernetes/configmapsSecrets/secret/my-secret/default/summary');
 });
 
 test('Expect namespace in column', async () => {

--- a/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretColumnName.svelte
+++ b/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretColumnName.svelte
@@ -9,11 +9,15 @@ export let object: ConfigMapSecretUI;
 function openDetails() {
   const configmapSecretUtils = new ConfigMapSecretUtils();
   if (configmapSecretUtils.isSecret(object)) {
-    router.goto(`/configmapsSecrets/secret/${encodeURI(object.name)}/${encodeURI(object.namespace)}/summary`);
+    router.goto(
+      `/kubernetes/configmapsSecrets/secret/${encodeURI(object.name)}/${encodeURI(object.namespace)}/summary`,
+    );
   }
 
   if (configmapSecretUtils.isConfigMap(object)) {
-    router.goto(`/configmapsSecrets/configmap/${encodeURI(object.name)}/${encodeURI(object.namespace)}/summary`);
+    router.goto(
+      `/kubernetes/configmapsSecrets/configmap/${encodeURI(object.name)}/${encodeURI(object.namespace)}/summary`,
+    );
   }
 }
 </script>

--- a/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretColumnName.svelte
+++ b/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretColumnName.svelte
@@ -1,22 +1,32 @@
 <script lang="ts">
-import { router } from 'tinro';
+import { meta, router } from 'tinro';
+
+import { withFullscreenParam } from '/@/navigation';
 
 import { ConfigMapSecretUtils } from './configmap-secret-utils';
 import type { ConfigMapSecretUI } from './ConfigMapSecretUI';
 
 export let object: ConfigMapSecretUI;
 
+const query = meta().query;
+
 function openDetails() {
   const configmapSecretUtils = new ConfigMapSecretUtils();
   if (configmapSecretUtils.isSecret(object)) {
     router.goto(
-      `/kubernetes/configmapsSecrets/secret/${encodeURI(object.name)}/${encodeURI(object.namespace)}/summary`,
+      withFullscreenParam(
+        `/kubernetes/configmapsSecrets/secret/${encodeURI(object.name)}/${encodeURI(object.namespace)}/summary`,
+        !!query['fullscreen'],
+      ),
     );
   }
 
   if (configmapSecretUtils.isConfigMap(object)) {
     router.goto(
-      `/kubernetes/configmapsSecrets/configmap/${encodeURI(object.name)}/${encodeURI(object.namespace)}/summary`,
+      withFullscreenParam(
+        `/kubernetes/configmapsSecrets/configmap/${encodeURI(object.name)}/${encodeURI(object.namespace)}/summary`,
+        !!query['fullscreen'],
+      ),
     );
   }
 }

--- a/packages/renderer/src/lib/configmaps-secrets/SecretDetails.svelte
+++ b/packages/renderer/src/lib/configmaps-secrets/SecretDetails.svelte
@@ -2,9 +2,10 @@
 import type { V1Secret } from '@kubernetes/client-node';
 import { StatusIcon, Tab } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
-import { router } from 'tinro';
+import { meta, router } from 'tinro';
 import { stringify } from 'yaml';
 
+import { withFullscreenParam } from '/@/navigation';
 import { kubernetesCurrentContextSecrets } from '/@/stores/kubernetes-contexts-state';
 
 import Route from '../../Route.svelte';
@@ -26,6 +27,8 @@ let secret: ConfigMapSecretUI;
 let detailsPage: DetailsPage;
 let kubeSecret: V1Secret | undefined;
 let kubeError: string;
+
+let query = meta().query;
 
 onMount(() => {
   const secretUtils = new ConfigMapSecretUtils();
@@ -68,9 +71,18 @@ async function loadDetails() {
       <StateChange state={secret.status} />
     </div>
     <svelte:fragment slot="tabs">
-      <Tab title="Summary" selected={isTabSelected($router.path, 'summary')} url={getTabUrl($router.path, 'summary')} />
-      <Tab title="Inspect" selected={isTabSelected($router.path, 'inspect')} url={getTabUrl($router.path, 'inspect')} />
-      <Tab title="Kube" selected={isTabSelected($router.path, 'kube')} url={getTabUrl($router.path, 'kube')} />
+      <Tab
+        title="Summary"
+        selected={isTabSelected($router.path, 'summary')}
+        url={withFullscreenParam(getTabUrl($router.path, 'summary'), !!query['fullscreen'])} />
+      <Tab
+        title="Inspect"
+        selected={isTabSelected($router.path, 'inspect')}
+        url={withFullscreenParam(getTabUrl($router.path, 'inspect'), !!query['fullscreen'])} />
+      <Tab
+        title="Kube"
+        selected={isTabSelected($router.path, 'kube')}
+        url={withFullscreenParam(getTabUrl($router.path, 'kube'), !!query['fullscreen'])} />
     </svelte:fragment>
     <svelte:fragment slot="content">
       <Route path="/summary" breadcrumb="Summary" navigationHint="tab">

--- a/packages/renderer/src/lib/deployments/DeploymentColumnName.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnName.spec.ts
@@ -54,7 +54,7 @@ test('Expect clicking works', async () => {
 
   fireEvent.click(text);
 
-  expect(routerGotoSpy).toBeCalledWith('/deployments/my-deployment/default/summary');
+  expect(routerGotoSpy).toBeCalledWith('/kubernetes/deployments/my-deployment/default/summary');
 });
 
 test('Expect to show namespace in column', async () => {

--- a/packages/renderer/src/lib/deployments/DeploymentColumnName.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnName.svelte
@@ -6,7 +6,7 @@ import type { DeploymentUI } from './DeploymentUI';
 export let object: DeploymentUI;
 
 function openDetails() {
-  router.goto(`/deployments/${encodeURI(object.name)}/${encodeURI(object.namespace)}/summary`);
+  router.goto(`/kubernetes/deployments/${encodeURI(object.name)}/${encodeURI(object.namespace)}/summary`);
 }
 </script>
 

--- a/packages/renderer/src/lib/deployments/DeploymentColumnName.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnName.svelte
@@ -1,12 +1,21 @@
 <script lang="ts">
-import { router } from 'tinro';
+import { meta, router } from 'tinro';
+
+import { withFullscreenParam } from '/@/navigation';
 
 import type { DeploymentUI } from './DeploymentUI';
 
 export let object: DeploymentUI;
 
+const query = meta().query;
+
 function openDetails() {
-  router.goto(`/kubernetes/deployments/${encodeURI(object.name)}/${encodeURI(object.namespace)}/summary`);
+  router.goto(
+    withFullscreenParam(
+      `/kubernetes/deployments/${encodeURI(object.name)}/${encodeURI(object.namespace)}/summary`,
+      !!query['fullscreen'],
+    ),
+  );
 }
 </script>
 

--- a/packages/renderer/src/lib/deployments/DeploymentDetails.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentDetails.svelte
@@ -2,9 +2,10 @@
 import type { V1Deployment } from '@kubernetes/client-node';
 import { StatusIcon, Tab } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
-import { router } from 'tinro';
+import { meta, router } from 'tinro';
 import { stringify } from 'yaml';
 
+import { withFullscreenParam } from '/@/navigation';
 import { kubernetesCurrentContextDeployments } from '/@/stores/kubernetes-contexts-state';
 
 import Route from '../../Route.svelte';
@@ -25,6 +26,8 @@ let deployment: DeploymentUI;
 let detailsPage: DetailsPage;
 let kubeDeployment: V1Deployment | undefined;
 let kubeError: string;
+
+let query = meta().query;
 
 onMount(() => {
   const deploymentUtils = new DeploymentUtils();
@@ -64,9 +67,18 @@ async function loadDetails() {
       <DeploymentActions deployment={deployment} detailed={true} on:update={() => (deployment = deployment)} />
     </svelte:fragment>
     <svelte:fragment slot="tabs">
-      <Tab title="Summary" selected={isTabSelected($router.path, 'summary')} url={getTabUrl($router.path, 'summary')} />
-      <Tab title="Inspect" selected={isTabSelected($router.path, 'inspect')} url={getTabUrl($router.path, 'inspect')} />
-      <Tab title="Kube" selected={isTabSelected($router.path, 'kube')} url={getTabUrl($router.path, 'kube')} />
+      <Tab
+        title="Summary"
+        selected={isTabSelected($router.path, 'summary')}
+        url={withFullscreenParam(getTabUrl($router.path, 'summary'), !!query['fullscreen'])} />
+      <Tab
+        title="Inspect"
+        selected={isTabSelected($router.path, 'inspect')}
+        url={withFullscreenParam(getTabUrl($router.path, 'inspect'), !!query['fullscreen'])} />
+      <Tab
+        title="Kube"
+        selected={isTabSelected($router.path, 'kube')}
+        url={withFullscreenParam(getTabUrl($router.path, 'kube'), !!query['fullscreen'])} />
     </svelte:fragment>
     <svelte:fragment slot="content">
       <Route path="/summary" breadcrumb="Summary" navigationHint="tab">

--- a/packages/renderer/src/lib/ingresses-routes/IngressDetails.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressDetails.svelte
@@ -2,9 +2,10 @@
 import type { V1Ingress } from '@kubernetes/client-node';
 import { StatusIcon, Tab } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
-import { router } from 'tinro';
+import { meta, router } from 'tinro';
 import { stringify } from 'yaml';
 
+import { withFullscreenParam } from '/@/navigation';
 import { kubernetesCurrentContextIngresses } from '/@/stores/kubernetes-contexts-state';
 
 import Route from '../../Route.svelte';
@@ -26,6 +27,8 @@ let ingressUI: IngressUI;
 let detailsPage: DetailsPage;
 let kubeService: V1Ingress | undefined;
 let kubeError: string;
+
+let query = meta().query;
 
 onMount(() => {
   const ingressRouteUtils = new IngressRouteUtils();
@@ -66,9 +69,18 @@ async function loadIngressDetails() {
       <StateChange state={ingressUI.status} />
     </div>
     <svelte:fragment slot="tabs">
-      <Tab title="Summary" selected={isTabSelected($router.path, 'summary')} url={getTabUrl($router.path, 'summary')} />
-      <Tab title="Inspect" selected={isTabSelected($router.path, 'inspect')} url={getTabUrl($router.path, 'inspect')} />
-      <Tab title="Kube" selected={isTabSelected($router.path, 'kube')} url={getTabUrl($router.path, 'kube')} />
+      <Tab
+        title="Summary"
+        selected={isTabSelected($router.path, 'summary')}
+        url={withFullscreenParam(getTabUrl($router.path, 'summary'), !!query['fullscreen'])} />
+      <Tab
+        title="Inspect"
+        selected={isTabSelected($router.path, 'inspect')}
+        url={withFullscreenParam(getTabUrl($router.path, 'inspect'), !!query['fullscreen'])} />
+      <Tab
+        title="Kube"
+        selected={isTabSelected($router.path, 'kube')}
+        url={withFullscreenParam(getTabUrl($router.path, 'kube'), !!query['fullscreen'])} />
     </svelte:fragment>
     <svelte:fragment slot="content">
       <Route path="/summary" breadcrumb="Summary" navigationHint="tab">

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnName.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnName.spec.ts
@@ -66,7 +66,7 @@ test('Expect clicking on Ingress works', async () => {
 
   fireEvent.click(text);
 
-  expect(routerGotoSpy).toBeCalledWith('/ingressesRoutes/ingress/my-ingress/test-namespace/summary');
+  expect(routerGotoSpy).toBeCalledWith('/kubernetes/ingressesRoutes/ingress/my-ingress/test-namespace/summary');
 });
 
 test('Expect simple column styling with Route', async () => {
@@ -88,7 +88,7 @@ test('Expect clicking on Route works', async () => {
 
   fireEvent.click(text);
 
-  expect(routerGotoSpy).toBeCalledWith('/ingressesRoutes/route/my-route/test-namespace/summary');
+  expect(routerGotoSpy).toBeCalledWith('/kubernetes/ingressesRoutes/route/my-route/test-namespace/summary');
 });
 
 test('Expect to show namespace in column', async () => {

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnName.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnName.svelte
@@ -10,9 +10,9 @@ export let object: IngressUI | RouteUI;
 function openDetails() {
   const ingressRouteUtils = new IngressRouteUtils();
   if (ingressRouteUtils.isIngress(object)) {
-    router.goto(`/ingressesRoutes/ingress/${encodeURI(object.name)}/${encodeURI(object.namespace)}/summary`);
+    router.goto(`/kubernetes/ingressesRoutes/ingress/${encodeURI(object.name)}/${encodeURI(object.namespace)}/summary`);
   } else {
-    router.goto(`/ingressesRoutes/route/${encodeURI(object.name)}/${encodeURI(object.namespace)}/summary`);
+    router.goto(`/kubernetes/ingressesRoutes/route/${encodeURI(object.name)}/${encodeURI(object.namespace)}/summary`);
   }
 }
 </script>

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnName.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnName.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-import { router } from 'tinro';
+import { meta, router } from 'tinro';
+
+import { withFullscreenParam } from '/@/navigation';
 
 import { IngressRouteUtils } from './ingress-route-utils';
 import type { IngressUI } from './IngressUI';
@@ -7,12 +9,24 @@ import type { RouteUI } from './RouteUI';
 
 export let object: IngressUI | RouteUI;
 
+const query = meta().query;
+
 function openDetails() {
   const ingressRouteUtils = new IngressRouteUtils();
   if (ingressRouteUtils.isIngress(object)) {
-    router.goto(`/kubernetes/ingressesRoutes/ingress/${encodeURI(object.name)}/${encodeURI(object.namespace)}/summary`);
+    router.goto(
+      withFullscreenParam(
+        `/kubernetes/ingressesRoutes/ingress/${encodeURI(object.name)}/${encodeURI(object.namespace)}/summary`,
+        !!query['fullscreen'],
+      ),
+    );
   } else {
-    router.goto(`/kubernetes/ingressesRoutes/route/${encodeURI(object.name)}/${encodeURI(object.namespace)}/summary`);
+    router.goto(
+      withFullscreenParam(
+        `/kubernetes/ingressesRoutes/route/${encodeURI(object.name)}/${encodeURI(object.namespace)}/summary`,
+        !!query['fullscreen'],
+      ),
+    );
   }
 }
 </script>

--- a/packages/renderer/src/lib/ingresses-routes/RouteDetails.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/RouteDetails.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 import { StatusIcon, Tab } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
-import { router } from 'tinro';
+import { meta, router } from 'tinro';
 import { stringify } from 'yaml';
 
+import { withFullscreenParam } from '/@/navigation';
 import { kubernetesCurrentContextRoutes } from '/@/stores/kubernetes-contexts-state';
 import type { V1Route } from '/@api/openshift-types';
 
@@ -26,6 +27,8 @@ let routeUI: RouteUI;
 let detailsPage: DetailsPage;
 let kubeService: V1Route | undefined;
 let kubeError: string;
+
+let query = meta().query;
 
 onMount(() => {
   const ingressRouteUtils = new IngressRouteUtils();
@@ -66,9 +69,18 @@ async function loadRouteDetails() {
       <StateChange state={routeUI.status} />
     </div>
     <svelte:fragment slot="tabs">
-      <Tab title="Summary" selected={isTabSelected($router.path, 'summary')} url={getTabUrl($router.path, 'summary')} />
-      <Tab title="Inspect" selected={isTabSelected($router.path, 'inspect')} url={getTabUrl($router.path, 'inspect')} />
-      <Tab title="Kube" selected={isTabSelected($router.path, 'kube')} url={getTabUrl($router.path, 'kube')} />
+      <Tab
+        title="Summary"
+        selected={isTabSelected($router.path, 'summary')}
+        url={withFullscreenParam(getTabUrl($router.path, 'summary'), !!query['fullscreen'])} />
+      <Tab
+        title="Inspect"
+        selected={isTabSelected($router.path, 'inspect')}
+        url={withFullscreenParam(getTabUrl($router.path, 'inspect'), !!query['fullscreen'])} />
+      <Tab
+        title="Kube"
+        selected={isTabSelected($router.path, 'kube')}
+        url={withFullscreenParam(getTabUrl($router.path, 'kube'), !!query['fullscreen'])} />
     </svelte:fragment>
     <svelte:fragment slot="content">
       <Route path="/summary" breadcrumb="Summary" navigationHint="tab">

--- a/packages/renderer/src/lib/node/NodeColumnName.spec.ts
+++ b/packages/renderer/src/lib/node/NodeColumnName.spec.ts
@@ -54,5 +54,5 @@ test('Expect clicking works', async () => {
 
   fireEvent.click(text);
 
-  expect(routerGotoSpy).toBeCalledWith('/nodes/my-node/summary');
+  expect(routerGotoSpy).toBeCalledWith('/kubernetes/nodes/my-node/summary');
 });

--- a/packages/renderer/src/lib/node/NodeColumnName.svelte
+++ b/packages/renderer/src/lib/node/NodeColumnName.svelte
@@ -6,7 +6,7 @@ import type { NodeUI } from './NodeUI';
 export let object: NodeUI;
 
 function openDetails() {
-  router.goto(`/nodes/${encodeURI(object.name)}/summary`);
+  router.goto(`/kubernetes/nodes/${encodeURI(object.name)}/summary`);
 }
 </script>
 

--- a/packages/renderer/src/lib/node/NodeColumnName.svelte
+++ b/packages/renderer/src/lib/node/NodeColumnName.svelte
@@ -1,12 +1,16 @@
 <script lang="ts">
-import { router } from 'tinro';
+import { meta, router } from 'tinro';
+
+import { withFullscreenParam } from '/@/navigation';
 
 import type { NodeUI } from './NodeUI';
 
 export let object: NodeUI;
 
+const query = meta().query;
+
 function openDetails() {
-  router.goto(`/kubernetes/nodes/${encodeURI(object.name)}/summary`);
+  router.goto(withFullscreenParam(`/kubernetes/nodes/${encodeURI(object.name)}/summary`, !!query['fullscreen']));
 }
 </script>
 

--- a/packages/renderer/src/lib/node/NodeDetails.svelte
+++ b/packages/renderer/src/lib/node/NodeDetails.svelte
@@ -2,9 +2,10 @@
 import type { V1Node } from '@kubernetes/client-node';
 import { StatusIcon, Tab } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
-import { router } from 'tinro';
+import { meta, router } from 'tinro';
 import { stringify } from 'yaml';
 
+import { withFullscreenParam } from '/@/navigation';
 import { kubernetesCurrentContextNodes } from '/@/stores/kubernetes-contexts-state';
 
 import Route from '../../Route.svelte';
@@ -23,6 +24,8 @@ let node: NodeUI;
 let detailsPage: DetailsPage;
 let kubeNode: V1Node | undefined;
 let kubeError: string;
+
+let query = meta().query;
 
 onMount(() => {
   const nodeUtils = new NodeUtils();
@@ -57,9 +60,18 @@ async function loadDetails() {
   <DetailsPage title={node.name} bind:this={detailsPage}>
     <StatusIcon slot="icon" icon={NodeIcon} size={24} status={node.status} />
     <svelte:fragment slot="tabs">
-      <Tab title="Summary" selected={isTabSelected($router.path, 'summary')} url={getTabUrl($router.path, 'summary')} />
-      <Tab title="Inspect" selected={isTabSelected($router.path, 'inspect')} url={getTabUrl($router.path, 'inspect')} />
-      <Tab title="Kube" selected={isTabSelected($router.path, 'kube')} url={getTabUrl($router.path, 'kube')} />
+      <Tab
+        title="Summary"
+        selected={isTabSelected($router.path, 'summary')}
+        url={withFullscreenParam(getTabUrl($router.path, 'summary'), !!query['fullscreen'])} />
+      <Tab
+        title="Inspect"
+        selected={isTabSelected($router.path, 'inspect')}
+        url={withFullscreenParam(getTabUrl($router.path, 'inspect'), !!query['fullscreen'])} />
+      <Tab
+        title="Kube"
+        selected={isTabSelected($router.path, 'kube')}
+        url={withFullscreenParam(getTabUrl($router.path, 'kube'), !!query['fullscreen'])} />
     </svelte:fragment>
     <svelte:fragment slot="content">
       <Route path="/summary" breadcrumb="Summary" navigationHint="tab">

--- a/packages/renderer/src/lib/pvc/PVCColumnName.spec.ts
+++ b/packages/renderer/src/lib/pvc/PVCColumnName.spec.ts
@@ -54,7 +54,7 @@ test('Expect clicking works', async () => {
 
   fireEvent.click(text);
 
-  expect(routerGotoSpy).toBeCalledWith('/persistentvolumeclaims/my-pvc/default/summary');
+  expect(routerGotoSpy).toBeCalledWith('/kubernetes/persistentvolumeclaims/my-pvc/default/summary');
 });
 
 test('Expect to show namespace in column', async () => {

--- a/packages/renderer/src/lib/pvc/PVCColumnName.svelte
+++ b/packages/renderer/src/lib/pvc/PVCColumnName.svelte
@@ -6,7 +6,7 @@ import type { PVCUI } from './PVCUI';
 export let object: PVCUI;
 
 function openDetails() {
-  router.goto(`/persistentvolumeclaims/${encodeURI(object.name)}/${encodeURI(object.namespace)}/summary`);
+  router.goto(`/kubernetes/persistentvolumeclaims/${encodeURI(object.name)}/${encodeURI(object.namespace)}/summary`);
 }
 </script>
 

--- a/packages/renderer/src/lib/pvc/PVCColumnName.svelte
+++ b/packages/renderer/src/lib/pvc/PVCColumnName.svelte
@@ -1,12 +1,21 @@
 <script lang="ts">
-import { router } from 'tinro';
+import { meta, router } from 'tinro';
+
+import { withFullscreenParam } from '/@/navigation';
 
 import type { PVCUI } from './PVCUI';
 
 export let object: PVCUI;
 
+const query = meta().query;
+
 function openDetails() {
-  router.goto(`/kubernetes/persistentvolumeclaims/${encodeURI(object.name)}/${encodeURI(object.namespace)}/summary`);
+  router.goto(
+    withFullscreenParam(
+      `/kubernetes/persistentvolumeclaims/${encodeURI(object.name)}/${encodeURI(object.namespace)}/summary`,
+      !!query['fullscreen'],
+    ),
+  );
 }
 </script>
 

--- a/packages/renderer/src/lib/pvc/PVCDetails.svelte
+++ b/packages/renderer/src/lib/pvc/PVCDetails.svelte
@@ -2,9 +2,10 @@
 import type { V1PersistentVolumeClaim } from '@kubernetes/client-node';
 import { StatusIcon, Tab } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
-import { router } from 'tinro';
+import { meta, router } from 'tinro';
 import { stringify } from 'yaml';
 
+import { withFullscreenParam } from '/@/navigation';
 import { kubernetesCurrentContextPersistentVolumeClaims } from '/@/stores/kubernetes-contexts-state';
 
 import Route from '../../Route.svelte';
@@ -26,6 +27,8 @@ let pvc: PVCUI;
 let detailsPage: DetailsPage;
 let kubePVC: V1PersistentVolumeClaim | undefined;
 let kubeError: string;
+
+let query = meta().query;
 
 onMount(() => {
   const pvcUtils = new PVCUtils();
@@ -66,9 +69,18 @@ async function loadDetails() {
       <StateChange state={pvc.status} />
     </div>
     <svelte:fragment slot="tabs">
-      <Tab title="Summary" selected={isTabSelected($router.path, 'summary')} url={getTabUrl($router.path, 'summary')} />
-      <Tab title="Inspect" selected={isTabSelected($router.path, 'inspect')} url={getTabUrl($router.path, 'inspect')} />
-      <Tab title="Kube" selected={isTabSelected($router.path, 'kube')} url={getTabUrl($router.path, 'kube')} />
+      <Tab
+        title="Summary"
+        selected={isTabSelected($router.path, 'summary')}
+        url={withFullscreenParam(getTabUrl($router.path, 'summary'), !!query['fullscreen'])} />
+      <Tab
+        title="Inspect"
+        selected={isTabSelected($router.path, 'inspect')}
+        url={withFullscreenParam(getTabUrl($router.path, 'inspect'), !!query['fullscreen'])} />
+      <Tab
+        title="Kube"
+        selected={isTabSelected($router.path, 'kube')}
+        url={withFullscreenParam(getTabUrl($router.path, 'kube'), !!query['fullscreen'])} />
     </svelte:fragment>
     <svelte:fragment slot="content">
       <Route path="/summary" breadcrumb="Summary" navigationHint="tab">

--- a/packages/renderer/src/lib/service/ServiceColumnName.spec.ts
+++ b/packages/renderer/src/lib/service/ServiceColumnName.spec.ts
@@ -55,7 +55,7 @@ test('Expect clicking works', async () => {
 
   fireEvent.click(text);
 
-  expect(routerGotoSpy).toBeCalledWith('/services/my-service/default/summary');
+  expect(routerGotoSpy).toBeCalledWith('/kubernetes/services/my-service/default/summary');
 });
 
 test('If loadBalancerIPs is set, expect it to be displayed', async () => {

--- a/packages/renderer/src/lib/service/ServiceColumnName.svelte
+++ b/packages/renderer/src/lib/service/ServiceColumnName.svelte
@@ -6,7 +6,7 @@ import type { ServiceUI } from './ServiceUI';
 export let object: ServiceUI;
 
 function openDetails() {
-  router.goto(`/services/${encodeURI(object.name)}/${encodeURI(object.namespace)}/summary`);
+  router.goto(`/kubernetes/services/${encodeURI(object.name)}/${encodeURI(object.namespace)}/summary`);
 }
 </script>
 

--- a/packages/renderer/src/lib/service/ServiceColumnName.svelte
+++ b/packages/renderer/src/lib/service/ServiceColumnName.svelte
@@ -1,12 +1,21 @@
 <script lang="ts">
-import { router } from 'tinro';
+import { meta, router } from 'tinro';
+
+import { withFullscreenParam } from '/@/navigation';
 
 import type { ServiceUI } from './ServiceUI';
 
 export let object: ServiceUI;
 
+const query = meta().query;
+
 function openDetails() {
-  router.goto(`/kubernetes/services/${encodeURI(object.name)}/${encodeURI(object.namespace)}/summary`);
+  router.goto(
+    withFullscreenParam(
+      `/kubernetes/services/${encodeURI(object.name)}/${encodeURI(object.namespace)}/summary`,
+      !!query['fullscreen'],
+    ),
+  );
 }
 </script>
 

--- a/packages/renderer/src/lib/service/ServiceDetails.svelte
+++ b/packages/renderer/src/lib/service/ServiceDetails.svelte
@@ -2,9 +2,10 @@
 import type { V1Service } from '@kubernetes/client-node';
 import { StatusIcon, Tab } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
-import { router } from 'tinro';
+import { meta, router } from 'tinro';
 import { stringify } from 'yaml';
 
+import { withFullscreenParam } from '/@/navigation';
 import { kubernetesCurrentContextServices } from '/@/stores/kubernetes-contexts-state';
 
 import Route from '../../Route.svelte';
@@ -54,6 +55,8 @@ async function loadDetails() {
     kubeError = `Unable to retrieve Kubernetes details for ${service.name}`;
   }
 }
+
+let query = meta().query;
 </script>
 
 {#if service}
@@ -66,9 +69,18 @@ async function loadDetails() {
       <StateChange state={service.status} />
     </div>
     <svelte:fragment slot="tabs">
-      <Tab title="Summary" selected={isTabSelected($router.path, 'summary')} url={getTabUrl($router.path, 'summary')} />
-      <Tab title="Inspect" selected={isTabSelected($router.path, 'inspect')} url={getTabUrl($router.path, 'inspect')} />
-      <Tab title="Kube" selected={isTabSelected($router.path, 'kube')} url={getTabUrl($router.path, 'kube')} />
+      <Tab
+        title="Summary"
+        selected={isTabSelected($router.path, 'summary')}
+        url={withFullscreenParam(getTabUrl($router.path, 'summary'), !!query['fullscreen'])} />
+      <Tab
+        title="Inspect"
+        selected={isTabSelected($router.path, 'inspect')}
+        url={withFullscreenParam(getTabUrl($router.path, 'inspect'), !!query['fullscreen'])} />
+      <Tab
+        title="Kube"
+        selected={isTabSelected($router.path, 'kube')}
+        url={withFullscreenParam(getTabUrl($router.path, 'kube'), !!query['fullscreen'])} />
     </svelte:fragment>
     <svelte:fragment slot="content">
       <Route path="/summary" breadcrumb="Summary" navigationHint="tab">

--- a/packages/renderer/src/lib/ui/NavItem.svelte
+++ b/packages/renderer/src/lib/ui/NavItem.svelte
@@ -6,6 +6,8 @@ import { getContext, onDestroy, onMount } from 'svelte';
 import type { MouseEventHandler } from 'svelte/elements';
 import type { Writable } from 'svelte/store';
 import type { TinroRouteMeta } from 'tinro';
+
+import { getFullscreenParam, getPath } from '/@/navigation';
 /* eslint-disable import/no-duplicates */
 
 export let href: string;
@@ -19,7 +21,11 @@ let inSection: boolean = false;
 let uri: string;
 $: uri = encodeURI(href);
 let selected: boolean;
-$: selected = meta.url === uri || (uri !== '/' && meta.url.startsWith(uri));
+$: selected =
+  meta.url === uri ||
+  (uri !== '/' &&
+    getPath(meta.url).startsWith(getPath(uri)) &&
+    getFullscreenParam(meta.url) === getFullscreenParam(uri));
 
 const navItems: Writable<number> = getContext('nav-items');
 

--- a/packages/renderer/src/navigation.spec.ts
+++ b/packages/renderer/src/navigation.spec.ts
@@ -21,7 +21,7 @@ import { beforeEach, expect, test, vi } from 'vitest';
 
 import { NavigationPage } from '/@api/navigation-page';
 
-import { handleNavigation } from './navigation';
+import { getFullscreenParam, handleNavigation, withFullscreenParam } from './navigation';
 
 // mock the router
 vi.mock('tinro', () => {
@@ -217,4 +217,28 @@ test(`Test navigationHandle for ${NavigationPage.EDIT_CONTAINER_CONNECTION}`, ()
   expect(vi.mocked(router.goto)).toHaveBeenCalledWith(
     '/preferences/container-connection/edit/dummyProviderId/dummyProviderName',
   );
+});
+
+test('withFullscreenParam', () => {
+  let result = withFullscreenParam('/path/to/page', false);
+  expect(result).toEqual('/path/to/page');
+
+  result = withFullscreenParam('/path/to/page?fullscreen=true', false);
+  expect(result).toEqual('/path/to/page');
+
+  result = withFullscreenParam('/path/to/page?other=value&fullscreen=true', false);
+  expect(result).toEqual('/path/to/page?other=value');
+
+  result = withFullscreenParam('/path/to/page', true);
+  expect(result).toEqual('/path/to/page?fullscreen=true');
+
+  result = withFullscreenParam('/path/to/page?other=value', true);
+  expect(result).toEqual('/path/to/page?other=value&fullscreen=true');
+});
+
+test('getFullscreenParam', () => {
+  expect(getFullscreenParam('/path/to/page')).toBeFalsy();
+  expect(getFullscreenParam('/path/to/page?other=value')).toBeFalsy();
+  expect(getFullscreenParam('/path/to/page?fullscreen=true')).toBeTruthy();
+  expect(getFullscreenParam('/path/to/page?other=value&fullscreen=true')).toBeTruthy();
 });

--- a/packages/renderer/src/navigation.ts
+++ b/packages/renderer/src/navigation.ts
@@ -112,3 +112,23 @@ export const handleNavigation = (request: InferredNavigationRequest<NavigationPa
       break;
   }
 };
+
+// getPath returns the path of a route (without the part after '?')
+export function getPath(route: string): string {
+  return new URL('http://localhost' + route).pathname;
+}
+
+export function withFullscreenParam(route: string, fullscreen: boolean): string {
+  const url = new URL('http://localhost' + route);
+  if (fullscreen) {
+    url.searchParams.set('fullscreen', 'true');
+  } else {
+    url.searchParams.delete('fullscreen');
+  }
+  return url.pathname + url.search;
+}
+
+export function getFullscreenParam(route: string): boolean {
+  const url = new URL('http://localhost' + route);
+  return url.searchParams.get('fullscreen') === 'true';
+}

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-configmap-secrets.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-configmap-secrets.svelte.spec.ts
@@ -51,7 +51,7 @@ test('createNavigationKubernetesConfigMapSecretsEntry', async () => {
 
   expect(entry).toBeDefined();
   expect(entry.name).toBe('ConfigMaps & Secrets');
-  expect(entry.link).toBe('/configmapsSecrets');
+  expect(entry.link).toBe('/kubernetes/configmapsSecrets');
   expect(entry.tooltip).toBe('ConfigMaps & Secrets');
   await vi.waitFor(() => {
     // receive 2 and 2

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-configmap-secrets.svelte.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-configmap-secrets.svelte.ts
@@ -38,7 +38,7 @@ export function createNavigationKubernetesConfigMapSecretsEntry(): NavigationReg
   const registry: NavigationRegistryEntry = {
     name: 'ConfigMaps & Secrets',
     icon: { iconComponent: ConfigMapSecretIcon },
-    link: '/configmapsSecrets',
+    link: '/kubernetes/configmapsSecrets',
     tooltip: 'ConfigMaps & Secrets',
     type: 'entry',
     get counter() {

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-configmap-secrets.svelte.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-configmap-secrets.svelte.ts
@@ -17,15 +17,19 @@
  ***********************************************************************/
 
 import ConfigMapSecretIcon from '/@/lib/images/ConfigMapSecretIcon.svelte';
+import { withFullscreenParam } from '/@/navigation';
 
 import { kubernetesCurrentContextConfigMaps, kubernetesCurrentContextSecrets } from '../../kubernetes-contexts-state';
 import type { NavigationRegistryEntry } from '../navigation-registry';
+import type { CreateNavigationEntryOptions } from './navigation-registry-k8s';
 
 let configmapsCount = 0;
 let secretsCount = 0;
 let count = $state(0);
 
-export function createNavigationKubernetesConfigMapSecretsEntry(): NavigationRegistryEntry {
+export function createNavigationKubernetesConfigMapSecretsEntry(
+  options?: CreateNavigationEntryOptions,
+): NavigationRegistryEntry {
   kubernetesCurrentContextConfigMaps.subscribe(value => {
     configmapsCount = value.length;
     count = configmapsCount + secretsCount;
@@ -38,7 +42,7 @@ export function createNavigationKubernetesConfigMapSecretsEntry(): NavigationReg
   const registry: NavigationRegistryEntry = {
     name: 'ConfigMaps & Secrets',
     icon: { iconComponent: ConfigMapSecretIcon },
-    link: '/kubernetes/configmapsSecrets',
+    link: withFullscreenParam('/kubernetes/configmapsSecrets', !!options?.fullscreen),
     tooltip: 'ConfigMaps & Secrets',
     type: 'entry',
     get counter() {

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-deployments.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-deployments.svelte.spec.ts
@@ -51,7 +51,7 @@ test('createNavigationKubernetesDeploymentsEntry', async () => {
 
   expect(entry).toBeDefined();
   expect(entry.name).toBe('Deployments');
-  expect(entry.link).toBe('/deployments');
+  expect(entry.link).toBe('/kubernetes/deployments');
   expect(entry.tooltip).toBe('Deployments');
   await vi.waitFor(() => {
     expect(entry.counter).toBe(2);

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-deployments.svelte.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-deployments.svelte.ts
@@ -30,7 +30,7 @@ export function createNavigationKubernetesDeploymentsEntry(): NavigationRegistry
   const registry: NavigationRegistryEntry = {
     name: 'Deployments',
     icon: { iconComponent: DeploymentIcon },
-    link: '/deployments',
+    link: '/kubernetes/deployments',
     tooltip: 'Deployments',
     type: 'entry',
     get counter() {

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-deployments.svelte.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-deployments.svelte.ts
@@ -17,20 +17,24 @@
  ***********************************************************************/
 
 import DeploymentIcon from '/@/lib/images/DeploymentIcon.svelte';
+import { withFullscreenParam } from '/@/navigation';
 
 import { kubernetesCurrentContextDeployments } from '../../kubernetes-contexts-state';
 import type { NavigationRegistryEntry } from '../navigation-registry';
+import type { CreateNavigationEntryOptions } from './navigation-registry-k8s';
 
 let count = $state(0);
 
-export function createNavigationKubernetesDeploymentsEntry(): NavigationRegistryEntry {
+export function createNavigationKubernetesDeploymentsEntry(
+  options?: CreateNavigationEntryOptions,
+): NavigationRegistryEntry {
   kubernetesCurrentContextDeployments.subscribe(nodes => {
     count = nodes.length;
   });
   const registry: NavigationRegistryEntry = {
     name: 'Deployments',
     icon: { iconComponent: DeploymentIcon },
-    link: '/kubernetes/deployments',
+    link: withFullscreenParam('/kubernetes/deployments', !!options?.fullscreen),
     tooltip: 'Deployments',
     type: 'entry',
     get counter() {

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-ingresses-routes.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-ingresses-routes.svelte.spec.ts
@@ -51,7 +51,7 @@ test('createNavigationKubernetesIngressesRoutesEntry', async () => {
 
   expect(entry).toBeDefined();
   expect(entry.name).toBe('Ingresses & Routes');
-  expect(entry.link).toBe('/ingressesRoutes');
+  expect(entry.link).toBe('/kubernetes/ingressesRoutes');
   expect(entry.tooltip).toBe('Ingresses & Routes');
   await vi.waitFor(() => {
     expect(entry.counter).toBe(2);

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-ingresses-routes.svelte.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-ingresses-routes.svelte.ts
@@ -45,7 +45,7 @@ export function createNavigationKubernetesIngressesRoutesEntry(): NavigationRegi
   const registry: NavigationRegistryEntry = {
     name: 'Ingresses & Routes',
     icon: { iconComponent: IngressRouteIcon },
-    link: '/ingressesRoutes',
+    link: '/kubernetes/ingressesRoutes',
     tooltip: 'Ingresses & Routes',
     type: 'entry',
     get counter() {

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-ingresses-routes.svelte.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-ingresses-routes.svelte.ts
@@ -17,6 +17,7 @@
  ***********************************************************************/
 
 import IngressRouteIcon from '/@/lib/images/IngressRouteIcon.svelte';
+import { withFullscreenParam } from '/@/navigation';
 
 import {
   kubernetesCurrentContextIngresses,
@@ -24,12 +25,15 @@ import {
   kubernetesCurrentContextRoutes,
 } from '../../kubernetes-contexts-state';
 import type { NavigationRegistryEntry } from '../navigation-registry';
+import type { CreateNavigationEntryOptions } from './navigation-registry-k8s';
 
 let ingressesCount = 0;
 let routesCount = 0;
 let count = $state(0);
 
-export function createNavigationKubernetesIngressesRoutesEntry(): NavigationRegistryEntry {
+export function createNavigationKubernetesIngressesRoutesEntry(
+  options?: CreateNavigationEntryOptions,
+): NavigationRegistryEntry {
   kubernetesCurrentContextIngresses.subscribe(value => {
     ingressesCount = value.length;
     count = ingressesCount + routesCount;
@@ -45,7 +49,7 @@ export function createNavigationKubernetesIngressesRoutesEntry(): NavigationRegi
   const registry: NavigationRegistryEntry = {
     name: 'Ingresses & Routes',
     icon: { iconComponent: IngressRouteIcon },
-    link: '/kubernetes/ingressesRoutes',
+    link: withFullscreenParam('/kubernetes/ingressesRoutes', !!options?.fullscreen),
     tooltip: 'Ingresses & Routes',
     type: 'entry',
     get counter() {

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-nodes.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-nodes.svelte.spec.ts
@@ -51,7 +51,7 @@ test('createNavigationKubernetesNodesEntry', async () => {
 
   expect(entry).toBeDefined();
   expect(entry.name).toBe('Nodes');
-  expect(entry.link).toBe('/nodes');
+  expect(entry.link).toBe('/kubernetes/nodes');
   expect(entry.tooltip).toBe('Nodes');
   await vi.waitFor(() => {
     expect(entry.counter).toBe(2);

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-nodes.svelte.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-nodes.svelte.ts
@@ -30,7 +30,7 @@ export function createNavigationKubernetesNodesEntry(): NavigationRegistryEntry 
   const registry: NavigationRegistryEntry = {
     name: 'Nodes',
     icon: { iconComponent: NodeIcon },
-    link: '/nodes',
+    link: '/kubernetes/nodes',
     tooltip: 'Nodes',
     type: 'entry',
     get counter() {

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-nodes.svelte.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-nodes.svelte.ts
@@ -17,20 +17,22 @@
  ***********************************************************************/
 
 import NodeIcon from '/@/lib/images/NodeIcon.svelte';
+import { withFullscreenParam } from '/@/navigation';
 
 import { kubernetesCurrentContextNodes } from '../../kubernetes-contexts-state';
 import type { NavigationRegistryEntry } from '../navigation-registry';
+import type { CreateNavigationEntryOptions } from './navigation-registry-k8s';
 
 let count = $state(0);
 
-export function createNavigationKubernetesNodesEntry(): NavigationRegistryEntry {
+export function createNavigationKubernetesNodesEntry(options?: CreateNavigationEntryOptions): NavigationRegistryEntry {
   kubernetesCurrentContextNodes.subscribe(nodes => {
     count = nodes.length;
   });
   const registry: NavigationRegistryEntry = {
     name: 'Nodes',
     icon: { iconComponent: NodeIcon },
-    link: '/kubernetes/nodes',
+    link: withFullscreenParam('/kubernetes/nodes', !!options?.fullscreen),
     tooltip: 'Nodes',
     type: 'entry',
     get counter() {

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-persistent-volume.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-persistent-volume.svelte.spec.ts
@@ -52,7 +52,7 @@ test('createNavigationKubernetesPersistentVolumeEntry', async () => {
 
   expect(entry).toBeDefined();
   expect(entry.name).toBe('Persistent Volume Claims');
-  expect(entry.link).toBe('/persistentvolumeclaims');
+  expect(entry.link).toBe('/kubernetes/persistentvolumeclaims');
   expect(entry.tooltip).toBe('Persistent Volume Claims');
   await vi.waitFor(() => {
     expect(entry.counter).toBe(2);

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-persistent-volume.svelte.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-persistent-volume.svelte.ts
@@ -31,7 +31,7 @@ export function createNavigationKubernetesPersistentVolumeEntry(): NavigationReg
   const registry: NavigationRegistryEntry = {
     name: 'Persistent Volume Claims',
     icon: { iconComponent: PvcIcon },
-    link: '/persistentvolumeclaims',
+    link: '/kubernetes/persistentvolumeclaims',
     tooltip: 'Persistent Volume Claims',
     type: 'entry',
     get counter() {

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-persistent-volume.svelte.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-persistent-volume.svelte.ts
@@ -17,13 +17,17 @@
  ***********************************************************************/
 
 import PvcIcon from '/@/lib/images/PVCIcon.svelte';
+import { withFullscreenParam } from '/@/navigation';
 
 import { kubernetesCurrentContextPersistentVolumeClaims } from '../../kubernetes-contexts-state';
 import type { NavigationRegistryEntry } from '../navigation-registry';
+import type { CreateNavigationEntryOptions } from './navigation-registry-k8s';
 
 let count = $state(0);
 
-export function createNavigationKubernetesPersistentVolumeEntry(): NavigationRegistryEntry {
+export function createNavigationKubernetesPersistentVolumeEntry(
+  options?: CreateNavigationEntryOptions,
+): NavigationRegistryEntry {
   kubernetesCurrentContextPersistentVolumeClaims.subscribe(value => {
     count = value.length;
   });
@@ -31,7 +35,7 @@ export function createNavigationKubernetesPersistentVolumeEntry(): NavigationReg
   const registry: NavigationRegistryEntry = {
     name: 'Persistent Volume Claims',
     icon: { iconComponent: PvcIcon },
-    link: '/kubernetes/persistentvolumeclaims',
+    link: withFullscreenParam('/kubernetes/persistentvolumeclaims', !!options?.fullscreen),
     tooltip: 'Persistent Volume Claims',
     type: 'entry',
     get counter() {

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-services.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-services.svelte.spec.ts
@@ -53,7 +53,7 @@ test('createNavigationKubernetesServicesEntry', async () => {
 
   expect(entry).toBeDefined();
   expect(entry.name).toBe('Services');
-  expect(entry.link).toBe('/services');
+  expect(entry.link).toBe('/kubernetes/services');
   expect(entry.tooltip).toBe('Services');
   await vi.waitFor(() => {
     expect(entry.counter).toBe(2);

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-services.svelte.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-services.svelte.ts
@@ -30,7 +30,7 @@ export function createNavigationKubernetesServicesEntry(): NavigationRegistryEnt
   const registry: NavigationRegistryEntry = {
     name: 'Services',
     icon: { iconComponent: ServiceIcon },
-    link: '/services',
+    link: '/kubernetes/services',
     tooltip: 'Services',
     type: 'entry',
     get counter() {

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-services.svelte.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-services.svelte.ts
@@ -17,20 +17,24 @@
  ***********************************************************************/
 
 import ServiceIcon from '/@/lib/images/ServiceIcon.svelte';
+import { withFullscreenParam } from '/@/navigation';
 
 import { kubernetesCurrentContextServices } from '../../kubernetes-contexts-state';
 import type { NavigationRegistryEntry } from '../navigation-registry';
+import type { CreateNavigationEntryOptions } from './navigation-registry-k8s';
 
 let count = $state(0);
 
-export function createNavigationKubernetesServicesEntry(): NavigationRegistryEntry {
+export function createNavigationKubernetesServicesEntry(
+  options?: CreateNavigationEntryOptions,
+): NavigationRegistryEntry {
   kubernetesCurrentContextServices.subscribe(services => {
     count = services.length;
   });
   const registry: NavigationRegistryEntry = {
     name: 'Services',
     icon: { iconComponent: ServiceIcon },
-    link: '/kubernetes/services',
+    link: withFullscreenParam('/kubernetes/services', !!options?.fullscreen),
     tooltip: 'Services',
     type: 'entry',
     get counter() {

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s.ts
@@ -1,0 +1,3 @@
+export interface CreateNavigationEntryOptions {
+  fullscreen?: boolean;
+}

--- a/packages/renderer/src/stores/navigation/navigation-registry-kubernetes.svelte.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-kubernetes.svelte.ts
@@ -18,7 +18,6 @@
 
 import KubeIcon from '/@/lib/images/KubeIcon.svelte';
 
-import { kubernetesContexts } from '../kubernetes-contexts';
 import { createNavigationKubernetesConfigMapSecretsEntry } from './kubernetes/navigation-registry-k8s-configmap-secrets.svelte';
 import { createNavigationKubernetesDeploymentsEntry } from './kubernetes/navigation-registry-k8s-deployments.svelte';
 import { createNavigationKubernetesIngressesRoutesEntry } from './kubernetes/navigation-registry-k8s-ingresses-routes.svelte';
@@ -28,13 +27,6 @@ import { createNavigationKubernetesServicesEntry } from './kubernetes/navigation
 import type { NavigationRegistryEntry } from './navigation-registry';
 
 let kubernetesNavigationGroupItems: NavigationRegistryEntry[] = $state([]);
-
-// default is false until we receive the kubernetes contexts
-let enabled = $state(false);
-
-kubernetesContexts.subscribe(value => {
-  enabled = value.length > 0;
-});
 
 export function createNavigationKubernetesGroup(): NavigationRegistryEntry {
   const newItems: NavigationRegistryEntry[] = [];
@@ -49,14 +41,11 @@ export function createNavigationKubernetesGroup(): NavigationRegistryEntry {
   const mainGroupEntry: NavigationRegistryEntry = {
     name: 'Kubernetes',
     icon: { iconComponent: KubeIcon },
-    link: ``,
-    tooltip: '',
-    type: 'section',
+    link: '/kubernetes',
+    tooltip: 'Kubernetes',
+    type: 'submenu',
     get counter() {
       return 0;
-    },
-    get enabled() {
-      return enabled;
     },
     get items() {
       return kubernetesNavigationGroupItems;

--- a/packages/renderer/src/stores/navigation/navigation-registry.spec.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry.spec.ts
@@ -38,7 +38,7 @@ test('check navigation registry items', async () => {
   await fetchNavigationRegistries();
   const registries = get(navigationRegistry);
   // expect 7 items in the registry
-  expect(registries.length).equal(7);
+  expect(registries.length).equal(13);
 });
 
 test('check update properties', async () => {

--- a/packages/renderer/src/stores/navigation/navigation-registry.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry.ts
@@ -72,12 +72,12 @@ const init = () => {
   values.push(createNavigationImageEntry());
   values.push(createNavigationVolumeEntry());
   values.push(createNavigationKubernetesGroup());
-  values.push(createNavigationKubernetesNodesEntry());
-  values.push(createNavigationKubernetesDeploymentsEntry());
-  values.push(createNavigationKubernetesServicesEntry());
-  values.push(createNavigationKubernetesIngressesRoutesEntry());
-  values.push(createNavigationKubernetesPersistentVolumeEntry());
-  values.push(createNavigationKubernetesConfigMapSecretsEntry());
+  values.push(createNavigationKubernetesNodesEntry({ fullscreen: true }));
+  values.push(createNavigationKubernetesDeploymentsEntry({ fullscreen: true }));
+  values.push(createNavigationKubernetesServicesEntry({ fullscreen: true }));
+  values.push(createNavigationKubernetesIngressesRoutesEntry({ fullscreen: true }));
+  values.push(createNavigationKubernetesPersistentVolumeEntry({ fullscreen: true }));
+  values.push(createNavigationKubernetesConfigMapSecretsEntry({ fullscreen: true }));
   values.push(createNavigationExtensionEntry());
   values.push(createNavigationExtensionGroup());
   hideItems();

--- a/packages/renderer/src/stores/navigation/navigation-registry.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry.ts
@@ -23,6 +23,12 @@ import type { IconSize } from 'svelte-fa';
 import { EventStore } from '/@/stores/event-store';
 
 import { configurationProperties } from '../configurationProperties';
+import { createNavigationKubernetesConfigMapSecretsEntry } from './kubernetes/navigation-registry-k8s-configmap-secrets.svelte';
+import { createNavigationKubernetesDeploymentsEntry } from './kubernetes/navigation-registry-k8s-deployments.svelte';
+import { createNavigationKubernetesIngressesRoutesEntry } from './kubernetes/navigation-registry-k8s-ingresses-routes.svelte';
+import { createNavigationKubernetesNodesEntry } from './kubernetes/navigation-registry-k8s-nodes.svelte';
+import { createNavigationKubernetesPersistentVolumeEntry } from './kubernetes/navigation-registry-k8s-persistent-volume.svelte';
+import { createNavigationKubernetesServicesEntry } from './kubernetes/navigation-registry-k8s-services.svelte';
 import { createNavigationContainerEntry } from './navigation-registry-container.svelte';
 import { createNavigationExtensionEntry, createNavigationExtensionGroup } from './navigation-registry-extension.svelte';
 import { createNavigationImageEntry } from './navigation-registry-image.svelte';
@@ -40,7 +46,7 @@ export interface NavigationRegistryEntry {
   tooltip: string;
   link: string;
   counter: number;
-  type: 'section' | 'entry' | 'group';
+  type: 'section' | 'entry' | 'group' | 'submenu';
   enabled?: boolean;
   items?: NavigationRegistryEntry[];
   hidden?: boolean;
@@ -66,6 +72,12 @@ const init = () => {
   values.push(createNavigationImageEntry());
   values.push(createNavigationVolumeEntry());
   values.push(createNavigationKubernetesGroup());
+  values.push(createNavigationKubernetesNodesEntry());
+  values.push(createNavigationKubernetesDeploymentsEntry());
+  values.push(createNavigationKubernetesServicesEntry());
+  values.push(createNavigationKubernetesIngressesRoutesEntry());
+  values.push(createNavigationKubernetesPersistentVolumeEntry());
+  values.push(createNavigationKubernetesConfigMapSecretsEntry());
   values.push(createNavigationExtensionEntry());
   values.push(createNavigationExtensionGroup());
   hideItems();


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Revamp Kubernetes menu according to #7759

TODO:

- [ ] Kubernetes Welcome page
- [ ] Pod page in Kubernetes section
- [ ] Hide Kubernetes resources menus by default

### Screenshot / video of UI

https://github.com/user-attachments/assets/4678ec95-671a-4a6c-ad7e-066f2ec7b67f

### What issues does this PR fix or reference?

Fixes #7759

### How to test this PR?

(TODO) 

- [ ] Tests are covering the bug fix or the new feature
