### PR TITLE
feat: allowing extension to provide routeId to progress task

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -1205,9 +1205,9 @@ declare module '@podman-desktop/api' {
      *     {
      *       location: ProgressLocation.TASK_WIDGET,
      *       title: 'My task',
-     *       navigation: {
+     *       details: {
      *         routeId: 'dummy-route-id',
-     *         arguments: ['hello', 'world'],
+     *         routeArgs: ['hello', 'world'],
      *       }
      *     },
      *     async () => {
@@ -1216,15 +1216,15 @@ declare module '@podman-desktop/api' {
      *   );
      * ```
      */
-    navigation?: {
+    details?: {
       /**
        * The routeId used in {@link navigation.register}
        */
       routeId: string;
       /**
-       * The arguments to provide the navigation route
+       * The arguments to provide the route
        */
-      arguments: string[];
+      routeArgs: string[];
     };
   }
 

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -1193,6 +1193,39 @@ declare module '@podman-desktop/api' {
      * button.
      */
     cancellable?: boolean;
+
+    /**
+     * You may specify a navigation object, making the task having a
+     * navigate action that the user can trigger.
+     * @example
+     * ```ts
+     * import { window, type ProgressLocation } from '@podman-desktop/api';
+     *
+     * await window.withProgress<string>(
+     *     {
+     *       location: ProgressLocation.TASK_WIDGET,
+     *       title: 'My task',
+     *       navigation: {
+     *         routeId: 'dummy-route-id',
+     *         arguments: ['hello', 'world'],
+     *       }
+     *     },
+     *     async () => {
+     *       return 'dummy result';
+     *     },
+     *   );
+     * ```
+     */
+    navigation?: {
+      /**
+       * The routeId used in {@link navigation.register}
+       */
+      routeId: string;
+      /**
+       * The arguments to provide the navigation route
+       */
+      arguments: string[];
+    };
   }
 
   /**

--- a/packages/main/src/plugin/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension-loader.spec.ts
@@ -64,7 +64,7 @@ import type { Proxy } from './proxy.js';
 import type { ExtensionSecretStorage, SafeStorageRegistry } from './safe-storage/safe-storage-registry.js';
 import type { StatusBarRegistry } from './statusbar/statusbar-registry.js';
 import type { NotificationRegistry } from './tasks/notification-registry.js';
-import type { ProgressImpl } from './tasks/progress-impl.js';
+import { type ProgressImpl, ProgressLocation } from './tasks/progress-impl.js';
 import type { Telemetry } from './telemetry/telemetry.js';
 import type { TrayMenuRegistry } from './tray-menu-registry.js';
 import type { IDisposable } from './types/disposable.js';
@@ -141,7 +141,9 @@ const trayMenuRegistry: TrayMenuRegistry = {} as unknown as TrayMenuRegistry;
 
 const messageBox: MessageBox = {} as MessageBox;
 
-const progress: ProgressImpl = {} as ProgressImpl;
+const progress: ProgressImpl = {
+  withProgress: vi.fn(),
+} as unknown as ProgressImpl;
 
 const statusBarRegistry: StatusBarRegistry = {} as unknown as StatusBarRegistry;
 
@@ -2284,6 +2286,45 @@ test('when registering a navigation route, should be pushed to disposables', () 
   expect(disposables.length).toBe(0);
   api.navigation.register('dummy-route-id', 'dummy-command-id');
   expect(disposables.length).toBe(1);
+});
+
+test('withProgress should add the extension id to the routeId', async () => {
+  vi.mocked(progress.withProgress).mockResolvedValue(undefined);
+  const disposables: IDisposable[] = [];
+
+  const api = extensionLoader.createApi(
+    '/path',
+    {
+      publisher: 'pub',
+      name: 'dummy',
+    },
+    disposables,
+  );
+  expect(api).toBeDefined();
+
+  await api.window.withProgress<void>(
+    {
+      location: ProgressLocation.TASK_WIDGET,
+      title: 'Dummy title',
+      navigation: {
+        routeId: 'dummy-route-id',
+        arguments: ['hello', 'world'],
+      },
+    },
+    async () => {},
+  );
+
+  expect(progress.withProgress).toHaveBeenCalledWith(
+    {
+      location: ProgressLocation.TASK_WIDGET,
+      title: 'Dummy title',
+      navigation: {
+        routeId: 'pub.dummy.dummy-route-id',
+        arguments: ['hello', 'world'],
+      },
+    },
+    expect.any(Function),
+  );
 });
 
 describe('loading extension folders', () => {

--- a/packages/main/src/plugin/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension-loader.spec.ts
@@ -2306,9 +2306,9 @@ test('withProgress should add the extension id to the routeId', async () => {
     {
       location: ProgressLocation.TASK_WIDGET,
       title: 'Dummy title',
-      navigation: {
+      details: {
         routeId: 'dummy-route-id',
-        arguments: ['hello', 'world'],
+        routeArgs: ['hello', 'world'],
       },
     },
     async () => {},
@@ -2318,9 +2318,9 @@ test('withProgress should add the extension id to the routeId', async () => {
     {
       location: ProgressLocation.TASK_WIDGET,
       title: 'Dummy title',
-      navigation: {
+      details: {
         routeId: 'pub.dummy.dummy-route-id',
-        arguments: ['hello', 'world'],
+        routeArgs: ['hello', 'world'],
       },
     },
     expect.any(Function),

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -983,7 +983,18 @@ export class ExtensionLoader {
           token: containerDesktopAPI.CancellationToken,
         ) => Promise<R>,
       ): Promise<R> => {
-        return progress.withProgress(options, task);
+        return progress.withProgress(
+          {
+            ...options,
+            navigation: options.navigation
+              ? {
+                  arguments: options.navigation.arguments,
+                  routeId: `${extensionInfo.id}.${options.navigation.routeId}`,
+                }
+              : undefined,
+          },
+          task,
+        );
       },
 
       showNotification: (notificationInfo: containerDesktopAPI.NotificationOptions): containerDesktopAPI.Disposable => {

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -986,10 +986,10 @@ export class ExtensionLoader {
         return progress.withProgress(
           {
             ...options,
-            navigation: options.navigation
+            details: options.details
               ? {
-                  arguments: options.navigation.arguments,
-                  routeId: `${extensionInfo.id}.${options.navigation.routeId}`,
+                  routeArgs: options.details.routeArgs,
+                  routeId: `${extensionInfo.id}.${options.details.routeId}`,
                 }
               : undefined,
           },

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -645,7 +645,7 @@ export class PluginSystem {
       apiSender,
       trayMenuRegistry,
       messageBox,
-      new ProgressImpl(taskManager),
+      new ProgressImpl(taskManager, navigationManager),
       statusBarRegistry,
       kubernetesClient,
       fileSystemMonitoring,

--- a/packages/main/src/plugin/tasks/progress-impl.spec.ts
+++ b/packages/main/src/plugin/tasks/progress-impl.spec.ts
@@ -21,6 +21,7 @@
 import type { Event } from '@podman-desktop/api';
 import { beforeEach, expect, test, vi } from 'vitest';
 
+import type { NavigationManager } from '/@/plugin/navigation/navigation-manager.js';
 import type { Task, TaskAction, TaskUpdateEvent } from '/@/plugin/tasks/tasks.js';
 import type { TaskState, TaskStatus } from '/@api/taskInfo.js';
 
@@ -30,6 +31,11 @@ import type { TaskManager } from './task-manager.js';
 const taskManager = {
   createTask: vi.fn(),
 } as unknown as TaskManager;
+
+const navigationManager = {
+  hasRoute: vi.fn(),
+  navigateToRoute: vi.fn(),
+} as unknown as NavigationManager;
 
 class TestTaskImpl implements Task {
   constructor(
@@ -62,7 +68,7 @@ test('Should create a task and report update', async () => {
   const task = new TestTaskImpl('test-task-id', 'test-title', 'running', 'in-progress');
   vi.mocked(taskManager.createTask).mockReturnValue(task);
 
-  const progress = new ProgressImpl(taskManager);
+  const progress = new ProgressImpl(taskManager, navigationManager);
   await progress.withProgress({ location: ProgressLocation.TASK_WIDGET, title: 'My task' }, async () => 0);
 
   expect(task.status).toBe('success');
@@ -72,7 +78,7 @@ test('Should create a task and report progress', async () => {
   const task = new TestTaskImpl('test-task-id', 'test-title', 'running', 'in-progress');
   vi.mocked(taskManager.createTask).mockReturnValue(task);
 
-  const progress = new ProgressImpl(taskManager);
+  const progress = new ProgressImpl(taskManager, navigationManager);
   await progress.withProgress({ location: ProgressLocation.TASK_WIDGET, title: 'My task' }, async progress => {
     progress.report({ increment: 50 });
   });
@@ -85,7 +91,7 @@ test('Should create a task and propagate the exception', async () => {
   const task = new TestTaskImpl('test-task-id', 'test-title', 'running', 'in-progress');
   vi.mocked(taskManager.createTask).mockReturnValue(task);
 
-  const progress = new ProgressImpl(taskManager);
+  const progress = new ProgressImpl(taskManager, navigationManager);
 
   await expect(
     progress.withProgress({ location: ProgressLocation.TASK_WIDGET, title: 'My task' }, async () => {
@@ -101,7 +107,7 @@ test('Should create a task and propagate the result', async () => {
   const task = new TestTaskImpl('test-task-id', 'test-title', 'running', 'in-progress');
   vi.mocked(taskManager.createTask).mockReturnValue(task);
 
-  const progress = new ProgressImpl(taskManager);
+  const progress = new ProgressImpl(taskManager, navigationManager);
 
   const result: string = await progress.withProgress<string>(
     { location: ProgressLocation.TASK_WIDGET, title: 'My task' },
@@ -118,7 +124,7 @@ test('Should update the task name', async () => {
   const task = new TestTaskImpl('test-task-id', 'test-title', 'running', 'in-progress');
   vi.mocked(taskManager.createTask).mockReturnValue(task);
 
-  const progress = new ProgressImpl(taskManager);
+  const progress = new ProgressImpl(taskManager, navigationManager);
 
   await progress.withProgress<void>({ location: ProgressLocation.TASK_WIDGET, title: 'My task' }, async progress => {
     progress.report({ message: 'New title' });
@@ -126,4 +132,44 @@ test('Should update the task name', async () => {
 
   expect(task.name).toBe('New title');
   expect(task.status).toBe('success');
+});
+
+test('Should create a task with a navigation action', async () => {
+  vi.mocked(navigationManager.hasRoute).mockReturnValue(true);
+
+  const task = new TestTaskImpl('test-task-id', 'test-title', 'running', 'in-progress');
+  const progress = new ProgressImpl(taskManager, navigationManager);
+
+  let taskAction: TaskAction | undefined;
+  vi.mocked(taskManager.createTask).mockImplementation(options => {
+    taskAction = options?.action;
+    return task;
+  });
+
+  await progress.withProgress<string>(
+    {
+      location: ProgressLocation.TASK_WIDGET,
+      title: 'My task',
+      navigation: {
+        routeId: 'dummy-route-id',
+        arguments: ['hello', 'world'],
+      },
+    },
+    async () => {
+      return 'dummy result';
+    },
+  );
+
+  await vi.waitFor(() => {
+    expect(taskAction).toBeDefined();
+  });
+
+  expect(taskAction?.name).toBe('Goto task >');
+  expect(taskAction?.execute).toBeInstanceOf(Function);
+
+  // execute the task action
+  taskAction?.execute(task);
+
+  // ensure the arguments and routeId is properly used
+  expect(navigationManager.navigateToRoute).toHaveBeenCalledWith('dummy-route-id', 'hello', 'world');
 });

--- a/packages/main/src/plugin/tasks/progress-impl.spec.ts
+++ b/packages/main/src/plugin/tasks/progress-impl.spec.ts
@@ -150,9 +150,9 @@ test('Should create a task with a navigation action', async () => {
     {
       location: ProgressLocation.TASK_WIDGET,
       title: 'My task',
-      navigation: {
+      details: {
         routeId: 'dummy-route-id',
-        arguments: ['hello', 'world'],
+        routeArgs: ['hello', 'world'],
       },
     },
     async () => {
@@ -164,7 +164,7 @@ test('Should create a task with a navigation action', async () => {
     expect(taskAction).toBeDefined();
   });
 
-  expect(taskAction?.name).toBe('Goto task >');
+  expect(taskAction?.name).toBe('View');
   expect(taskAction?.execute).toBeInstanceOf(Function);
 
   // execute the task action

--- a/packages/main/src/plugin/tasks/progress-impl.ts
+++ b/packages/main/src/plugin/tasks/progress-impl.ts
@@ -18,6 +18,8 @@
 import type * as extensionApi from '@podman-desktop/api';
 
 import { findWindow } from '/@/electron-util.js';
+import type { NavigationManager } from '/@/plugin/navigation/navigation-manager.js';
+import type { TaskAction } from '/@/plugin/tasks/tasks.js';
 
 import { CancellationTokenImpl } from '../cancellation-token.js';
 import type { TaskManager } from './task-manager.js';
@@ -35,7 +37,10 @@ export enum ProgressLocation {
 }
 
 export class ProgressImpl {
-  constructor(private taskManager: TaskManager) {}
+  constructor(
+    private taskManager: TaskManager,
+    private navigationManager: NavigationManager,
+  ) {}
 
   /**
    * Execute a task with progress, based on the provided options and task function.
@@ -78,6 +83,23 @@ export class ProgressImpl {
     );
   }
 
+  protected getTaskAction(options: extensionApi.ProgressOptions): TaskAction | undefined {
+    if (!options.navigation) return undefined;
+
+    if (!this.navigationManager.hasRoute(options.navigation.routeId)) {
+      console.warn(`cannot created task action for unknown routeId ${options.navigation.routeId}`);
+      return undefined;
+    }
+
+    return {
+      name: 'Goto task >',
+      execute: (): unknown => {
+        if (!options.navigation) return;
+        return this.navigationManager.navigateToRoute(options.navigation.routeId, ...options.navigation.arguments);
+      },
+    };
+  }
+
   async withWidget<R>(
     options: extensionApi.ProgressOptions,
     task: (
@@ -85,7 +107,10 @@ export class ProgressImpl {
       token: extensionApi.CancellationToken,
     ) => Promise<R>,
   ): Promise<R> {
-    const t = this.taskManager.createTask({ title: options.title });
+    const t = this.taskManager.createTask({
+      title: options.title,
+      action: this.getTaskAction(options),
+    });
 
     return task(
       {

--- a/packages/main/src/plugin/tasks/progress-impl.ts
+++ b/packages/main/src/plugin/tasks/progress-impl.ts
@@ -84,18 +84,18 @@ export class ProgressImpl {
   }
 
   protected getTaskAction(options: extensionApi.ProgressOptions): TaskAction | undefined {
-    if (!options.navigation) return undefined;
+    if (!options.details) return undefined;
 
-    if (!this.navigationManager.hasRoute(options.navigation.routeId)) {
-      console.warn(`cannot created task action for unknown routeId ${options.navigation.routeId}`);
+    if (!this.navigationManager.hasRoute(options.details.routeId)) {
+      console.warn(`cannot created task action for unknown routeId ${options.details.routeId}`);
       return undefined;
     }
 
     return {
-      name: 'Goto task >',
+      name: 'View',
       execute: (): unknown => {
-        if (!options.navigation) return;
-        return this.navigationManager.navigateToRoute(options.navigation.routeId, ...options.navigation.arguments);
+        if (!options.details) return;
+        return this.navigationManager.navigateToRoute(options.details.routeId, ...options.details.routeArgs);
       },
     };
   }


### PR DESCRIPTION
### What does this PR do?

Allow extensions to provide a `navigation` object when using `window.withProgress`.

### Screenshot / video of UI

https://github.com/user-attachments/assets/40fa7bee-adc3-4c27-987c-ee351012d26b

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/7709

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

**Testing manually**

Inside the activate of an extension add the following

```ts
  extensionApi.commands.registerCommand('podman.dummy-command-id', (...args) => {
    console.log('[podman] command triggered ', args);
    return extensionApi.navigation.navigateToContainers();
  });

  extensionApi.navigation.register('dummy-route-id', 'podman.dummy-command-id');

  extensionApi.window.withProgress<string>({
    location: ProgressLocation.TASK_WIDGET,
    details: {
      routeId: 'dummy-route-id',
      routeArfs: ['tracking-id'],
    },
    title: 'Task example'
  }, async (): Promise<string> => {
    return new Promise<string>((resolve, reject) => {
      setTimeout(() => {
        resolve('patate');
      }, 10 * 1000);
    });
  }).catch((err: unknown) => {
    console.error(err);
  });
```

and add the following to the extension package.json

```
{
....
  "contributes": {
    "commands": [
      {
        "command": "podman.dummy-command-id",
        "title": "Podman: Dummy command (navigation related)"
      },
....
```

1. Then activate / deactivate the given extension
2. See the TaskManager
