### PR TITLE
feat: podman machine should allow image URL and registry in addition to local file path

### DIFF
--- a/extensions/podman/packages/extension/package.json
+++ b/extensions/podman/packages/extension/package.json
@@ -144,10 +144,10 @@
           "when": "podman.podmanMachineDiskSupported"
         },
         "podman.factory.machine.image-path": {
+          "markdownDescription": "Image path (optional) in a form of fully qualified registry, path, or URL to a VM image. Registry target must be in the form of _docker://registry/repo/image:version_.",
           "type": "string",
-          "format": "file",
-          "scope": "ContainerProviderConnectionFactory",
-          "description": "Image Path (Optional)"
+          "format": "file,url,fullyQualifiedRegistry",
+          "scope": "ContainerProviderConnectionFactory"
         },
         "podman.factory.machine.rootful": {
           "type": "boolean",

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
@@ -496,11 +496,6 @@ function getConnectionResourceConfigurationValue(
                   {:else if configurationKey.markdownDescription && configurationKey.type !== 'markdown'}
                     <Markdown markdown={configurationKey.markdownDescription} />
                   {/if}
-                  {#if configurationKey.format?.includes(',')}
-                    <!-- <div>
-                      very complicated element with radio buttons
-                    </div> -->
-                  {/if}
                   {#if configurationKey.format === 'memory' || configurationKey.format === 'diskSize' || configurationKey.format === 'cpu'}
                     <div class="text-gray-600">
                       <EditableConnectionResourceItem

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
@@ -496,6 +496,11 @@ function getConnectionResourceConfigurationValue(
                   {:else if configurationKey.markdownDescription && configurationKey.type !== 'markdown'}
                     <Markdown markdown={configurationKey.markdownDescription} />
                   {/if}
+                  {#if configurationKey.format?.includes(',')}
+                    <!-- <div>
+                      very complicated element with radio buttons
+                    </div> -->
+                  {/if}
                   {#if configurationKey.format === 'memory' || configurationKey.format === 'diskSize' || configurationKey.format === 'cpu'}
                     <div class="text-gray-600">
                       <EditableConnectionResourceItem

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { getInitialValue, startCase } from '/@/lib/preferences/Util';
+import { getInitialValue } from '/@/lib/preferences/Util';
 
 import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import Markdown from '../markdown/Markdown.svelte';

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { getInitialValue } from '/@/lib/preferences/Util';
+import { getInitialValue, startCase } from '/@/lib/preferences/Util';
 
 import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import Markdown from '../markdown/Markdown.svelte';
@@ -15,12 +15,6 @@ let recordUI: {
   original: IConfigurationPropertyRecordedSchema;
 };
 
-// add space from camel case and upper case on the first letter
-function startCase(str: string): string {
-  return str.replace(/([A-Z])/g, ' $1').replace(/^./, str => {
-    return str.toUpperCase();
-  });
-}
 function update(record: IConfigurationPropertyRecordedSchema) {
   const id = record.id;
   // take string after the last dot

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { getInitialValue } from '/@/lib/preferences/Util';
+import { getInitialValue, startCase } from '/@/lib/preferences/Util';
 
 import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import Markdown from '../markdown/Markdown.svelte';

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -186,7 +186,7 @@ async function onChange(recordId: string, value: boolean | string | number): Pro
             name={`${record.id}_format`}
             value={format}
             class="align-middle" />
-          <label for={`${record.id}.${format}`} class="align-middle">{startCase(format)}</label>
+          <label for={`${record.id}.${format}`} class="align-middle mr-2">{startCase(format)}</label>
         {/each}
         <div class="flex-row">
           {#if selectedFormat === 'file' || record.format === 'folder'}

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -183,7 +183,7 @@ async function onChange(recordId: string, value: boolean | string | number): Pro
             type="radio"
             on:change={onFormatChange}
             checked={selectedFormat === format}
-            name={`${record.id}_format`}
+            name={`${record.id}-format`}
             value={format}
             class="align-middle" />
           <label for={`${record.id}.${format}`} class="align-middle mr-2">{startCase(format)}</label>

--- a/packages/renderer/src/lib/preferences/Util.ts
+++ b/packages/renderer/src/lib/preferences/Util.ts
@@ -179,3 +179,9 @@ export function calcHalfCpuCores(osCpu: string): number {
   const hCores = Math.floor(cores / 2);
   return hCores === 0 ? 1 : hCores;
 }
+
+export function startCase(str: string): string {
+  return str.replace(/([A-Z])/g, ' $1').replace(/^./, str => {
+    return str.toUpperCase();
+  });
+}


### PR DESCRIPTION
### What does this PR do?

This pr introduce a way to say that an option can have different formats and in this specific fix it allows to switch between different formats for podman desktop --image-path options. It does not have full implementation with validation for URI and URL fields using just StringInput and let `podman machine init` fail if something is not right with option value. 

Specific issues should be opened for URI and URL inputs if this PR is merged.

### Screenshot / video of UI

https://github.com/user-attachments/assets/d70e46aa-ea6e-4794-b964-348f2e980486

### What issues does this PR fix or reference?

Fix #8109.

### How to test this PR?

See screen recording above

- [x] Tests are covering the bug fix or the new feature
