### PR TITLE
feat: search image

### DIFF
--- a/packages/renderer/src/lib/image/PullImage.spec.ts
+++ b/packages/renderer/src/lib/image/PullImage.spec.ts
@@ -136,7 +136,7 @@ describe('PullImage', () => {
     expect(button).toBeInTheDocument();
     expect(button).toBeDisabled();
 
-    const textbox = screen.getByRole('textbox', { name: 'imageName' });
+    const textbox = screen.getByRole('textbox', { name: 'Image to Pull' });
     await userEvent.click(textbox);
     await userEvent.paste('some-valid-image');
 
@@ -173,7 +173,7 @@ describe('PullImage', () => {
     setup();
     render(PullImage);
 
-    const pullImageInput = screen.getByRole('textbox', { name: 'imageName' });
+    const pullImageInput = screen.getByRole('textbox', { name: 'Image to Pull' });
     expect(pullImageInput.matches(':focus')).toBe(true);
   });
 

--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -195,6 +195,8 @@ async function searchImages(value: string): Promise<string[]> {
       <label for="imageName" class="block mb-2 font-bold text-[var(--pd-content-card-header-text)]"
         >Image to Pull</label>
       <Typeahead
+        id="imageName"
+        name="imageName"
         placeholder="Image name"
         searchFunction={searchImages}
         onChange={(s: string) => {

--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -166,14 +166,10 @@ async function searchImages(value: string): Promise<string[]> {
     options.query = rest.join('/');
   }
   let result: string[];
-  try {
-    const searchResult = await window.searchImageInRegistry(options);
-    result = searchResult.map(r => {
-      return [options.registry, r.name].join('/');
-    });
-  } catch {
-    result = [];
-  }
+  const searchResult = await window.searchImageInRegistry(options);
+  result = searchResult.map(r => {
+    return [options.registry, r.name].join('/');
+  });
   return result;
 }
 </script>

--- a/packages/renderer/src/lib/ui/Typeahead.spec.ts
+++ b/packages/renderer/src/lib/ui/Typeahead.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/renderer/src/lib/ui/Typeahead.spec.ts
+++ b/packages/renderer/src/lib/ui/Typeahead.spec.ts
@@ -1,0 +1,227 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen, within } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { tick } from 'svelte';
+import { expect, test } from 'vitest';
+
+import Typeahead from './Typeahead.svelte';
+
+window.HTMLElement.prototype.scrollIntoView = function () {};
+
+function assertIsListVisible(visible: boolean): void {
+  if (visible) {
+    const list = screen.getByRole('row');
+    expect(list).toBeDefined();
+  } else {
+    const list = screen.queryByRole('row');
+    expect(list).toBeNull();
+  }
+}
+
+function assertItemSelected(items: HTMLElement[], r: number): void {
+  for (let i = 0; i < items.length; i++) {
+    if (i === r) {
+      expect(items[i]).toHaveClass('bg-[var(--pd-content-card-hover-bg)]');
+    } else {
+      expect(items[i]).not.toHaveClass('bg-[var(--pd-content-card-hover-bg)]');
+    }
+  }
+}
+
+test('a textbox is created', async () => {
+  render(Typeahead);
+
+  const input = screen.getByRole('textbox');
+  expect(input).toBeDefined();
+});
+
+test('placeholder is set', async () => {
+  render(Typeahead, {
+    placeholder: 'a placeholder',
+  });
+
+  const input = screen.getByPlaceholderText('a placeholder');
+  expect(input).toBeDefined();
+});
+
+test('initial focus is not set by default', async () => {
+  render(Typeahead);
+
+  const input = screen.getByRole('textbox');
+  expect(input).not.toHaveFocus();
+});
+
+test('initial focus is set with option', async () => {
+  render(Typeahead, {
+    initialFocus: true,
+  });
+
+  const input = screen.getByRole('textbox');
+  expect(input).toHaveFocus();
+});
+
+test('should list the result after the delay, and display spinner during loading', async () => {
+  const searchFunction = async (s: string) => {
+    await new Promise(resolve => setTimeout(resolve, 100));
+    return [s + '01', s + '02', s + '03'];
+  };
+  render(Typeahead, {
+    initialFocus: true,
+    searchFunction,
+    delay: 10,
+  });
+
+  const input = screen.getByRole('textbox');
+  assertIsListVisible(false);
+
+  await userEvent.type(input, 'aze');
+
+  await new Promise(resolve => setTimeout(resolve, 5));
+  assertIsListVisible(false);
+  await new Promise(resolve => setTimeout(resolve, 10));
+  tick();
+  screen.getByRole('progressbar');
+
+  await new Promise(resolve => setTimeout(resolve, 100));
+  expect(screen.queryByRole('progressbar')).toBeNull();
+  assertIsListVisible(true);
+
+  const list = screen.getByRole('row');
+  const items = within(list).getAllByRole('button');
+  expect(items.length).toBe(3);
+  within(list).getByText('aze01');
+  within(list).getByText('aze02');
+  within(list).getByText('aze03');
+});
+
+test('should navigate in list with keys', async () => {
+  const searchFunction = async (s: string) => {
+    const result: string[] = [];
+    for (let i = 1; i <= 15; i++) {
+      result.push(s + `${i}`.padStart(2, '0'));
+    }
+    return result;
+  };
+  render(Typeahead, {
+    initialFocus: true,
+    searchFunction,
+    delay: 10,
+  });
+  const input = screen.getByRole('textbox');
+  await userEvent.type(input, 'term');
+
+  await new Promise(resolve => setTimeout(resolve, 11));
+
+  let list = screen.getByRole('row');
+  let items = within(list).getAllByRole('button');
+  expect(items.length).toBe(15);
+
+  // No item is selected first
+  assertItemSelected(items, -1);
+  screen.getByDisplayValue('term');
+
+  await userEvent.keyboard('[ArrowDown]');
+  assertItemSelected(items, 0);
+  screen.getByDisplayValue('term01');
+
+  await userEvent.keyboard('[ArrowDown]');
+  assertItemSelected(items, 1);
+  screen.getByDisplayValue('term02');
+
+  await userEvent.keyboard('[PageDown]');
+  assertItemSelected(items, 11);
+  screen.getByDisplayValue('term12');
+
+  await userEvent.keyboard('[PageDown]');
+  assertItemSelected(items, 14);
+  screen.getByDisplayValue('term15');
+
+  await userEvent.keyboard('[ArrowUp]');
+  await userEvent.keyboard('[ArrowUp]');
+  await userEvent.keyboard('[ArrowUp]');
+  await userEvent.keyboard('[ArrowUp]');
+  await userEvent.keyboard('[ArrowUp]');
+  assertItemSelected(items, 9);
+  screen.getByDisplayValue('term10');
+
+  await userEvent.keyboard('[PageUp]');
+  assertItemSelected(items, 0);
+  screen.getByDisplayValue('term01');
+
+  // Close the list when pressing Up at top of the list
+  await userEvent.keyboard('[ArrowUp]');
+  assertIsListVisible(false);
+  screen.getByDisplayValue('term');
+
+  // Down opens the list again, no item selected
+  await userEvent.keyboard('[ArrowDown]');
+  assertIsListVisible(true);
+
+  list = screen.getByRole('row');
+  items = within(list).getAllByRole('button');
+  assertItemSelected(items, -1);
+  screen.getByDisplayValue('term');
+
+  await userEvent.keyboard('[ArrowDown]');
+  assertItemSelected(items, 0);
+  screen.getByDisplayValue('term01');
+
+  await userEvent.keyboard('[ArrowDown]');
+  await userEvent.keyboard('[ArrowDown]');
+  assertItemSelected(items, 2);
+  screen.getByDisplayValue('term03');
+  // Select an item by pressing Enter
+  await userEvent.keyboard('[Enter]');
+  // closes the list
+  assertIsListVisible(false);
+  // copies the item in the input
+  screen.getByDisplayValue('term03');
+});
+
+test('should display error on tooltip, which disappears after next successful search', async () => {
+  let first: boolean = true;
+  const searchFunction = async (s: string) => {
+    if (first) {
+      first = false;
+      throw new Error('an error!');
+    } else {
+      return [s + '01'];
+    }
+  };
+  render(Typeahead, {
+    initialFocus: true,
+    searchFunction,
+    delay: 10,
+  });
+  const input = screen.getByRole('textbox');
+  await userEvent.type(input, 'term');
+  await new Promise(resolve => setTimeout(resolve, 11));
+  assertIsListVisible(false);
+  screen.getByRole('alert');
+  const tooltip = screen.getByLabelText('tooltip');
+  expect(tooltip).toHaveTextContent('Error: an error!');
+
+  await userEvent.type(input, 'tosearch');
+  await new Promise(resolve => setTimeout(resolve, 11));
+  assertIsListVisible(true);
+  expect(screen.queryByRole('alert')).toBeNull();
+  expect(screen.queryByLabelText('tooltip')).toBeNull();
+});

--- a/packages/renderer/src/lib/ui/Typeahead.spec.ts
+++ b/packages/renderer/src/lib/ui/Typeahead.spec.ts
@@ -195,33 +195,3 @@ test('should navigate in list with keys', async () => {
   // copies the item in the input
   screen.getByDisplayValue('term03');
 });
-
-test('should display error on tooltip, which disappears after next successful search', async () => {
-  let first: boolean = true;
-  const searchFunction = async (s: string) => {
-    if (first) {
-      first = false;
-      throw new Error('an error!');
-    } else {
-      return [s + '01'];
-    }
-  };
-  render(Typeahead, {
-    initialFocus: true,
-    searchFunction,
-    delay: 10,
-  });
-  const input = screen.getByRole('textbox');
-  await userEvent.type(input, 'term');
-  await new Promise(resolve => setTimeout(resolve, 11));
-  assertIsListVisible(false);
-  screen.getByRole('alert');
-  const tooltip = screen.getByLabelText('tooltip');
-  expect(tooltip).toHaveTextContent('Error: an error!');
-
-  await userEvent.type(input, 'tosearch');
-  await new Promise(resolve => setTimeout(resolve, 11));
-  assertIsListVisible(true);
-  expect(screen.queryByRole('alert')).toBeNull();
-  expect(screen.queryByLabelText('tooltip')).toBeNull();
-});

--- a/packages/renderer/src/lib/ui/Typeahead.svelte
+++ b/packages/renderer/src/lib/ui/Typeahead.svelte
@@ -19,6 +19,7 @@ export let onChange = function (_s: string) {};
 export let onEnter = function () {};
 
 let input: HTMLInputElement;
+let list: HTMLDivElement;
 let scrollElements: HTMLElement[] = [];
 let value: string;
 let items: string[] = [];
@@ -175,7 +176,15 @@ function requestFocus(e: HTMLInputElement): void {
     e.focus();
   }
 }
+
+function onWindowClick(e: Event): void {
+  if (list && e.target instanceof Node && !list.contains(e.target)) {
+    close();
+  }
+}
 </script>
+
+<svelte:window on:click={onWindowClick} />
 
 <div
   class="flex flex-row grow items-center px-1 py-1 group bg-[var(--pd-input-field-bg)] border-[1px] border-transparent {$$props.class ||
@@ -216,6 +225,7 @@ function requestFocus(e: HTMLInputElement): void {
 </div>
 {#if opened && items.length > 0}
   <div
+    bind:this={list}
     class="max-h-80 overflow-auto bg-[var(--pd-content-card-bg)] border-[var(--pd-input-field-hover-stroke)] border-[1px]">
     {#each items as item, i}
       <button

--- a/packages/renderer/src/lib/ui/Typeahead.svelte
+++ b/packages/renderer/src/lib/ui/Typeahead.svelte
@@ -1,0 +1,206 @@
+<script lang="ts">
+type SearchFunction = (s: string) => Promise<string[]>;
+
+// the text displayed when no option is selected
+export let placeholder: string | undefined = undefined;
+export let required: boolean = false;
+export let delay: number = 200;
+export let disabled: boolean = false;
+export let initialFocus: boolean = false;
+
+export let searchFunction: SearchFunction = async (_s: string) => [];
+export let onChange = function (_s: string) {};
+export let onEnter = function () {};
+
+let input: HTMLInputElement;
+let scrollElements: HTMLElement[] = [];
+let value: string;
+let items: string[] = [];
+let inputDelayTimeout: NodeJS.Timeout;
+let opened: boolean = false;
+let highlightIndex: number = -1;
+let pageStep = 10;
+let userValue: string = '';
+
+function onItemSelected(s: string): void {
+  value = s;
+  userValue = s;
+  input.focus();
+  close();
+  onChange(s);
+}
+
+function onInput(): void {
+  userValue = value;
+  onChange(value);
+  clearTimeout(inputDelayTimeout);
+  inputDelayTimeout = setTimeout(processInput, delay);
+}
+
+function onKeyDown(e: KeyboardEvent): void {
+  switch (e.key) {
+    case 'ArrowDown':
+      onDownKey(e);
+      break;
+    case 'PageDown':
+      onPageDownKey(e);
+      break;
+    case 'ArrowUp':
+      onUpKey(e);
+      break;
+    case 'PageUp':
+      onPageUpKey(e);
+      break;
+    case 'Escape':
+      onEscKey(e);
+      break;
+    case 'Enter':
+      onEnterKey(e);
+      break;
+  }
+}
+
+function onUpKey(e: KeyboardEvent): void {
+  if (opened) {
+    if (highlightIndex > 0) {
+      highlightIndex--;
+      value = items[highlightIndex];
+      makeVisible();
+    } else if (highlightIndex === 0) {
+      highlightIndex = -1;
+      value = userValue;
+      close();
+    }
+  }
+  e.preventDefault();
+}
+
+function onPageUpKey(e: KeyboardEvent): void {
+  if (opened) {
+    highlightIndex = Math.max(0, highlightIndex - pageStep);
+    value = items[highlightIndex];
+    makeVisible();
+    e.preventDefault();
+  }
+}
+
+function onDownKey(e: KeyboardEvent): void {
+  if (!opened) {
+    processInput();
+  } else {
+    if (highlightIndex < items.length - 1) {
+      highlightIndex++;
+      value = items[highlightIndex];
+      makeVisible();
+    }
+  }
+  e.preventDefault();
+}
+
+function onPageDownKey(e: KeyboardEvent): void {
+  if (opened) {
+    highlightIndex = Math.min(items.length - 1, highlightIndex + pageStep);
+    value = items[highlightIndex];
+    makeVisible();
+    e.preventDefault();
+  }
+}
+
+function onEscKey(e: KeyboardEvent): void {
+  if (opened) {
+    close();
+    e.stopPropagation();
+  }
+}
+
+function onEnterKey(e: KeyboardEvent): void {
+  if (opened && highlightIndex >= 0) {
+    onItemSelected(items[highlightIndex]);
+    close();
+    e.stopPropagation();
+  } else {
+    close();
+    onEnter();
+  }
+}
+
+function makeVisible(): void {
+  scrollElements[highlightIndex].scrollIntoView({
+    behavior: 'smooth',
+    block: 'nearest',
+    inline: 'start',
+  });
+}
+
+function processInput(): void {
+  searchFunction(value)
+    .then(result => {
+      // if the component has been disabled in the meantime
+      if (disabled) {
+        return;
+      }
+      items = result;
+      highlightIndex = -1;
+      open();
+    })
+    .catch((err: unknown) => {
+      console.error('error searching images', err);
+    });
+}
+
+function open(): void {
+  opened = true;
+}
+
+function close(): void {
+  opened = false;
+}
+
+function requestFocus(e: HTMLInputElement): void {
+  if (initialFocus) {
+    e.focus();
+  }
+}
+</script>
+
+<div
+  class="flex flex-row grow items-center px-1 py-1 group bg-[var(--pd-input-field-bg)] border-[1px] border-transparent {$$props.class ||
+    ''}"
+  class:not(focus-within):hover:bg-[var(--pd-input-field-hover-bg)]={!disabled}
+  class:focus-within:bg-[var(--pd-input-field-focused-bg)]={!disabled}
+  class:focus-within:rounded-md={!disabled}
+  class:border-b-[var(--pd-input-field-stroke)]={!disabled}
+  class:hover:border-b-[var(--pd-input-field-hover-stroke)]={!disabled}
+  class:focus-within:border-[var(--pd-input-field-hover-stroke)]={!disabled}
+  class:border-b-[var(--pd-input-field-stroke-readonly)]={disabled}>
+  <input
+    class="w-full px-0.5 outline-0 bg-[var(--pd-input-field-bg)] placeholder:text-[color:var(--pd-input-field-placeholder-text)] overflow-hidden"
+    class:text-[color:var(--pd-input-field-focused-text)]={!disabled}
+    class:text-[color:var(--pd-input-field-disabled-text)]={disabled}
+    class:group-hover:bg-[var(--pd-input-field-hover-bg)]={!disabled}
+    class:group-focus-within:bg-[var(--pd-input-field-hover-bg)]={!disabled}
+    class:group-hover-placeholder:text-[color:var(--pd-input-field-placeholder-text)]={!disabled}
+    bind:this={input}
+    bind:value={value}
+    placeholder={placeholder}
+    required={required}
+    disabled={disabled}
+    on:input={onInput}
+    on:keydown={onKeyDown}
+    use:requestFocus />
+</div>
+{#if opened && items.length > 0}
+  <div
+    class="max-h-80 overflow-auto bg-[var(--pd-content-card-bg)] border-[var(--pd-input-field-hover-stroke)] border-[1px]">
+    {#each items as item, i}
+      <button
+        bind:this={scrollElements[i]}
+        class:bg-[var(--pd-content-card-hover-bg)]={i !== highlightIndex}
+        class="p-1 text-start w-full cursor-pointer"
+        on:click={() => onItemSelected(item)}
+        on:pointerenter={() => {
+          highlightIndex = i;
+        }}>{item}</button>
+    {/each}
+  </div>
+{/if}

--- a/packages/renderer/src/lib/ui/Typeahead.svelte
+++ b/packages/renderer/src/lib/ui/Typeahead.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
-import { faExclamationCircle } from '@fortawesome/free-solid-svg-icons';
-import { Spinner, Tooltip } from '@podman-desktop/ui-svelte';
-import Fa from 'svelte-fa';
+import { Spinner } from '@podman-desktop/ui-svelte';
 
 type SearchFunction = (s: string) => Promise<string[]>;
 
@@ -29,7 +27,6 @@ let highlightIndex: number = -1;
 let pageStep = 10;
 let userValue: string = '';
 let loading: boolean = false;
-let error: string = '';
 
 function onItemSelected(s: string): void {
   value = s;
@@ -145,7 +142,6 @@ function processInput(): void {
   loading = true;
   searchFunction(value)
     .then(result => {
-      error = '';
       // if the component has been disabled in the meantime
       if (disabled) {
         return;
@@ -154,8 +150,8 @@ function processInput(): void {
       highlightIndex = -1;
       open();
     })
-    .catch((err: unknown) => {
-      error = String(err);
+    .catch(() => {
+      // We do not display the error
       items = [];
     })
     .finally(() => {
@@ -216,11 +212,6 @@ function onWindowClick(e: Event): void {
     use:requestFocus />
   {#if loading}
     <Spinner size="1em" />
-  {/if}
-  {#if error}
-    <Tooltip left={true} tip={error}>
-      <span role="alert"><Fa size="1.1x" class="text-[var(--pd-state-error)]" icon={faExclamationCircle} /></span>
-    </Tooltip>
   {/if}
 </div>
 {#if opened && items.length > 0}

--- a/packages/renderer/src/lib/ui/Typeahead.svelte
+++ b/packages/renderer/src/lib/ui/Typeahead.svelte
@@ -7,6 +7,8 @@ export let required: boolean = false;
 export let delay: number = 200;
 export let disabled: boolean = false;
 export let initialFocus: boolean = false;
+export let id: string | undefined = undefined;
+export let name: string | undefined = undefined;
 
 export let searchFunction: SearchFunction = async (_s: string) => [];
 export let onChange = function (_s: string) {};
@@ -174,6 +176,7 @@ function requestFocus(e: HTMLInputElement): void {
   class:focus-within:border-[var(--pd-input-field-hover-stroke)]={!disabled}
   class:border-b-[var(--pd-input-field-stroke-readonly)]={disabled}>
   <input
+    type="text"
     class="w-full px-0.5 outline-0 bg-[var(--pd-input-field-bg)] placeholder:text-[color:var(--pd-input-field-placeholder-text)] overflow-hidden"
     class:text-[color:var(--pd-input-field-focused-text)]={!disabled}
     class:text-[color:var(--pd-input-field-disabled-text)]={disabled}
@@ -185,6 +188,8 @@ function requestFocus(e: HTMLInputElement): void {
     placeholder={placeholder}
     required={required}
     disabled={disabled}
+    id={id}
+    name={name}
     on:input={onInput}
     on:keydown={onKeyDown}
     use:requestFocus />

--- a/packages/renderer/src/lib/ui/Typeahead.svelte
+++ b/packages/renderer/src/lib/ui/Typeahead.svelte
@@ -219,18 +219,19 @@ function onWindowClick(e: Event): void {
   {/if}
   {#if error}
     <Tooltip left={true} tip={error}>
-      <Fa size="1.1x" class="text-[var(--pd-state-error)]" icon={faExclamationCircle} />
+      <span role="alert"><Fa size="1.1x" class="text-[var(--pd-state-error)]" icon={faExclamationCircle} /></span>
     </Tooltip>
   {/if}
 </div>
 {#if opened && items.length > 0}
   <div
+    role="row"
     bind:this={list}
     class="max-h-80 overflow-auto bg-[var(--pd-content-card-bg)] border-[var(--pd-input-field-hover-stroke)] border-[1px]">
     {#each items as item, i}
       <button
         bind:this={scrollElements[i]}
-        class:bg-[var(--pd-content-card-hover-bg)]={i !== highlightIndex}
+        class:bg-[var(--pd-content-card-hover-bg)]={i === highlightIndex}
         class="p-1 text-start w-full cursor-pointer"
         on:click={() => onItemSelected(item)}
         on:pointerenter={() => {

--- a/packages/renderer/src/lib/ui/Typeahead.svelte
+++ b/packages/renderer/src/lib/ui/Typeahead.svelte
@@ -1,4 +1,8 @@
 <script lang="ts">
+import { faExclamationCircle } from '@fortawesome/free-solid-svg-icons';
+import { Spinner, Tooltip } from '@podman-desktop/ui-svelte';
+import Fa from 'svelte-fa';
+
 type SearchFunction = (s: string) => Promise<string[]>;
 
 // the text displayed when no option is selected
@@ -23,6 +27,8 @@ let opened: boolean = false;
 let highlightIndex: number = -1;
 let pageStep = 10;
 let userValue: string = '';
+let loading: boolean = false;
+let error: string = '';
 
 function onItemSelected(s: string): void {
   value = s;
@@ -135,8 +141,10 @@ function makeVisible(): void {
 }
 
 function processInput(): void {
+  loading = true;
   searchFunction(value)
     .then(result => {
+      error = '';
       // if the component has been disabled in the meantime
       if (disabled) {
         return;
@@ -146,7 +154,11 @@ function processInput(): void {
       open();
     })
     .catch((err: unknown) => {
-      console.error('error searching images', err);
+      error = String(err);
+      items = [];
+    })
+    .finally(() => {
+      loading = false;
     });
 }
 
@@ -193,6 +205,14 @@ function requestFocus(e: HTMLInputElement): void {
     on:input={onInput}
     on:keydown={onKeyDown}
     use:requestFocus />
+  {#if loading}
+    <Spinner size="1em" />
+  {/if}
+  {#if error}
+    <Tooltip left={true} tip={error}>
+      <Fa size="1.1x" class="text-[var(--pd-state-error)]" icon={faExclamationCircle} />
+    </Tooltip>
+  {/if}
 </div>
 {#if opened && items.length > 0}
   <div

--- a/tests/playwright/src/model/pages/pull-image-page.ts
+++ b/tests/playwright/src/model/pages/pull-image-page.ts
@@ -27,7 +27,6 @@ export class PullImagePage extends BasePage {
   readonly closeLink: Locator;
   readonly backToImagesLink: Locator;
   readonly manageRegistriesButton: Locator;
-  readonly imageToPullLabel: Locator;
   readonly imageNameInput: Locator;
 
   constructor(page: Page) {
@@ -37,8 +36,7 @@ export class PullImagePage extends BasePage {
     this.closeLink = page.getByRole('link', { name: 'Close' });
     this.backToImagesLink = page.getByRole('link', { name: 'Go back to Images' });
     this.manageRegistriesButton = page.getByRole('button', { name: 'Manage registries' });
-    this.imageToPullLabel = page.getByLabel('Image to Pull');
-    this.imageNameInput = page.getByLabel('imageName');
+    this.imageNameInput = page.getByLabel('Image to Pull');
   }
 
   async pullImage(imageName: string, tag = '', timeout = 60000): Promise<ImagesPage> {


### PR DESCRIPTION
### What does this PR do?

Pull image with typeahead using a custom component for searching an image (inspired by https://github.com/pstanoev/simple-svelte-autocomplete)

TODO:
- [x] display loading...
- [x] close list when clicking outside
- [x] unit tests 

### Screenshot / video of UI

https://github.com/user-attachments/assets/61e05b60-04aa-4770-98d7-7bab08f993b7


### What issues does this PR fix or reference?

Fixes #971 

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
