### PR TITLE
chore: fix size of TerminalWindow in PushImageModal

### DIFF
--- a/packages/renderer/src/lib/image/PushImageModal.svelte
+++ b/packages/renderer/src/lib/image/PushImageModal.svelte
@@ -33,6 +33,7 @@ async function pushImage(imageTag: string) {
   gotErrorDuringPush = false;
   initTerminal = true;
   await tick();
+  window.dispatchEvent(new Event('resize'));
   logsPush?.reset();
 
   pushInProgress = true;
@@ -104,8 +105,8 @@ $: window.hasAuthconfigForImage(imageInfoToPush.name).then(result => (isAuthenti
         </p>{/if}
     </div>
 
-    <div class="max-h-[185px]" hidden={initTerminal === false}>
-      <TerminalWindow bind:terminal={logsPush} disableStdIn />
+    <div class="h-[185px]" hidden={initTerminal === false}>
+      <TerminalWindow class="h-full" bind:terminal={logsPush} disableStdIn />
     </div>
   </div>
 


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Fixes the sizing of the terminal in `PushImageModal`

### Screenshot / video of UI
![Screenshot from 2024-09-23 10-23-59](https://github.com/user-attachments/assets/20bc4bbb-97b9-4cfc-86df-86178ed95a6b)

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Closes https://github.com/containers/podman-desktop/issues/8078

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->
Open `PushImageModal` by pushing an image and assert that there is only one scroll bar and it's the terminal's 

- [ ] Tests are covering the bug fix or the new feature
