### PR TITLE
fix: redirect kube page to pods page

### DIFF
--- a/packages/renderer/src/lib/kube/KubePlayYAML.spec.ts
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.spec.ts
@@ -21,6 +21,7 @@ import '@testing-library/jest-dom/vitest';
 import type { ProviderStatus } from '@podman-desktop/api';
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
+import { router } from 'tinro';
 import { beforeAll, expect, test, vi } from 'vitest';
 
 import type { ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provider-info';
@@ -67,6 +68,15 @@ const mockedErroredPlayKubeInfo: PlayKubeInfo = {
     },
   ],
 };
+
+// mock the router
+vi.mock('tinro', () => {
+  return {
+    router: {
+      goto: vi.fn(),
+    },
+  };
+});
 
 // fake the window.events object
 beforeAll(() => {
@@ -148,7 +158,7 @@ test('error: When pressing the Play button, expect us to show the errors to the 
   expect(error).toBeInTheDocument();
 });
 
-test('expect done button is there at the end', async () => {
+test('expect done button is there at the end and redirects to pods', async () => {
   (window as any).playKube = vi.fn().mockResolvedValue({
     Pods: [],
   });
@@ -179,4 +189,10 @@ test('expect done button is there at the end', async () => {
   expect(doneButton).toBeInTheDocument();
   // check that text value is also 'Done'
   expect(doneButton).toHaveTextContent('Done');
+
+  // check that clicking redirects to the pods page
+  expect(router.goto).not.toHaveBeenCalled();
+  await userEvent.click(doneButton);
+
+  expect(router.goto).toHaveBeenCalledWith(`/pods`);
 });

--- a/packages/renderer/src/lib/kube/KubePlayYAML.svelte
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.svelte
@@ -11,7 +11,9 @@ import type { V1NamespaceList } from '@kubernetes/client-node/dist/api';
 import type { OpenDialogOptions } from '@podman-desktop/api';
 import { Button, ErrorMessage, Input } from '@podman-desktop/ui-svelte';
 import Fa from 'svelte-fa';
-import { router } from 'tinro';
+
+import { handleNavigation } from '/@/navigation';
+import { NavigationPage } from '/@api/navigation-page';
 
 import { providerInfos } from '../../stores/providers';
 import MonacoEditor from '../editor/MonacoEditor.svelte';
@@ -158,7 +160,9 @@ onDestroy(() => {
 
 function goBackToPodsPage(): void {
   // redirect to the pods page
-  router.goto('/pods');
+  handleNavigation({
+    page: NavigationPage.PODS,
+  });
 }
 </script>
 

--- a/packages/renderer/src/lib/kube/KubePlayYAML.svelte
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.svelte
@@ -11,6 +11,7 @@ import type { V1NamespaceList } from '@kubernetes/client-node/dist/api';
 import type { OpenDialogOptions } from '@podman-desktop/api';
 import { Button, ErrorMessage, Input } from '@podman-desktop/ui-svelte';
 import Fa from 'svelte-fa';
+import { router } from 'tinro';
 
 import { providerInfos } from '../../stores/providers';
 import MonacoEditor from '../editor/MonacoEditor.svelte';
@@ -155,8 +156,9 @@ onDestroy(() => {
   }
 });
 
-function goBackToHistory(): void {
-  window.history.go(-1);
+function goBackToPodsPage(): void {
+  // redirect to the pods page
+  router.goto('/pods');
 }
 </script>
 
@@ -339,7 +341,7 @@ function goBackToHistory(): void {
       {/if}
 
       {#if runFinished}
-        <Button on:click={() => goBackToHistory()} class="w-full">Done</Button>
+        <Button on:click={() => goBackToPodsPage()} class="w-full">Done</Button>
       {/if}
     </div>
   </EngineFormPage>


### PR DESCRIPTION
### What does this PR do?

window.history.go doesn't work, just goto the pods page since that is the only page the play kube button is available from and equivalent to what we do on some other forms.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #8652.

### How to test this PR?

Go to Pods page and click Play Yaml, play a valid yaml file and then confirm clicking Done works.