### PR TITLE
feat: reduce minimum amount of memory required to install podman on windows

### DIFF
--- a/extensions/podman/packages/extension/src/podman-install.spec.ts
+++ b/extensions/podman/packages/extension/src/podman-install.spec.ts
@@ -261,7 +261,7 @@ test('expect winversion preflight check return failure result if the version is 
   expect(result.docLinks?.[0].title).equal('WSL2 Manual Installation Steps');
 });
 
-test('expect winMemory preflight check return successful result if the machine has more than 6GB of memory', async () => {
+test('expect winMemory preflight check return successful result if the machine has more than 5GB of memory', async () => {
   const SYSTEM_MEM = 7 * 1024 * 1024 * 1024;
   vi.spyOn(os, 'totalmem').mockReturnValue(SYSTEM_MEM);
 
@@ -272,7 +272,7 @@ test('expect winMemory preflight check return successful result if the machine h
   expect(result.successful).toBeTruthy();
 });
 
-test('expect winMemory preflight check return failure result if the machine has less than 6GB of memory', async () => {
+test('expect winMemory preflight check return failure result if the machine has less than 5GB of memory', async () => {
   const SYSTEM_MEM = 4 * 1024 * 1024 * 1024;
   vi.spyOn(os, 'totalmem').mockReturnValue(SYSTEM_MEM);
 
@@ -280,7 +280,7 @@ test('expect winMemory preflight check return failure result if the machine has 
   const preflights = installer.getPreflightChecks();
   const winMemoryCheck = preflights[2];
   const result = await winMemoryCheck.execute();
-  expect(result.description).equal('You need at least 6GB to run Podman.');
+  expect(result.description).equal('You need at least 5GB to run Podman.');
   expect(result.docLinksDescription).toBeUndefined();
   expect(result.docLinks).toBeUndefined();
   expect(result.fixCommand).toBeUndefined();

--- a/extensions/podman/packages/extension/src/podman-install.ts
+++ b/extensions/podman/packages/extension/src/podman-install.ts
@@ -611,7 +611,7 @@ class WinVersionCheck extends BaseCheck {
 
 class WinMemoryCheck extends BaseCheck {
   title = 'RAM';
-  private REQUIRED_MEM = 6 * 1024 * 1024 * 1024; // 6Gb
+  private REQUIRED_MEM = 5 * 1024 * 1024 * 1024; // 5Gb
 
   async execute(): Promise<extensionApi.CheckResult> {
     const totalMem = os.totalmem();
@@ -619,7 +619,7 @@ class WinMemoryCheck extends BaseCheck {
       return this.createSuccessfulResult();
     } else {
       return this.createFailureResult({
-        description: 'You need at least 6GB to run Podman.',
+        description: 'You need at least 5GB to run Podman.',
       });
     }
   }


### PR DESCRIPTION
### What does this PR do?
Reduces minimum memory required to install Podman on Windows

With 5GB: 
![image](https://github.com/user-attachments/assets/85717aaf-4f88-4902-b7e4-84bf55bc4b57)

With 6GB:
![image](https://github.com/user-attachments/assets/ce0b2cb2-1173-4247-a56e-f6de60626d98)


### What issues does this PR fix or reference?
Closes #8916 

- [x] Tests are covering the bug fix or the new feature
