### PR TITLE
chore: fix linting rules for storybook package

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -301,6 +301,15 @@ export default [
   },
 
   {
+    files: ['storybook/**'],
+    languageOptions: {
+      globals: {
+        ...Object.fromEntries(Object.entries(globals.node).map(([key]) => [key, 'off'])),
+        ...globals.browser,
+      },
+    },
+  },
+  {
     files: ['**/*.spec.ts'],
 
     rules: {


### PR DESCRIPTION
### What does this PR do?
when adding new stories, I faced errors of the linter

in storybook package, we do have access to browser items but not from Node.js (default is the reverse)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

#7441 

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
