### PR TITLE
chore: reduce header width

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -144,7 +144,7 @@ li.footer__item a svg {
 }
 
 .navbar__item {
-  font-size: 1em;
+  font-size: 0.9em;
 }
 
 .pagination-nav {
@@ -191,13 +191,13 @@ li.footer__item a svg {
   background-color: transparent !important;
 }
 
-@media (min-width: 1200px) {
+@media (min-width: 1230px) {
   .navbar__title {
-    font-size: 2em;
+    font-size: 1.7em;
   }
 
   .navbar__item {
-    font-size: 1.2em;
+    font-size: 1em;
   }
 }
 


### PR DESCRIPTION
### What does this PR do?

Even after removing Core Values (#8964), the Podman Desktop title is often cut off when I open our website in a browser. You have to have a large or full- screen browser to see the whole Podman Desktop title.

Comparing with other sites, our logo + title is a bit wide (not much we can do about the name) and our header font sizes are also on the high side. This just reduces the font size a little and slightly increases the reactive width where it jumps between regular and large fonts so that Podman Desktop is usually visible.

### Screenshot / video of UI

Before:

https://github.com/user-attachments/assets/c62caf5a-29ab-43f9-90a9-06d7bf68d58b

After:

https://github.com/user-attachments/assets/b0c4fa0d-6c1e-4ee0-9748-258beecc7ab7

### What issues does this PR fix or reference?

Fixes #5761.

### How to test this PR?

`pnpm website:dev`