### PR TITLE
refactor: move SecondaryResourceWatchersRegistry to its own file 

### DIFF
--- a/packages/main/src/plugin/kubernetes/kubernetes-context-state.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-context-state.ts
@@ -62,6 +62,7 @@ import {
   connectTimeout,
   dispatchTimeout,
 } from './kubernetes-context-state-constants.js';
+import { ResourceWatchersRegistry } from './resource-watchers-registry.js';
 
 // If the number of contexts in the kubeconfig file is greater than this number,
 // only the connectivity to the current context will be checked
@@ -360,40 +361,13 @@ export class ContextsStates {
   }
 }
 
-class SecondaryResourceWatchersRegistry {
-  // Map resourceName to number of watchers
-  private watchingSecondaryResource = new Map<string, number>();
-
-  subscribe(resourceName: string): void {
-    let count = this.watchingSecondaryResource.get(resourceName);
-    if (count === undefined) {
-      this.watchingSecondaryResource.set(resourceName, 0);
-      count = 0;
-    }
-    this.watchingSecondaryResource.set(resourceName, count + 1);
-  }
-
-  unsubscribe(resourceName: string): void {
-    const count = this.watchingSecondaryResource.get(resourceName);
-    if (count === undefined) {
-      throw new Error(`unsubscribe before subscribe on resource ${resourceName}`);
-    }
-    this.watchingSecondaryResource.set(resourceName, count - 1);
-  }
-
-  hasSubscribers(resourceName: string): boolean {
-    const count = this.watchingSecondaryResource.get(resourceName);
-    return !!count;
-  }
-}
-
 // the ContextsState singleton (instantiated by the kubernetes-client singleton)
 // manages the state of the different kube contexts
 export class ContextsManager {
   private kubeConfig = new KubeConfig();
   private states = new ContextsStates();
   private currentContext: KubeContext | undefined;
-  private secondaryWatchers = new SecondaryResourceWatchersRegistry();
+  private secondaryWatchers = new ResourceWatchersRegistry();
 
   private dispatchContextsGeneralStateTimer: NodeJS.Timeout | undefined;
   private dispatchCurrentContextGeneralStateTimer: NodeJS.Timeout | undefined;

--- a/packages/main/src/plugin/kubernetes/resource-watchers-registry.spec.ts
+++ b/packages/main/src/plugin/kubernetes/resource-watchers-registry.spec.ts
@@ -1,0 +1,39 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test } from 'vitest';
+
+import { ResourceWatchersRegistry } from './resource-watchers-registry.js';
+
+test('ResourceWatchersRegistry', () => {
+  const registry = new ResourceWatchersRegistry();
+  expect(registry.hasSubscribers('a-resource')).toBeFalsy();
+  expect(registry.hasSubscribers('another-resource')).toBeFalsy();
+  registry.subscribe('a-resource');
+  expect(registry.hasSubscribers('a-resource')).toBeTruthy();
+  expect(registry.hasSubscribers('another-resource')).toBeFalsy();
+  registry.subscribe('another-resource');
+  expect(registry.hasSubscribers('a-resource')).toBeTruthy();
+  expect(registry.hasSubscribers('another-resource')).toBeTruthy();
+  registry.unsubscribe('a-resource');
+  expect(registry.hasSubscribers('a-resource')).toBeFalsy();
+  expect(registry.hasSubscribers('another-resource')).toBeTruthy();
+  registry.unsubscribe('another-resource');
+  expect(registry.hasSubscribers('a-resource')).toBeFalsy();
+  expect(registry.hasSubscribers('another-resource')).toBeFalsy();
+});

--- a/packages/main/src/plugin/kubernetes/resource-watchers-registry.ts
+++ b/packages/main/src/plugin/kubernetes/resource-watchers-registry.ts
@@ -1,0 +1,44 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export class ResourceWatchersRegistry {
+  // Map resourceName to number of watchers
+  private watchingResources = new Map<string, number>();
+
+  subscribe(resourceName: string): void {
+    let count = this.watchingResources.get(resourceName);
+    if (count === undefined) {
+      this.watchingResources.set(resourceName, 0);
+      count = 0;
+    }
+    this.watchingResources.set(resourceName, count + 1);
+  }
+
+  unsubscribe(resourceName: string): void {
+    const count = this.watchingResources.get(resourceName);
+    if (count === undefined) {
+      throw new Error(`unsubscribe before subscribe on resource ${resourceName}`);
+    }
+    this.watchingResources.set(resourceName, count - 1);
+  }
+
+  hasSubscribers(resourceName: string): boolean {
+    const count = this.watchingResources.get(resourceName);
+    return !!count;
+  }
+}


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Move SecondaryResourceWatchersRegistry to its own file  with a more generic name + unit tests


### What issues does this PR fix or reference?

Part of #8775 

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
