### PR TITLE
chore(test): Stabilize tests on CI MAC OS by increasing Kind cluster creation timeout

### DIFF
--- a/tests/playwright/src/model/pages/create-kind-cluster-page.ts
+++ b/tests/playwright/src/model/pages/create-kind-cluster-page.ts
@@ -108,7 +108,7 @@ export class CreateKindClusterPage extends BasePage {
     await this.createCluster(timeout);
   }
 
-  private async createCluster(timeout: number = 300000): Promise<void> {
+  private async createCluster(timeout: number = 300_000): Promise<void> {
     await playExpect(this.clusterCreationButton).toBeVisible();
     await this.clusterCreationButton.click();
     await this.logsButton.scrollIntoViewIfNeeded();

--- a/tests/playwright/src/model/pages/create-kind-cluster-page.ts
+++ b/tests/playwright/src/model/pages/create-kind-cluster-page.ts
@@ -108,7 +108,7 @@ export class CreateKindClusterPage extends BasePage {
     await this.createCluster(timeout);
   }
 
-  private async createCluster(timeout: number = 200000): Promise<void> {
+  private async createCluster(timeout: number = 300000): Promise<void> {
     await playExpect(this.clusterCreationButton).toBeVisible();
     await this.clusterCreationButton.click();
     await this.logsButton.scrollIntoViewIfNeeded();

--- a/tests/playwright/src/specs/deploy-to-kubernetes.spec.ts
+++ b/tests/playwright/src/specs/deploy-to-kubernetes.spec.ts
@@ -30,7 +30,7 @@ import {
 import { waitForPodmanMachineStartup } from '../utility/wait';
 
 const CLUSTER_NAME: string = 'kind-cluster';
-const CLUSTER_CREATION_TIMEOUT: number = 300000;
+const CLUSTER_CREATION_TIMEOUT: number = 300_000;
 const KIND_CONTAINER_NAME: string = `${CLUSTER_NAME}-control-plane`;
 const KUBERNETES_CONTEXT: string = `kind-${CLUSTER_NAME}`;
 const IMAGE_TO_PULL: string = 'ghcr.io/linuxcontainers/alpine';

--- a/tests/playwright/src/specs/deploy-to-kubernetes.spec.ts
+++ b/tests/playwright/src/specs/deploy-to-kubernetes.spec.ts
@@ -30,7 +30,7 @@ import {
 import { waitForPodmanMachineStartup } from '../utility/wait';
 
 const CLUSTER_NAME: string = 'kind-cluster';
-const CLUSTER_CREATION_TIMEOUT: number = 200000;
+const CLUSTER_CREATION_TIMEOUT: number = 300000;
 const KIND_CONTAINER_NAME: string = `${CLUSTER_NAME}-control-plane`;
 const KUBERNETES_CONTEXT: string = `kind-${CLUSTER_NAME}`;
 const IMAGE_TO_PULL: string = 'ghcr.io/linuxcontainers/alpine';

--- a/tests/playwright/src/specs/kind.spec.ts
+++ b/tests/playwright/src/specs/kind.spec.ts
@@ -34,7 +34,7 @@ const RESOURCE_NAME: string = 'kind';
 const EXTENSION_LABEL: string = 'podman-desktop.kind';
 const CLUSTER_NAME: string = 'kind-cluster';
 const KIND_CONTAINER_NAME: string = `${CLUSTER_NAME}-control-plane`;
-const CLUSTER_CREATION_TIMEOUT: number = 300000;
+const CLUSTER_CREATION_TIMEOUT: number = 300_000;
 let resourcesPage: ResourcesPage;
 
 let kindResourceCard: ResourceConnectionCardPage;

--- a/tests/playwright/src/specs/kind.spec.ts
+++ b/tests/playwright/src/specs/kind.spec.ts
@@ -34,7 +34,7 @@ const RESOURCE_NAME: string = 'kind';
 const EXTENSION_LABEL: string = 'podman-desktop.kind';
 const CLUSTER_NAME: string = 'kind-cluster';
 const KIND_CONTAINER_NAME: string = `${CLUSTER_NAME}-control-plane`;
-const CLUSTER_CREATION_TIMEOUT: number = 200000;
+const CLUSTER_CREATION_TIMEOUT: number = 300000;
 let resourcesPage: ResourcesPage;
 
 let kindResourceCard: ResourceConnectionCardPage;

--- a/tests/playwright/src/specs/kubernetes.spec.ts
+++ b/tests/playwright/src/specs/kubernetes.spec.ts
@@ -23,7 +23,7 @@ import { createKindCluster, deleteKindCluster, ensureKindCliInstalled } from '..
 import { waitForPodmanMachineStartup } from '../utility/wait';
 
 const CLUSTER_NAME: string = 'kind-cluster';
-const CLUSTER_CREATION_TIMEOUT: number = 200000;
+const CLUSTER_CREATION_TIMEOUT: number = 300000;
 const KIND_NODE: string = `${CLUSTER_NAME}-control-plane`;
 
 const skipKindInstallation = process.env.SKIP_KIND_INSTALL ? process.env.SKIP_KIND_INSTALL : false;

--- a/tests/playwright/src/specs/kubernetes.spec.ts
+++ b/tests/playwright/src/specs/kubernetes.spec.ts
@@ -23,7 +23,7 @@ import { createKindCluster, deleteKindCluster, ensureKindCliInstalled } from '..
 import { waitForPodmanMachineStartup } from '../utility/wait';
 
 const CLUSTER_NAME: string = 'kind-cluster';
-const CLUSTER_CREATION_TIMEOUT: number = 300000;
+const CLUSTER_CREATION_TIMEOUT: number = 300_000;
 const KIND_NODE: string = `${CLUSTER_NAME}-control-plane`;
 
 const skipKindInstallation = process.env.SKIP_KIND_INSTALL ? process.env.SKIP_KIND_INSTALL : false;

--- a/tests/playwright/src/utility/operations.ts
+++ b/tests/playwright/src/utility/operations.ts
@@ -283,7 +283,7 @@ export async function createKindCluster(
   page: Page,
   clusterName: string,
   usedefaultOptions: boolean,
-  timeout: number = 200000,
+  timeout: number = 300000,
   { providerType, httpPort, httpsPort, useIngressController, containerImage }: KindClusterOptions = {},
 ): Promise<void> {
   const navigationBar = new NavigationBar(page);

--- a/tests/playwright/src/utility/operations.ts
+++ b/tests/playwright/src/utility/operations.ts
@@ -283,7 +283,7 @@ export async function createKindCluster(
   page: Page,
   clusterName: string,
   usedefaultOptions: boolean,
-  timeout: number = 300000,
+  timeout: number = 300_000,
   { providerType, httpPort, httpsPort, useIngressController, containerImage }: KindClusterOptions = {},
 ): Promise<void> {
   const navigationBar = new NavigationBar(page);


### PR DESCRIPTION
Signed-off-by: Anton Misskii <amisskii@redhat.com>

### What does this PR do?

Stabilizes the `kubernetes.spec.ts`, `kind.spec.ts`, and `deploy-to-kubernetes.spec.ts` e2e test scenarios on CI for macOS.

### What issues does this PR fix or reference?

https://github.com/containers/podman-desktop/issues/8943
https://github.com/containers/podman-desktop/issues/8944
https://github.com/containers/podman-desktop/issues/8946

- [ ] Tests are covering the bug fix or the new feature
