### PR TITLE
feat: filter embeddable extensions by keywords

### DIFF
--- a/packages/main/src/plugin/extensions-catalog/extensions-catalog-api.ts
+++ b/packages/main/src/plugin/extensions-catalog/extensions-catalog-api.ts
@@ -36,6 +36,7 @@ export interface CatalogExtension {
   extensionName: string;
   displayName: string;
   categories: string[];
+  keywords: string[];
   unlisted: boolean;
   versions: CatalogExtensionVersion[];
 }

--- a/packages/main/src/plugin/extensions-catalog/extensions-catalog.ts
+++ b/packages/main/src/plugin/extensions-catalog/extensions-catalog.ts
@@ -127,6 +127,7 @@ export class ExtensionsCatalog {
           publisherName: extension.publisher.publisherName,
           publisherDisplayName: extension.publisher.displayName,
           categories: extension.categories,
+          keywords: extension.keywords,
           unlisted: extension.unlisted ?? false,
           extensionName: extension.extensionName,
           shortDescription: extension.shortDescription,
@@ -250,6 +251,7 @@ interface InternalCatalogExtensionJSON {
   extensionName: string;
   displayName: string;
   categories: string[];
+  keywords: string[];
   unlisted?: boolean;
   shortDescription: string;
   versions: InternalCatalogExtensionVersionJSON[];

--- a/packages/main/src/plugin/extensions-updater/extensions-updater.spec.ts
+++ b/packages/main/src/plugin/extensions-updater/extensions-updater.spec.ts
@@ -45,6 +45,7 @@ const catalogExtension1: CatalogExtension = {
   publisherDisplayName: 'Foo publisher display name',
   shortDescription: 'Foo extension short description',
   categories: ['Kubernetes'],
+  keywords: [],
   unlisted: false,
   versions: [
     {
@@ -65,6 +66,7 @@ const catalogExtension2: CatalogExtension = {
   publisherDisplayName: 'Foo publisher display name',
   shortDescription: 'Foo extension short description',
   categories: [],
+  keywords: [],
   unlisted: false,
   versions: [
     {

--- a/packages/renderer/src/lib/extensions/EmbeddableCatalogExtensionList.spec.ts
+++ b/packages/renderer/src/lib/extensions/EmbeddableCatalogExtensionList.spec.ts
@@ -41,6 +41,7 @@ export const aFakeExtension: CatalogExtension = {
   extensionName: 'a-extension',
   displayName: 'A Extension',
   categories: ['Authentication'],
+  keywords: ['key1', 'key2', 'keyA'],
   unlisted: false,
   versions: [
     {
@@ -66,6 +67,7 @@ export const bFakeExtension: CatalogExtension = {
   extensionName: 'b-extension',
   displayName: 'B Extension',
   categories: [],
+  keywords: ['key1', 'key2', 'keyB'],
   unlisted: false,
   versions: [
     {
@@ -146,4 +148,40 @@ test('Check with a not displaying installed', async () => {
   // this one should be there
   const extensionB = screen.queryByRole('group', { name: 'B Extension' });
   expect(extensionB).toBeInTheDocument();
+});
+
+test('Check with specific keywords common to both extensions', async () => {
+  catalogExtensionInfos.set([aFakeExtension, bFakeExtension]);
+  extensionInfos.set(combined);
+
+  render(EmbeddableCatalogExtensionList, { keywords: ['key1', 'key2'] });
+
+  // 'Available extensions' text
+  const availableExtensions = screen.queryByText('Available extensions');
+  expect(availableExtensions).toBeInTheDocument();
+
+  // we should have both extensions
+  const extensionA = screen.getByRole('group', { name: 'A Extension' });
+  expect(extensionA).toBeInTheDocument();
+
+  const extensionB = screen.queryByRole('group', { name: 'B Extension' });
+  expect(extensionB).toBeInTheDocument();
+});
+
+test('Check with a specific keyword set to one extensions only', async () => {
+  catalogExtensionInfos.set([aFakeExtension, bFakeExtension]);
+  extensionInfos.set(combined);
+
+  render(EmbeddableCatalogExtensionList, { keywords: ['keyA'] });
+
+  // 'Available extensions' text
+  const availableExtensions = screen.queryByText('Available extensions');
+  expect(availableExtensions).toBeInTheDocument();
+
+  // we should have extension A only
+  const extensionA = screen.getByRole('group', { name: 'A Extension' });
+  expect(extensionA).toBeInTheDocument();
+
+  const extensionB = screen.queryByRole('group', { name: 'B Extension' });
+  expect(extensionB).not.toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/extensions/EmbeddableCatalogExtensionList.svelte
+++ b/packages/renderer/src/lib/extensions/EmbeddableCatalogExtensionList.svelte
@@ -11,6 +11,7 @@ import { ExtensionsUtils } from './extensions-utils';
 
 // restricted category to display
 export let category: string | undefined = undefined;
+export let keywords: string[] = [];
 
 // show installed extensions
 export let showInstalled: boolean = true;
@@ -24,6 +25,12 @@ const catalogExtensions: Readable<CatalogExtensionInfoUI[]> = derived(
       const filteredCategory = category;
       $catalogExtensionInfos = $catalogExtensionInfos.filter(catalogExtension =>
         catalogExtension.categories.includes(filteredCategory),
+      );
+    }
+    for (const keyword of keywords) {
+      const filteredKeyword = keyword;
+      $catalogExtensionInfos = $catalogExtensionInfos.filter(catalogExtension =>
+        catalogExtension.keywords.includes(filteredKeyword),
       );
     }
     if (!showInstalled) {

--- a/packages/renderer/src/lib/extensions/ExtensionDetails.spec.ts
+++ b/packages/renderer/src/lib/extensions/ExtensionDetails.spec.ts
@@ -46,6 +46,7 @@ export const aFakeExtension: CatalogExtension = {
   extensionName: 'a-extension',
   displayName: 'A Extension',
   categories: [],
+  keywords: [],
   unlisted: false,
   versions: [
     {
@@ -71,6 +72,7 @@ export const withSpacesFakeExtension: CatalogExtension = {
   extensionName: 'a-extension',
   displayName: 'A Extension',
   categories: [],
+  keywords: [],
   unlisted: false,
   versions: [
     {

--- a/packages/renderer/src/lib/extensions/ExtensionList.spec.ts
+++ b/packages/renderer/src/lib/extensions/ExtensionList.spec.ts
@@ -40,6 +40,7 @@ export const aFakeExtension: CatalogExtension = {
   extensionName: 'a-extension',
   displayName: 'A Extension',
   categories: [],
+  keywords: [],
   unlisted: false,
   versions: [
     {
@@ -65,6 +66,7 @@ export const bFakeExtension: CatalogExtension = {
   extensionName: 'b-extension',
   displayName: 'B Extension',
   categories: [],
+  keywords: [],
   unlisted: false,
   versions: [
     {

--- a/packages/renderer/src/lib/extensions/extensions-utils.spec.ts
+++ b/packages/renderer/src/lib/extensions/extensions-utils.spec.ts
@@ -34,6 +34,7 @@ export const aFakeExtension: CatalogExtension = {
   extensionName: 'a-extension',
   displayName: 'A Extension',
   categories: [],
+  keywords: [],
   unlisted: false,
   versions: [
     {
@@ -59,6 +60,7 @@ export const bFakeExtension: CatalogExtension = {
   extensionName: 'b-extension',
   displayName: 'B Extension',
   categories: [],
+  keywords: [],
   unlisted: false,
   versions: [
     {
@@ -84,6 +86,7 @@ export const unlistedFakeCatalogExtension: CatalogExtension = {
   extensionName: 'unlisted-extension',
   displayName: 'Unlisted Extension',
   categories: [],
+  keywords: [],
   unlisted: true,
 
   versions: [
@@ -110,6 +113,7 @@ export const yFakeCatalogExtension: CatalogExtension = {
   extensionName: 'y-extension',
   displayName: 'Y Extension',
   categories: [],
+  keywords: [],
   unlisted: false,
 
   versions: [
@@ -136,6 +140,7 @@ export const zFakeCatalogExtension: CatalogExtension = {
   extensionName: 'z-extension',
   displayName: 'Z Extension',
   categories: [],
+  keywords: [],
   unlisted: false,
   versions: [
     {

--- a/packages/renderer/src/stores/catalog-extensions.spec.ts
+++ b/packages/renderer/src/stores/catalog-extensions.spec.ts
@@ -74,6 +74,7 @@ test('catalog extension should be updated in case of a container is removed', as
       publisherDisplayName: 'Foo publisher display name',
       unlisted: false,
       categories: [],
+      keywords: [],
       versions: [
         {
           version: '1.0.0',
@@ -92,6 +93,7 @@ test('catalog extension should be updated in case of a container is removed', as
       shortDescription: 'short description',
       publisherDisplayName: 'Foo publisher display name',
       categories: [],
+      keywords: [],
       unlisted: true,
       versions: [
         {


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Filter embeddable extensions by keywords


### What issues does this PR fix or reference?

Part of #8571 (https://github.com/containers/podman-desktop/issues/8571#issuecomment-2362916912)

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
