### PR TITLE
chore(ci): adding concurrency option to pr-check

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -17,9 +17,13 @@
 
 name: pr-check
 
-on: 
+on:
   pull_request:
     types: [labeled, synchronize, opened, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   windows:
@@ -337,7 +341,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Evaluate changes in files   
+      - name: Evaluate changes in files
         id: pnpm_changed
         run: |
           git fetch origin ${{ github.event.pull_request.base.ref }}
@@ -411,7 +415,7 @@ jobs:
       always()
     steps:
       - name: Evaluate the Windows Update test results
-        run: | 
+        run: |
           echo "Windows updater result: ${{ needs.run-update-e2e-test.result }}"
           if [ "${{ needs.run-update-e2e-test.result }}" = "failure" ]; then
             echo "Windows udpater test failed..."

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -22,7 +22,7 @@ on:
     types: [labeled, synchronize, opened, reopened]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
### What does this PR do?

Adding the `concurrency` option to pr-check, making Github cancel previous github actions for a given branch if new one are started (E.g. new commits, rebase etc.)

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/8811

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
