### PR TITLE
chore(test): add catchall settings object for development

### DIFF
--- a/tests/playwright/src/runner/runner-options.ts
+++ b/tests/playwright/src/runner/runner-options.ts
@@ -25,6 +25,7 @@ export class RunnerOptions {
   public readonly _extensionsDisabled: string[];
   public readonly _aiLabModelUploadDisabled: boolean;
   public readonly _binaryPath: string | undefined;
+  public readonly _customSettings: { [key: string]: unknown } = {};
 
   constructor({
     profile = '',
@@ -35,6 +36,7 @@ export class RunnerOptions {
     extensionsDisabled = [],
     aiLabModelUploadDisabled = false,
     binaryPath = undefined,
+    customSettings = {},
   }: {
     profile?: string;
     customFolder?: string;
@@ -44,6 +46,7 @@ export class RunnerOptions {
     extensionsDisabled?: string[];
     aiLabModelUploadDisabled?: boolean;
     binaryPath?: string;
+    customSettings?: { [key: string]: unknown };
   } = {}) {
     this._profile = profile;
     this._customFolder = customFolder;
@@ -53,6 +56,7 @@ export class RunnerOptions {
     this._extensionsDisabled = extensionsDisabled;
     this._aiLabModelUploadDisabled = aiLabModelUploadDisabled;
     this._binaryPath = binaryPath;
+    this._customSettings = customSettings;
   }
 
   public createSettingsJson(): string {
@@ -66,6 +70,7 @@ export class RunnerOptions {
         'extensions.disabled': this._extensionsDisabled,
         'ai-lab.modelUploadDisabled': this._aiLabModelUploadDisabled,
         'podman.binary.path': this._binaryPath,
+        ...this._customSettings,
       });
     }
 
@@ -75,6 +80,7 @@ export class RunnerOptions {
       'extensions.autoCheckUpdates': this._autoCheckUpdates,
       'extensions.disabled': this._extensionsDisabled,
       'ai-lab.modelUploadDisabled': this._aiLabModelUploadDisabled,
+      ...this._customSettings,
     });
   }
 }


### PR DESCRIPTION
### What does this PR do?
Adds a general catchall settings object that can be used outside for development purposes for settings that are not currently part of the model.

### What issues does this PR fix or reference?
https://github.com/containers/podman-desktop/issues/9043
