### PR TITLE
chore(test): view pod deployment info logs and increase deployment timeout

### DIFF
--- a/packages/renderer/src/lib/pod/DeployPodToKube.svelte
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.svelte
@@ -557,7 +557,7 @@ function updateKubeResult() {
             </div>
           {/if}
         </div>
-        <div class="text-[var(--pd-content-card-text)]">
+        <div class="text-[var(--pd-content-card-text)]" role="region" aria-label="Pod Deployment Status Info">
           {#if createdPod.metadata?.name}
             <p class="pt-2">Name: {createdPod.metadata.name}</p>
           {/if}

--- a/tests/playwright/src/model/pages/deploy-to-kubernetes-page.ts
+++ b/tests/playwright/src/model/pages/deploy-to-kubernetes-page.ts
@@ -31,6 +31,7 @@ export class DeployToKubernetesPage extends BasePage {
   readonly restrictedContextCheckbox: Locator;
   readonly createIngressCheckbox: Locator;
   readonly selectPortCombobox: Locator;
+  readonly deploymentStatus: Locator;
 
   constructor(page: Page) {
     super(page);
@@ -44,6 +45,7 @@ export class DeployToKubernetesPage extends BasePage {
     this.restrictedContextCheckbox = this.content.getByRole('checkbox', { name: 'Use restricted security context' });
     this.createIngressCheckbox = this.content.getByRole('checkbox', { name: 'Create Ingress' });
     this.selectPortCombobox = this.content.getByRole('combobox', { name: 'Select a Port' });
+    this.deploymentStatus = this.content.getByRole('region', { name: 'Pod Deployment Status Info' });
   }
 
   public async deployPod(
@@ -56,7 +58,7 @@ export class DeployToKubernetesPage extends BasePage {
     }: DeployPodOptions = {},
     context: string,
     namespace: string = 'default',
-    timeout: number = 80000,
+    timeout: number = 100_000,
   ): Promise<void> {
     await playExpect(this.podName).toBeVisible();
     await this.podName.clear();
@@ -107,6 +109,8 @@ export class DeployToKubernetesPage extends BasePage {
 
     await playExpect(this.deployButton).toBeEnabled();
     await this.deployButton.click();
+    await playExpect(this.deploymentStatus).toBeVisible();
+    await this.deploymentStatus.scrollIntoViewIfNeeded();
     await playExpect(this.doneButton).toBeVisible({ timeout: timeout });
   }
 


### PR DESCRIPTION

Signed-off-by: Anton Misskii <amisskii@redhat.com>

### What does this PR do?

- Scrolls to the pod deployment logs.
- Increases the deployment timeout.



### What issues does this PR fix or reference?

https://github.com/containers/podman-desktop/issues/8943

- [ ] Tests are covering the bug fix or the new feature
