### PR TITLE
chore: increase timeout on pull-image-page

### DIFF
--- a/tests/playwright/src/model/pages/pull-image-page.ts
+++ b/tests/playwright/src/model/pages/pull-image-page.ts
@@ -39,7 +39,7 @@ export class PullImagePage extends BasePage {
     this.imageNameInput = page.getByLabel('Image to Pull');
   }
 
-  async pullImage(imageName: string, tag = '', timeout = 60000): Promise<ImagesPage> {
+  async pullImage(imageName: string, tag = '', timeout = 120000): Promise<ImagesPage> {
     const fullImageName = `${imageName}${tag.length === 0 ? '' : ':' + tag}`;
     await this.imageNameInput.fill(fullImageName);
     await playExpect(this.pullImageButton).toBeEnabled();

--- a/tests/playwright/src/model/pages/pull-image-page.ts
+++ b/tests/playwright/src/model/pages/pull-image-page.ts
@@ -39,7 +39,7 @@ export class PullImagePage extends BasePage {
     this.imageNameInput = page.getByLabel('Image to Pull');
   }
 
-  async pullImage(imageName: string, tag = '', timeout = 120000): Promise<ImagesPage> {
+  async pullImage(imageName: string, tag = '', timeout = 60000): Promise<ImagesPage> {
     const fullImageName = `${imageName}${tag.length === 0 ? '' : ':' + tag}`;
     await this.imageNameInput.fill(fullImageName);
     await playExpect(this.pullImageButton).toBeEnabled();

--- a/tests/playwright/src/specs/volume-smoke.spec.ts
+++ b/tests/playwright/src/specs/volume-smoke.spec.ts
@@ -97,7 +97,7 @@ test.describe.serial('Volume workflow verification @smoke', () => {
   });
 
   test('Create volumes from bootc-image-builder', async ({ navigationBar }) => {
-    test.setTimeout(150000);
+    test.setTimeout(210000);
 
     //count the number of existing volumes
     let volumesPage = await navigationBar.openVolumes();
@@ -119,7 +119,7 @@ test.describe.serial('Volume workflow verification @smoke', () => {
     //pull image from quay.io/centos-bootc/bootc-image-builder
     let images = await navigationBar.openImages();
     const pullImagePage = await images.openPullImage();
-    images = await pullImagePage.pullImage(imageToPull, imageTag);
+    images = await pullImagePage.pullImage(imageToPull, imageTag, 120000);
     await playExpect.poll(async () => await images.waitForImageExists(imageToPull)).toBeTruthy();
 
     //start a container from the image (generates 4 new volumes)


### PR DESCRIPTION
### What does this PR do?
Increase the timeout on pull-image-page to increase test stability
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#8939 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
Run `pnpm test:e2e:smoke`
<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
