### PR TITLE
feat: handle both hyperv and wsl machines

### DIFF
--- a/extensions/podman/packages/extension/src/podman-install.spec.ts
+++ b/extensions/podman/packages/extension/src/podman-install.spec.ts
@@ -639,10 +639,33 @@ describe('HyperV', () => {
     expect(result.docLinks?.[0].title).equal('Hyper-V Manual Installation Steps');
   });
 
+  test('expect HyperV preflight check return failure result if Podman Desktop is not run with elevated privileges', async () => {
+    let index = 0;
+    vi.spyOn(extensionApi.process, 'exec').mockImplementation(() => {
+      if (index++ < 1) {
+        return Promise.resolve({
+          stdout: 'True',
+          stderr: '',
+          command: 'command',
+        });
+      } else {
+        throw new Error();
+      }
+    });
+
+    const hyperVCheck = new HyperVCheck();
+    const result = await hyperVCheck.execute();
+    expect(result.successful).toBeFalsy();
+    expect(result.description).equal(
+      'You must run Podman Desktop with administrative rights to run Hyper-V Podman machines.',
+    );
+    expect(result.docLinks).toBeUndefined();
+  });
+
   test('expect HyperV preflight check return failure result if HyperV not installed', async () => {
     let index = 0;
     vi.spyOn(extensionApi.process, 'exec').mockImplementation(() => {
-      if (index++ === 0) {
+      if (index++ <= 1) {
         return Promise.resolve({
           stdout: 'True',
           stderr: '',
@@ -666,7 +689,7 @@ describe('HyperV', () => {
   test('expect HyperV preflight check return failure result if HyperV not running', async () => {
     let index = 0;
     vi.spyOn(extensionApi.process, 'exec').mockImplementation(() => {
-      if (index++ < 2) {
+      if (index++ <= 2) {
         return Promise.resolve({
           stdout: 'True',
           stderr: '',
@@ -690,9 +713,9 @@ describe('HyperV', () => {
   test('expect HyperV preflight check return OK', async () => {
     let index = 0;
     vi.spyOn(extensionApi.process, 'exec').mockImplementation(() => {
-      if (index++ < 3) {
+      if (index++ < 4) {
         return Promise.resolve({
-          stdout: index === 3 ? 'Running' : 'True',
+          stdout: index === 4 ? 'Running' : 'True',
           stderr: '',
           command: 'command',
         });


### PR DESCRIPTION
### What does this PR do?

This PR enhances Desktop to show both WSL and HyperV machines if both are enabled. 
I added a missing check for hyperv - desktop has to be run with elevated rights

### Screenshot / video of UI

![wsl_hyperv](https://github.com/user-attachments/assets/2aad5384-8fee-490e-82aa-4f7c9ae97438)

### What issues does this PR fix or reference?

it resolves #8862 

### How to test this PR?

1. create a hyper-v and wsl machines using the cli, then you should see both on desktop and being able to interact with them

- [x] Tests are covering the bug fix or the new feature
