### PR TITLE
refactor: extract the circle dot to its own component

### DIFF
--- a/packages/renderer/src/lib/ui/ProviderInfo.spec.ts
+++ b/packages/renderer/src/lib/ui/ProviderInfo.spec.ts
@@ -55,3 +55,14 @@ test('Expect docker is blue', async () => {
   expect(label.parentElement?.firstChild).toBeInTheDocument();
   expect(label.parentElement?.firstChild).toHaveClass('bg-sky-400');
 });
+
+test('Expect kubernetes is blue', async () => {
+  const provider = 'Kubernetes';
+  render(ProviderInfo, {
+    provider,
+  });
+  const label = screen.getByText(provider);
+  expect(label).toBeInTheDocument();
+  expect(label.parentElement?.firstChild).toBeInTheDocument();
+  expect(label.parentElement?.firstChild).toHaveClass('bg-sky-600');
+});

--- a/packages/renderer/src/lib/ui/ProviderInfo.svelte
+++ b/packages/renderer/src/lib/ui/ProviderInfo.svelte
@@ -4,14 +4,16 @@ import { PodGroupInfoTypeUI } from '../pod/PodInfoUI';
 import Label from './Label.svelte';
 import ProviderInfoCircle from './ProviderInfoCircle.svelte';
 
+type ProviderNameType = 'docker' | 'podman' | 'kubernetes' | undefined;
+
 // provider: name of the provider (e.g. podman, docker, kubernetes)
 // context: only used for Kubernetes-like distros
 let { provider = '', context = '' }: { provider?: string; context?: string } = $props();
 
 // providerName: name of the provider in lowercase (e.g. podman, docker, kubernetes)
-let providerName: 'docker' | 'podman' | 'kubernetes' | undefined = $state(undefined);
+let providerName: ProviderNameType = $state(undefined);
 
-function getProviderName(providerName: string): 'docker' | 'podman' | 'kubernetes' | undefined {
+function getProviderName(providerName: string): ProviderNameType {
   switch (providerName?.toLowerCase()) {
     case ContainerGroupInfoTypeUI.PODMAN:
       return 'podman';

--- a/packages/renderer/src/lib/ui/ProviderInfo.svelte
+++ b/packages/renderer/src/lib/ui/ProviderInfo.svelte
@@ -2,32 +2,33 @@
 import { ContainerGroupInfoTypeUI } from '../container/ContainerInfoUI';
 import { PodGroupInfoTypeUI } from '../pod/PodInfoUI';
 import Label from './Label.svelte';
+import ProviderInfoCircle from './ProviderInfoCircle.svelte';
 
-// Name of the provider (e.g. podman, docker, kubernetes)
-export let provider = '';
+// provider: name of the provider (e.g. podman, docker, kubernetes)
+// context: only used for Kubernetes-like distros
+let { provider = '', context = '' }: { provider?: string; context?: string } = $props();
 
-// Only used for Kubernetes-like distros
-export let context = '';
+// providerName: name of the provider in lowercase (e.g. podman, docker, kubernetes)
+let providerName: 'docker' | 'podman' | 'kubernetes' | undefined = $state(undefined);
 
-// Each provider has a colour associated to it within tailwind, this is a map of those colours.
-// bg-purple-600 = podman
-// bg-sky-300 = docker
-// bg-sky-600 = kubernetes
-// bg-gray-900 = unknown
-function getProviderColour(providerName: string): string {
+function getProviderName(providerName: string): 'docker' | 'podman' | 'kubernetes' | undefined {
   switch (providerName?.toLowerCase()) {
     case ContainerGroupInfoTypeUI.PODMAN:
-      return 'bg-purple-600';
+      return 'podman';
     case ContainerGroupInfoTypeUI.DOCKER:
-      return 'bg-sky-400';
+      return 'docker';
     case PodGroupInfoTypeUI.KUBERNETES:
-      return 'bg-sky-600';
+      return 'kubernetes';
     default:
-      return 'bg-gray-900';
+      return undefined;
   }
 }
+
+$effect(() => {
+  providerName = getProviderName(provider);
+});
 </script>
 
 <Label tip={provider === 'Kubernetes' ? context : ''} name={provider} capitalize>
-  <div class="w-2 h-2 {getProviderColour(provider)} rounded-full"></div>
+  <ProviderInfoCircle type={providerName} />
 </Label>

--- a/packages/renderer/src/lib/ui/ProviderInfoCircle.spec.ts
+++ b/packages/renderer/src/lib/ui/ProviderInfoCircle.spec.ts
@@ -1,0 +1,72 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import ProviderInfoCircle from './ProviderInfoCircle.svelte';
+
+test('Expect podman is purple', async () => {
+  const type = 'podman';
+  render(ProviderInfoCircle, {
+    type,
+  });
+
+  const circle = screen.getByLabelText('Provider info circle');
+  expect(circle).toBeInTheDocument();
+  expect(circle).toHaveClass('bg-purple-600');
+});
+
+test('Expect kubernetes is purple', async () => {
+  const type = 'kubernetes';
+  render(ProviderInfoCircle, {
+    type,
+  });
+  const circle = screen.getByLabelText('Provider info circle');
+  expect(circle).toBeInTheDocument();
+  expect(circle).toHaveClass('bg-sky-600');
+});
+
+test('Expect docker is blue', async () => {
+  const type = 'docker';
+  render(ProviderInfoCircle, {
+    type,
+  });
+  const circle = screen.getByLabelText('Provider info circle');
+  expect(circle).toBeInTheDocument();
+  expect(circle).toHaveClass('bg-sky-400');
+});
+
+test('Expect unknown is gray', async () => {
+  const type = undefined;
+  render(ProviderInfoCircle, {
+    type,
+  });
+  const circle = screen.getByLabelText('Provider info circle');
+  expect(circle).toBeInTheDocument();
+  expect(circle).toHaveClass('bg-gray-900');
+});
+
+test('Expect missing is gray', async () => {
+  render(ProviderInfoCircle);
+  const circle = screen.getByLabelText('Provider info circle');
+  expect(circle).toBeInTheDocument();
+  expect(circle).toHaveClass('bg-gray-900');
+});

--- a/packages/renderer/src/lib/ui/ProviderInfoCircle.svelte
+++ b/packages/renderer/src/lib/ui/ProviderInfoCircle.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+let { type }: { type: 'kubernetes' | 'podman' | 'docker' | undefined } = $props();
+let color = $state('');
+
+// Each provider has a colour associated to it within tailwind, this is a map of those colours.
+// bg-purple-600 = podman
+// bg-sky-300    = docker
+// bg-sky-600    = kubernetes
+// bg-gray-900   = unknown
+$effect(() => {
+  switch (type) {
+    case 'podman':
+      color = 'bg-purple-600';
+      break;
+    case 'docker':
+      color = 'bg-sky-400';
+      break;
+    case 'kubernetes':
+      color = 'bg-sky-600';
+      break;
+    default:
+      color = 'bg-gray-900';
+  }
+});
+</script>
+
+<div aria-label="Provider info circle" class="w-2 h-2 {color} rounded-full"></div>


### PR DESCRIPTION
### What does this PR do?
no UI change

### Screenshot / video of UI

![image](https://github.com/user-attachments/assets/c7c925f0-694f-423c-9663-42b0eb836387)

### What issues does this PR fix or reference?
fixes https://github.com/containers/podman-desktop/issues/9024

### How to test this PR?

tests provided but you can look at the environment column of containers & images to see the color

- [x] Tests are covering the bug fix or the new feature
