### PR TITLE
feat(renderer): enhance feedback form with github star link

### DIFF
--- a/packages/renderer/src/lib/feedback/SendFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/SendFeedback.spec.ts
@@ -35,6 +35,7 @@ beforeAll(() => {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (window as any).openExternal = vi.fn();
+  (window as any).telemetryTrack = vi.fn();
 });
 
 test('Expect that the button is disabled when loading the page', async () => {
@@ -117,23 +118,45 @@ test('Expect sad smiley warns without feedback', async () => {
   expect(warn).not.toBeInTheDocument();
 });
 
+test('Expect message for very-happy-smiley to use love', async () => {
+  const { getByRole, getByLabelText } = render(SendFeedback, {});
+
+  // click on a smiley
+  const smiley = getByRole('button', { name: 'very-happy-smiley' });
+  await fireEvent.click(smiley);
+
+  // and the GitHub star text is visible
+  const region = getByLabelText('Like Podman Desktop? Give us a star on GitHub');
+  expect(region.textContent).toBe('Love It ? Give us a on GitHub');
+});
+
+test('Expect message for happy-smiley to use like', async () => {
+  const { getByRole, getByLabelText } = render(SendFeedback, {});
+
+  // click on a smiley
+  const smiley = getByRole('button', { name: 'happy-smiley' });
+  await fireEvent.click(smiley);
+
+  // and the GitHub star text is visible
+  const region = getByLabelText('Like Podman Desktop? Give us a star on GitHub');
+  expect(region.textContent).toBe('Like It ? Give us a on GitHub');
+});
+
 test('Expect GitHub dialog visible when very-happy-smiley selected', async () => {
   render(SendFeedback, {});
-
-  // expect to have indication why the button is disabled
-  expect(screen.getByText('Please select an experience smiley')).toBeInTheDocument();
 
   // click on a smiley
   const smiley = screen.getByRole('button', { name: 'very-happy-smiley' });
   await fireEvent.click(smiley);
 
   // and the GitHub star text is visible
-  expect(screen.getByLabelText('Like Podman-Desktop? Give us a star on GitHub')).toBeInTheDocument();
+  expect(screen.getByLabelText('Like Podman Desktop? Give us a star on GitHub')).toBeInTheDocument();
 
   const link = screen.getByRole('link', { name: 'GitHub' });
   await fireEvent.click(link);
 
   await vi.waitFor(() => {
+    expect(window.telemetryTrack).toHaveBeenCalledWith('feedback.openGithub');
     expect(window.openExternal).toHaveBeenCalledWith('https://github.com/containers/podman-desktop');
   });
 });

--- a/packages/renderer/src/lib/feedback/SendFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/SendFeedback.spec.ts
@@ -156,7 +156,7 @@ test('Expect GitHub dialog visible when very-happy-smiley selected', async () =>
   await fireEvent.click(link);
 
   await vi.waitFor(() => {
-    expect(window.telemetryTrack).toHaveBeenCalledWith('feedback.openGithub');
+    expect(window.telemetryTrack).toHaveBeenCalledWith('feedback.openGitHub');
     expect(window.openExternal).toHaveBeenCalledWith('https://github.com/containers/podman-desktop');
   });
 });

--- a/packages/renderer/src/lib/feedback/SendFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/SendFeedback.spec.ts
@@ -127,7 +127,7 @@ test('Expect message for very-happy-smiley to use love', async () => {
 
   // and the GitHub star text is visible
   const region = getByLabelText('Like Podman Desktop? Give us a star on GitHub');
-  expect(region.textContent).toBe('Love It ? Give us a on GitHub');
+  expect(region.textContent).toBe('Love It? Give us a on GitHub');
 });
 
 test('Expect message for happy-smiley to use like', async () => {
@@ -139,7 +139,7 @@ test('Expect message for happy-smiley to use like', async () => {
 
   // and the GitHub star text is visible
   const region = getByLabelText('Like Podman Desktop? Give us a star on GitHub');
-  expect(region.textContent).toBe('Like It ? Give us a on GitHub');
+  expect(region.textContent).toBe('Like It? Give us a on GitHub');
 });
 
 test('Expect GitHub dialog visible when very-happy-smiley selected', async () => {

--- a/packages/renderer/src/lib/feedback/SendFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/SendFeedback.svelte
@@ -139,11 +139,11 @@ async function openGitHub(): Promise<void> {
         <ErrorMessage class="text-xs" error="Please share contact info or details on how we can improve" />
       {:else if smileyRating === 2 && !hasFeedback}
         <WarningMessage class="text-xs" error="We would really appreciate knowing how we can improve" />
-      {:else}
+      {:else if smileyRating > 2}
         <div class="text-[var(--pd-modal-text)] p-1 flex flex-row items-center text-xs">
           <Fa size="1.125x" class="cursor-pointer" icon={faQuestionCircle} />
           <span aria-label="Like Podman Desktop? Give us a star on GitHub" class="flex items-center">
-            <Fa class="px-1 text-purple-500" icon={faHeart} />{smileyRating === 3 ? 'Like' : 'Love'} It ? Give us a <Fa
+            <Fa class="px-1 text-purple-500" icon={faHeart} />{smileyRating === 3 ? 'Like' : 'Love'} It? Give us a <Fa
               class="px-1 text-amber-400"
               icon={faStar} />on <Link aria-label="GitHub" onclick={openGitHub}>GitHub</Link>
           </span>

--- a/packages/renderer/src/lib/feedback/SendFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/SendFeedback.svelte
@@ -143,8 +143,8 @@ async function openGitHub(): Promise<void> {
         <div class="text-[var(--pd-modal-text)] p-1 flex flex-row items-center text-xs">
           <Fa size="1.125x" class="cursor-pointer" icon={faQuestionCircle} />
           <span aria-label="Like Podman Desktop? Give us a star on GitHub" class="flex items-center">
-            <Fa class="px-1 text-amber-400" icon={faHeart} />{smileyRating === 3 ? 'Like' : 'Love'} It ? Give us a <Fa
-              class="px-1 text-github-star-icon"
+            <Fa class="px-1 text-purple-500" icon={faHeart} />{smileyRating === 3 ? 'Like' : 'Love'} It ? Give us a <Fa
+              class="px-1 text-amber-400"
               icon={faStar} />on <Link aria-label="GitHub" onclick={openGitHub}>GitHub</Link>
           </span>
         </div>

--- a/packages/renderer/src/lib/feedback/SendFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/SendFeedback.svelte
@@ -62,9 +62,9 @@ async function sendFeedback(): Promise<void> {
   hideModal();
 }
 
-async function openGithub(): Promise<void> {
+async function openGitHub(): Promise<void> {
   hideModal();
-  await window.telemetryTrack('feedback.openGithub');
+  await window.telemetryTrack('feedback.openGitHub');
   await window.openExternal('https://github.com/containers/podman-desktop');
 }
 </script>
@@ -143,9 +143,9 @@ async function openGithub(): Promise<void> {
         <div class="text-[var(--pd-modal-text)] p-1 flex flex-row items-center text-xs">
           <Fa size="1.125x" class="cursor-pointer" icon={faQuestionCircle} />
           <span aria-label="Like Podman Desktop? Give us a star on GitHub" class="flex items-center">
-            <Fa class="px-1 text-purple-600" icon={faHeart} />{smileyRating === 3 ? 'Like' : 'Love'} It ? Give us a <Fa
+            <Fa class="px-1 text-amber-400" icon={faHeart} />{smileyRating === 3 ? 'Like' : 'Love'} It ? Give us a <Fa
               class="px-1 text-github-star-icon"
-              icon={faStar} />on <Link aria-label="GitHub" onclick={openGithub}>GitHub</Link>
+              icon={faStar} />on <Link aria-label="GitHub" onclick={openGitHub}>GitHub</Link>
           </span>
         </div>
       {/if}

--- a/packages/renderer/src/lib/feedback/SendFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/SendFeedback.svelte
@@ -1,5 +1,13 @@
 <script lang="ts">
-import { faFrown, faGrinStars, faMeh, faSmile, faStar } from '@fortawesome/free-solid-svg-icons';
+import {
+  faFrown,
+  faGrinStars,
+  faHeart,
+  faMeh,
+  faQuestionCircle,
+  faSmile,
+  faStar,
+} from '@fortawesome/free-solid-svg-icons';
 import { Button, ErrorMessage, Link } from '@podman-desktop/ui-svelte';
 import Fa from 'svelte-fa';
 
@@ -54,9 +62,10 @@ async function sendFeedback(): Promise<void> {
   hideModal();
 }
 
-function openGithub(): void {
+async function openGithub(): Promise<void> {
   hideModal();
-  window.openExternal('https://github.com/containers/podman-desktop');
+  await window.telemetryTrack('feedback.openGithub');
+  await window.openExternal('https://github.com/containers/podman-desktop');
 }
 </script>
 
@@ -99,14 +108,8 @@ function openGithub(): void {
             icon={faGrinStars} />
         </button>
       </div>
-      {#if smileyRating === 4}
-        <span aria-label="Like Podman-Desktop? Give us a star on GitHub" class="flex items-center"
-          >Like Podman-Desktop ? Give us a<Fa class="px-1 text-github-star-icon" icon={faStar} /> on <Link
-            aria-label="GitHub"
-            onclick={openGithub}>GitHub</Link
-          ></span>
-      {/if}
-      <label for="tellUsWhyFeedback" class="block mt-2 mb-2 text-sm font-medium text-[var(--pd-modal-text)]"
+
+      <label for="tellUsWhyFeedback" class="block mt-4 mb-2 text-sm font-medium text-[var(--pd-modal-text)]"
         >Tell us why, or share any suggestion or issue to improve your experience: ({1000 - tellUsWhyFeedback.length} characters
         left)</label>
       <textarea
@@ -136,6 +139,15 @@ function openGithub(): void {
         <ErrorMessage class="text-xs" error="Please share contact info or details on how we can improve" />
       {:else if smileyRating === 2 && !hasFeedback}
         <WarningMessage class="text-xs" error="We would really appreciate knowing how we can improve" />
+      {:else}
+        <div class="text-[var(--pd-modal-text)] p-1 flex flex-row items-center text-xs">
+          <Fa size="1.125x" class="cursor-pointer" icon={faQuestionCircle} />
+          <span aria-label="Like Podman Desktop? Give us a star on GitHub" class="flex items-center">
+            <Fa class="px-1 text-purple-600" icon={faHeart} />{smileyRating === 3 ? 'Like' : 'Love'} It ? Give us a <Fa
+              class="px-1 text-github-star-icon"
+              icon={faStar} />on <Link aria-label="GitHub" onclick={openGithub}>GitHub</Link>
+          </span>
+        </div>
       {/if}
     </svelte:fragment>
     <svelte:fragment slot="buttons">

--- a/packages/renderer/src/lib/feedback/SendFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/SendFeedback.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-import { faFrown, faGrinStars, faMeh, faSmile } from '@fortawesome/free-solid-svg-icons';
-import { Button, ErrorMessage } from '@podman-desktop/ui-svelte';
+import { faFrown, faGrinStars, faMeh, faSmile, faStar } from '@fortawesome/free-solid-svg-icons';
+import { Button, ErrorMessage, Link } from '@podman-desktop/ui-svelte';
 import Fa from 'svelte-fa';
 
 import type { FeedbackProperties } from '../../../../preload/src/index';
@@ -53,6 +53,11 @@ async function sendFeedback(): Promise<void> {
   // close the modal
   hideModal();
 }
+
+function openGithub(): void {
+  hideModal();
+  window.openExternal('https://github.com/containers/podman-desktop');
+}
 </script>
 
 {#if displayModal}
@@ -94,8 +99,14 @@ async function sendFeedback(): Promise<void> {
             icon={faGrinStars} />
         </button>
       </div>
-
-      <label for="tellUsWhyFeedback" class="block mt-4 mb-2 text-sm font-medium text-[var(--pd-modal-text)]"
+      {#if smileyRating === 4}
+        <span aria-label="Like Podman-Desktop? Give us a star on GitHub" class="flex items-center"
+          >Like Podman-Desktop ? Give us a<Fa class="px-1 text-github-star-icon" icon={faStar} /> on <Link
+            aria-label="GitHub"
+            onclick={openGithub}>GitHub</Link
+          ></span>
+      {/if}
+      <label for="tellUsWhyFeedback" class="block mt-2 mb-2 text-sm font-medium text-[var(--pd-modal-text)]"
         >Tell us why, or share any suggestion or issue to improve your experience: ({1000 - tellUsWhyFeedback.length} characters
         left)</label>
       <textarea

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -74,7 +74,6 @@ module.exports = {
         600: tailwindColors.violet[600],
         700: tailwindColors.violet[700],
       },
-      'github-star-icon': '#e3b341'
     },
   },
   plugins: [],

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -56,7 +56,7 @@ module.exports = {
     colors: {
       // import colors from the color palette
       ...colorPalette,
-      
+
       // The remaining colors below are not part of our palette and are only here
       // to maintain existing code. No new use.
       'zinc': {
@@ -74,6 +74,7 @@ module.exports = {
         600: tailwindColors.violet[600],
         700: tailwindColors.violet[700],
       },
+      'github-star-icon': '#e3b341'
     },
   },
   plugins: [],

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -56,7 +56,7 @@ module.exports = {
     colors: {
       // import colors from the color palette
       ...colorPalette,
-
+      
       // The remaining colors below are not part of our palette and are only here
       // to maintain existing code. No new use.
       'zinc': {


### PR DESCRIPTION
### What does this PR do?

On the feedback form, user selecting the best emoji will have a text suggesting to give a star to the podman-desktop repository.

### Screenshot / video of UI

![image](https://github.com/user-attachments/assets/533473c0-8d46-41d2-8234-926f9cfd4ccd)

https://github.com/user-attachments/assets/5c51f258-28e4-41ac-85bc-ca4d8ff074ea

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-internal/issues/314

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature

**Manually**

- start podman-desktop
- open feedback form
- select emoji
- assert suggestion visible on best emoji selected