### PR TITLE
fix: change Containerfile relative path to build context

### DIFF
--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -2476,6 +2476,9 @@ export class ContainerProviderRegistry {
         if (options?.pull) {
           buildOptions.pull = options.pull;
         }
+        if (options?.containerFile) {
+          buildOptions.dockerfile = options.containerFile;
+        }
         streamingPromise = await matchingContainerProviderApi.buildImage(tarStream, buildOptions);
       } catch (error: unknown) {
         console.log('error in buildImage', error);

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
@@ -399,4 +399,8 @@ test('Expect Containerfile path to be relative to build context', () => {
   buildContext = 'User//test/test1/test2';
   containerFilePath = 'User/test//test1/test2//test3/file1';
   expect(component.getRelativePath(buildContext, containerFilePath)).toBe('test3/file1');
+
+  buildContext = 'User\\test\\test1\\test2';
+  containerFilePath = 'User\\test\\test1\\test3\\file1';
+  expect(component.getRelativePath(buildContext, containerFilePath)).toBe('../test3/file1');
 });

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
@@ -392,13 +392,17 @@ test('Expect build to include build arguments', async () => {
 test('Expect Containerfile path to be relative to build context', () => {
   setup();
   const { component } = render(BuildImageFromContainerfile, {});
-  let buildContext = 'User/test/test1/test2';
-  let containerFilePath = 'User/file1';
+  let buildContext = '/User/test/test1/test2';
+  let containerFilePath = '/User/file1';
   expect(component.getRelativePath(buildContext, containerFilePath)).toBe('../../../file1');
 
-  buildContext = 'User//test/test1/test2';
-  containerFilePath = 'User/test//test1/test2//test3/file1';
+  buildContext = '/User//test/test1/test2';
+  containerFilePath = '/User/test//test1/test2//test3/file1';
   expect(component.getRelativePath(buildContext, containerFilePath)).toBe('test3/file1');
+
+  buildContext = '/User//test/test1/test2';
+  containerFilePath = '/User/test1//test1/test2//test3/file1';
+  expect(component.getRelativePath(buildContext, containerFilePath)).toBe('../../../test1/test1/test2/test3/file1');
 
   buildContext = 'User\\test\\test1\\test2';
   containerFilePath = 'User\\test\\test1\\test3\\file1';

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
@@ -388,3 +388,15 @@ test('Expect build to include build arguments', async () => {
   expect(buildButton).toBeEnabled();
   await userEvent.click(buildButton);
 });
+
+test('Expect Containerfile path to be relative to build context', () => {
+  setup();
+  const { component } = render(BuildImageFromContainerfile, {});
+  let buildContext = 'User/test/test1/test2';
+  let containerFilePath = 'User/file1';
+  expect(component.getRelativePath(buildContext, containerFilePath)).toBe('../../../file1');
+
+  buildContext = 'User//test/test1/test2';
+  containerFilePath = 'User/test//test1/test2//test3/file1';
+  expect(component.getRelativePath(buildContext, containerFilePath)).toBe('test3/file1');
+});

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
@@ -110,6 +110,23 @@ function getTerminalCallback(): BuildImageCallback {
   };
 }
 
+export function getRelativePath(context: string, file: string): string {
+  let relativePath = '';
+  let contextPath = context.split(/[\\/]/).filter(dir => dir);
+  let filePath = file.split(/[\\/]/).filter(dir => dir);
+  let index = 0;
+  while (index < contextPath.length && index < filePath.length && contextPath[index] === filePath[index]) {
+    index++;
+  }
+  if (index < contextPath.length) {
+    let back = Array(contextPath.length - index).fill('..');
+    relativePath = `${back.join('/')}/${filePath.slice(index).join('/')}`;
+  } else {
+    relativePath = filePath.slice(index).join('/');
+  }
+  return relativePath;
+}
+
 async function buildContainerImage(): Promise<void> {
   buildParentImageName = undefined;
   buildError = undefined;
@@ -139,7 +156,7 @@ async function buildSinglePlatformImage(): Promise<void> {
 
   if (containerFilePath && selectedProvider) {
     // Extract the relative path from the containerFilePath and containerBuildContextDirectory
-    const relativeContainerfilePath = containerFilePath.substring(containerBuildContextDirectory.length + 1);
+    const relativeContainerfilePath = getRelativePath(containerBuildContextDirectory, containerFilePath);
     buildImageInfo = startBuild(containerImageName, getTerminalCallback());
 
     // Store the key
@@ -181,7 +198,7 @@ async function buildMultiplePlatformImagesAndCreateManifest(): Promise<void> {
 
   if (containerFilePath && selectedProvider) {
     // Extract the relative path from the containerFilePath and containerBuildContextDirectory
-    const relativeContainerfilePath = containerFilePath.substring(containerBuildContextDirectory.length + 1);
+    const relativeContainerfilePath = getRelativePath(containerBuildContextDirectory, containerFilePath);
 
     // We'll iterate over each platform and build the image
     for (const platform of platforms) {

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
@@ -112,12 +112,16 @@ function getTerminalCallback(): BuildImageCallback {
 
 export function getRelativePath(context: string, file: string): string {
   let relativePath = '';
+  // split paths based on backward or forward slashes (works for both Windows and Mac/Linux path formats)
   let contextPath = context.split(/[\\/]/).filter(dir => dir);
   let filePath = file.split(/[\\/]/).filter(dir => dir);
   let index = 0;
+  // find the first place where both paths don't match
   while (index < contextPath.length && index < filePath.length && contextPath[index] === filePath[index]) {
     index++;
   }
+  // add .. for the remaining length of the context path (if the context path didn't fully match part of the file path)
+  // then add the remaining path of the file
   if (index < contextPath.length) {
     let back = Array(contextPath.length - index).fill('..');
     relativePath = `${back.join('/')}/${filePath.slice(index).join('/')}`;


### PR DESCRIPTION
### What does this PR do?
This PR fixes the Containerfile's relative path when building an image.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
https://github.com/containers/podman-desktop/issues/8460

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
- Open build image page
- Choose containerfile to use for the build
- Change the build context to something different from the default
- Check that the image is successfully built

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
