### PR TITLE
feat: more info about sizes displayed in images layers

### DIFF
--- a/packages/renderer/src/lib/image/ImageDetailsFilesLayers.spec.ts
+++ b/packages/renderer/src/lib/image/ImageDetailsFilesLayers.spec.ts
@@ -1,0 +1,67 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import type { ImageFile } from '@podman-desktop/api';
+import { render, screen, within } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import type { FilesystemTree } from './filesystem-tree';
+import type { ImageFilesystemLayerUI } from './imageDetailsFiles';
+import { signedHumanSize } from './ImageDetailsFilesLayers';
+import ImageDetailsFilesLayers from './ImageDetailsFilesLayers.svelte';
+
+test('signedHumanSize', () => {
+  expect(signedHumanSize(1000)).toEqual('+1 kB');
+  expect(signedHumanSize(-1000)).toEqual('-1 kB');
+});
+
+test('render', async () => {
+  const layers: ImageFilesystemLayerUI[] = [
+    {
+      id: 'layer1',
+      createdBy: 'creator',
+      sizeInArchive: 1000,
+      sizeInContainer: 900,
+      stackTree: {
+        size: 2000,
+      } as unknown as FilesystemTree<ImageFile>,
+    } as unknown as ImageFilesystemLayerUI,
+    {
+      id: 'layer2',
+      createdBy: 'creator',
+      sizeInArchive: 0,
+      sizeInContainer: -300,
+      stackTree: {
+        size: 1700,
+      } as unknown as FilesystemTree<ImageFile>,
+    } as unknown as ImageFilesystemLayerUI,
+  ];
+  render(ImageDetailsFilesLayers, { layers });
+  const rows = screen.getAllByRole('row');
+  expect(rows.length).toBe(2);
+  within(rows[0]).getByText('layer1');
+  within(rows[0]).getByText('on disk: 1 kB');
+  within(rows[0]).getByText('contribute to FS: +900 B');
+  within(rows[0]).getByText('total FS: 2 kB');
+  within(rows[1]).getByText('layer2');
+  within(rows[1]).getByText('on disk: 0 B');
+  within(rows[1]).getByText('contribute to FS: -300 B');
+  within(rows[1]).getByText('total FS: 1.7 kB');
+});

--- a/packages/renderer/src/lib/image/ImageDetailsFilesLayers.svelte
+++ b/packages/renderer/src/lib/image/ImageDetailsFilesLayers.svelte
@@ -14,6 +14,14 @@ function onLayerSelected(layer: ImageFilesystemLayerUI) {
   currentLayerId = layer.id;
   dispatch('selected', layer);
 }
+
+function signedHumanSize(n: number): string {
+  if (n < 0) {
+    return new ImageUtils().getHumanSize(n);
+  } else {
+    return '+' + new ImageUtils().getHumanSize(n);
+  }
+}
 </script>
 
 {#each layers as layer}
@@ -28,11 +36,11 @@ function onLayerSelected(layer: ImageFilesystemLayerUI) {
       <ImageDetailsFilesExpandableCommand command={layer.createdBy} />
       <div class="text-sm opacity-70">{layer.id}</div>
       <div class="text-sm opacity-70">
-        <span>{new ImageUtils().getHumanSize(layer.sizeInArchive)}</span>
+        <span>at rest: {new ImageUtils().getHumanSize(layer.sizeInArchive)}</span>
         <span> | </span>
-        <span>{new ImageUtils().getHumanSize(layer.sizeInContainer)}</span>
+        <span>contribute: {signedHumanSize(layer.sizeInContainer)}</span>
         <span> | </span>
-        <span>{new ImageUtils().getHumanSize(layer.stackTree.size)}</span>
+        <span>total: {new ImageUtils().getHumanSize(layer.stackTree.size)}</span>
       </div>
     </div>
   </button>

--- a/packages/renderer/src/lib/image/ImageDetailsFilesLayers.svelte
+++ b/packages/renderer/src/lib/image/ImageDetailsFilesLayers.svelte
@@ -4,6 +4,7 @@ import { createEventDispatcher } from 'svelte';
 import { ImageUtils } from './image-utils';
 import type { ImageFilesystemLayerUI } from './imageDetailsFiles';
 import ImageDetailsFilesExpandableCommand from './ImageDetailsFilesExpandableCommand.svelte';
+import { signedHumanSize } from './ImageDetailsFilesLayers';
 
 const dispatch = createEventDispatcher();
 
@@ -13,14 +14,6 @@ let currentLayerId: string | undefined;
 function onLayerSelected(layer: ImageFilesystemLayerUI) {
   currentLayerId = layer.id;
   dispatch('selected', layer);
-}
-
-function signedHumanSize(n: number): string {
-  if (n < 0) {
-    return new ImageUtils().getHumanSize(n);
-  } else {
-    return '+' + new ImageUtils().getHumanSize(n);
-  }
 }
 </script>
 

--- a/packages/renderer/src/lib/image/ImageDetailsFilesLayers.svelte
+++ b/packages/renderer/src/lib/image/ImageDetailsFilesLayers.svelte
@@ -36,11 +36,11 @@ function signedHumanSize(n: number): string {
       <ImageDetailsFilesExpandableCommand command={layer.createdBy} />
       <div class="text-sm opacity-70">{layer.id}</div>
       <div class="text-sm opacity-70">
-        <span>at rest: {new ImageUtils().getHumanSize(layer.sizeInArchive)}</span>
+        <span>on disk: {new ImageUtils().getHumanSize(layer.sizeInArchive)}</span>
         <span> | </span>
-        <span>contribute: {signedHumanSize(layer.sizeInContainer)}</span>
+        <span>contribute to FS: {signedHumanSize(layer.sizeInContainer)}</span>
         <span> | </span>
-        <span>total: {new ImageUtils().getHumanSize(layer.stackTree.size)}</span>
+        <span>total FS: {new ImageUtils().getHumanSize(layer.stackTree.size)}</span>
       </div>
     </div>
   </button>

--- a/packages/renderer/src/lib/image/ImageDetailsFilesLayers.ts
+++ b/packages/renderer/src/lib/image/ImageDetailsFilesLayers.ts
@@ -1,0 +1,28 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ImageUtils } from './image-utils';
+
+export function signedHumanSize(n: number): string {
+  const value = new ImageUtils().getHumanSize(n);
+  if (n < 0) {
+    return value;
+  } else {
+    return '+' + value;
+  }
+}

--- a/packages/renderer/src/lib/image/ImageDetailsFilesLayers.ts
+++ b/packages/renderer/src/lib/image/ImageDetailsFilesLayers.ts
@@ -23,6 +23,6 @@ export function signedHumanSize(n: number): string {
   if (n < 0) {
     return value;
   } else {
-    return '+' + value;
+    return `+${value}`;
   }
 }


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Display more info about sizes displayed in images layers

### Screenshot / video of UI

![layer-siezs-help](https://github.com/user-attachments/assets/b433e680-1360-4933-a9dd-07d5360a39ba)

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop-extension-layers-explorer/issues/43

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
