### PR TITLE
chore: update style of xterm terminal

### DIFF
--- a/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 import '@xterm/xterm/css/xterm.css';
-import '../ui/xterm.css';
 
 import { EmptyScreen } from '@podman-desktop/ui-svelte';
 import { FitAddon } from '@xterm/addon-fit';
@@ -160,7 +159,11 @@ onDestroy(() => {
 });
 </script>
 
-<div class="h-full" bind:this={terminalXtermDiv} class:hidden={container.state !== 'RUNNING'}></div>
+<div
+  class="h-full p-[5px] pr-0 bg-[var(--pd-terminal-background)]"
+  bind:this={terminalXtermDiv}
+  class:hidden={container.state !== 'RUNNING'}>
+</div>
 
 <EmptyScreen
   hidden={container.state === 'RUNNING'}

--- a/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import '@xterm/xterm/css/xterm.css';
+import '../ui/xterm.css';
 
 import { EmptyScreen } from '@podman-desktop/ui-svelte';
 import { FitAddon } from '@xterm/addon-fit';

--- a/packages/renderer/src/lib/dashboard/ProviderConfiguring.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderConfiguring.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import '@xterm/xterm/css/xterm.css';
+import '../ui/xterm.css';
 
 import { Spinner } from '@podman-desktop/ui-svelte';
 import { FitAddon } from '@xterm/addon-fit';

--- a/packages/renderer/src/lib/dashboard/ProviderConfiguring.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderConfiguring.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 import '@xterm/xterm/css/xterm.css';
-import '../ui/xterm.css';
 
 import { Spinner } from '@podman-desktop/ui-svelte';
 import { FitAddon } from '@xterm/addon-fit';
@@ -100,7 +99,7 @@ onDestroy(() => {
     </div>
 
     <div
-      class="bg-[var(--pd-terminal-background)]"
+      class="bg-[var(--pd-terminal-background)] p-[5px] pr-0"
       style="width: 100%; text-align: left; display: {initializeError ? 'block' : 'none'}"
       bind:this={logsXtermDiv}>
     </div>

--- a/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 import '@xterm/xterm/css/xterm.css';
-import '../ui/xterm.css';
 
 import { Spinner } from '@podman-desktop/ui-svelte';
 import { FitAddon } from '@xterm/addon-fit';
@@ -201,7 +200,7 @@ function onInstallationClick() {
     </div>
 
     <div
-      class="bg-[var(--pd-terminal-background)]"
+      class="bg-[var(--pd-terminal-background)] p-[5px] pr-0"
       style="width: 100%; text-align: left; display: {initializeError ? 'block' : 'none'}"
       bind:this={logsXtermDiv}>
     </div>

--- a/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import '@xterm/xterm/css/xterm.css';
+import '../ui/xterm.css';
 
 import { Spinner } from '@podman-desktop/ui-svelte';
 import { FitAddon } from '@xterm/addon-fit';

--- a/packages/renderer/src/lib/pod/KubernetesTerminal.svelte
+++ b/packages/renderer/src/lib/pod/KubernetesTerminal.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+import '../ui/xterm.css';
+
 import { FitAddon } from '@xterm/addon-fit';
 import { SerializeAddon } from '@xterm/addon-serialize';
 import { type IDisposable, Terminal } from '@xterm/xterm';

--- a/packages/renderer/src/lib/pod/KubernetesTerminal.svelte
+++ b/packages/renderer/src/lib/pod/KubernetesTerminal.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-import '../ui/xterm.css';
-
 import { FitAddon } from '@xterm/addon-fit';
 import { SerializeAddon } from '@xterm/addon-serialize';
 import { type IDisposable, Terminal } from '@xterm/xterm';
@@ -161,4 +159,4 @@ function saveTerminalState(podName: string, containerName: string, state: State)
 }
 </script>
 
-<div class="h-full w-full" bind:this={terminalXtermDiv}></div>
+<div class="h-full w-full p-[5px] pr-0 bg-[var(--pd-terminal-background)]" bind:this={terminalXtermDiv}></div>

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsLogs.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsLogs.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 import '@xterm/xterm/css/xterm.css';
-import '../ui/xterm.css';
 
 import { EmptyScreen } from '@podman-desktop/ui-svelte';
 import { FitAddon } from '@xterm/addon-fit';
@@ -105,7 +104,7 @@ onDestroy(() => {
 
 <div
   aria-label="terminal"
-  class="min-w-full flex flex-col bg-[var(--pd-terminal-background)]"
+  class="min-w-full flex flex-col bg-[var(--pd-terminal-background)] p-[5px] pr-0"
   class:invisible={noLogs === true}
   class:h-0={noLogs === true}
   class:h-full={noLogs === false}

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsLogs.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsLogs.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import '@xterm/xterm/css/xterm.css';
+import '../ui/xterm.css';
 
 import { EmptyScreen } from '@podman-desktop/ui-svelte';
 import { FitAddon } from '@xterm/addon-fit';

--- a/packages/renderer/src/lib/ui/TerminalWindow.svelte
+++ b/packages/renderer/src/lib/ui/TerminalWindow.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import '@xterm/xterm/css/xterm.css';
+import './xterm.css';
 
 import { FitAddon } from '@xterm/addon-fit';
 import { Terminal } from '@xterm/xterm';

--- a/packages/renderer/src/lib/ui/TerminalWindow.svelte
+++ b/packages/renderer/src/lib/ui/TerminalWindow.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 import '@xterm/xterm/css/xterm.css';
-import './xterm.css';
 
 import { FitAddon } from '@xterm/addon-fit';
 import { Terminal } from '@xterm/xterm';
@@ -67,4 +66,4 @@ onDestroy(() => {
 });
 </script>
 
-<div class={$$props.class} bind:this={logsXtermDiv}></div>
+<div class="{$$props.class} p-[5px] pr-0 bg-[var(--pd-terminal-background)]" bind:this={logsXtermDiv}></div>

--- a/packages/renderer/src/lib/ui/xterm.css
+++ b/packages/renderer/src/lib/ui/xterm.css
@@ -1,7 +1,3 @@
 .xterm {
   padding: 5px;
 }
-
-.xterm .xterm-viewport {
-  overflow-y: auto;
-}

--- a/packages/renderer/src/lib/ui/xterm.css
+++ b/packages/renderer/src/lib/ui/xterm.css
@@ -1,0 +1,7 @@
+.xterm {
+  padding: 5px;
+}
+
+.xterm .xterm-viewport {
+  overflow-y: auto;
+}

--- a/packages/renderer/src/lib/ui/xterm.css
+++ b/packages/renderer/src/lib/ui/xterm.css
@@ -1,3 +1,0 @@
-.xterm {
-  padding: 5px;
-}


### PR DESCRIPTION
### What does this PR do?
This PR adds padding to all terminal instances

### Screenshot / video of UI
before:
![Screenshot from 2024-09-19 15-17-49](https://github.com/user-attachments/assets/39bab2dd-6787-4280-ac2f-c225dc721826)
![Screenshot from 2024-09-19 13-48-29](https://github.com/user-attachments/assets/4252434a-2099-423d-97b8-85fa73300ddd)

after:
![Screenshot from 2024-09-19 17-08-26](https://github.com/user-attachments/assets/26a17902-beb5-4a37-9cdf-910fe2215469)

![Screenshot from 2024-09-19 17-08-13](https://github.com/user-attachments/assets/975f26b4-4d5d-4485-9a1f-80b35f2a8119)


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/containers/podman-desktop/issues/8079

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
