### PR TITLE
fix: reflecting light and dark theme by AuditMessageBox

### DIFF
--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -1307,6 +1307,10 @@ export class ColorRegistry {
       dark: colorPalette.red[500],
       light: colorPalette.red[600],
     });
+    this.registerColor(`${state}info`, {
+      dark: colorPalette.purple[500],
+      light: colorPalette.purple[600],
+    });
   }
 
   // colors for image files explorer

--- a/packages/renderer/src/lib/ui/AuditMessageBox.svelte
+++ b/packages/renderer/src/lib/ui/AuditMessageBox.svelte
@@ -16,12 +16,15 @@ $: errorRecords = auditResult?.records.filter(record => record.type === 'error')
 
 {#if errorRecords && errorRecords.length > 0}
   {#each errorRecords as record}
-    <div class="bg-charcoal-600 border-t-2 border-red-500 p-4 mb-2" role="alert" aria-label="error">
+    <div
+      class="bg-[var(--pd-content-bg)] text-[var(--pd-state-error)] border-t-2 border-[var(--pd-state-error)] p-4 mb-2"
+      role="alert"
+      aria-label="error">
       <div class="flex flex-row">
         <div class="mr-3">
           <Fa size="1.1x" class="text-red-400" icon={faXmarkCircle} />
         </div>
-        <div class="text-sm text-white">
+        <div class="text-sm">
           {record.record}
         </div>
       </div>
@@ -31,12 +34,15 @@ $: errorRecords = auditResult?.records.filter(record => record.type === 'error')
 
 {#if warningRecords && warningRecords.length > 0}
   {#each warningRecords as record}
-    <div class="bg-charcoal-600 border-t-2 border-amber-500 p-4 mb-2" role="alert" aria-label="warning">
+    <div
+      class="bg-[var(--pd-content-bg)] text-[var(--pd-state-warning)] border-t-2 border-[var(--pd-state-warning)] p-4 mb-2"
+      role="alert"
+      aria-label="warning">
       <div class="flex flex-row">
         <div class="mr-3">
           <Fa size="1.1x" class="flex text-amber-400" icon={faTriangleExclamation} />
         </div>
-        <div class="text-sm text-white">
+        <div class="text-sm">
           {record.record}
         </div>
       </div>
@@ -46,12 +52,15 @@ $: errorRecords = auditResult?.records.filter(record => record.type === 'error')
 
 {#if infoRecords && infoRecords.length > 0}
   {#each infoRecords as record}
-    <div class="bg-charcoal-600 border-t-2 border-purple-500 p-4 mb-2" role="alert" aria-label="info">
+    <div
+      class="bg-[var(--pd-content-bg)] border-t-2 border-[var(--pd-state-info)] p-4 mb-2"
+      role="alert"
+      aria-label="info">
       <div class="flex flex-row">
         <div class="mr-3">
-          <Fa size="1.1x" class="text-purple-500" icon={faCircleInfo} />
+          <Fa size="1.1x" class="text-[var(--pd-state-info)]" icon={faCircleInfo} />
         </div>
-        <div class="text-sm text-white">
+        <div class="text-sm">
           {record.record}
         </div>
       </div>


### PR DESCRIPTION
### What does this PR do?
Fixes AuditMessageBox, which didn't reflect light/dark mode

### Screenshot / video of UI
Prev:
![image](https://github.com/user-attachments/assets/0083df20-d309-43d4-8dab-5ee7d89c87b6)

Now:
![image](https://github.com/user-attachments/assets/a775cb82-6d67-425f-a2dd-ea4e1c0a31b8)
![image](https://github.com/user-attachments/assets/3d3e6de3-d0f3-4e4f-9e78-1476d4bfb8a0)

### What issues does this PR fix or reference?
Closes #9038 

### How to test this PR?
Try to create kind cluster (virtual-machine needs to have at most 6gb for AuditMessageBox to appear)

- [x] Tests are covering the bug fix or the new feature
