### PR TITLE
fix: prevent configuration from being deleted on extension deactivate

### DIFF
--- a/packages/main/src/plugin/autostart-engine.spec.ts
+++ b/packages/main/src/plugin/autostart-engine.spec.ts
@@ -111,6 +111,19 @@ test('Check that default value is true if provider autostart setting is not set'
   expect(mockRegisterConfiguration).toBeCalledWith([autoStartConfigurationNode]);
 });
 
+test('Disposing the provider should not delete the configuration', async () => {
+  vi.spyOn(configurationRegistry, 'getConfiguration').mockImplementation(() => {
+    return {
+      get: (_section: string, defaultValue: boolean) => defaultValue,
+    } as Configuration;
+  });
+
+  const disposable = autostartEngine.registerProvider(extensionId, extensionDisplayName, 'internalId');
+  disposable.dispose();
+
+  expect(configurationRegistry.deregisterConfigurations).not.toHaveBeenCalled();
+});
+
 test('Check that runAutostart is called once if only one provider has registered autostart process', async () => {
   vi.spyOn(configurationRegistry, 'getConfiguration').mockImplementation(() => {
     return {

--- a/packages/main/src/plugin/autostart-engine.spec.ts
+++ b/packages/main/src/plugin/autostart-engine.spec.ts
@@ -52,35 +52,6 @@ beforeAll(() => {
   providerRegistry.runAutostart = mockRunAutostart;
 });
 
-test('Check that default value is false if provider autostart setting is false', async () => {
-  vi.spyOn(configurationRegistry, 'getConfiguration').mockImplementation(() => {
-    return {
-      get: (_section: string, _defaultValue: boolean) => false,
-    } as Configuration;
-  });
-
-  const autoStartConfigurationNode: IConfigurationNode = {
-    id: `preferences.${extensionId}.engine.autostart`,
-    title: `Autostart ${extensionDisplayName} engine`,
-    type: 'object',
-    extension: {
-      id: extensionId,
-    },
-    properties: {
-      [`preferences.${extensionId}.engine.autostart`]: {
-        description: `Autostart ${extensionDisplayName} engine when launching Podman Desktop`,
-        type: 'boolean',
-        default: false,
-        scope: [CONFIGURATION_DEFAULT_SCOPE, CONFIGURATION_ONBOARDING_SCOPE],
-      },
-    },
-  };
-
-  const disposable = autostartEngine.registerProvider(extensionId, extensionDisplayName, 'internalId');
-  disposable.dispose();
-  expect(mockRegisterConfiguration).toBeCalledWith([autoStartConfigurationNode]);
-});
-
 test('Check that default value is true if provider autostart setting is not set', async () => {
   vi.spyOn(configurationRegistry, 'getConfiguration').mockImplementation(() => {
     return {

--- a/packages/main/src/plugin/autostart-engine.ts
+++ b/packages/main/src/plugin/autostart-engine.ts
@@ -38,9 +38,6 @@ export class AutostartEngine {
   }
 
   private registerProviderConfiguration(extensionId: string, extensionDisplayName: string): IConfigurationNode {
-    const extensionConfiguration = this.configurationRegistry.getConfiguration(`preferences.${extensionId}`);
-    const autostart = extensionConfiguration.get<boolean>('engine.autostart', true);
-
     const autoStartConfigurationNode: IConfigurationNode = {
       id: `preferences.${extensionId}.engine.autostart`,
       title: `Autostart ${extensionDisplayName} engine`,
@@ -52,7 +49,7 @@ export class AutostartEngine {
         [`preferences.${extensionId}.engine.autostart`]: {
           description: `Autostart ${extensionDisplayName} engine when launching Podman Desktop`,
           type: 'boolean',
-          default: autostart,
+          default: true,
           scope: [CONFIGURATION_DEFAULT_SCOPE, CONFIGURATION_ONBOARDING_SCOPE],
         },
       },

--- a/packages/main/src/plugin/autostart-engine.ts
+++ b/packages/main/src/plugin/autostart-engine.ts
@@ -31,10 +31,9 @@ export class AutostartEngine {
 
   registerProvider(extensionId: string, extensionDisplayName: string, providerInternalId: string): Disposable {
     this.providerExtension.set(providerInternalId, extensionId);
-    const autostartConfiguration = this.registerProviderConfiguration(extensionId, extensionDisplayName);
+    this.registerProviderConfiguration(extensionId, extensionDisplayName);
     return Disposable.create(() => {
       this.providerExtension.delete(providerInternalId);
-      this.configurationRegistry.deregisterConfigurations([autostartConfiguration]);
     });
   }
 

--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -176,6 +176,11 @@ export class ConfigurationRegistry implements IConfigurationRegistry {
     return notifications;
   }
 
+  /**
+   * Register a configuration
+   * @param configurations
+   * @return the {@link Disposable} object provided **delete** definitely the value from the settings.
+   */
   public registerConfigurations(configurations: IConfigurationNode[]): Disposable {
     this.doRegisterConfigurations(configurations, true);
     return Disposable.create(() => {
@@ -229,10 +234,21 @@ export class ConfigurationRegistry implements IConfigurationRegistry {
     return scope === CONFIGURATION_DEFAULT_SCOPE;
   }
 
+  /**
+   * This method remove the configuration value from the settings definitely
+   * @remarks this would lose the value provided by the user
+   * @param configurations
+   */
   public deregisterConfigurations(configurations: IConfigurationNode[]): void {
     this.doDeregisterConfigurations(configurations, true);
   }
 
+  /**
+   * This method remove the configuration value from the settings definitely
+   * @remarks this would lose the value provided by the user
+   * @param configurations
+   * @param notify
+   */
   public doDeregisterConfigurations(configurations: IConfigurationNode[], notify?: boolean): string[] {
     const properties: string[] = [];
     for (const configuration of configurations) {

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -695,7 +695,7 @@ export class ExtensionLoader {
       extensionConfiguration.title = `Extension: ${extensionConfiguration.title}`;
       extensionConfiguration.id = 'preferences.' + extension.id;
 
-      extension.subscriptions.push(this.configurationRegistry.registerConfigurations([extensionConfiguration]));
+      this.configurationRegistry.registerConfigurations([extensionConfiguration]);
     }
 
     const extensionCommands = extension.manifest?.contributes?.commands;

--- a/tests/playwright/src/specs/podman-extension-smoke.spec.ts
+++ b/tests/playwright/src/specs/podman-extension-smoke.spec.ts
@@ -111,15 +111,8 @@ async function verifyPodmanExtensionStatus(enabled: boolean): Promise<void> {
   settingsBar = await navigationBar.openSettings();
   await settingsBar.preferencesTab.click();
 
-  if (enabled) {
-    await playExpect(
-      settingsBar.getSettingsNavBarTabLocator(SETTINGS_NAVBAR_PREFERENCES_PODMAN_EXTENSION),
-    ).toBeVisible();
-  } else {
-    await playExpect(
-      settingsBar.getSettingsNavBarTabLocator(SETTINGS_NAVBAR_PREFERENCES_PODMAN_EXTENSION),
-    ).not.toBeVisible();
-  }
+  await playExpect(settingsBar.getSettingsNavBarTabLocator(SETTINGS_NAVBAR_PREFERENCES_PODMAN_EXTENSION)).toBeVisible();
+
   // collapse Settings -> Preferences menu
   await settingsBar.preferencesTab.click();
 }


### PR DESCRIPTION
### What does this PR do?

The `Disposale` returned by the `ConfigurationRegistry::registerConfigurations` is particular, as **it delete completely the configuration from the settings discarding any user change**.

The extension loader was adding it to the subscriptions, and the AutoStart was also adding it so another disposale, leading to the side effect of deleting the settings when the extension is deactivated. 

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Related to https://github.com/containers/podman-desktop/issues/8435

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

Replicate steps in https://github.com/containers/podman-desktop/issues/8435#issue-2461547983
