### PR TITLE
feat(extension-api): allow extension to register custom navigation route

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -4687,16 +4687,38 @@ declare module '@podman-desktop/api' {
     export function navigateToEditProviderContainerConnection(connection: ProviderContainerConnection): Promise<void>;
 
     /**
-     * Allow to define custom route
-     * @param routeId
-     * @param commandId
+     * Allow to define custom route for an extension.
+     *
+     * @remarks
+     * You commandId used must have been registered through {@link commands.registerCommand}
+     *
+     * @example
+     * ```ts
+     * import { navigation, commands } from '@podman-desktop/api';
+     *
+     * commands.registerCommand('redirect-download-command', (trackingId: string) => {
+     *   // todo: do something with the trackingId
+     * });
+     *
+     * // register the route
+     * navigation.register('download-page', 'redirect-download-command');
+     *
+     * // when needed call the navigate with the route id registered to
+     * // trigger the command
+     * navigation.navigate('download-page', 'dummy-tracking-id');
+     * ```
+     *
+     * @param routeId a unique string value that could be used in {@link navigation.navigate}
+     * @param commandId the command that will be executed on navigate
      */
     export function register(routeId: string, commandId: string): Disposable;
 
     /**
-     * Allow extension to navigate to a custom route
-     * @param routeId
-     * @param args
+     * Allow extension to navigate to a custom route.
+     * The route need to have been registered using {@link navigation.register}
+     *
+     * @param routeId the identifier of the route to use
+     * @param args the arguments to provide to the command linked to the routeId
      */
     export function navigate(routeId: string, ...args: unknown[]): Promise<void>;
   }

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -4690,7 +4690,7 @@ declare module '@podman-desktop/api' {
      * Allow to define custom route for an extension.
      *
      * @remarks
-     * You commandId used must have been registered through {@link commands.registerCommand}
+     * The commandId used must have been registered through {@link commands.registerCommand}
      *
      * @example
      * ```ts
@@ -4715,7 +4715,7 @@ declare module '@podman-desktop/api' {
 
     /**
      * Allow extension to navigate to a custom route.
-     * The route need to have been registered using {@link navigation.register}
+     * The route needs to have been registered using {@link navigation.register}
      *
      * @param routeId the identifier of the route to use
      * @param args the arguments to provide to the command linked to the routeId

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -4685,6 +4685,20 @@ declare module '@podman-desktop/api' {
      * Navigate to the Edit Provider Container Connection page
      */
     export function navigateToEditProviderContainerConnection(connection: ProviderContainerConnection): Promise<void>;
+
+    /**
+     * Allow to define custom route
+     * @param routeId
+     * @param commandId
+     */
+    export function register(routeId: string, commandId: string): Disposable;
+
+    /**
+     * Allow extension to navigate to a custom route
+     * @param routeId
+     * @param args
+     */
+    export function navigate(routeId: string, ...args: unknown[]): Promise<void>;
   }
 
   /**

--- a/packages/main/src/plugin/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension-loader.spec.ts
@@ -229,6 +229,7 @@ const navigationManager: NavigationManager = new NavigationManager(
   contributionManager,
   providerRegistry,
   webviewRegistry,
+  commandRegistry,
 );
 
 const colorRegistry = {
@@ -2272,6 +2273,17 @@ test('when loading registry registerRegistry, do not push to disposables', async
   api.registry.registerRegistry(fakeRegistry);
 
   expect(disposables.length).toBe(0);
+});
+
+test('when registering a navigation route, should be pushed to disposables', () => {
+  const disposables: IDisposable[] = [];
+
+  const api = extensionLoader.createApi('/path', {}, disposables);
+  expect(api).toBeDefined();
+
+  expect(disposables.length).toBe(0);
+  api.navigation.register('dummy-route-id', 'dummy-command-id');
+  expect(disposables.length).toBe(1);
 });
 
 describe('loading extension folders', () => {

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -1421,11 +1421,11 @@ export class ExtensionLoader {
         await this.navigationManager.navigateToEditProviderContainerConnection(connection);
       },
       navigate: async (routeId: string, ...args: unknown[]): Promise<void> => {
-        return this.navigationManager.navigateToRoute(routeId, args);
+        return this.navigationManager.navigateToRoute(`${extensionInfo.id}.${routeId}`, args);
       },
       register: (routeId: string, commandId: string): Disposable => {
         const disposable = this.navigationManager.registerRoute({
-          routeId: routeId,
+          routeId: `${extensionInfo.id}.${routeId}`,
           commandId: commandId,
         });
 

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -1427,10 +1427,14 @@ export class ExtensionLoader {
         return this.navigationManager.navigateToRoute(`${extensionInfo.id}.${routeId}`, args);
       },
       register: (routeId: string, commandId: string): Disposable => {
-        return this.navigationManager.registerRoute({
+        const disposable = this.navigationManager.registerRoute({
           routeId: `${extensionInfo.id}.${routeId}`,
           commandId: commandId,
         });
+
+        disposables.push(disposable);
+
+        return disposable;
       },
     };
 

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -1420,6 +1420,18 @@ export class ExtensionLoader {
       ): Promise<void> => {
         await this.navigationManager.navigateToEditProviderContainerConnection(connection);
       },
+      navigate: async (routeId: string, ...args: unknown[]): Promise<void> => {
+        if (this.navigationManager.hasRoute(routeId)) {
+          return this.navigationManager.navigateToRoute(routeId, args);
+        }
+        return this.navigationManager.navigateToRoute(`${extensionInfo.id}.${routeId}`, args);
+      },
+      register: (routeId: string, commandId: string): Disposable => {
+        return this.navigationManager.registerRoute({
+          routeId: `${extensionInfo.id}.${routeId}`,
+          commandId: commandId,
+        });
+      },
     };
 
     const version = app.getVersion();

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -1421,14 +1421,11 @@ export class ExtensionLoader {
         await this.navigationManager.navigateToEditProviderContainerConnection(connection);
       },
       navigate: async (routeId: string, ...args: unknown[]): Promise<void> => {
-        if (this.navigationManager.hasRoute(routeId)) {
-          return this.navigationManager.navigateToRoute(routeId, args);
-        }
-        return this.navigationManager.navigateToRoute(`${extensionInfo.id}.${routeId}`, args);
+        return this.navigationManager.navigateToRoute(routeId, args);
       },
       register: (routeId: string, commandId: string): Disposable => {
         const disposable = this.navigationManager.registerRoute({
-          routeId: `${extensionInfo.id}.${routeId}`,
+          routeId: routeId,
           commandId: commandId,
         });
 

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -633,6 +633,7 @@ export class PluginSystem {
       contributionManager,
       providerRegistry,
       webviewRegistry,
+      commandRegistry,
     );
 
     this.extensionLoader = new ExtensionLoader(

--- a/packages/main/src/plugin/navigation/navigation-manager.spec.ts
+++ b/packages/main/src/plugin/navigation/navigation-manager.spec.ts
@@ -185,6 +185,21 @@ describe('register route', () => {
     expect(navigationManager.hasRoute(routeId)).toBeFalsy();
   });
 
+  test('registering existing route should throw an error', async () => {
+    const routeId = 'dummy-route-id';
+    navigationManager.registerRoute({
+      routeId: routeId,
+      commandId: 'fake-command-id',
+    });
+
+    expect(() => {
+      return navigationManager.registerRoute({
+        routeId: routeId,
+        commandId: 'fake-command-id',
+      });
+    }).toThrowError('routeId dummy-route-id is already registered.');
+  });
+
   test('calling navigateToRoute with invalid routeId should raise an error', async () => {
     await expect(() => {
       return navigationManager.navigateToRoute('invalidId');

--- a/packages/main/src/plugin/navigation/navigation-manager.spec.ts
+++ b/packages/main/src/plugin/navigation/navigation-manager.spec.ts
@@ -17,8 +17,9 @@
  ***********************************************************************/
 
 import type { ProviderContainerConnection } from '@podman-desktop/api';
-import { beforeEach, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
+import type { CommandRegistry } from '/@/plugin/command-registry.js';
 import { NavigationPage } from '/@api/navigation-page.js';
 import type { WebviewInfo } from '/@api/webview-info.js';
 
@@ -59,6 +60,11 @@ const webviewRegistry = {
   listWebviews: vi.fn(),
 } as unknown as WebviewRegistry;
 
+const commandRegistry: CommandRegistry = {
+  hasCommand: vi.fn(),
+  executeCommand: vi.fn(),
+} as unknown as CommandRegistry;
+
 beforeEach(() => {
   vi.resetAllMocks();
   navigationManager = new TestNavigationManager(
@@ -67,6 +73,7 @@ beforeEach(() => {
     contributionManager,
     providerRegistry,
     webviewRegistry,
+    commandRegistry,
   );
 });
 
@@ -160,5 +167,70 @@ test('check navigateToEditProviderContainerConnection', async () => {
       provider: 'id',
       name: Buffer.from(connection.connection.name).toString('base64'),
     },
+  });
+});
+
+describe('register route', () => {
+  test('registering route should provide a disposable', () => {
+    const routeId = 'dummy-route-id';
+    const disposable = navigationManager.registerRoute({
+      routeId: routeId,
+      commandId: 'fake-command-id',
+    });
+
+    expect(navigationManager.hasRoute(routeId)).toBeTruthy();
+
+    disposable.dispose();
+
+    expect(navigationManager.hasRoute(routeId)).toBeFalsy();
+  });
+
+  test('calling navigateToRoute with invalid routeId should raise an error', async () => {
+    await expect(() => {
+      return navigationManager.navigateToRoute('invalidId');
+    }).rejects.toThrowError('navigation route invalidId does not exists.');
+  });
+
+  test('calling navigateToRoute on route with invalid command should raise an error', async () => {
+    vi.mocked(commandRegistry.hasCommand).mockReturnValue(false);
+    const routeId = 'dummy-route-id';
+    navigationManager.registerRoute({
+      routeId: routeId,
+      commandId: 'fake-command-id',
+    });
+
+    await expect(() => {
+      return navigationManager.navigateToRoute(routeId);
+    }).rejects.toThrowError('navigation route dummy-route-id registered an unknown command: fake-command-id');
+
+    expect(commandRegistry.hasCommand).toHaveBeenCalledOnce();
+  });
+
+  test('calling navigateToRoute should propagate the argument to the command', async () => {
+    vi.mocked(commandRegistry.hasCommand).mockReturnValue(true);
+    vi.mocked(commandRegistry.executeCommand).mockResolvedValue(undefined);
+    const routeId = 'dummy-route-id';
+    navigationManager.registerRoute({
+      routeId: routeId,
+      commandId: 'dummy-command-id',
+    });
+
+    await navigationManager.navigateToRoute(routeId, 'potatoes', 'candies');
+
+    expect(commandRegistry.executeCommand).toHaveBeenCalledWith('dummy-command-id', 'potatoes', 'candies');
+  });
+
+  test('error in the command should be propagate to the caller', async () => {
+    vi.mocked(commandRegistry.hasCommand).mockReturnValue(true);
+    vi.mocked(commandRegistry.executeCommand).mockRejectedValue('Dummy error');
+    const routeId = 'dummy-route-id';
+    navigationManager.registerRoute({
+      routeId: routeId,
+      commandId: 'dummy-command-id',
+    });
+
+    await expect(() => {
+      return navigationManager.navigateToRoute(routeId);
+    }).rejects.toThrowError('Dummy error');
   });
 });

--- a/packages/main/src/plugin/navigation/navigation-manager.ts
+++ b/packages/main/src/plugin/navigation/navigation-manager.ts
@@ -74,7 +74,7 @@ export class NavigationManager {
       throw new Error(`navigation route ${routeId} registered an unknown command: ${route.commandId}`);
     }
 
-    return this.commandRegistry.executeCommand(route.commandId, args);
+    return this.commandRegistry.executeCommand(route.commandId, ...args);
   }
 
   async navigateToProviderTask(internalProviderId: string, taskId?: number): Promise<void> {

--- a/packages/main/src/plugin/navigation/navigation-manager.ts
+++ b/packages/main/src/plugin/navigation/navigation-manager.ts
@@ -53,6 +53,9 @@ export class NavigationManager {
   }
 
   registerRoute(route: NavigationRoute): Disposable {
+    if (this.hasRoute(route.routeId)) {
+      throw new Error(`routeId ${route.routeId} is already registered.`);
+    }
     this.#registry.set(route.routeId, route);
 
     return Disposable.create(() => {


### PR DESCRIPTION
### What does this PR do?

Following a discussion we had with @benoitf about https://github.com/containers/podman-desktop/issues/7709. The idea would be to make the extension register a unique navigation route id.

When they create a notification or a task, they could register the navigation route id with some arguments, so the core could navigate to the appropriate route.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Required for https://github.com/containers/podman-desktop/issues/7709

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
