### PR TITLE
chore: add release notes to version button in status bar

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -577,7 +577,7 @@ export class PluginSystem {
       configurationRegistry,
       statusBarRegistry,
       commandRegistry,
-      taskManager,
+      taskManager, apiSender,
     );
     podmanDesktopUpdater.init();
 

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -577,7 +577,8 @@ export class PluginSystem {
       configurationRegistry,
       statusBarRegistry,
       commandRegistry,
-      taskManager, apiSender,
+      taskManager,
+      apiSender,
     );
     podmanDesktopUpdater.init();
 

--- a/packages/main/src/plugin/updater.spec.ts
+++ b/packages/main/src/plugin/updater.spec.ts
@@ -325,7 +325,7 @@ test('expect command update not to be called when configuration value on never',
 
 test('clicking on "Update Never" should set the configuration value to never', async () => {
   vi.mocked(messageBoxMock.showMessageBox).mockResolvedValue({
-    response: 2, // Update never
+    response: 3, // Update never
   });
 
   let mListener: (() => Promise<void>) | undefined;
@@ -404,7 +404,7 @@ describe('expect update command to depends on context', async () => {
 
     expect(messageBoxMock.showMessageBox).toHaveBeenCalledWith({
       cancelId: 1,
-      buttons: ['Update now', 'Remind me later', 'Do not show again'],
+      buttons: ['Update now', 'View release notes', 'Remind me later', 'Do not show again'],
       message:
         'A new version v@debug-next of Podman Desktop is available. Do you want to update your current version v@debug?',
       title: 'Update Available now',
@@ -420,7 +420,7 @@ describe('expect update command to depends on context', async () => {
 
     expect(messageBoxMock.showMessageBox).toHaveBeenCalledWith({
       cancelId: 1,
-      buttons: ['Update now', 'Cancel'],
+      buttons: ['Update now', 'View release notes', 'Cancel'],
       message:
         'A new version v@debug-next of Podman Desktop is available. Do you want to update your current version v@debug?',
       title: 'Update Available now',

--- a/packages/main/src/plugin/updater.spec.ts
+++ b/packages/main/src/plugin/updater.spec.ts
@@ -34,6 +34,7 @@ import { Disposable } from '/@/plugin/types/disposable.js';
 import { Updater } from '/@/plugin/updater.js';
 import * as util from '/@/util.js';
 
+import type { ApiSenderType } from './api.js';
 import type { TaskManager } from './tasks/task-manager.js';
 
 vi.mock('electron', () => ({
@@ -101,6 +102,10 @@ const taskManagerMock = {
   updateTask: vi.fn(),
 } as unknown as TaskManager;
 
+const apiSenderMock = {
+  send: vi.fn(),
+} as unknown as ApiSenderType;
+
 beforeEach(() => {
   vi.useFakeTimers();
   vi.resetAllMocks();
@@ -136,6 +141,7 @@ test('expect init to provide a disposable', () => {
     statusBarRegistryMock,
     commandRegistryMock,
     taskManagerMock,
+    apiSenderMock,
   );
   const disposable: unknown = updater.init();
   expect(disposable).toBeDefined();
@@ -149,6 +155,7 @@ test('expect init to register commands', () => {
     statusBarRegistryMock,
     commandRegistryMock,
     taskManagerMock,
+    apiSenderMock,
   ).init();
   expect(commandRegistryMock.registerCommand).toHaveBeenCalled();
 });
@@ -160,6 +167,7 @@ test('expect init to register configuration', () => {
     statusBarRegistryMock,
     commandRegistryMock,
     taskManagerMock,
+    apiSenderMock,
   ).init();
   expect(configurationRegistryMock.registerConfigurations).toHaveBeenCalled();
 });
@@ -190,6 +198,7 @@ test('expect update available entry to be displayed when expected', () => {
     statusBarRegistryMock,
     commandRegistryMock,
     taskManagerMock,
+    apiSenderMock,
   ).init();
 
   // listener should exist
@@ -227,6 +236,7 @@ test('expect default status entry to be displayed when no update available', () 
     statusBarRegistryMock,
     commandRegistryMock,
     taskManagerMock,
+    apiSenderMock,
   ).init();
 
   // listener should exist
@@ -264,6 +274,7 @@ test('expect default status entry when error No published versions on GitHub', (
     statusBarRegistryMock,
     commandRegistryMock,
     taskManagerMock,
+    apiSenderMock,
   ).init();
 
   // listener should exist
@@ -290,6 +301,7 @@ test('expect command update to be called when configuration value on startup', (
     statusBarRegistryMock,
     commandRegistryMock,
     taskManagerMock,
+    apiSenderMock,
   ).init();
 
   // call the listener (which should be the private updateAvailableEntry method)
@@ -314,6 +326,7 @@ test('expect command update not to be called when configuration value on never',
     statusBarRegistryMock,
     commandRegistryMock,
     taskManagerMock,
+    apiSenderMock,
   ).init();
 
   // call the listener (which should be the private updateAvailableEntry method)
@@ -342,6 +355,7 @@ test('clicking on "Update Never" should set the configuration value to never', a
     statusBarRegistryMock,
     commandRegistryMock,
     taskManagerMock,
+    apiSenderMock,
   ).init();
   expect(mListener).toBeDefined();
 
@@ -377,6 +391,7 @@ describe('expect update command to depends on context', async () => {
       statusBarRegistryMock,
       commandRegistryMock,
       taskManagerMock,
+      apiSenderMock,
     );
     updater.init();
 
@@ -467,6 +482,7 @@ describe('download task and progress', async () => {
       statusBarRegistryMock,
       commandRegistryMock,
       taskManagerMock,
+      apiSenderMock,
     ).init();
 
     // callbacks should exist
@@ -537,6 +553,7 @@ describe('download task and progress', async () => {
       statusBarRegistryMock,
       commandRegistryMock,
       taskManagerMock,
+      apiSenderMock,
     ).init();
 
     // call the update command callback

--- a/packages/main/src/plugin/updater.spec.ts
+++ b/packages/main/src/plugin/updater.spec.ts
@@ -590,6 +590,7 @@ test('open release notes from podman-desktop.io', async () => {
     statusBarRegistryMock,
     commandRegistryMock,
     taskManagerMock,
+    apiSenderMock,
   );
 
   vi.mocked(shell.openExternal).mockResolvedValue();
@@ -617,6 +618,7 @@ test('open release notes from GitHub', async () => {
     statusBarRegistryMock,
     commandRegistryMock,
     taskManagerMock,
+    apiSenderMock,
   );
   vi.mocked(shell.openExternal).mockResolvedValue();
   updater.init();
@@ -640,6 +642,7 @@ test('get release notes', async () => {
     statusBarRegistryMock,
     commandRegistryMock,
     taskManagerMock,
+    apiSenderMock,
   );
 
   updater.init();

--- a/packages/main/src/plugin/updater.ts
+++ b/packages/main/src/plugin/updater.ts
@@ -162,7 +162,7 @@ export class Updater {
         buttons: ['View release notes'],
       });
       if (result.response === 0) {
-        await this.configurationRegistry.updateConfigurationValue(`releaseNotesBanner.show.${app.getVersion()}`, true);
+        await this.configurationRegistry.updateConfigurationValue(`releaseNotesBanner.show`, 'show');
         console.log(`this.apiSender.send('show-release-notes');`);
       }
     });

--- a/packages/main/src/plugin/updater.ts
+++ b/packages/main/src/plugin/updater.ts
@@ -37,6 +37,7 @@ import { Disposable } from '/@/plugin/types/disposable.js';
 import { isLinux } from '/@/util.js';
 import type { ReleaseNotesInfo } from '/@api/release-notes-info.js';
 
+import type { ApiSenderType } from './api.js';
 import { homepage, repository } from '../../../../package.json';
 import type { TaskManager } from './tasks/task-manager.js';
 
@@ -59,6 +60,7 @@ export class Updater {
     private statusBarRegistry: StatusBarRegistry,
     private commandRegistry: CommandRegistry,
     private taskManager: TaskManager,
+    private apiSender: ApiSenderType,
   ) {
     this.#currentVersion = `v${app.getVersion()}`;
     this.#updateInProgress = false;

--- a/packages/main/src/plugin/updater.ts
+++ b/packages/main/src/plugin/updater.ts
@@ -37,8 +37,8 @@ import { Disposable } from '/@/plugin/types/disposable.js';
 import { isLinux } from '/@/util.js';
 import type { ReleaseNotesInfo } from '/@api/release-notes-info.js';
 
-import type { ApiSenderType } from './api.js';
 import { homepage, repository } from '../../../../package.json';
+import type { ApiSenderType } from './api.js';
 import type { TaskManager } from './tasks/task-manager.js';
 
 /**
@@ -163,7 +163,7 @@ export class Updater {
       });
       if (result.response === 0) {
         await this.configurationRegistry.updateConfigurationValue(`releaseNotesBanner.show`, 'show');
-        console.log(`this.apiSender.send('show-release-notes');`);
+        this.apiSender.send('show-release-notes');
       }
     });
   }
@@ -217,7 +217,7 @@ export class Updater {
       if (result.response === 3) {
         this.updateConfigurationValue('never');
       } else if (result.response === 1) {
-        console.log('await this.openReleaseNotes(updateVersion)');
+        await this.openReleaseNotes(updateVersion);
       } else if (result.response === 0) {
         this.#updateInProgress = true;
         this.#updateAlreadyDownloaded = false;


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Adds `View release notes` button to the status bar version message box. 

### Screenshot / video of UI
(will work like this after https://github.com/containers/podman-desktop/pull/8753 is merged)

[Screencast from 2024-09-23 21-26-30.webm](https://github.com/user-attachments/assets/ff8cf715-a9af-41a2-88dd-d9178fbdbfb0)

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/containers/podman-desktop/issues/8521

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
