### PR TITLE
fix: always prefer podman cli from installer path (macOS)

### DIFF
--- a/extensions/kind/src/util.ts
+++ b/extensions/kind/src/util.ts
@@ -22,7 +22,7 @@ import { isAbsolute, join } from 'node:path';
 
 import * as extensionApi from '@podman-desktop/api';
 
-const macosExtraPath = '/usr/local/bin:/opt/homebrew/bin:/opt/local/bin:/opt/podman/bin';
+const macosExtraPath = '/opt/podman/bin:/usr/local/bin:/opt/homebrew/bin:/opt/local/bin';
 const localBinDir = '/usr/local/bin';
 
 export function getSystemBinaryPath(binaryName: string): string {

--- a/extensions/podman/packages/extension/src/compatibility-mode.ts
+++ b/extensions/podman/packages/extension/src/compatibility-mode.ts
@@ -52,14 +52,14 @@ export class DarwinSocketCompatibility extends SocketCompatibility {
   // Find the podman-mac-helper binary which should only be located in either
   // brew or podman's install location
   findPodmanHelper(): string {
-    const homebrewPath = '/opt/homebrew/bin/podman-mac-helper';
     const podmanPath = '/opt/podman/bin/podman-mac-helper';
+    const homebrewPath = '/opt/homebrew/bin/podman-mac-helper';
     const userBinaryPath = '/usr/local/bin/podman-mac-helper';
 
-    if (fs.existsSync(homebrewPath)) {
-      return homebrewPath;
-    } else if (fs.existsSync(podmanPath)) {
+    if (fs.existsSync(podmanPath)) {
       return podmanPath;
+    } else if (fs.existsSync(homebrewPath)) {
+      return homebrewPath;
     } else if (fs.existsSync(userBinaryPath)) {
       return userBinaryPath;
     } else {

--- a/extensions/podman/packages/extension/src/podman-cli.ts
+++ b/extensions/podman/packages/extension/src/podman-cli.ts
@@ -19,7 +19,7 @@ import * as extensionApi from '@podman-desktop/api';
 
 import { isMac, isWindows } from './util';
 
-const macosExtraPath = '/usr/local/bin:/opt/homebrew/bin:/opt/local/bin:/opt/podman/bin';
+const macosExtraPath = '/opt/podman/bin:/usr/local/bin:/opt/homebrew/bin:/opt/local/bin';
 
 export function getInstallationPath(): string | undefined {
   const env = process.env;

--- a/packages/main/src/plugin/docker-extension/docker-plugin-adapter.ts
+++ b/packages/main/src/plugin/docker-extension/docker-plugin-adapter.ts
@@ -37,7 +37,7 @@ export interface RawExecResult {
 }
 
 export class DockerPluginAdapter {
-  static readonly MACOS_EXTRA_PATH = '/usr/local/bin:/opt/homebrew/bin:/opt/local/bin:/opt/podman/bin';
+  static readonly MACOS_EXTRA_PATH = '/opt/podman/bin:/usr/local/bin:/opt/homebrew/bin:/opt/local/bin';
 
   constructor(
     private contributionManager: ContributionManager,

--- a/packages/main/src/plugin/util/exec.spec.ts
+++ b/packages/main/src/plugin/util/exec.spec.ts
@@ -608,7 +608,7 @@ describe('getInstallationPath', () => {
 
     const path = getInstallationPath();
 
-    expect(path).toBe(`/usr/bin:${macosExtraPath}`);
+    expect(path).toBe(`${macosExtraPath}:/usr/bin`);
   });
 
   test('should return the installation path for macOS with defined param', () => {
@@ -619,7 +619,7 @@ describe('getInstallationPath', () => {
 
     const path = getInstallationPath('/usr/other');
 
-    expect(path).toBe(`/usr/other:${macosExtraPath}`);
+    expect(path).toBe(`${macosExtraPath}:/usr/other`);
   });
 
   test('should return the installation path for other platforms', () => {

--- a/packages/main/src/plugin/util/exec.ts
+++ b/packages/main/src/plugin/util/exec.ts
@@ -25,7 +25,7 @@ import * as sudo from 'sudo-prompt';
 import { isLinux, isMac, isWindows } from '../../util.js';
 import type { Proxy } from '../proxy.js';
 
-export const macosExtraPath = '/usr/local/bin:/opt/homebrew/bin:/opt/local/bin:/opt/podman/bin';
+export const macosExtraPath = '/opt/podman/bin:/usr/local/bin:/opt/homebrew/bin:/opt/local/bin';
 
 class RunErrorImpl extends Error implements RunError {
   constructor(
@@ -248,7 +248,7 @@ export function getInstallationPath(envPATH?: string): string {
     if (!envPATH) {
       return macosExtraPath;
     } else {
-      return envPATH.concat(':').concat(macosExtraPath);
+      return macosExtraPath.concat(':').concat(envPATH);
     }
   } else {
     return envPATH ?? '';


### PR DESCRIPTION
### What does this PR do?
- prefer podman CLI from the podman installer instead of the brew podman CLI if both of them are installed.
- change the path order

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/8982

### How to test this PR?

only on macOS:
- install for example podman 5.1.x from an installer from podman release
- install podman from brew `brew install podman`

wipe out any existing podman machines.

From the Podman Desktop UI (using the production release `pnpm compile:current`):
- dashboard screen should tell you that you need to create a podman machine, follow the wizard

with my PR: at the end you should see a podman's version being 5.1.1 in resources page (installer version)
without my PR: see a podman v5.2.2 in resources page (brew one)

- [x] Tests are covering the bug fix or the new feature
