### PR TITLE
fix: add missing aria-label attributes

### DIFF
--- a/packages/renderer/src/lib/compose/ComposeActions.spec.ts
+++ b/packages/renderer/src/lib/compose/ComposeActions.spec.ts
@@ -68,11 +68,13 @@ test('Expect no error and status starting compose', async () => {
   const startButton = screen.getByRole('button', { name: 'Start Compose' });
   await fireEvent.click(startButton);
 
-  expect(compose.status).toEqual('STARTING');
-  expect(compose.actionError).toEqual('');
-  expect(compose.containers[0].state).toEqual('STARTING');
-  expect(compose.containers[0].actionError).toEqual('');
-  expect(updateMock).toHaveBeenCalled();
+  vi.waitFor(() => {
+    expect(compose.status).toEqual('STARTING');
+    expect(compose.actionError).toEqual('');
+    expect(compose.containers[0].state).toEqual('STARTING');
+    expect(compose.containers[0].actionError).toEqual('');
+    expect(updateMock).toHaveBeenCalled();
+  });
 });
 
 test('Expect no error and status stopping compose', async () => {

--- a/packages/renderer/src/lib/compose/ComposeActions.spec.ts
+++ b/packages/renderer/src/lib/compose/ComposeActions.spec.ts
@@ -68,13 +68,11 @@ test('Expect no error and status starting compose', async () => {
   const startButton = screen.getByRole('button', { name: 'Start Compose' });
   await fireEvent.click(startButton);
 
-  vi.waitFor(() => {
-    expect(compose.status).toEqual('STARTING');
-    expect(compose.actionError).toEqual('');
-    expect(compose.containers[0].state).toEqual('STARTING');
-    expect(compose.containers[0].actionError).toEqual('');
-    expect(updateMock).toHaveBeenCalled();
-  });
+  expect(compose.status).toEqual('STARTING');
+  expect(compose.actionError).toEqual('');
+  expect(compose.containers[0].state).toEqual('STARTING');
+  expect(compose.containers[0].actionError).toEqual('');
+  expect(updateMock).toHaveBeenCalled();
 });
 
 test('Expect no error and status stopping compose', async () => {

--- a/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
@@ -148,6 +148,7 @@ function onInstallationClick() {
           </button>
           <button
             class="inline-block bg-purple-600 hover:bg-purple-500 text-[13px] text-white pt-2 pr-3 pl-3 pb-2 w-[32px]"
+            aria-label="Installation options menu"
             on:click={() => updateOptionsMenu(!installationOptionsMenuVisible)}>
             <i class="fas fa-caret-down"></i>
           </button>

--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
@@ -328,6 +328,7 @@ function removeExistingRegistry(registry: containerDesktopAPI.Registry) {
                       class="justify-center"
                       id="hide-password"
                       title="Hide password"
+                      aria-label="Hide password"
                       aria-expanded="true"
                       aria-haspopup="true"
                       on:click={() => setPasswordForRegistryVisible(registry, false)}>
@@ -339,6 +340,7 @@ function removeExistingRegistry(registry: containerDesktopAPI.Registry) {
                       class="justify-center"
                       id="show-password"
                       title="Show password"
+                      aria-label="Show password"
                       aria-expanded="true"
                       aria-haspopup="true"
                       on:click={() => setPasswordForRegistryVisible(registry, true)}>

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
@@ -70,7 +70,10 @@ $: resetToDefault = false;
       {recordUI.title}
       {#if showResetButton}
         <div class="ml-2">
-          <button class="text-xs text-violet-500" on:click={() => doResetToDefault()}>
+          <button
+            class="text-xs text-violet-500"
+            on:click={() => doResetToDefault()}
+            aria-label="Reset to default value">
             <i class="fas fa-undo" aria-hidden="true"></i>
           </button>
         </div>


### PR DESCRIPTION
### What does this PR do?

add missing aria-label attributes to avoid linter errors after migration to next version of svelte see (#9033 PR from dependabot)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Related to #9033.

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
