### PR TITLE
fix: apply light theme on preflight checks box

### DIFF
--- a/packages/renderer/src/lib/dashboard/PreflightChecks.spec.ts
+++ b/packages/renderer/src/lib/dashboard/PreflightChecks.spec.ts
@@ -17,10 +17,20 @@
  ***********************************************************************/
 import '@testing-library/jest-dom/vitest';
 
-import { render, screen } from '@testing-library/svelte';
-import { expect, test } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
 
 import PreflightChecks from './PreflightChecks.svelte';
+
+beforeEach(() => {
+  Object.defineProperty(global, 'window', {
+    value: {
+      openExternal: vi.fn(),
+    },
+    writable: true,
+  });
+  vi.resetAllMocks();
+});
 
 test('Expect preCheck to be displayed when having just title and description', async () => {
   render(PreflightChecks, {
@@ -75,5 +85,8 @@ test('Expect preCheck to be displayed when having all props', async () => {
   const docLinks = screen.getByLabelText('precheck-link');
   expect(docLinks).toBeInTheDocument();
   expect(docLinks.textContent).equals('link');
-  expect(docLinks.getAttribute('href')).equals('url');
+  // click on the button
+  await fireEvent.click(docLinks);
+  // check openExternal is called
+  expect(window.openExternal).toHaveBeenCalledWith('url');
 });

--- a/packages/renderer/src/lib/dashboard/PreflightChecks.svelte
+++ b/packages/renderer/src/lib/dashboard/PreflightChecks.svelte
@@ -1,19 +1,17 @@
 <script lang="ts">
-import { Spinner } from '@podman-desktop/ui-svelte';
+import { Link, Spinner } from '@podman-desktop/ui-svelte';
 
 import type { CheckStatus } from '/@api/provider-info';
 
 export let preflightChecks: CheckStatus[] = [];
 
-function openLink(e: MouseEvent, url: string): void {
-  e.preventDefault();
-  e.stopPropagation();
+function openLink(url: string): void {
   window.openExternal(url);
 }
 </script>
 
 {#if preflightChecks.length > 0}
-  <div class="flex flex-col w-full mt-5 px-5 pt-5 pb-0 rounded-lg bg-zinc-600">
+  <div class="flex flex-col w-full p-2 rounded-lg bg-[var(--pd-invert-content-card-bg)]">
     {#each preflightChecks as preCheck}
       <div class="flex flex-col">
         <div class="mb-4 flex flex-row">
@@ -27,19 +25,20 @@ function openLink(e: MouseEvent, url: string): void {
           <div aria-label="precheck-title" class="ml-2">{preCheck.name}</div>
         </div>
         {#if preCheck.description}
-          Details: <p aria-label="precheck-description" class="text-gray-400 w-full break-all">
+          Details: <p
+            aria-label="precheck-description"
+            class="text-[var(--pd-invert-content-card-text)] w-full break-all">
             {preCheck.description}
           </p>
           {#if preCheck.docLinksDescription}
-            <p aria-label="precheck-docLinksDescription" class="text-gray-400 w-full">
+            <p aria-label="precheck-docLinksDescription" class="text-[var(--pd-invert-content-card-text)] w-full">
               {preCheck.docLinksDescription}
             </p>
           {/if}
           {#if preCheck.docLinks}
             See:
             {#each preCheck.docLinks as link}
-              <a aria-label="precheck-link" href={link.url} target="_blank" on:click={e => openLink(e, link.url)}
-                >{link.title}</a>
+              <Link aria-label="precheck-link" on:click={() => openLink(link.url)}>{link.title}</Link>
             {/each}
           {/if}
         {/if}


### PR DESCRIPTION
### What does this PR do?
when implementing the light theme, this component was omitted so it was still using hardcoded colors.
Using a light theme, the rendering was like broken.
switch the colors to use light mode and instead of using `<a>` use Link that is supporting theming.

### Screenshot / video of UI

you can check 'before' state by going to the issue


after

with dark mode:
![image](https://github.com/user-attachments/assets/1b4ad767-3740-4281-810f-90e8928ae6c6)

with light mode:
![image](https://github.com/user-attachments/assets/7257fdc3-dd4e-494f-96cb-e4a035cc52e5)



### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/8587

### How to test this PR?

on macOS: install podman with brew and copy like an old podman cli to this brew binary (so that podman CLI from brew will return an old version) then you can see the update box in the card on the dashboard
click on the update button and you should see the warning

- [x] Tests are covering the bug fix or the new feature
