### PR TITLE
chore: avoid package reserved keyword

### DIFF
--- a/extensions/kubectl-cli/scripts/build.js
+++ b/extensions/kubectl-cli/scripts/build.js
@@ -19,15 +19,15 @@
 
 const AdmZip = require('adm-zip');
 const path = require('path');
-const package = require('../package.json');
+const packageJson = require('../package.json');
 const { mkdirp } = require('mkdirp');
 const fs = require('fs');
 const byline = require('byline');
 const cp = require('copyfiles');
 
-const destFile = path.resolve(__dirname, `../${package.name}.cdix`);
+const destFile = path.resolve(__dirname, `../${packageJson.name}.cdix`);
 const builtinDirectory = path.resolve(__dirname, '../builtin');
-const zipDirectory = path.resolve(builtinDirectory, `${package.name}.cdix`);
+const zipDirectory = path.resolve(builtinDirectory, `${packageJson.name}.cdix`);
 const extFiles = path.resolve(__dirname, '../.extfiles');
 const fileStream = fs.createReadStream(extFiles, { encoding: 'utf8' });
 


### PR DESCRIPTION
### What does this PR do?
avoid package name
(copy from other extension scripts that has the fix)
example:
https://github.com/containers/podman-desktop/blob/903b2cce225d27a39fecf5744e6a0fda3cd53590/extensions/podman/packages/extension/scripts/build.cjs#L22-L28

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
