### PR TITLE
fix(docusaurus): storybook empty page

### DIFF
--- a/website/src/pages/storybook/empty-page.tsx
+++ b/website/src/pages/storybook/empty-page.tsx
@@ -21,7 +21,7 @@ import React from 'react';
 
 export default function EmptyPage(): JSX.Element {
   return (
-    <div className="justify-center grow flex w-full">
+    <div className="justify-center items-center grow flex w-full">
       <span>No component selected</span>
     </div>
   );

--- a/website/src/pages/storybook/empty-page.tsx
+++ b/website/src/pages/storybook/empty-page.tsx
@@ -21,7 +21,7 @@ import React from 'react';
 
 export default function EmptyPage(): JSX.Element {
   return (
-    <div className="justify-center items-center grow flex w-full">
+    <div className="justify-center grow flex w-full">
       <span>No component selected</span>
     </div>
   );

--- a/website/src/pages/storybook/styles.module.css
+++ b/website/src/pages/storybook/styles.module.css
@@ -11,6 +11,7 @@
     will-change: width;
     transition: width var(--ifm-transition-fast) ease;
     clip-path: inset(0);
+    height: 100vh;
   }
 
   .docSidebarContainerHidden {


### PR DESCRIPTION
### What does this PR do?

Removing the `align-item` as it was making the empty text vertically center, but when the navigation was containing too many items, it was making invisible as too bar bellow.

### Screenshot / video of UI

Before

![image](https://github.com/user-attachments/assets/14fd5fc0-366f-4515-9f6c-a81220695452)

After

![image](https://github.com/user-attachments/assets/8afaed56-e6c5-4e0b-974a-cfc6a4aec70e)

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/8840

### How to test this PR?

Uses the branch from https://github.com/containers/podman-desktop/pull/8836 and apply fix
