### PR TITLE
feat(extension-api): adding the id property to the WebviewPanel object

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -1894,6 +1894,10 @@ declare module '@podman-desktop/api' {
    */
   interface WebviewPanel {
     /**
+     * The identifier of the webview. Useful for {@link navigation.navigateToWebview}.
+     */
+    readonly id: string;
+    /**
      * Identifies the type of the webview panel.
      */
     readonly viewType: string;

--- a/packages/main/src/plugin/webview/webview-panel-impl.spec.ts
+++ b/packages/main/src/plugin/webview/webview-panel-impl.spec.ts
@@ -52,7 +52,7 @@ beforeEach(() => {
 
 test('check internalId', async () => {
   // expect internalId is correct
-  expect(webviewPanelImpl.internalId).toBe('internalId0');
+  expect(webviewPanelImpl.id).toBe('internalId0');
 });
 
 test('check viewType', async () => {
@@ -78,7 +78,7 @@ test('allow to update title', async () => {
 
   // expect apiSender.send has been called with correct parameters
   expect(apiSender.send).toHaveBeenCalledWith('webview-panel-update:title', {
-    id: webviewPanelImpl.internalId,
+    id: webviewPanelImpl.id,
     title: 'newTitle',
   });
 });

--- a/packages/main/src/plugin/webview/webview-panel-impl.ts
+++ b/packages/main/src/plugin/webview/webview-panel-impl.ts
@@ -76,6 +76,10 @@ export class WebviewPanelImpl implements WebviewPanel {
     this.#viewType = panelDetails.viewType;
   }
 
+  get id(): string {
+    return this.internalId;
+  }
+
   get internalId(): string {
     return this.#internalId;
   }

--- a/packages/main/src/plugin/webview/webview-panel-impl.ts
+++ b/packages/main/src/plugin/webview/webview-panel-impl.ts
@@ -35,7 +35,7 @@ import type { WebviewRegistry } from './webview-registry.js';
 type IconPath = Uri | { readonly light: Uri; readonly dark: Uri };
 
 export class WebviewPanelImpl implements WebviewPanel {
-  readonly #internalId: string;
+  readonly #id: string;
   readonly #webviewRegistry: WebviewRegistry;
   readonly #apiSender: ApiSenderType;
 
@@ -55,7 +55,7 @@ export class WebviewPanelImpl implements WebviewPanel {
   readonly onDidChangeViewState: Event<WebviewPanelOnDidChangeViewStateEvent> = this.#onDidChangeViewState.event;
 
   constructor(
-    internalId: string,
+    id: string,
     webviewRegistry: WebviewRegistry,
     apiSender: ApiSenderType,
     webview: WebviewImpl,
@@ -66,7 +66,7 @@ export class WebviewPanelImpl implements WebviewPanel {
       viewType: string;
     },
   ) {
-    this.#internalId = internalId;
+    this.#id = id;
     this.#webviewRegistry = webviewRegistry;
     this.#apiSender = apiSender;
     this.#webview = webview;
@@ -77,11 +77,7 @@ export class WebviewPanelImpl implements WebviewPanel {
   }
 
   get id(): string {
-    return this.internalId;
-  }
-
-  get internalId(): string {
-    return this.#internalId;
+    return this.#id;
   }
 
   get viewType(): string {
@@ -99,7 +95,7 @@ export class WebviewPanelImpl implements WebviewPanel {
     if (this.#title !== val) {
       this.#title = val;
       // need to notify the render that the title has changed
-      this.#apiSender.send('webview-panel-update:title', { id: this.#internalId, title: val });
+      this.#apiSender.send('webview-panel-update:title', { id: this.#id, title: val });
     }
   }
 
@@ -159,7 +155,7 @@ export class WebviewPanelImpl implements WebviewPanel {
     const navigationRequest: NavigationRequest<NavigationPage.WEBVIEW> = {
       page: NavigationPage.WEBVIEW,
       parameters: {
-        id: this.#internalId,
+        id: this.#id,
       },
     };
     this.#apiSender.send('navigate', navigationRequest);

--- a/packages/main/src/plugin/webview/webview-registry.spec.ts
+++ b/packages/main/src/plugin/webview/webview-registry.spec.ts
@@ -246,6 +246,7 @@ test('check configureRouter with valid uuid and file exists', async () => {
     'viewTypeInfo',
     'customTitle',
   );
+  expect(panel.id).toBeDefined();
   const panelImpl = panel as WebviewPanelImpl;
   const uuid = panelImpl.webview.uuid;
 

--- a/packages/main/src/plugin/webview/webview-registry.spec.ts
+++ b/packages/main/src/plugin/webview/webview-registry.spec.ts
@@ -387,7 +387,7 @@ test('check makeDefaultWebviewVisible', async () => {
   const panelImpl2 = panel2 as WebviewPanelImpl;
   const spyUpdateViewState2 = vi.spyOn(panelImpl2, 'updateViewState');
 
-  await webviewRegistry.makeDefaultWebviewVisible(panelImpl1.internalId);
+  await webviewRegistry.makeDefaultWebviewVisible(panelImpl1.id);
 
   expect(spyUpdateViewState1).toHaveBeenCalledWith(true, true);
   expect(spyUpdateViewState2).toHaveBeenCalledWith(false, false);
@@ -395,7 +395,7 @@ test('check makeDefaultWebviewVisible', async () => {
   // now call again with the second webview (reset first the calls)
   spyUpdateViewState1.mockClear();
   spyUpdateViewState2.mockClear();
-  await webviewRegistry.makeDefaultWebviewVisible(panelImpl2.internalId);
+  await webviewRegistry.makeDefaultWebviewVisible(panelImpl2.id);
   expect(spyUpdateViewState1).toHaveBeenCalledWith(false, false);
   expect(spyUpdateViewState2).toHaveBeenCalledWith(true, true);
 });
@@ -411,7 +411,7 @@ test('check postMessageToWebview', async () => {
   // spy webviewImpl.handleMessage
   const spyHandleMessage = vi.spyOn(panelImpl1.webview, 'handleMessage');
 
-  await webviewRegistry.postMessageToWebview(panelImpl1.internalId, { data: 'hello world' });
+  await webviewRegistry.postMessageToWebview(panelImpl1.id, { data: 'hello world' });
 
   // check
   expect(spyHandleMessage).toHaveBeenCalledWith('hello world');
@@ -425,7 +425,7 @@ test('check updateWebviewState', async () => {
   );
   const panelImpl1 = panel1 as WebviewPanelImpl;
 
-  await webviewRegistry.updateWebviewState(panelImpl1.internalId, { state: 'myState' });
+  await webviewRegistry.updateWebviewState(panelImpl1.id, { state: 'myState' });
 
   // check
   expect(panelImpl1.webview.state).toStrictEqual({ state: 'myState' });
@@ -452,11 +452,11 @@ test('check listWebviews', async () => {
 
   // check
   expect(webviews.length).toBe(2);
-  expect(webviews[0]?.id).toBe(panelImpl1.internalId);
+  expect(webviews[0]?.id).toBe(panelImpl1.id);
   expect(webviews[0]?.viewType).toBe('viewTypeInfo');
   expect(webviews[0]?.html).toBe('html1');
 
-  expect(webviews[1]?.id).toBe(panelImpl2.internalId);
+  expect(webviews[1]?.id).toBe(panelImpl2.id);
   expect(webviews[1]?.viewType).toBe('viewTypeInfo');
   expect(webviews[1]?.html).toBe('html2');
 });
@@ -482,11 +482,11 @@ test('check listSimpleWebviews', async () => {
 
   // check
   expect(webviews.length).toBe(2);
-  expect(webviews[0]?.id).toBe(panelImpl1.internalId);
+  expect(webviews[0]?.id).toBe(panelImpl1.id);
   expect(webviews[0]?.viewType).toBe('viewTypeInfo');
   expect(webviews[0]?.title).toBe('customTitle1');
 
-  expect(webviews[1]?.id).toBe(panelImpl2.internalId);
+  expect(webviews[1]?.id).toBe(panelImpl2.id);
   expect(webviews[1]?.viewType).toBe('viewTypeInfo');
   expect(webviews[1]?.title).toBe('customTitle2');
 });

--- a/packages/main/src/plugin/webview/webview-registry.ts
+++ b/packages/main/src/plugin/webview/webview-registry.ts
@@ -193,7 +193,7 @@ export class WebviewRegistry {
   async makeDefaultWebviewVisible(id: string): Promise<void> {
     // filter all webviews matching the given id
     const activeWebviewPanels = Array.from(this.#webviews.values()).filter(webviewPanel => {
-      return webviewPanel.internalId === id;
+      return webviewPanel.id === id;
     });
 
     // update the state of the webviews
@@ -203,7 +203,7 @@ export class WebviewRegistry {
 
     // now, update the state of the non active webviews
     const nonActiveWebviewPanels = Array.from(this.#webviews.values()).filter(webviewPanel => {
-      return webviewPanel.internalId !== id;
+      return webviewPanel.id !== id;
     });
     for (const webviewPanel of nonActiveWebviewPanels) {
       webviewPanel.updateViewState(false, false);
@@ -254,14 +254,14 @@ export class WebviewRegistry {
     });
 
     this.#uuidAndPaths.set(webview.uuid, extensionInfo.extensionPath);
-    this.#webviews.set(webviewPanelImpl.internalId, webviewPanelImpl);
-    this.#apiSender.send('webview-create', webviewPanelImpl.internalId);
+    this.#webviews.set(webviewPanelImpl.id, webviewPanelImpl);
+    this.#apiSender.send('webview-create', webviewPanelImpl.id);
     return webviewPanelImpl;
   }
 
   disposeWebviewPanel(webviewPanelImpl: WebviewPanelImpl): void {
-    this.#webviews.delete(webviewPanelImpl.internalId);
-    this.#apiSender.send('webview-delete', webviewPanelImpl.internalId);
+    this.#webviews.delete(webviewPanelImpl.id);
+    this.#apiSender.send('webview-delete', webviewPanelImpl.id);
   }
 
   async postMessageToWebview(id: string, message: { data: unknown }): Promise<void> {


### PR DESCRIPTION
### What does this PR do?

To use the `navigation.navigateToWebview` we need the `id` of the webview, but it is not on the WebviewPanel object...
 The only way to get this object is to list the webviews and search by title `windows.listWebviews().find(panel => panel.title === "<my-title>"`.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

N/A

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
