### PR TITLE
fix: mock values using objects with getters setters

### DIFF
--- a/packages/renderer/src/lib/compose/ComposeActions.spec.ts
+++ b/packages/renderer/src/lib/compose/ComposeActions.spec.ts
@@ -25,21 +25,40 @@ import type { ContainerInfoUI } from '../container/ContainerInfoUI';
 import ComposeActions from './ComposeActions.svelte';
 import type { ComposeInfoUI } from './ComposeInfoUI';
 
-const compose: ComposeInfoUI = {
-  engineId: 'podman',
-  engineType: 'podman',
-  name: 'my-compose-group',
-  status: 'STOPPED',
-  actionInProgress: false,
-  actionError: undefined,
-  containers: [
+class ComposeInfoUIImpl implements ComposeInfoUI {
+  #status: string = 'STOPPED';
+  constructor(
+    public engineId: string,
+    public engineType: 'docker' | 'podman',
+    public name: string,
+    initialStatus: string,
+    public actionInProgress: boolean,
+    public actionError: string | undefined,
+    public containers: ContainerInfoUI[],
+  ) {}
+  set status(status: string) {
+    this.#status = status;
+  }
+  get status(): string {
+    return this.#status;
+  }
+}
+
+const compose: ComposeInfoUI = new ComposeInfoUIImpl(
+  'podman',
+  'podman',
+  'my-compose-group',
+  'STOPPED',
+  false,
+  undefined,
+  [
     {
       actionInProgress: false,
       actionError: undefined,
       state: 'STOPPED',
     } as ContainerInfoUI,
   ],
-} as ComposeInfoUI;
+);
 
 const getContributedMenusMock = vi.fn();
 const updateMock = vi.fn();

--- a/packages/renderer/src/lib/container/ContainerActions.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerActions.spec.ts
@@ -25,10 +25,24 @@ import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import ContainerActions from './ContainerActions.svelte';
 import type { ContainerInfoUI } from './ContainerInfoUI';
 
-const container: ContainerInfoUI = {
-  id: 'container-id',
-  engineId: 'container-engine-id',
-} as ContainerInfoUI;
+class ContainerInfoUIImpl {
+  #actionError: string = '';
+  constructor(
+    public id: string,
+    public engineId: string,
+  ) {}
+  set actionError(error: string) {
+    this.#actionError = error;
+  }
+  get actionError(): string {
+    return this.#actionError;
+  }
+}
+
+const container: ContainerInfoUI = new ContainerInfoUIImpl(
+  'container-id',
+  'container-engine-id',
+) as unknown as ContainerInfoUI;
 
 const getContributedMenusMock = vi.fn();
 const updateMock = vi.fn();
@@ -57,7 +71,7 @@ test('Expect no error and status starting container', async () => {
   const startButton = screen.getByRole('button', { name: 'Start Container' });
   await fireEvent.click(startButton);
 
-  expect(container.state).toEqual('STARTING');
+  await waitFor(() => expect(container.state).toEqual('STARTING'));
   expect(container.actionError).toEqual('');
   expect(updateMock).toHaveBeenCalled();
 });
@@ -69,7 +83,7 @@ test('Expect no error and status stopping container', async () => {
   const stopButton = screen.getByRole('button', { name: 'Stop Container' });
   await fireEvent.click(stopButton);
 
-  expect(container.state).toEqual('STOPPING');
+  await waitFor(() => expect(container.state).toEqual('STOPPING'));
   expect(container.actionError).toEqual('');
   expect(updateMock).toHaveBeenCalled();
 });
@@ -81,7 +95,7 @@ test('Expect no error and status restarting container', async () => {
   const restartButton = screen.getByRole('button', { name: 'Restart Container' });
   await fireEvent.click(restartButton);
 
-  expect(container.state).toEqual('RESTARTING');
+  await waitFor(() => expect(container.state).toEqual('RESTARTING'));
   expect(container.actionError).toEqual('');
   expect(updateMock).toHaveBeenCalled();
 });
@@ -98,7 +112,7 @@ test('Expect no error and status deleting container', async () => {
   // Wait for confirmation modal to disappear after clicking on delete
   await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
 
-  expect(container.state).toEqual('DELETING');
+  await waitFor(() => expect(container.state).toEqual('DELETING'));
   expect(container.actionError).toEqual('');
   expect(updateMock).toHaveBeenCalled();
 });

--- a/packages/renderer/src/lib/container/ContainerActions.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerActions.spec.ts
@@ -71,7 +71,7 @@ test('Expect no error and status starting container', async () => {
   const startButton = screen.getByRole('button', { name: 'Start Container' });
   await fireEvent.click(startButton);
 
-  await waitFor(() => expect(container.state).toEqual('STARTING'));
+  expect(container.state).toEqual('STARTING');
   expect(container.actionError).toEqual('');
   expect(updateMock).toHaveBeenCalled();
 });
@@ -83,7 +83,7 @@ test('Expect no error and status stopping container', async () => {
   const stopButton = screen.getByRole('button', { name: 'Stop Container' });
   await fireEvent.click(stopButton);
 
-  await waitFor(() => expect(container.state).toEqual('STOPPING'));
+  expect(container.state).toEqual('STOPPING');
   expect(container.actionError).toEqual('');
   expect(updateMock).toHaveBeenCalled();
 });
@@ -95,7 +95,7 @@ test('Expect no error and status restarting container', async () => {
   const restartButton = screen.getByRole('button', { name: 'Restart Container' });
   await fireEvent.click(restartButton);
 
-  await waitFor(() => expect(container.state).toEqual('RESTARTING'));
+  expect(container.state).toEqual('RESTARTING');
   expect(container.actionError).toEqual('');
   expect(updateMock).toHaveBeenCalled();
 });
@@ -112,7 +112,7 @@ test('Expect no error and status deleting container', async () => {
   // Wait for confirmation modal to disappear after clicking on delete
   await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
 
-  await waitFor(() => expect(container.state).toEqual('DELETING'));
+  expect(container.state).toEqual('DELETING');
   expect(container.actionError).toEqual('');
   expect(updateMock).toHaveBeenCalled();
 });

--- a/packages/renderer/src/lib/dashboard/ProviderInstalled.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ProviderInstalled.spec.ts
@@ -36,6 +36,29 @@ vi.mock('@xterm/xterm', () => {
   };
 });
 
