### PR TITLE
chore(test): expand extension's details page pom and make extensions …

### DIFF
--- a/tests/playwright/src/model/pages/extension-details-page.ts
+++ b/tests/playwright/src/model/pages/extension-details-page.ts
@@ -23,22 +23,32 @@ import { BasePage } from './base-page';
 import { ExtensionsPage } from './extensions-page';
 
 export class ExtensionDetailsPage extends BasePage {
+  readonly header: Locator;
+  readonly tabs: Locator;
+  readonly tabContent: Locator;
+  readonly buttonGroup: Locator;
   readonly enableButton: Locator;
   readonly disableButton: Locator;
   readonly removeExtensionButton: Locator;
   readonly status: Locator;
   readonly heading: Locator;
+  readonly errorStackTrace: Locator;
 
   constructor(
     page: Page,
     public readonly extensionName: string,
   ) {
     super(page);
-    this.heading = page.getByRole('heading', { name: extensionName });
-    this.enableButton = page.getByRole('button', { name: 'Start' });
-    this.disableButton = page.getByRole('button', { name: 'Stop' });
-    this.removeExtensionButton = page.getByRole('button', { name: 'Delete' });
-    this.status = page.getByLabel('Extension Status Label');
+    this.header = page.getByRole('region', { name: 'Header' });
+    this.tabs = page.getByRole('region', { name: 'Tabs' });
+    this.tabContent = page.getByRole('region', { name: 'Tab Content' });
+    this.heading = this.header.getByRole('heading', { name: extensionName });
+    this.buttonGroup = this.header.getByRole('group', { name: 'Control Actions' });
+    this.enableButton = this.buttonGroup.getByRole('button', { name: 'Start' });
+    this.disableButton = this.buttonGroup.getByRole('button', { name: 'Stop' });
+    this.removeExtensionButton = this.buttonGroup.getByRole('button', { name: 'Delete' });
+    this.status = this.header.getByLabel('Extension Status Label');
+    this.errorStackTrace = this.tabContent.getByRole('group', { name: 'Stack Trace', exact: true });
   }
 
   async disableExtension(): Promise<this> {
@@ -61,5 +71,12 @@ export class ExtensionDetailsPage extends BasePage {
     await this.disableExtension();
     await this.removeExtensionButton.click();
     return new ExtensionsPage(this.page);
+  }
+
+  async activateTab(tabName: string): Promise<this> {
+    const tabItem = this.tabs.getByRole('button', { name: tabName, exact: true });
+    await playExpect(tabItem).toBeVisible();
+    await tabItem.click();
+    return this;
   }
 }

--- a/tests/playwright/src/model/pages/extension-details-page.ts
+++ b/tests/playwright/src/model/pages/extension-details-page.ts
@@ -26,7 +26,6 @@ export class ExtensionDetailsPage extends BasePage {
   readonly header: Locator;
   readonly tabs: Locator;
   readonly tabContent: Locator;
-  readonly buttonGroup: Locator;
   readonly enableButton: Locator;
   readonly disableButton: Locator;
   readonly removeExtensionButton: Locator;
@@ -43,10 +42,9 @@ export class ExtensionDetailsPage extends BasePage {
     this.tabs = page.getByRole('region', { name: 'Tabs' });
     this.tabContent = page.getByRole('region', { name: 'Tab Content' });
     this.heading = this.header.getByRole('heading', { name: extensionName });
-    this.buttonGroup = this.header.getByRole('group', { name: 'Control Actions' });
-    this.enableButton = this.buttonGroup.getByRole('button', { name: 'Start' });
-    this.disableButton = this.buttonGroup.getByRole('button', { name: 'Stop' });
-    this.removeExtensionButton = this.buttonGroup.getByRole('button', { name: 'Delete' });
+    this.enableButton = this.header.getByRole('button', { name: 'Start' });
+    this.disableButton = this.header.getByRole('button', { name: 'Stop' });
+    this.removeExtensionButton = this.header.getByRole('button', { name: 'Delete' });
     this.status = this.header.getByLabel('Extension Status Label');
     this.errorStackTrace = this.tabContent.getByRole('group', { name: 'Stack Trace', exact: true });
   }

--- a/tests/playwright/src/specs/extension-installation-smoke.spec.ts
+++ b/tests/playwright/src/specs/extension-installation-smoke.spec.ts
@@ -27,7 +27,6 @@ import { SettingsBar } from '../model/pages/settings-bar';
 import { WelcomePage } from '../model/pages/welcome-page';
 import { NavigationBar } from '../model/workbench/navigation';
 import { Runner } from '../runner/podman-desktop-runner';
-import { waitUntil } from '../utility/wait';
 
 const DISABLED = 'DISABLED';
 const ACTIVE = 'ACTIVE';
@@ -148,16 +147,9 @@ for (const { extensionName, extensionType } of extentionTypes) {
         const errorTab = extensionPage.tabs.getByRole('button', { name: 'Error' });
         // we would like to propagate the error's stack trace into test failure message
         let stackTrace = '';
-        await waitUntil(
-          async () => {
-            if ((await errorTab.count()) > 0) {
-              stackTrace = await errorTab.innerText();
-              return true;
-            }
-            return false;
-          },
-          { timeout: 3500, sendError: false },
-        );
+        if ((await errorTab.count()) > 0) {
+          stackTrace = await errorTab.innerText();
+        }
         await playExpect(errorTab, `Error Tab was present with stackTrace: ${stackTrace}`).not.toBeVisible();
       });
 

--- a/tests/playwright/src/specs/extension-installation-smoke.spec.ts
+++ b/tests/playwright/src/specs/extension-installation-smoke.spec.ts
@@ -134,15 +134,11 @@ for (const { extensionName, extensionType } of extentionTypes) {
         await playExpect(extensionDetailsPage.status).toBeVisible({ timeout: 15000 });
       });
 
