### PR TITLE
chore(test): enable user mode networking

### DIFF
--- a/tests/playwright/src/specs/podman-machine-tests.spec.ts
+++ b/tests/playwright/src/specs/podman-machine-tests.spec.ts
@@ -16,14 +16,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import * as os from 'node:os';
-
 import { PodmanMachineDetails } from '../model/pages/podman-machine-details-page';
 import { PodmanOnboardingPage } from '../model/pages/podman-onboarding-page';
 import { ResourceConnectionCardPage } from '../model/pages/resource-connection-card-page';
 import { ResourcesPage } from '../model/pages/resources-page';
 import { expect as playExpect, test } from '../utility/fixtures';
 import { deletePodmanMachine, handleConfirmationDialog } from '../utility/operations';
+import { isLinux, isWindows } from '../utility/platform';
 import { waitForPodmanMachineStartup } from '../utility/wait';
 
 const DEFAULT_PODMAN_MACHINE = 'Podman Machine';
@@ -32,7 +31,7 @@ const ROOTLESS_PODMAN_MACHINE_VISIBLE = 'podman-machine-rootless';
 const ROOTLESS_PODMAN_MACHINE = 'Podman Machine rootless';
 const RESOURCE_NAME = 'podman';
 
-test.skip(os.platform() === 'linux', 'Tests suite should not run on Linux platform');
+test.skip(isLinux, 'Tests suite should not run on Linux platform');
 
 test.beforeAll(async ({ runner, welcomePage, page }) => {
   runner.setVideoAndTraceName('podman-machine-tests');
@@ -115,6 +114,14 @@ test.describe.serial(`Podman machine switching validation `, () => {
       await podmanMachineCreatePage.podmanMachineRootfulCheckbox.locator('..').click();
       await playExpect(podmanMachineCreatePage.podmanMachineRootfulCheckbox).not.toBeChecked();
     });
+
+    if (isWindows) {
+      await test.step('Set podman machine to use user mode networking', async () => {
+        await playExpect(podmanMachineCreatePage.podmanMachineUserModeNetworkingCheckbox).not.toBeChecked();
+        await podmanMachineCreatePage.podmanMachineUserModeNetworkingCheckbox.locator('..').click();
+        await playExpect(podmanMachineCreatePage.podmanMachineUserModeNetworkingCheckbox).toBeChecked();
+      });
+    }
 
     await test.step('Set podman machine to not start after creation', async () => {
       await playExpect(podmanMachineCreatePage.podmanMachineStartAfterCreationCheckbox).toBeChecked();


### PR DESCRIPTION
### What does this PR do?
Enable user mode networking when creating podman machine on windows platforms.

### What issues does this PR fix or reference?
https://github.com/containers/podman-desktop/issues/4666
