### PR TITLE
chore(test): increment trace names upon retry

### DIFF
--- a/tests/playwright/src/runner/podman-desktop-runner.ts
+++ b/tests/playwright/src/runner/podman-desktop-runner.ts
@@ -349,6 +349,10 @@ export class Runner {
 
   public setVideoAndTraceName(name: string): void {
     this._videoAndTraceName = name;
+
+    if (test.info().retry > 0) {
+      this._videoAndTraceName += `_retry${test.info().retry}`;
+    }
   }
 
   public getTestOutput(): string {


### PR DESCRIPTION
### What does this PR do?
Increments trace and video recording file names for retries so as to not overwrite the previously failed tries in order to investigate the flakyness.

### What issues does this PR fix or reference?
https://github.com/containers/podman-desktop/issues/8766

