### PR TITLE
fix: update containerState in effect

### DIFF
--- a/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
@@ -31,6 +31,7 @@ let lastState = $state('');
 let containerState = $state(container);
 
 $effect(() => {
+  containerState = container;
   if (lastState === 'STARTING' && containerState.state === 'RUNNING') {
     restartTerminal();
   }


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR fixes the reactivity of `ContainerDetailsTerminal` so that `containerState` is updated every time `$effect` runs.
This fixes the problem of `containerState` not always updating, causing the terminal to not work when starting the container from the terminal tab or stopping and starting again.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
