### PR TITLE
fix: update app label before displaying pod yaml

### DIFF
--- a/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
@@ -23,6 +23,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
 import * as jsYaml from 'js-yaml';
 import { tick } from 'svelte';
 import { router } from 'tinro';
@@ -111,7 +112,12 @@ beforeEach(() => {
 
   // podYaml with volumes
   const podYaml = {
-    metadata: { name: 'hello' },
+    metadata: {
+      labels: {
+        app: 'hello',
+      },
+      name: 'hello',
+    },
     spec: {
       containers: [
         {
@@ -330,7 +336,12 @@ test('When deploying a pod, volumes should not be added (they are deleted by pod
   // Expect kubernetesCreatePod to be called with default namespace and a modified bodyPod with volumes removed
   await waitFor(() =>
     expect(kubernetesCreatePodMock).toBeCalledWith('default', {
-      metadata: { name: 'hello' },
+      metadata: {
+        labels: {
+          app: 'hello',
+        },
+        name: 'hello',
+      },
       spec: {
         containers: [
           {
@@ -363,7 +374,12 @@ test('Test deploying a group of compose containers with type compose still funct
   // Expect to return the correct create pod yaml
   await waitFor(() =>
     expect(kubernetesCreatePodMock).toBeCalledWith('default', {
-      metadata: { name: 'hello' },
+      metadata: {
+        labels: {
+          app: 'hello',
+        },
+        name: 'hello',
+      },
       spec: {
         containers: [
           {
@@ -390,13 +406,23 @@ test('When modifying the pod name, metadata.apps.label should also have been cha
   expect(createButton).toBeInTheDocument();
   expect(createButton).toBeEnabled();
 
+  const podNameInput = screen.getByLabelText('Pod Name');
+  await userEvent.click(podNameInput);
+  await userEvent.clear(podNameInput);
+  await userEvent.keyboard('newName');
+
   // Press the deploy button
   await fireEvent.click(createButton);
 
   // Expect kubernetesCreatePod to be called with default namespace and a modified bodyPod with volumes removed
   await waitFor(() =>
     expect(kubernetesCreatePodMock).toBeCalledWith('default', {
-      metadata: { name: 'hello' },
+      metadata: {
+        labels: {
+          app: 'newName',
+        },
+        name: 'newName',
+      },
       spec: {
         containers: [
           {
@@ -432,7 +458,12 @@ test('When deploying a pod, restricted security context is added', async () => {
   // Expect kubernetesCreatePod to be called with default namespace and a modified bodyPod with volumes removed
   await waitFor(() =>
     expect(kubernetesCreatePodMock).toBeCalledWith('default', {
-      metadata: { name: 'hello' },
+      metadata: {
+        labels: {
+          app: 'hello',
+        },
+        name: 'hello',
+      },
       spec: {
         containers: [
           {

--- a/packages/renderer/src/lib/pod/DeployPodToKube.svelte
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.svelte
@@ -363,8 +363,6 @@ async function deployToKube() {
   }
 }
 
-$: bodyPod && updateKubeResult();
-
 // Update bodyPod.metadata.labels.app to be the same as bodyPod.metadata.name
 // If statement required as bodyPod.metadata is undefined when bodyPod is undefined
 $: {
@@ -372,6 +370,8 @@ $: {
     bodyPod.metadata.labels.app = bodyPod.metadata.name;
   }
 }
+
+$: bodyPod && updateKubeResult();
 
 function updateKubeResult() {
   kubeDetails = jsYaml.dump(bodyPod, { noArrayIndent: true, quotingType: '"', lineWidth: -1 });


### PR DESCRIPTION
### What does this PR do?

It just reorders the reactive clauses so that the `updateKubeResult` is called after the app label is updated

### Screenshot / video of UI

![update_yaml](https://github.com/user-attachments/assets/08c5ef0a-abaf-483f-88ba-3e2e3a572b0e)

### What issues does this PR fix or reference?

it fixes #8412 

### How to test this PR?

1. update the pod name on the deploy pod page and check that the name and app labels in the generated yaml are the same

- [x] Tests are covering the bug fix or the new feature
