### PR TITLE
fix: floating precision when adding numbers

### DIFF
--- a/packages/renderer/src/lib/ui/NumberInput.spec.ts
+++ b/packages/renderer/src/lib/ui/NumberInput.spec.ts
@@ -291,3 +291,20 @@ test('Expect multiple decrement with floating values', async () => {
   // the value should be 0.55
   expect(input).toHaveValue('0.55');
 });
+
+test('Expect decrement with floating values', async () => {
+  renderInput('test', 1.1, false, 0, 10, 'number', 0.1);
+
+  const input = screen.getByRole('textbox');
+  expect(input).toBeInTheDocument();
+  expect(input).toHaveValue('1.1');
+
+  const increment = screen.getByLabelText('increment');
+  expect(increment).toBeInTheDocument();
+
+  // click 1 time on increment
+  await userEvent.click(increment);
+
+  // the value should be 1.2
+  expect(input).toHaveValue('1.2');
+});

--- a/packages/renderer/src/lib/ui/NumberInput.svelte
+++ b/packages/renderer/src/lib/ui/NumberInput.svelte
@@ -59,16 +59,27 @@ function onKeyPress(event: any) {
   }
 }
 
+// handle float precision when adding floating point numbers
+function precision(value: number, incrementOrDecrement: number): number {
+  const valuePrecisionDigits = value.toString().split('.')[1]?.length ?? 0;
+  const stepPrecisionDigits = incrementOrDecrement.toString().split('.')[1]?.length ?? 0;
+  // use as precision either the value precision or the step precision
+  const precisionDigits = Math.max(valuePrecisionDigits, stepPrecisionDigits);
+
+  // if incrementOrDecrement is negative, it will decrement
+  return Number((Number(value) + incrementOrDecrement).toFixed(precisionDigits));
+}
+
 function onDecrement(e: MouseEvent) {
   const dec = step ? step : 1;
   e.preventDefault();
-  value = (100 * Number(value) - 100 * dec) / 100;
+  value = precision(value, -dec);
 }
 
 function onIncrement(e: MouseEvent) {
   const inc = step ? step : 1;
   e.preventDefault();
-  value = (100 * Number(value) + 100 * inc) / 100;
+  value = precision(value, inc);
 }
 </script>
 


### PR DESCRIPTION
### What does this PR do?
1.1 + 0.1 was ending into 1.2000000000000002 in widget numbers

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?


### How to test this PR?

unit tests added

- [x] Tests are covering the bug fix or the new feature
