### PR TITLE
fix: correctly split env files values

### DIFF
--- a/packages/main/src/plugin/env-file-parser.spec.ts
+++ b/packages/main/src/plugin/env-file-parser.spec.ts
@@ -151,6 +151,13 @@ describe('check values', () => {
     expect(result.key).toBe('VAR');
     expect(result.value).toBe(`{"hello": "json"}`);
   });
+
+  test('simple value containing equal signs', () => {
+    const item = `VAR=dGhpcyBpcyBqdXN0IGEgdGVzdA==`;
+    const result = envfileParser.envFileCleanEntry(item);
+    expect(result.key).toBe('VAR');
+    expect(result.value).toBe(`dGhpcyBpcyBqdXN0IGEgdGVzdA==`);
+  });
 });
 
 test('check parseEnvFile', async () => {

--- a/packages/main/src/plugin/env-file-parser.ts
+++ b/packages/main/src/plugin/env-file-parser.ts
@@ -105,8 +105,8 @@ export class EnvfileParser {
       }
     } else {
       // if there is a comment, and that it is preceded by a space, remove it
-      if (updatedValue?.includes(' #')) {
-        updatedValue = updatedValue.split(' #')[0];
+      if (updatedValue.includes(' #')) {
+        updatedValue = updatedValue.split(' #')[0] ?? '';
       }
     }
 

--- a/packages/main/src/plugin/env-file-parser.ts
+++ b/packages/main/src/plugin/env-file-parser.ts
@@ -81,7 +81,8 @@ export class EnvfileParser {
       return { key: undefined, value: undefined };
     }
 
-    const [key, value] = entry.split('=');
+    const [key, ...rest] = entry.split('=');
+    const value = rest.join('=');
 
     let updatedValue = value;
 


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Correctly split env files values when value contains `=` signs

### What issues does this PR fix or reference?

Fixes #8762

### How to test this PR?

See steps to reproduce in #8762 

- [x] Tests are covering the bug fix or the new feature
