### PR TITLE
fix: use docker.io registry credentials for index.docker.io images

### DIFF
--- a/packages/main/src/plugin/image-registry.spec.ts
+++ b/packages/main/src/plugin/image-registry.spec.ts
@@ -867,6 +867,21 @@ test('getAuthconfigForServer returns the expected authconfig', async () => {
   expect(config?.serveraddress).toBe('my-podman-desktop-fake-registry.io');
 });
 
+test('getAuthconfigForServer returns docker.io authconfig when server is index.docker.io', async () => {
+  imageRegistry.registerRegistry({
+    serverUrl: 'docker.io',
+    username: 'foo',
+    secret: 'my-secret',
+    source: 'podman-desktop',
+  });
+  const config = imageRegistry.getAuthconfigForServer('index.docker.io');
+
+  expect(config).toBeDefined();
+  expect(config?.username).toBe('foo');
+  expect(config?.password).toBe('my-secret');
+  expect(config?.serveraddress).toBe('https://index.docker.io/v2/');
+});
+
 test('getToken with registry auth', async () => {
   imageRegistry.registerRegistry({
     serverUrl: 'my-podman-desktop-fake-registry.io',

--- a/packages/main/src/plugin/image-registry.ts
+++ b/packages/main/src/plugin/image-registry.ts
@@ -114,7 +114,10 @@ export class ImageRegistry {
   }
 
   getAuthconfigForServer(registryServer: string): Dockerode.AuthConfig | undefined {
-    const matchingUrl = registryServer;
+    let matchingUrl = registryServer;
+    if (matchingUrl === 'index.docker.io') {
+      matchingUrl = 'docker.io';
+    }
     // grab authentication data for this server
     const matchingRegistry = this.getRegistries().find(
       registry => registry.serverUrl.toLowerCase() === matchingUrl.toLowerCase(),


### PR DESCRIPTION
### What does this PR do?

Use docker.io registry credentials for index.docker.io images


### What issues does this PR fix or reference?

Fixes #8293 

### How to test this PR?

Try to install an extension from a private Docker repository (you should have added credentials for the Docker registry)

- [x] Tests are covering the bug fix or the new feature
