### PR TITLE
chore(tests): added runner context to fixtures and registry tests

### DIFF
--- a/tests/playwright/src/runner/podman-desktop-runner.ts
+++ b/tests/playwright/src/runner/podman-desktop-runner.ts
@@ -19,7 +19,7 @@
 import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 
-import type { ElectronApplication, JSHandle, Page } from '@playwright/test';
+import type { BrowserContext, ElectronApplication, JSHandle, Page } from '@playwright/test';
 import { _electron as electron, test } from '@playwright/test';
 import type { BrowserWindow } from 'electron';
 
@@ -125,6 +125,14 @@ export class Runner {
   public getPage(): Page {
     if (this._page) {
       return this._page;
+    } else {
+      throw Error('Application was not started yet');
+    }
+  }
+
+  public getNewContext(): BrowserContext {
+    if (this._app) {
+      return this._app.context();
     } else {
       throw Error('Application was not started yet');
     }

--- a/tests/playwright/src/specs/registry-image.spec.ts
+++ b/tests/playwright/src/specs/registry-image.spec.ts
@@ -52,7 +52,8 @@ test.afterAll(async ({ runner, page }) => {
 });
 
 test.describe.serial('Pulling image from authenticated registry workflow verification', () => {
-  test('Cannot pull image from unauthenticated registry', async ({ page, navigationBar }) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  test('Cannot pull image from unauthenticated registry', async ({ context, page, navigationBar }) => {
     const imagesPage = await navigationBar.openImages();
 
     const fullImageTitle = imageUrl.concat(':' + imageTag);

--- a/tests/playwright/src/specs/registry.spec.ts
+++ b/tests/playwright/src/specs/registry.spec.ts
@@ -39,7 +39,8 @@ test.afterAll(async ({ runner }) => {
 });
 
 test.describe.serial('Registries handling verification', () => {
-  test('Check Registries page components and presence of default registries', async ({ navigationBar }) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  test('Check Registries page components and presence of default registries', async ({ context, navigationBar }) => {
     const settingsBar = await navigationBar.openSettings();
     const registryPage = await settingsBar.openTabPage(RegistriesPage);
 
@@ -53,7 +54,8 @@ test.describe.serial('Registries handling verification', () => {
   });
 
   test.describe.serial('Registry addition workflow verification', () => {
-    test('Cannot add invalid registry', async ({ page, navigationBar }) => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    test('Cannot add invalid registry', async ({ context, page, navigationBar }) => {
       await navigationBar.openDashboard();
       const settingsBar = await navigationBar.openSettings();
       const registryPage = await settingsBar.openTabPage(RegistriesPage);

--- a/tests/playwright/src/utility/fixtures.ts
+++ b/tests/playwright/src/utility/fixtures.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { Page } from '@playwright/test';
+import type { BrowserContext, Page } from '@playwright/test';
 import { test as base } from '@playwright/test';
 
 import { WelcomePage } from '../model/pages/welcome-page';
@@ -30,6 +30,7 @@ export type TestFixtures = {
   navigationBar: NavigationBar;
   welcomePage: WelcomePage;
   page: Page;
+  context: BrowserContext;
   statusBar: StatusBar;
 };
 
@@ -37,14 +38,21 @@ export type FixtureOptions = {
   runnerOptions: RunnerOptions;
 };
 
+let newContext = false;
+
 export const test = base.extend<TestFixtures & FixtureOptions>({
   runnerOptions: [new RunnerOptions(), { option: true }],
   runner: async ({ runnerOptions }, use) => {
     const runner = await Runner.getInstance({ runnerOptions });
     await use(runner);
   },
-  page: async ({ runner }, use) => {
-    await use(runner.getPage());
+  context: async ({ runner }, use) => {
+    newContext = true;
+    await use(runner.getNewContext());
+  },
+  page: async ({ runner, context }, use) => {
+    const page = newContext ? context.pages()[0] : runner.getPage();
+    await use(page);
   },
   navigationBar: async ({ page }, use) => {
     const navigationBar = new NavigationBar(page);


### PR DESCRIPTION
Signed-off-by: xbabalov <t.babalova.17@gmail.com>

### What does this PR do?
Adds new context in between non-depending registry tests to prevent isolation failures.

### Screenshot / video of UI

### What issues does this PR fix or reference?
https://github.com/containers/podman-desktop/issues/6972

### How to test this PR?
npm run test:e2e