### PR TITLE
feat: display Kubernetes empty page when no current context

### DIFF
--- a/packages/api/src/kubernetes-contexts-states.ts
+++ b/packages/api/src/kubernetes-contexts-states.ts
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+export const NO_CURRENT_CONTEXT_ERROR = 'no current context';
+
 // CheckingState indicates the state of the check for a context
 export interface CheckingState {
   state: 'waiting' | 'checking' | 'gaveup';

--- a/packages/main/src/plugin/kubernetes/contexts-states.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-states.ts
@@ -24,7 +24,7 @@ import type {
   ResourceName,
   SecondaryResourceName,
 } from '/@api/kubernetes-contexts-states.js';
-import { secondaryResources } from '/@api/kubernetes-contexts-states.js';
+import { NO_CURRENT_CONTEXT_ERROR, secondaryResources } from '/@api/kubernetes-contexts-states.js';
 
 // ContextInternalState stores informers for a kube context
 export type ContextInternalState = Map<ResourceName, Informer<KubernetesObject>>;
@@ -114,7 +114,7 @@ export class ContextsStates {
     }
     return {
       reachable: false,
-      error: 'no current context',
+      error: NO_CURRENT_CONTEXT_ERROR,
       resources: { pods: 0, deployments: 0 },
     };
   }

--- a/packages/renderer/src/App.spec.ts
+++ b/packages/renderer/src/App.spec.ts
@@ -24,6 +24,7 @@ import { beforeEach, expect, test, vi } from 'vitest';
 
 import * as kubeContextStore from '/@/stores/kubernetes-contexts-state';
 import type { ContextGeneralState } from '/@api/kubernetes-contexts-states';
+import { NO_CURRENT_CONTEXT_ERROR } from '/@api/kubernetes-contexts-states';
 
 import App from './App.svelte';
 import { navigationRegistry } from './stores/navigation/navigation-registry';
