### PR TITLE
fix: do not display badge when no current context

### DIFF
--- a/packages/api/src/kubernetes-contexts-states.ts
+++ b/packages/api/src/kubernetes-contexts-states.ts
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+export const NO_CURRENT_CONTEXT_ERROR = 'no current context';
+
 // CheckingState indicates the state of the check for a context
 export interface CheckingState {
   state: 'waiting' | 'checking' | 'gaveup';

--- a/packages/main/src/plugin/kubernetes/contexts-states.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-states.ts
@@ -24,7 +24,7 @@ import type {
   ResourceName,
   SecondaryResourceName,
 } from '/@api/kubernetes-contexts-states.js';
-import { secondaryResources } from '/@api/kubernetes-contexts-states.js';
+import { NO_CURRENT_CONTEXT_ERROR, secondaryResources } from '/@api/kubernetes-contexts-states.js';
 
 // ContextInternalState stores informers for a kube context
 export type ContextInternalState = Map<ResourceName, Informer<KubernetesObject>>;
@@ -114,7 +114,7 @@ export class ContextsStates {
     }
     return {
       reachable: false,
-      error: 'no current context',
+      error: NO_CURRENT_CONTEXT_ERROR,
       resources: { pods: 0, deployments: 0 },
     };
   }

--- a/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.spec.ts
+++ b/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.spec.ts
@@ -60,6 +60,15 @@ test('expect no badges shown as no context has been provided.', async () => {
   expect(status).toBeNull();
 });
 
+test('expect no badges shown with no current context error', async () => {
+  mocks.getCurrentKubeContextState.mockReturnValue({ error: 'no current context' });
+  render(KubernetesCurrentContextConnectionBadge);
+
+  expect(mocks.getCurrentKubeContextState).toHaveBeenCalled();
+  const status = screen.queryByRole('status');
+  expect(status).toBeNull();
+});
+
 test('expect badges to show as there is a context', async () => {
   mocks.getCurrentKubeContextState.mockReturnValue({
     error: undefined,

--- a/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.svelte
+++ b/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { kubernetesCurrentContextState } from '/@/stores/kubernetes-contexts-state';
-import type { ContextGeneralState } from '/@api/kubernetes-contexts-states';
+import { type ContextGeneralState, NO_CURRENT_CONTEXT_ERROR } from '/@api/kubernetes-contexts-states';
 
 import Label from './Label.svelte';
 
@@ -17,7 +17,7 @@ function getClassColor(state?: ContextGeneralState): string {
 $: text = getText($kubernetesCurrentContextState);
 </script>
 
-{#if $kubernetesCurrentContextState}
+{#if $kubernetesCurrentContextState && $kubernetesCurrentContextState.error !== NO_CURRENT_CONTEXT_ERROR}
   <Label role="status" name={text} tip={$kubernetesCurrentContextState.error}
     ><div class="w-2 h-2 {getClassColor($kubernetesCurrentContextState)} rounded-full mx-1"></div></Label>
 {/if}


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

On Kubernetes pages, do not display the connection badge when there is no current context.

(other PRs will follow to also hide other unnecessary buttons when there is no context)

### What issues does this PR fix or reference?

Part of #8571 

### How to test this PR?

Start Podman Desktop with no current Kubernetes context, and check that the badge is not displayed in Kubernetes pages.

Define a current context and check that the badge is visible.

- [x] Tests are covering the bug fix or the new feature
