### PR TITLE
chore: rework variables to avoid potential undefined values

### DIFF
--- a/packages/main/src/plugin/image-registry.ts
+++ b/packages/main/src/plugin/image-registry.ts
@@ -718,7 +718,7 @@ export class ImageRegistry {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  getBestManifest(manifests: any[], wantedArch: string, wantedOs: string): any {
+  getBestManifest(manifests: any[], wantedArch: string, wantedOs: string): any | undefined {
     // eslint-disable-next-line etc/no-commented-out-code
     // manifestsMap [os] [arch] = manifest
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -739,14 +739,16 @@ export class ImageRegistry {
     if (!wantedOses) {
       wantedOses = manifestsMap.get('linux');
     }
-    if (!wantedOses) {
+
+    const keys = Array.from(wantedOses?.keys() ?? []);
+    if (!wantedOses || !keys[0]) {
       return;
     }
 
     let wanted = wantedOses.get(wantedArch);
     if (!wanted) {
       if (wantedOses.size === 1) {
-        wanted = wantedOses.get(wantedOses.keys().next().value);
+        wanted = wantedOses.get(keys[0]);
       } else {
         wanted = wantedOses.get('amd64');
       }


### PR DESCRIPTION
### What does this PR do?
avoid to have `wantedOses.keys().next().value` that can be undefined

in newer typescript version, it fixed the behavior of getting the first value of an iterator that can return undefined

but then map.get(undefined) is not possible and then leading to an error

prevent that by ensuring that we have valid values before continuing

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/containers/podman-desktop/pull/8814

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