+class InitializationContextImpl {
+  #promise: unknown;
+  #error: unknown;
+
+  constructor(public mode: string) {}
+
+  set promise(promise: unknown) {
+    this.#promise = promise;
+  }
+
+  get promise(): unknown {
+    return this.#promise;
+  }
+
+  set error(error: unknown) {
+    this.#error = error;
+  }
+
+  get error(): unknown {
+    return this.#error;
+  }
+}
+
 // fake the window.events object
 beforeAll(() => {
   (window as any).ResizeObserver = vi.fn().mockReturnValue({ observe: vi.fn(), unobserve: vi.fn() });
@@ -70,7 +93,9 @@ test('Expect installed provider shows button', async () => {
     cleanupSupport: false,
   };
 
-  const initializationContext: InitializationContext = { mode: InitializeAndStartMode };
+  const initializationContext: InitializationContext = new InitializationContextImpl(
+    InitializeAndStartMode,
+  ) as unknown as InitializationContext;
   render(ProviderInstalled, { provider: provider, initializationContext: initializationContext });
 
   const providerText = screen.getByText(content => content === 'MyProvider');
@@ -118,7 +143,9 @@ test('Expect to see the initialize context error if provider installation fails'
     cleanupSupport: false,
   };
 
-  const initializationContext: InitializationContext = { mode: InitializeAndStartMode };
+  const initializationContext: InitializationContext = new InitializationContextImpl(
+    InitializeAndStartMode,
+  ) as unknown as InitializationContext;
   render(ProviderInstalled, { provider: provider, initializationContext: initializationContext });
 
   const providerText = screen.getByText(content => content === 'MyProvider');

--- a/packages/renderer/src/lib/deployments/DeploymentActions.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentActions.spec.ts
@@ -27,15 +27,36 @@ import type { DeploymentUI } from './DeploymentUI';
 const updateMock = vi.fn();
 const deleteMock = vi.fn();
 
-const deployment: DeploymentUI = {
-  name: 'my-deployment',
-  status: 'RUNNING',
-  namespace: '',
-  replicas: 0,
-  ready: 0,
-  selected: false,
-  conditions: [],
-};
+class DeploymentfUIImpl {
+  #status: string;
+  constructor(
+    public name: string,
+    initialStatus: string,
+    public namespace: string,
+    public replicas: number,
+    public ready: number,
+    public selected: boolean,
+    public conditions: unknown[],
+  ) {
+    this.#status = initialStatus;
+  }
+  set status(status: string) {
+    this.#status = status;
+  }
+  get status(): string {
+    return this.#status;
+  }
+}
+
+const deployment: DeploymentUI = new DeploymentfUIImpl(
+  'my-deployment',
+  'RUNNING',
+  '',
+  0,
+  0,
+  false,
+  [],
+) as unknown as DeploymentUI;
 
 beforeEach(() => {
   (window as any).kubernetesDeleteDeployment = deleteMock;

--- a/packages/renderer/src/lib/image/ImageActions.spec.ts
+++ b/packages/renderer/src/lib/image/ImageActions.spec.ts
@@ -61,6 +61,24 @@ const fakedImage: ImageInfoUI = {
   name: 'dummy',
 } as unknown as ImageInfoUI;
 
+class Image {
+  #status: string;
+  constructor(
+    public name: string,
+    initialStatus: string,
+  ) {
+    this.#status = initialStatus;
+  }
+
+  set status(status: string) {
+    this.#status = status;
+  }
+
+  get status(): string {
+    return this.#status;
+  }
+}
+
 beforeEach(() => {
   vi.resetAllMocks();
 });
@@ -69,10 +87,7 @@ test('Expect showMessageBox to be called when error occurs', async () => {
   vi.mocked(withConfirmation).mockImplementation(f => f());
   getContributedMenusMock.mockImplementation(() => Promise.resolve([]));
 
-  const image: ImageInfoUI = {
-    name: 'dummy',
-    status: 'UNUSED',
-  } as ImageInfoUI;
+  const image: ImageInfoUI = new Image('dummy', 'UNUSED') as unknown as ImageInfoUI;
 
   render(ImageActions, {
     onPushImage: vi.fn(),
@@ -87,7 +102,7 @@ test('Expect showMessageBox to be called when error occurs', async () => {
     expect(showMessageBoxMock).toHaveBeenCalledOnce();
   });
 
-  expect(image.status).toBe('DELETING');
+  await waitFor(() => expect(image.status).toBe('DELETING'));
 });
 
 test('Expect no dropdown when one contribution and dropdownMenu off', async () => {

--- a/packages/renderer/src/lib/image/ImageActions.spec.ts
+++ b/packages/renderer/src/lib/image/ImageActions.spec.ts
@@ -102,7 +102,7 @@ test('Expect showMessageBox to be called when error occurs', async () => {
     expect(showMessageBoxMock).toHaveBeenCalledOnce();
   });
 
-  await waitFor(() => expect(image.status).toBe('DELETING'));
+  expect(image.status).toBe('DELETING');
 });
 
 test('Expect no dropdown when one contribution and dropdownMenu off', async () => {

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteActions.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteActions.spec.ts
@@ -39,13 +39,24 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
+class StatusHolder {
+  #status: string;
+  constructor(initialStatus: string) {
+    this.#status = initialStatus;
+  }
+  set status(status: string) {
+    this.#status = status;
+  }
+  get status(): string {
+    return this.#status;
+  }
+}
+
 test('Expect no error and status deleting ingress', async () => {
-  const ingressUI: IngressUI = {
-    name: 'my-ingress',
-    namespace: 'test-namespace',
-    status: 'RUNNING',
-    selected: false,
-  };
+  const ingressUI: IngressUI = new StatusHolder('RUNNING') as unknown as IngressUI;
+  ingressUI.name = 'my-ingress';
+  ingressUI.namespace = 'test-namespace';
+  ingressUI.selected = false;
 
   render(IngressRouteActions, { ingressRoute: ingressUI, onUpdate: updateMock });
 
@@ -59,19 +70,18 @@ test('Expect no error and status deleting ingress', async () => {
 });
 
 test('Expect no error and status deleting route', async () => {
-  const routeUI: RouteUI = {
-    name: 'my-route',
-    namespace: 'test-namespace',
-    status: 'RUNNING',
-    host: 'foo.bar.com',
-    port: '80',
-    to: {
-      kind: 'Service',
-      name: 'service',
-    },
-    selected: false,
-    tlsEnabled: false,
+  const routeUI: RouteUI = new StatusHolder('RUNNING') as unknown as RouteUI;
+  routeUI.name = 'my-route';
+  routeUI.namespace = 'test-namespace';
+  routeUI.status = 'RUNNING';
+  routeUI.host = 'foo.bar.com';
+  routeUI.port = '80';
+  routeUI.to = {
+    kind: 'Service',
+    name: 'service',
   };
+  routeUI.selected = false;
+  routeUI.tlsEnabled = false;
 
   render(IngressRouteActions, { ingressRoute: routeUI, onUpdate: updateMock });
 

--- a/packages/renderer/src/lib/pod/PodActions.spec.ts
+++ b/packages/renderer/src/lib/pod/PodActions.spec.ts
@@ -27,12 +27,34 @@ import type { V1Route } from '/@api/openshift-types';
 import PodActions from './PodActions.svelte';
 import type { PodInfoUI } from './PodInfoUI';
 
-const podmanPod: PodInfoUI = {
-  id: 'pod',
-  containers: [{ Id: 'pod' }],
-  status: 'RUNNING',
-  kind: 'podman',
-} as PodInfoUI;
+class Pod {
+  #status: string;
+  #actionError: string;
+  constructor(
+    public id: string,
+    public containers: { Id: string }[],
+    initialStatus: string,
+    public kind: string,
+    actionError: string,
+  ) {
+    this.#status = initialStatus;
+    this.#actionError = actionError;
+  }
+  set acitonError(error: string) {
+    this.#actionError = error;
+  }
+  get acitonError(): string {
+    return this.#actionError;
+  }
+  set status(status: string) {
+    this.#status = status;
+  }
+  get status() {
+    return this.#status;
+  }
+}
+
+const podmanPod: PodInfoUI = new Pod('pod', [{ Id: 'pod' }], 'RUNNING', 'podman', '') as unknown as PodInfoUI;
 
 const kubernetesPod: PodInfoUI = {
   id: 'pod',

--- a/packages/renderer/src/lib/pvc/PVCActions.spec.ts
+++ b/packages/renderer/src/lib/pvc/PVCActions.spec.ts
@@ -28,15 +28,27 @@ const updateMock = vi.fn();
 const deleteMock = vi.fn();
 const showMessageBoxMock = vi.fn();
 
-const fakePVC: PVCUI = {
-  name: 'pvc-1',
-  namespace: 'default',
-  status: 'RUNNING',
-  storageClass: 'standard',
-  accessModes: ['ReadWriteOnce'],
-  selected: false,
-  size: '1Gi',
-};
+class StatusHolder {
+  #status: string;
+  constructor(initialStatus: string) {
+    this.#status = initialStatus;
+  }
+  set status(status: string) {
+    this.#status = status;
+  }
+  get status(): string {
+    return this.#status;
+  }
+}
+
+const fakePVC: PVCUI = new StatusHolder('RUNNING') as unknown as PVCUI;
+fakePVC.name = 'pvc-1';
+fakePVC.namespace = 'default';
+fakePVC.status = 'RUNNING';
+fakePVC.storageClass = 'standard';
+fakePVC.accessModes = ['ReadWriteOnce'];
+fakePVC.selected = false;
+fakePVC.size = '1Gi';
 
 beforeEach(() => {
   (window as any).showMessageBox = showMessageBoxMock;
@@ -62,7 +74,7 @@ test('Expect no error and status deleting PVC', async () => {
   await fireEvent.click(deleteButton);
 
   await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
-  expect(fakePVC.status).toEqual('DELETING');
+  await waitFor(() => expect(fakePVC.status).toEqual('DELETING'));
   expect(updateMock).toHaveBeenCalled();
   expect(deleteMock).toHaveBeenCalled();
 });

--- a/packages/renderer/src/lib/pvc/PVCActions.spec.ts
+++ b/packages/renderer/src/lib/pvc/PVCActions.spec.ts
@@ -74,7 +74,7 @@ test('Expect no error and status deleting PVC', async () => {
   await fireEvent.click(deleteButton);
 
   await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
-  await waitFor(() => expect(fakePVC.status).toEqual('DELETING'));
+  expect(fakePVC.status).toEqual('DELETING');
   expect(updateMock).toHaveBeenCalled();
   expect(deleteMock).toHaveBeenCalled();
 });

--- a/packages/renderer/src/lib/service/ServiceActions.spec.ts
+++ b/packages/renderer/src/lib/service/ServiceActions.spec.ts
@@ -28,15 +28,30 @@ const updateMock = vi.fn();
 const deleteMock = vi.fn();
 const showMessageBoxMock = vi.fn();
 
-const service: ServiceUI = {
-  name: 'my-service',
-  status: 'RUNNING',
-  namespace: '',
-  selected: false,
-  type: '',
-  clusterIP: '',
-  ports: '',
-};
+class ServiceUIImpl {
+  #status: string;
+  constructor(
+    public name: string,
+    initStatus: string,
+    public namespace: string,
+    public selected: boolean,
+    public type: string,
+    public clusterIP: string,
+    public ports: string,
+  ) {
+    this.#status = initStatus;
+  }
+
+  set status(status: string) {
+    this.#status = status;
+  }
+
+  get status(): string {
+    return this.#status;
+  }
+}
+
+const service: ServiceUI = new ServiceUIImpl('my-service', 'RUNNING', '', false, '', '', '');
 
 beforeEach(() => {
   (window as any).showMessageBox = showMessageBoxMock;
@@ -58,9 +73,10 @@ test('Expect no error and status deleting service', async () => {
   await fireEvent.click(deleteButton);
 
   // Wait for confirmation modal to disappear after clicking on delete
-  await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
-
-  expect(service.status).toEqual('DELETING');
-  expect(updateMock).toHaveBeenCalled();
-  expect(deleteMock).toHaveBeenCalled();
+  await waitFor(() => {
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(service.status).toEqual('DELETING');
+    expect(updateMock).toHaveBeenCalled();
+    expect(deleteMock).toHaveBeenCalled();
+  });
 });

--- a/packages/renderer/src/lib/service/ServiceActions.spec.ts
+++ b/packages/renderer/src/lib/service/ServiceActions.spec.ts
@@ -18,7 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { fireEvent, render, screen } from '@testing-library/svelte';
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
 import ServiceActions from './ServiceActions.svelte';
@@ -72,11 +72,8 @@ test('Expect no error and status deleting service', async () => {
   const deleteButton = screen.getByRole('button', { name: 'Delete Service' });
   await fireEvent.click(deleteButton);
 
-  // Wait for confirmation modal to disappear after clicking on delete
-  await waitFor(() => {
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-    expect(service.status).toEqual('DELETING');
-    expect(updateMock).toHaveBeenCalled();
-    expect(deleteMock).toHaveBeenCalled();
-  });
+  expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  expect(service.status).toEqual('DELETING');
+  expect(updateMock).toHaveBeenCalled();
+  expect(deleteMock).toHaveBeenCalled();
 });

--- a/packages/renderer/src/lib/volume/VolumeActions.spec.ts
+++ b/packages/renderer/src/lib/volume/VolumeActions.spec.ts
@@ -27,6 +27,23 @@ import type { VolumeInfoUI } from './VolumeInfoUI';
 const showMessageBoxMock = vi.fn();
 const removeVolumeMock = vi.fn();
 
+class VolumeInfoUIImpl {
+  #status: string;
+  constructor(
+    public name: string,
+    initialStatus: string,
+  ) {
+    this.#status = initialStatus;
+  }
+
+  get status() {
+    return this.#status;
+  }
+  set status(status: string) {
+    this.#status = status;
+  }
+}
+
 beforeAll(() => {
   (window as any).showMessageBox = showMessageBoxMock;
   (window as any).removeVolume = removeVolumeMock;
@@ -36,10 +53,7 @@ test('Expect prompt dialog and deletion', async () => {
   // Mock the showMessageBox to return 0 (yes)
   showMessageBoxMock.mockResolvedValue({ response: 0 });
 
-  const volume: VolumeInfoUI = {
-    name: 'dummy',
-    status: 'UNUSED',
-  } as VolumeInfoUI;
+  const volume: VolumeInfoUI = new VolumeInfoUIImpl('dummy', 'UNUSED') as unknown as VolumeInfoUI;
 
   render(VolumeActions, {
     volume,


### PR DESCRIPTION
### What does this PR do?

Due to latest changes in svelte plain objects cannot be used when rendering component in tests. It seems [this change](https://redirect.github.com/sveltejs/svelte/pull/13341) is breaking our tests.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Related to #9033. It fixes errors in component tests after migration to latest svelte release.

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