-      test('Extension is active', async () => {
+      test('Extension is active and there are not errors', async () => {
         const extensionsPage = await navigationBar.openExtensions();
         const extensionPage = await extensionsPage.openExtensionDetails(extensionName, extensionLabel, extensionType);
+        await playExpect(extensionPage.header).toBeVisible();
         await playExpect(extensionPage.status).toHaveText(ACTIVE);
-      });
-
-      test('Extension has no errors present', async () => {
-        const extensionsPage = await navigationBar.openExtensions();
-        const extensionPage = await extensionsPage.openExtensionDetails(extensionName, extensionLabel, extensionType);
         // tabs are empty in case there is no error. If there is error, there are two tabs' buttons present
         const errorTab = extensionPage.tabs.getByRole('button', { name: 'Error' });
         // we would like to propagate the error's stack trace into test failure message

--- a/tests/playwright/src/specs/extension-installation-smoke.spec.ts
+++ b/tests/playwright/src/specs/extension-installation-smoke.spec.ts
@@ -137,7 +137,7 @@ for (const { extensionName, extensionType } of extentionTypes) {
       test('Extension is active and there are not errors', async () => {
         const extensionsPage = await navigationBar.openExtensions();
         const extensionPage = await extensionsPage.openExtensionDetails(extensionName, extensionLabel, extensionType);
-        await playExpect(extensionPage.header).toBeVisible();
+        await playExpect(extensionPage.heading).toBeVisible();
         await playExpect(extensionPage.status).toHaveText(ACTIVE);
         // tabs are empty in case there is no error. If there is error, there are two tabs' buttons present
         const errorTab = extensionPage.tabs.getByRole('button', { name: 'Error' });


### PR DESCRIPTION
…e2e test smoke

### What does this PR do?
Adds some pom object into extension's details page, extends test for error states and includes extension-installation into smoke testing suite.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#8876 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
`pnpm test:e2e:smoke` -> should run extensions e2e tests as well.
<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