@@ -170,7 +171,7 @@ test('do not display kubernetes empty screen if current context', async () => {
 test('displays kubernetes empty screen if no current context', async () => {
   vi.mocked(kubeContextStore).kubernetesCurrentContextState = readable({
     reachable: false,
-    error: 'no current context',
+    error: NO_CURRENT_CONTEXT_ERROR,
     resources: { pods: 0, deployments: 0 },
   } as ContextGeneralState);
 

--- a/packages/renderer/src/App.spec.ts
+++ b/packages/renderer/src/App.spec.ts
@@ -18,8 +18,12 @@
 
 import { render, waitFor } from '@testing-library/svelte';
 import { tick } from 'svelte';
+import { readable } from 'svelte/store';
 import { router } from 'tinro';
 import { beforeEach, expect, test, vi } from 'vitest';
+
+import * as kubeContextStore from '/@/stores/kubernetes-contexts-state';
+import type { ContextGeneralState } from '/@api/kubernetes-contexts-states';
 
 import App from './App.svelte';
 import { navigationRegistry } from './stores/navigation/navigation-registry';
@@ -29,6 +33,8 @@ const mocks = vi.hoisted(() => ({
   RunImage: vi.fn(),
   ImagesList: vi.fn(),
   SubmenuNavigation: vi.fn(),
+  KubernetesEmptyPage: vi.fn(),
+  DeploymentsList: vi.fn(),
 }));
 
 vi.mock('./lib/dashboard/DashboardPage.svelte', () => ({
@@ -60,6 +66,18 @@ vi.mock('./SubmenuNavigation.svelte', () => ({
   default: mocks.SubmenuNavigation,
 }));
 
+vi.mock('./lib/kube/KubernetesEmptyPage.svelte', () => ({
+  default: mocks.KubernetesEmptyPage,
+}));
+
+vi.mock('./lib/deployments/DeploymentsList.svelte', () => ({
+  default: mocks.DeploymentsList,
+}));
+
+vi.mock('/@/stores/kubernetes-contexts-state', async () => {
+  return {};
+});
+
 const dispatchEventMock = vi.fn();
 const messages = new Map<string, (args: any) => void>();
 
@@ -72,6 +90,11 @@ beforeEach(() => {
     }),
   };
   (window as any).dispatchEvent = dispatchEventMock;
+  vi.mocked(kubeContextStore).kubernetesCurrentContextState = readable({
+    reachable: false,
+    error: 'initializing',
+    resources: { pods: 0, deployments: 0 },
+  } as ContextGeneralState);
 });
 
 test('test /image/run/* route', async () => {
@@ -134,4 +157,26 @@ test('opens submenu when a `submenu` menu is opened', async () => {
   router.goto('/tosubmenu');
   await tick();
   expect(mocks.SubmenuNavigation).toHaveBeenCalled();
+});
+
+test('do not display kubernetes empty screen if current context', async () => {
+  render(App);
+  router.goto('/kubernetes/deployments');
+  await tick();
+  expect(mocks.KubernetesEmptyPage).not.toHaveBeenCalled();
+  expect(mocks.DeploymentsList).toHaveBeenCalled();
+});
+
+test('displays kubernetes empty screen if no current context', async () => {
+  vi.mocked(kubeContextStore).kubernetesCurrentContextState = readable({
+    reachable: false,
+    error: 'no current context',
+    resources: { pods: 0, deployments: 0 },
+  } as ContextGeneralState);
+
+  render(App);
+  router.goto('/kubernetes/deployments');
+  await tick();
+  expect(mocks.KubernetesEmptyPage).toHaveBeenCalled();
+  expect(mocks.DeploymentsList).not.toHaveBeenCalled();
 });

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -5,6 +5,7 @@ import '@fortawesome/fontawesome-free/css/all.min.css';
 import { router } from 'tinro';
 
 import { handleNavigation } from '/@/navigation';
+import { NO_CURRENT_CONTEXT_ERROR } from '/@api/kubernetes-contexts-states';
 import type { NavigationRequest } from '/@api/navigation-request';
 
 import AppNavigation from './AppNavigation.svelte';
@@ -41,6 +42,7 @@ import IngressDetails from './lib/ingresses-routes/IngressDetails.svelte';
 import IngressesRoutesList from './lib/ingresses-routes/IngressesRoutesList.svelte';
 import RouteDetails from './lib/ingresses-routes/RouteDetails.svelte';
 import KubePlayYAML from './lib/kube/KubePlayYAML.svelte';
+import KubernetesEmptyPage from './lib/kube/KubernetesEmptyPage.svelte';
 import ManifestDetails from './lib/manifest/ManifestDetails.svelte';
 import NodeDetails from './lib/node/NodeDetails.svelte';
 import NodesList from './lib/node/NodesList.svelte';
@@ -67,6 +69,7 @@ import Webview from './lib/webview/Webview.svelte';
 import WelcomePage from './lib/welcome/WelcomePage.svelte';
 import PreferencesNavigation from './PreferencesNavigation.svelte';
 import Route from './Route.svelte';
+import { kubernetesCurrentContextState } from './stores/kubernetes-contexts-state';
 import { navigationRegistry } from './stores/navigation/navigation-registry';
 import SubmenuNavigation from './SubmenuNavigation.svelte';
 
@@ -224,76 +227,82 @@ window.events?.receive('navigate', (navigationRequest: unknown) => {
         <Route path="/volumes/:name/:engineId/*" breadcrumb="Volume Details" let:meta navigationHint="details">
           <VolumeDetails volumeName={decodeURI(meta.params.name)} engineId={decodeURI(meta.params.engineId)} />
         </Route>
-        <Route path="/kubernetes/nodes" breadcrumb="Nodes" navigationHint="root">
-          <NodesList />
-        </Route>
-        <Route path="/kubernetes/nodes/:name/*" breadcrumb="Node Details" let:meta navigationHint="details">
-          <NodeDetails name={decodeURI(meta.params.name)} />
-        </Route>
-        <Route path="/kubernetes/persistentvolumeclaims" breadcrumb="Persistent Volume Claims" navigationHint="root">
-          <PVCList />
-        </Route>
-        <Route
-          path="/kubernetes/persistentvolumeclaims/:name/:namespace/*"
-          breadcrumb="Persistent Volume Claim Details"
-          let:meta
-          navigationHint="details">
-          <PVCDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
-        </Route>
-        <Route path="/kubernetes/deployments" breadcrumb="Deployments" navigationHint="root">
-          <DeploymentsList />
-        </Route>
-        <Route
-          path="/kubernetes/deployments/:name/:namespace/*"
-          breadcrumb="Deployment Details"
-          let:meta
-          navigationHint="details">
-          <DeploymentDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
-        </Route>
-        <Route path="/kubernetes/services" breadcrumb="Services" navigationHint="root">
-          <ServicesList />
-        </Route>
-        <Route
-          path="/kubernetes/services/:name/:namespace/*"
-          breadcrumb="Service Details"
-          let:meta
-          navigationHint="details">
-          <ServiceDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
-        </Route>
-        <Route path="/kubernetes/ingressesRoutes" breadcrumb="Ingresses & Routes" navigationHint="root">
-          <IngressesRoutesList />
-        </Route>
-        <Route
-          path="/kubernetes/ingressesRoutes/ingress/:name/:namespace/*"
-          breadcrumb="Ingress Details"
-          let:meta
-          navigationHint="details">
-          <IngressDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
-        </Route>
-        <Route path="/kubernetes/configmapsSecrets" breadcrumb="ConfigMaps & Secrets" navigationHint="root">
-          <ConfigMapSecretList />
-        </Route>
-        <Route
-          path="/kubernetes/configmapsSecrets/configmap/:name/:namespace/*"
-          breadcrumb="ConfigMap Details"
-          let:meta
-          navigationHint="details">
-          <ConfigMapDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
-        </Route>
-        <Route
-          path="/kubernetes/configmapsSecrets/secret/:name/:namespace/*"
-          breadcrumb="Secret Details"
-          let:meta
-          navigationHint="details">
-          <SecretDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
-        </Route>
-        <Route
-          path="/kubernetes/ingressesRoutes/route/:name/:namespace/*"
-          breadcrumb="Route Details"
-          let:meta
-          navigationHint="details">
-          <RouteDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
-        </Route>
+        {#if $kubernetesCurrentContextState.error === NO_CURRENT_CONTEXT_ERROR}
+          <Route path="/kubernetes/*" breadcrumb="Kubernetes" navigationHint="root">
+            <KubernetesEmptyPage />
+          </Route>
+        {:else}
+          <Route path="/kubernetes/nodes" breadcrumb="Nodes" navigationHint="root">
+            <NodesList />
+          </Route>
+          <Route path="/kubernetes/nodes/:name/*" breadcrumb="Node Details" let:meta navigationHint="details">
+            <NodeDetails name={decodeURI(meta.params.name)} />
+          </Route>
+          <Route path="/kubernetes/persistentvolumeclaims" breadcrumb="Persistent Volume Claims" navigationHint="root">
+            <PVCList />
+          </Route>
+          <Route
+            path="/kubernetes/persistentvolumeclaims/:name/:namespace/*"
+            breadcrumb="Persistent Volume Claim Details"
+            let:meta
+            navigationHint="details">
+            <PVCDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+          </Route>
+          <Route path="/kubernetes/deployments" breadcrumb="Deployments" navigationHint="root">
+            <DeploymentsList />
+          </Route>
+          <Route
+            path="/kubernetes/deployments/:name/:namespace/*"
+            breadcrumb="Deployment Details"
+            let:meta
+            navigationHint="details">
+            <DeploymentDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+          </Route>
+          <Route path="/kubernetes/services" breadcrumb="Services" navigationHint="root">
+            <ServicesList />
+          </Route>
+          <Route
+            path="/kubernetes/services/:name/:namespace/*"
+            breadcrumb="Service Details"
+            let:meta
+            navigationHint="details">
+            <ServiceDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+          </Route>
+          <Route path="/kubernetes/ingressesRoutes" breadcrumb="Ingresses & Routes" navigationHint="root">
+            <IngressesRoutesList />
+          </Route>
+          <Route
+            path="/kubernetes/ingressesRoutes/ingress/:name/:namespace/*"
+            breadcrumb="Ingress Details"
+            let:meta
+            navigationHint="details">
+            <IngressDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+          </Route>
+          <Route path="/kubernetes/configmapsSecrets" breadcrumb="ConfigMaps & Secrets" navigationHint="root">
+            <ConfigMapSecretList />
+          </Route>
+          <Route
+            path="/kubernetes/configmapsSecrets/configmap/:name/:namespace/*"
+            breadcrumb="ConfigMap Details"
+            let:meta
+            navigationHint="details">
+            <ConfigMapDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+          </Route>
+          <Route
+            path="/kubernetes/configmapsSecrets/secret/:name/:namespace/*"
+            breadcrumb="Secret Details"
+            let:meta
+            navigationHint="details">
+            <SecretDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+          </Route>
+          <Route
+            path="/kubernetes/ingressesRoutes/route/:name/:namespace/*"
+            breadcrumb="Route Details"
+            let:meta
+            navigationHint="details">
+            <RouteDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
+          </Route>
+        {/if}
         <Route path="/preferences/*" breadcrumb="Settings">
           <PreferencesPage />
         </Route>

--- a/packages/renderer/src/lib/kube/KubernetesEmptyPage.spec.ts
+++ b/packages/renderer/src/lib/kube/KubernetesEmptyPage.spec.ts
@@ -1,0 +1,121 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { router } from 'tinro';
+import { expect, test, vi } from 'vitest';
+
+import { providerInfos } from '/@/stores/providers';
+import type { ProviderInfo } from '/@api/provider-info';
+
+import KubernetesEmptyPage from './KubernetesEmptyPage.svelte';
+
+const mocks = vi.hoisted(() => ({
+  EmbeddableCatalogExtensionList: vi.fn(),
+}));
+
+vi.mock('../extensions/EmbeddableCatalogExtensionList.svelte', () => ({
+  default: mocks.EmbeddableCatalogExtensionList,
+}));
+
+// mock the router
+vi.mock('tinro', () => {
+  return {
+    router: {
+      goto: vi.fn(),
+    },
+  };
+});
+
+test('expect to call EmbeddableCatealogExtensionList for Kubernetes providers local and remote', () => {
+  render(KubernetesEmptyPage);
+  expect(mocks.EmbeddableCatalogExtensionList).toHaveBeenCalledTimes(2);
+  expect(mocks.EmbeddableCatalogExtensionList).toHaveBeenNthCalledWith(
+    1,
+    expect.anything(),
+    expect.objectContaining({
+      category: 'Kubernetes',
+      keywords: expect.arrayContaining(['provider']),
+    }),
+  );
+  expect(mocks.EmbeddableCatalogExtensionList).toHaveBeenNthCalledWith(
+    2,
+    expect.anything(),
+    expect.objectContaining({
+      category: 'Kubernetes',
+      keywords: expect.arrayContaining(['provider']),
+    }),
+  );
+
+  expect(mocks.EmbeddableCatalogExtensionList).toHaveBeenCalledWith(
+    expect.anything(),
+    expect.objectContaining({
+      keywords: expect.arrayContaining(['local']),
+      title: 'Extensions to help you deploy Kubernetes clusters on your machine',
+    }),
+  );
+  expect(mocks.EmbeddableCatalogExtensionList).toHaveBeenCalledWith(
+    expect.anything(),
+    expect.objectContaining({
+      keywords: expect.arrayContaining(['remote']),
+      title: 'Extensions to help you connect to remote Kubernetes clusters',
+    }),
+  );
+});
+
+test('expect to have links for each Kubernetes provider', async () => {
+  providerInfos.set([
+    {
+      internalId: '101',
+      name: 'Name 1',
+      kubernetesProviderConnectionCreation: true,
+      kubernetesProviderConnectionCreationDisplayName: 'Provider 1',
+      kubernetesProviderConnectionCreationButtonTitle: 'Go create',
+    } as unknown as ProviderInfo,
+    {
+      internalId: '102',
+      name: 'Name 2',
+      kubernetesProviderConnectionCreation: true,
+    } as unknown as ProviderInfo,
+    {
+      internalId: '103',
+      name: 'Name 3',
+    } as unknown as ProviderInfo,
+  ]);
+  render(KubernetesEmptyPage);
+  await waitFor(() => {
+    expect(screen.queryByLabelText('Go create Provider 1...')).not.toBeNull();
+  });
+
+  const link1 = screen.getByLabelText('Go create Provider 1...');
+  await fireEvent.click(link1);
+  expect(router.goto).toHaveBeenCalledWith('/preferences/provider/101');
+
+  const link2 = screen.getByLabelText('Create new Name 2...');
+  await fireEvent.click(link2);
+  expect(router.goto).toHaveBeenCalledWith('/preferences/provider/102');
+
+  expect(screen.queryByLabelText(/Name 3/)).toBeNull();
+
+  providerInfos.set([]);
+  // Links should be updated (removed)
+  await waitFor(() => {
+    expect(screen.queryByLabelText(/Provider 1/)).toBeNull();
+    expect(screen.queryByLabelText(/Name 2/)).toBeNull();
+  });
+});

--- a/packages/renderer/src/lib/kube/KubernetesEmptyPage.spec.ts
+++ b/packages/renderer/src/lib/kube/KubernetesEmptyPage.spec.ts
@@ -42,7 +42,7 @@ vi.mock('tinro', () => {
   };
 });
 
-test('expect to call EmbeddableCatealogExtensionList for Kubernetes providers local and remote', () => {
+test('expect to call EmbeddableCatalogExtensionList for Kubernetes providers local and remote', () => {
   render(KubernetesEmptyPage);
   expect(mocks.EmbeddableCatalogExtensionList).toHaveBeenCalledTimes(2);
   expect(mocks.EmbeddableCatalogExtensionList).toHaveBeenNthCalledWith(

--- a/packages/renderer/src/lib/kube/KubernetesEmptyPage.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesEmptyPage.svelte
@@ -9,7 +9,18 @@ import KubeIcon from '../images/KubeIcon.svelte';
   icon={KubeIcon}
   title="No Kubernetes cluster"
   message="Deploy a Kubernetes cluster or connect to a remote one">
-  <div class="flex gap-2 justify-center max-w-[800px]">
-    <EmbeddableCatalogExtensionList category="Kubernetes" showInstalled={false} />
+  <div class="max-w-[800px]">
+    <EmbeddableCatalogExtensionList
+      showEmptyScreen={false}
+      title="Extensions to help you deploy Kubernetes clusters on your machine"
+      category="Kubernetes"
+      keywords={['provider', 'local']}
+      showInstalled={false} />
+    <EmbeddableCatalogExtensionList
+      showEmptyScreen={false}
+      title="Extensions to help you connect to remote Kubernetes clusters"
+      category="Kubernetes"
+      keywords={['provider', 'remote']}
+      showInstalled={false} />
   </div>
 </EmptyScreen>

--- a/packages/renderer/src/lib/kube/KubernetesEmptyPage.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesEmptyPage.svelte
@@ -1,15 +1,32 @@
 <script lang="ts">
-import { EmptyScreen } from '@podman-desktop/ui-svelte';
+import { Link } from '@podman-desktop/ui-svelte';
+import { router } from 'tinro';
 
+import { providerInfos } from '../../stores/providers';
 import EmbeddableCatalogExtensionList from '../extensions/EmbeddableCatalogExtensionList.svelte';
 import KubeIcon from '../images/KubeIcon.svelte';
 </script>
 
-<EmptyScreen
-  icon={KubeIcon}
-  title="No Kubernetes cluster"
-  message="Deploy a Kubernetes cluster or connect to a remote one">
-  <div class="max-w-[800px]">
+<div class="mt-8 flex justify-center overflow-auto">
+  <div class="max-w-[800px] flex flex-col text-center space-y-3">
+    <div class="flex justify-center text-[var(--pd-details-empty-icon)] py-2">
+      <KubeIcon />
+    </div>
+    <h1 class="text-xl text-[var(--pd-details-empty-header)]">No Kubernetes cluster</h1>
+    <div class="text-[var(--pd-details-empty-sub-header)] text-pretty">
+      Deploy a Kubernetes cluster or connect to a remote one
+    </div>
+
+    <div class="w-full justify-center flex flex-row space-x-3">
+      {#each $providerInfos.filter(p => p.kubernetesProviderConnectionCreation) as provider}
+        <Link
+          onclick={() => router.goto(`/preferences/provider/${provider.internalId}`)}
+          aria-label="Create new {provider.kubernetesProviderConnectionCreationDisplayName ?? provider.name}">
+          {provider.kubernetesProviderConnectionCreationButtonTitle ?? 'Create new'}
+          {provider.kubernetesProviderConnectionCreationDisplayName ?? provider.name}...
+        </Link>
+      {/each}
+    </div>
     <EmbeddableCatalogExtensionList
       showEmptyScreen={false}
       title="Extensions to help you deploy Kubernetes clusters on your machine"
@@ -23,4 +40,4 @@ import KubeIcon from '../images/KubeIcon.svelte';
       keywords={['provider', 'remote']}
       showInstalled={false} />
   </div>
-</EmptyScreen>
+</div>

--- a/packages/renderer/src/lib/kube/KubernetesEmptyPage.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesEmptyPage.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+import { EmptyScreen } from '@podman-desktop/ui-svelte';
+
+import EmbeddableCatalogExtensionList from '../extensions/EmbeddableCatalogExtensionList.svelte';
+import KubeIcon from '../images/KubeIcon.svelte';
+</script>
+
+<EmptyScreen
+  icon={KubeIcon}
+  title="No Kubernetes cluster"
+  message="Deploy a Kubernetes cluster or connect to a remote one">
+  <div class="flex gap-2 justify-center max-w-[800px]">
+    <EmbeddableCatalogExtensionList category="Kubernetes" showInstalled={false} />
+  </div>
+</EmptyScreen>

--- a/packages/renderer/src/lib/kube/KubernetesEmptyPage.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesEmptyPage.svelte
@@ -19,11 +19,9 @@ import KubeIcon from '../images/KubeIcon.svelte';
 
     <div class="w-full justify-center flex flex-row space-x-3">
       {#each $providerInfos.filter(p => p.kubernetesProviderConnectionCreation) as provider}
-        <Link
-          onclick={() => router.goto(`/preferences/provider/${provider.internalId}`)}
-          aria-label="Create new {provider.kubernetesProviderConnectionCreationDisplayName ?? provider.name}">
-          {provider.kubernetesProviderConnectionCreationButtonTitle ?? 'Create new'}
-          {provider.kubernetesProviderConnectionCreationDisplayName ?? provider.name}...
+        {@const label = `${provider.kubernetesProviderConnectionCreationButtonTitle ?? 'Create new'} ${provider.kubernetesProviderConnectionCreationDisplayName ?? provider.name}...`}
+        <Link onclick={() => router.goto(`/preferences/provider/${provider.internalId}`)} aria-label={label}>
+          {label}
         </Link>
       {/each}
     </div>


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Display Kubernetes empty page when no current context

Part of #8571, see https://github.com/containers/podman-desktop/issues/8571#issuecomment-2362916912 for next steps

### Screenshot / video of UI


https://github.com/user-attachments/assets/0caafe75-e3d5-478a-997a-8a9ec435dd41


### What issues does this PR fix or reference?

Part of #8571

There is a glitch on the Download button after the download is finished and the extension is removed from the list (the button of the next extension is displayed as Downloading for a second). Visible in the video around 0:16. The fix will be done as part of another PR


### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
