### PR TITLE
docs: document extension API: Event, commands, proxy

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 /**
- * The Podman Desktop API provides a way to build extensions interacting with Podman Desktop.
+ * The Podman Desktop API is intended to be consumed by extensions interacting with Podman Desktop.
  *
  * This documentation is automatically generated from typedoc comments
  * in the source code `extension-api.d.ts` and provided [on our website](https://podman-desktop.io/api).


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

document API's:

- Event interface, 
- commands namespace and functions, 
- proxy namespace and functions.

### Screenshot / video of UI

Preview: https://66e2b831fd45c538c0622409--podman-desktop-pr.netlify.app/api

### What issues does this PR fix or reference?

Part of #5812 

### How to test this PR?

Copy examples and add them to an extension

