### PR TITLE
refactor: turn appearance isDarkMode function to a reactive variable

### DIFF
--- a/packages/renderer/src/lib/appearance/Appearance.spec.ts
+++ b/packages/renderer/src/lib/appearance/Appearance.spec.ts
@@ -22,6 +22,8 @@ import '@testing-library/jest-dom/vitest';
 import { render, type RenderResult } from '@testing-library/svelte';
 import { beforeEach, expect, test, vi } from 'vitest';
 
+import { configurationProperties } from '/@/stores/configurationProperties';
+
 import { AppearanceSettings } from '../../../../main/src/plugin/appearance-settings';
 import Appearance from './Appearance.svelte';
 
@@ -71,10 +73,11 @@ test('Expect light mode using system when OS is set to light', async () => {
   });
 
   getConfigurationValueMock.mockResolvedValue(AppearanceSettings.SystemEnumValue);
+  configurationProperties.set([]);
 
   const { baseElement } = await awaitRender();
   // expect to have no (dark) class as OS is using light
-  expect(getRootElementClassesValue(baseElement)).toBe('');
+  await vi.waitFor(() => expect(getRootElementClassesValue(baseElement)).toBe(''));
 });
 
 test('Expect dark mode using system when OS is set to dark', async () => {
@@ -85,14 +88,16 @@ test('Expect dark mode using system when OS is set to dark', async () => {
   });
 
   getConfigurationValueMock.mockResolvedValue(AppearanceSettings.SystemEnumValue);
+  configurationProperties.set([]);
 
   const { baseElement } = await awaitRender();
   // expect to have class being "dark" as OS is using dark
-  expect(getRootElementClassesValue(baseElement)).toBe('dark');
+  await vi.waitFor(() => expect(getRootElementClassesValue(baseElement)).toBe('dark'));
 });
 
 test('Expect light mode using light configuration', async () => {
   getConfigurationValueMock.mockResolvedValue(AppearanceSettings.LightEnumValue);
+  configurationProperties.set([]);
 
   const { baseElement } = await awaitRender();
 
@@ -105,10 +110,11 @@ test('Expect light mode using light configuration', async () => {
 
 test('Expect dark mode using dark configuration', async () => {
   getConfigurationValueMock.mockResolvedValue(AppearanceSettings.DarkEnumValue);
+  configurationProperties.set([]);
 
   const { baseElement } = await awaitRender();
 
-  // expect to have class being "dark" as we should be in light mode
+  // expect to have class being "dark" as we should be in dark mode
   expect(getRootElementClassesValue(baseElement)).toBe('dark');
 
   // expect to have color-scheme: dark

--- a/packages/renderer/src/lib/appearance/Appearance.svelte
+++ b/packages/renderer/src/lib/appearance/Appearance.svelte
@@ -1,18 +1,20 @@
 <script lang="ts">
 import { onDestroy, onMount } from 'svelte';
+import type { Unsubscriber } from 'svelte/store';
 
 import { AppearanceSettings } from '../../../../main/src/plugin/appearance-settings';
+import { isDark } from '../../stores/appearance';
 import { onDidChangeConfiguration } from '../../stores/configurationProperties';
-import { AppearanceUtil } from './appearance-util';
+
+let isDarkUnsubscribe: Unsubscriber;
+let isDarkTheme = false;
 
 const APPEARANCE_CONFIGURATION_KEY = AppearanceSettings.SectionName + '.' + AppearanceSettings.Appearance;
 async function updateAppearance(): Promise<void> {
   const html = document.documentElement;
 
   // toggle the dark class on the html element
-  const appearanceUtil = new AppearanceUtil();
-  let isDark = await appearanceUtil.isDarkMode();
-  if (isDark) {
+  if (isDarkTheme) {
     html.classList.add('dark');
     html.setAttribute('style', 'color-scheme: dark;');
   } else {
@@ -35,6 +37,11 @@ onMount(async () => {
     // notify changes
     window.dispatchEvent(new Event('appearance-changed'));
   });
+
+  isDarkUnsubscribe = isDark.subscribe(value => {
+    isDarkTheme = value;
+    updateAppearance();
+  });
 });
 
 // now, need to do the same for the appearance setting
@@ -43,5 +50,9 @@ onDidChangeConfiguration.addEventListener(APPEARANCE_CONFIGURATION_KEY, onDidCha
 // remove callback when the component is destroyed
 onDestroy(() => {
   onDidChangeConfiguration.removeEventListener(APPEARANCE_CONFIGURATION_KEY, onDidChangeConfigurationCallback);
+
+  if (isDarkUnsubscribe) {
+    isDarkUnsubscribe();
+  }
 });
 </script>

--- a/packages/renderer/src/lib/appearance/IconImage.spec.ts
+++ b/packages/renderer/src/lib/appearance/IconImage.spec.ts
@@ -26,6 +26,15 @@ import { AppearanceSettings } from '../../../../main/src/plugin/appearance-setti
 import IconImage from './IconImage.svelte';
 
 const getConfigurationValueMock = vi.fn();
+const getImageMock = vi.fn();
+
+vi.mock('./appearance-util', () => {
+  return {
+    AppearanceUtil: class {
+      getImage = getImageMock;
+    },
+  };
+});
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -38,7 +47,7 @@ beforeEach(() => {
 });
 
 test('Expect valid source and alt text with dark mode', async () => {
-  getConfigurationValueMock.mockResolvedValue(AppearanceSettings.DarkEnumValue);
+  getImageMock.mockReturnValue('dark.png');
 
   const image = render(IconImage, { image: { light: 'light.png', dark: 'dark.png' }, alt: 'this is alt text' });
 
@@ -49,12 +58,12 @@ test('Expect valid source and alt text with dark mode', async () => {
   const imageElement = image.getByRole('img');
 
   // expect to have valid source
-  expect(imageElement).toHaveAttribute('src', 'dark.png');
+  await vi.waitFor(async () => expect(imageElement).toHaveAttribute('src', 'dark.png'));
   expect(imageElement).toHaveAttribute('alt', 'this is alt text');
 });
 
 test('Expect valid source and alt text with light mode', async () => {
-  getConfigurationValueMock.mockResolvedValue(AppearanceSettings.LightEnumValue);
+  getImageMock.mockReturnValue('light.png');
 
   const image = render(IconImage, { image: { light: 'light.png', dark: 'dark.png' }, alt: 'this is alt text' });
 
@@ -65,12 +74,13 @@ test('Expect valid source and alt text with light mode', async () => {
   const imageElement = image.getByRole('img');
 
   // expect to have valid source
-  expect(imageElement).toHaveAttribute('src', 'light.png');
+  await vi.waitFor(async () => expect(imageElement).toHaveAttribute('src', 'light.png'));
   expect(imageElement).toHaveAttribute('alt', 'this is alt text');
 });
 
 test('Expect no alt attribute if missing and default image', async () => {
   getConfigurationValueMock.mockResolvedValue(AppearanceSettings.LightEnumValue);
+  getImageMock.mockReturnValue('image.png');
 
   const image = render(IconImage, { image: 'image.png' });
 

--- a/packages/renderer/src/lib/appearance/appearance-util.ts
+++ b/packages/renderer/src/lib/appearance/appearance-util.ts
@@ -16,10 +16,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { get } from 'svelte/store';
-
 import { AppearanceSettings } from '../../../../main/src/plugin/appearance-settings';
 import { isDark } from '../../stores/appearance';
+
+let isDarkTheme = false;
+isDark.subscribe(value => {
+  isDarkTheme = value;
+});
 
 export class AppearanceUtil {
   async getTheme(): Promise<string> {
@@ -48,7 +51,6 @@ export class AppearanceUtil {
       return icon;
     }
 
-    const isDarkTheme = get(isDark);
     if (isDarkTheme && icon.dark) {
       return icon.dark;
     } else if (!isDarkTheme && icon.light) {

--- a/packages/renderer/src/lib/appearance/appearance-util.ts
+++ b/packages/renderer/src/lib/appearance/appearance-util.ts
@@ -16,28 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { get } from 'svelte/store';
+
 import { AppearanceSettings } from '../../../../main/src/plugin/appearance-settings';
+import { isDark } from '../../stores/appearance';
 
 export class AppearanceUtil {
-  async isDarkMode(): Promise<boolean> {
-    // get the configuration of the appearance
-    const appearance = await window.getConfigurationValue<string>(
-      AppearanceSettings.SectionName + '.' + AppearanceSettings.Appearance,
-    );
-
-    let isDark = false;
-
-    if (appearance === AppearanceSettings.SystemEnumValue) {
-      // need to read the system default theme using the window.matchMedia
-      isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    } else if (appearance === AppearanceSettings.LightEnumValue) {
-      isDark = false;
-    } else if (appearance === AppearanceSettings.DarkEnumValue) {
-      isDark = true;
-    }
-    return isDark;
-  }
-
   async getTheme(): Promise<string> {
     const themeName = await window.getConfigurationValue<string>(
       AppearanceSettings.SectionName + '.' + AppearanceSettings.Appearance,
@@ -64,10 +48,10 @@ export class AppearanceUtil {
       return icon;
     }
 
-    const isDark: boolean = await this.isDarkMode();
-    if (isDark && icon.dark) {
+    const isDarkTheme = get(isDark);
+    if (isDarkTheme && icon.dark) {
       return icon.dark;
-    } else if (!isDark && icon.light) {
+    } else if (!isDarkTheme && icon.light) {
       return icon.light;
     }
     return undefined;

--- a/packages/renderer/src/lib/appearance/appearance-utils.spec.ts
+++ b/packages/renderer/src/lib/appearance/appearance-utils.spec.ts
@@ -20,6 +20,8 @@
 
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
+import { configurationProperties } from '/@/stores/configurationProperties';
+
 import { AppearanceSettings } from '../../../../main/src/plugin/appearance-settings';
 import { AppearanceUtil } from './appearance-util';
 
@@ -31,50 +33,6 @@ const getConfigurationValueMock = vi.fn();
 beforeEach(() => {
   vi.clearAllMocks();
   (window as any).getConfigurationValue = getConfigurationValueMock;
-});
-
-test('Expect light mode using system when OS is set to light', async () => {
-  (window as any).matchMedia = vi.fn().mockReturnValue({
-    matches: false,
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-  });
-
-  getConfigurationValueMock.mockResolvedValue(AppearanceSettings.SystemEnumValue);
-
-  // expect to have class being "light" as OS is using light
-  expect(await appearanceUtil.isDarkMode()).toBe(false);
-});
-
-test('Expect dark mode using system when OS is set to dark', async () => {
-  (window as any).matchMedia = vi.fn().mockReturnValue({
-    matches: true,
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-  });
-
-  getConfigurationValueMock.mockResolvedValue(AppearanceSettings.SystemEnumValue);
-
-  // expect to have class being "dark" as OS is using dark
-  expect(await appearanceUtil.isDarkMode()).toBe(true);
-});
-
-test('Expect light mode using light configuration', async () => {
-  getConfigurationValueMock.mockResolvedValue(AppearanceSettings.LightEnumValue);
-
-  expect(await appearanceUtil.isDarkMode()).toBe(false);
-});
-
-test('Expect dark mode using dark configuration', async () => {
-  getConfigurationValueMock.mockResolvedValue(AppearanceSettings.DarkEnumValue);
-
-  expect(await appearanceUtil.isDarkMode()).toBe(true);
-});
-
-test('Expect light mode using light configuration', async () => {
-  getConfigurationValueMock.mockResolvedValue(AppearanceSettings.LightEnumValue);
-
-  expect(await appearanceUtil.isDarkMode()).toBe(false);
 });
 
 test('Expect standard icon using dark configuration', async () => {
@@ -94,15 +52,17 @@ test('Expect standard icon using light configuration', async () => {
 test('Expect dark icon using dark configuration', async () => {
   const img = { light: 'light.png', dark: 'dark.png' };
   getConfigurationValueMock.mockResolvedValue(AppearanceSettings.DarkEnumValue);
+  configurationProperties.set([]);
 
-  expect(await appearanceUtil.getImage(img)).toBe(img.dark);
+  await vi.waitFor(async () => expect(await appearanceUtil.getImage(img)).toBe(img.dark));
 });
 
 test('Expect light icon using light configuration', async () => {
   const img = { light: 'light.png', dark: 'dark.png' };
   getConfigurationValueMock.mockResolvedValue(AppearanceSettings.LightEnumValue);
+  configurationProperties.set([]);
 
-  expect(await appearanceUtil.getImage(img)).toBe(img.light);
+  await vi.waitFor(async () => expect(await appearanceUtil.getImage(img)).toBe(img.light));
 });
 
 describe('getTheme', () => {

--- a/packages/renderer/src/lib/editor/MonacoEditor.svelte
+++ b/packages/renderer/src/lib/editor/MonacoEditor.svelte
@@ -3,13 +3,17 @@ import type monaco from 'monaco-editor';
 import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
 import jsonWorker from 'monaco-editor/esm/vs/language/json/json.worker?worker';
 import { createEventDispatcher, onDestroy, onMount } from 'svelte';
+import type { Unsubscriber } from 'svelte/store';
 
 import { EditorSettings } from '../../../../main/src/plugin/editor-settings';
+import { isDark } from '../../stores/appearance';
 import { AppearanceUtil } from '../appearance/appearance-util';
 
 let divEl: HTMLDivElement;
 let editor: monaco.editor.IStandaloneCodeEditor;
 let Monaco;
+let isDarkUnsubscribe: Unsubscriber;
+let isDarkTheme = false;
 
 export let content = '';
 export let language = 'json';
@@ -37,12 +41,11 @@ onMount(async () => {
 
   // check if we're in light or dark mode and get the terminal background color
   const appearanceUtil = new AppearanceUtil();
-  const isDark = await appearanceUtil.isDarkMode();
   const bgColor = appearanceUtil.getColor('--pd-terminal-background');
 
   // create a theme with the current light or dark mode, but customize the background color
   Monaco.editor.defineTheme('podmanDesktopTheme', {
-    base: isDark ? 'vs-dark' : 'vs',
+    base: isDarkTheme ? 'vs-dark' : 'vs',
     inherit: true,
     rules: [{ token: 'custom-color', background: bgColor }],
     colors: {
@@ -64,10 +67,17 @@ onMount(async () => {
     // Emit the content change so we can use it in the parent component
     dispatch('contentChange', editor.getValue());
   });
+
+  isDarkUnsubscribe = isDark.subscribe(value => {
+    isDarkTheme = value;
+  });
 });
 
 onDestroy(() => {
   editor?.dispose();
+  if (isDarkUnsubscribe) {
+    isDarkUnsubscribe();
+  }
 });
 
 $: content, editor?.getModel()?.setValue(content);

--- a/packages/renderer/src/lib/editor/MonacoEditor.svelte
+++ b/packages/renderer/src/lib/editor/MonacoEditor.svelte
@@ -13,7 +13,6 @@ let divEl: HTMLDivElement;
 let editor: monaco.editor.IStandaloneCodeEditor;
 let Monaco;
 let isDarkUnsubscribe: Unsubscriber;
-let isDarkTheme = false;
 
 export let content = '';
 export let language = 'json';
@@ -21,7 +20,28 @@ export let readOnly = true;
 
 const dispatch = createEventDispatcher<{ contentChange: string }>();
 
+async function updateTheme(isDarkTheme: boolean) {
+  Monaco = await import('monaco-editor');
+  // check if we're in light or dark mode and get the terminal background color
+  const appearanceUtil = new AppearanceUtil();
+  const bgColor = appearanceUtil.getColor('--pd-terminal-background');
+
+  // create a theme with the current light or dark mode, but customize the background color
+  Monaco.editor.defineTheme('podmanDesktopTheme', {
+    base: isDarkTheme ? 'vs-dark' : 'vs',
+    inherit: true,
+    rules: [{ token: 'custom-color', background: bgColor }],
+    colors: {
+      'editor.background': bgColor,
+    },
+  });
+}
+
 onMount(async () => {
+  isDarkUnsubscribe = isDark.subscribe(value => {
+    updateTheme(value);
+  });
+
   self.MonacoEnvironment = {
     getWorker: function (_moduleId: any, label: string) {
       if (label === 'json') {
@@ -39,20 +59,6 @@ onMount(async () => {
     EditorSettings.SectionName + '.' + EditorSettings.FontSize,
   );
 
-  // check if we're in light or dark mode and get the terminal background color
-  const appearanceUtil = new AppearanceUtil();
-  const bgColor = appearanceUtil.getColor('--pd-terminal-background');
-
-  // create a theme with the current light or dark mode, but customize the background color
-  Monaco.editor.defineTheme('podmanDesktopTheme', {
-    base: isDarkTheme ? 'vs-dark' : 'vs',
-    inherit: true,
-    rules: [{ token: 'custom-color', background: bgColor }],
-    colors: {
-      'editor.background': bgColor,
-    },
-  });
-
   editor = Monaco.editor.create(divEl, {
     value: content,
     fontSize,
@@ -66,10 +72,6 @@ onMount(async () => {
   editor.onDidChangeModelContent(() => {
     // Emit the content change so we can use it in the parent component
     dispatch('contentChange', editor.getValue());
-  });
-
-  isDarkUnsubscribe = isDark.subscribe(value => {
-    isDarkTheme = value;
   });
 });
 

--- a/packages/renderer/src/lib/image/ImageColumnName.spec.ts
+++ b/packages/renderer/src/lib/image/ImageColumnName.spec.ts
@@ -23,7 +23,6 @@ import { render, screen } from '@testing-library/svelte';
 import { router } from 'tinro';
 import { expect, test, vi } from 'vitest';
 
-import { AppearanceSettings } from '../../../../main/src/plugin/appearance-settings';
 import ImageIcon from '../images/ImageIcon.svelte';
 import ImageColumnName from './ImageColumnName.svelte';
 import type { ImageInfoUI } from './ImageInfoUI';
@@ -46,6 +45,15 @@ const image: ImageInfoUI = {
   badges: [],
   digest: 'sha256:1234567890',
 };
+const getImageMock = vi.fn();
+
+vi.mock('/@/lib/appearance/appearance-util', () => {
+  return {
+    AppearanceUtil: class {
+      getImage = getImageMock;
+    },
+  };
+});
 
 test('Expect simple column styling', async () => {
   render(ImageColumnName, { object: image });
@@ -88,6 +96,7 @@ test('Expect badge with simple color', async () => {
       },
     ],
   };
+  getImageMock.mockReturnValue('#ff0000');
   render(ImageColumnName, { object: imageWithBadges });
 
   // wait for image to be rendered using timeout
@@ -101,11 +110,10 @@ test('Expect badge with simple color', async () => {
   expect(badge).toBeInTheDocument();
 
   // check background color
-  expect(badge).toHaveStyle('background-color: #ff0000');
+  await vi.waitFor(async () => expect(badge).toHaveStyle('background-color: #ff0000'));
 });
 
 test('Expect badge with dark color', async () => {
-  (window as any).getConfigurationValue = vi.fn().mockResolvedValue(AppearanceSettings.DarkEnumValue);
   const imageWithBadges: ImageInfoUI = {
     ...image,
     badges: [
@@ -118,6 +126,7 @@ test('Expect badge with dark color', async () => {
       },
     ],
   };
+  getImageMock.mockReturnValue('#0000ff');
   render(ImageColumnName, { object: imageWithBadges });
 
   // wait for image to be rendered using timeout
@@ -131,11 +140,10 @@ test('Expect badge with dark color', async () => {
   expect(badge).toBeInTheDocument();
 
   // check background color
-  expect(badge).toHaveStyle('background-color: #0000ff');
+  await vi.waitFor(async () => expect(badge).toHaveStyle('background-color: #0000ff'));
 });
 
 test('Expect badge with light color', async () => {
-  (window as any).getConfigurationValue = vi.fn().mockResolvedValue(AppearanceSettings.LightEnumValue);
   const imageWithBadges: ImageInfoUI = {
     ...image,
     badges: [
@@ -148,6 +156,7 @@ test('Expect badge with light color', async () => {
       },
     ],
   };
+  getImageMock.mockReturnValue('#00ff00');
   render(ImageColumnName, { object: imageWithBadges });
 
   // wait for image to be rendered using timeout
@@ -161,7 +170,7 @@ test('Expect badge with light color', async () => {
   expect(badge).toBeInTheDocument();
 
   // check background color
-  expect(badge).toHaveStyle('background-color: #00ff00');
+  await vi.waitFor(async () => expect(badge).toHaveStyle('background-color: #00ff00'));
 });
 
 test('Expect if image is a manifest, the on:click IS there', async () => {

--- a/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.spec.ts
@@ -34,6 +34,15 @@ class ResizeObserver {
 }
 
 const configMock = vi.fn();
+const getImageMock = vi.fn();
+
+vi.mock('../appearance/appearance-util', () => {
+  return {
+    AppearanceUtil: class {
+      getImage = getImageMock;
+    },
+  };
+});
 
 beforeAll(() => {
   (window as any).ResizeObserver = ResizeObserver;
@@ -219,6 +228,7 @@ test('Expects images.icon option to be used when no themes are present', async (
       sessionRequests: [],
     },
   ];
+  getImageMock.mockReturnValue('./icon.png');
   authenticationProviders.set(providerWithImageIcon);
   render(PreferencesAuthenticationProvidersRendering, {});
 
@@ -245,6 +255,7 @@ test('Expects images.icon.dark option to be used when theme is dark', async () =
       sessionRequests: [],
     },
   ];
+  getImageMock.mockReturnValue('./icon-dark.png');
   authenticationProviders.set(providerWithImageIcon);
 
   configMock.mockReturnValue('dark');

--- a/packages/renderer/src/lib/recommendation/ExtensionBanner.svelte
+++ b/packages/renderer/src/lib/recommendation/ExtensionBanner.svelte
@@ -6,7 +6,7 @@ import FeaturedExtension from '/@/lib/featured/FeaturedExtension.svelte';
 import type { ExtensionBanner } from '../../../../main/src/plugin/recommendations/recommendations-api';
 
 export let banner: ExtensionBanner;
-// Pass in the theme appearance colour of PD to the banner, we do it here so we don't have to do multiple isDarkMode() checks when rendering multiple banners.
+// Pass in the theme appearance colour of PD to the banner, we do it here so we don't have to do multiple isDark checks when rendering multiple banners.
 export let isDark: boolean;
 
 let style: string | undefined = undefined;

--- a/packages/renderer/src/lib/recommendation/ExtensionBanners.svelte
+++ b/packages/renderer/src/lib/recommendation/ExtensionBanners.svelte
@@ -1,20 +1,10 @@
 <script lang="ts">
-import { onMount } from 'svelte';
-
 import ExtensionBanner from '/@/lib/recommendation/ExtensionBanner.svelte';
 import { extensionBannerInfos } from '/@/stores/extensionBanners';
 
-import { AppearanceUtil } from '../appearance/appearance-util';
-
-let isDark: boolean;
-
-onMount(async () => {
-  // Retrieve the current theme appearance colour of PD for the banners we will be showing
-  const appearanceUtil = new AppearanceUtil();
-  isDark = await appearanceUtil.isDarkMode();
-});
+import { isDark } from '../../stores/appearance';
 </script>
 
 {#each $extensionBannerInfos as banner (banner.extensionId)}
-  <ExtensionBanner banner={banner} isDark={isDark} />
+  <ExtensionBanner banner={banner} isDark={$isDark} />
 {/each}

--- a/packages/renderer/src/lib/ui/Badge.spec.ts
+++ b/packages/renderer/src/lib/ui/Badge.spec.ts
@@ -21,11 +21,19 @@ import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/svelte';
 import { beforeEach, expect, test, vi } from 'vitest';
 
-import { AppearanceSettings } from '../../../../main/src/plugin/appearance-settings';
 import Badge from './Badge.svelte';
 
 // mock window.getConfigurationValue
 const getConfigurationValueMock = vi.fn();
+const getImageMock = vi.fn();
+
+vi.mock('/@/lib/appearance/appearance-util', () => {
+  return {
+    AppearanceUtil: class {
+      getImage = getImageMock;
+    },
+  };
+});
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -33,6 +41,7 @@ beforeEach(() => {
 });
 
 test('Should display badge', async () => {
+  getImageMock.mockReturnValue('bg-gray-500');
   render(Badge, { label: 'customLabel' });
 
   // expect to see label inside the label
@@ -47,6 +56,7 @@ test('Should display badge', async () => {
 });
 
 test('Should display badge with rgb color', async () => {
+  getImageMock.mockReturnValue('#ff0000');
   render(Badge, { label: 'customLabel', color: '#ff0000' });
 
   // expect to see label inside the label
@@ -61,8 +71,7 @@ test('Should display badge with rgb color', async () => {
 });
 
 test('Should display badge with light color', async () => {
-  getConfigurationValueMock.mockResolvedValueOnce(AppearanceSettings.LightEnumValue);
-
+  getImageMock.mockReturnValue('#ff0000');
   render(Badge, { label: 'customLabel', color: { light: '#ff0000', dark: '#00ff00' } });
 
   // expect to see label inside the label
@@ -77,9 +86,8 @@ test('Should display badge with light color', async () => {
 });
 
 test('Should display badge with dark color', async () => {
-  getConfigurationValueMock.mockResolvedValueOnce(AppearanceSettings.DarkEnumValue);
-
-  render(Badge, { label: 'customLabel', color: { light: '#ff0000', dark: '#00ff00' } });
+  getImageMock.mockReturnValue('#00FF00');
+  render(Badge, { label: 'customLabel', color: { light: '#FF0000', dark: '#00FF00' } });
 
   // expect to see label inside the label
   const label = screen.getByText('customLabel');

--- a/packages/renderer/src/stores/appearance.spec.ts
+++ b/packages/renderer/src/stores/appearance.spec.ts
@@ -1,0 +1,74 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { get } from 'svelte/store';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { AppearanceSettings } from '../../../main/src/plugin/appearance-settings';
+import { isDark } from './appearance';
+import { configurationProperties } from './configurationProperties';
+
+// mock window.getConfigurationValue
+const getConfigurationValueMock = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (window as any).getConfigurationValue = getConfigurationValueMock;
+});
+
+test('Expect light mode using system when OS is set to light', async () => {
+  (window as any).matchMedia = vi.fn().mockReturnValue({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  });
+
+  getConfigurationValueMock.mockResolvedValue(AppearanceSettings.SystemEnumValue);
+  configurationProperties.set([]);
+
+  // expect to have class being "light" as OS is using light
+  await vi.waitFor(() => expect(get(isDark)).toBe(false));
+});
+
+test('Expect dark mode using system when OS is set to dark', async () => {
+  (window as any).matchMedia = vi.fn().mockReturnValue({
+    matches: true,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  });
+
+  getConfigurationValueMock.mockResolvedValue(AppearanceSettings.SystemEnumValue);
+  configurationProperties.set([]);
+
+  // expect to have class being "dark" as OS is using dark
+  await vi.waitFor(() => expect(get(isDark)).toBe(true));
+});
+
+test('Expect light mode using light configuration', async () => {
+  getConfigurationValueMock.mockResolvedValue(AppearanceSettings.LightEnumValue);
+  configurationProperties.set([]);
+
+  await vi.waitFor(() => expect(get(isDark)).toBe(false));
+});
+
+test('Expect dark mode using dark configuration', async () => {
+  getConfigurationValueMock.mockResolvedValue(AppearanceSettings.DarkEnumValue);
+  configurationProperties.set([]);
+
+  await vi.waitFor(() => expect(get(isDark)).toBe(true));
+});

--- a/packages/renderer/src/stores/appearance.ts
+++ b/packages/renderer/src/stores/appearance.ts
@@ -1,0 +1,47 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { type Writable, writable } from 'svelte/store';
+
+import { AppearanceSettings } from '../../../main/src/plugin/appearance-settings';
+import { configurationProperties } from './configurationProperties';
+
+export const isDark: Writable<boolean> = writable(false);
+
+configurationProperties.subscribe(() => {
+  if (window?.getConfigurationValue) {
+    window
+      .getConfigurationValue<string>(AppearanceSettings.SectionName + '.' + AppearanceSettings.Appearance)
+      .then(value => {
+        if (value) {
+          updateIsDark(value);
+        }
+      });
+  }
+});
+
+function updateIsDark(appearance: string) {
+  if (appearance === AppearanceSettings.SystemEnumValue) {
+    // need to read the system default theme using the window.matchMedia
+    isDark.set(window.matchMedia('(prefers-color-scheme: dark)').matches);
+  } else if (appearance === AppearanceSettings.LightEnumValue) {
+    isDark.set(false);
+  } else if (appearance === AppearanceSettings.DarkEnumValue) {
+    isDark.set(true);
+  }
+}


### PR DESCRIPTION
### What does this PR do?
Refactors appearance-utils isDarkMode function to be reactive => changes it to reactive variable

Prerequisite of https://github.com/containers/podman-desktop/pull/8744

- [x] Tests are covering the bug fix or the new feature
