### PR TITLE
fix: call fileItem onChange only when there is actually a change

### DIFF
--- a/packages/renderer/src/lib/preferences/item-formats/FileItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/FileItem.spec.ts
@@ -93,7 +93,7 @@ test('Ensure clicking on browse invokes openDialog with corresponding directory 
   });
 });
 
-test('Ensure the onChange is called if on:change is triggered', async () => {
+test('Ensure the onChange is called if the fileInput onChange is triggered', async () => {
   const filename = 'somefile';
   openDialogMock.mockResolvedValue([filename]);
 

--- a/packages/renderer/src/lib/preferences/item-formats/FileItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/FileItem.spec.ts
@@ -26,6 +26,7 @@ import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/s
 import FileItem from './FileItem.svelte';
 
 const openDialogMock = vi.fn();
+
 beforeAll(() => {
   (window as any).getConfigurationValue = vi.fn();
   (window as any).openDialog = openDialogMock;
@@ -90,4 +91,28 @@ test('Ensure clicking on browse invokes openDialog with corresponding directory 
     title: 'Select record-description',
     selectors: ['openDirectory'],
   });
+});
+
+test('Ensure the onChange is called if on:change is triggered', async () => {
+  const filename = 'somefile';
+  openDialogMock.mockResolvedValue([filename]);
+
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'string',
+    format: 'file',
+  };
+
+  const onChangeMock = vi.fn().mockResolvedValue('');
+  render(FileItem, { record, value: '', onChange: onChangeMock });
+  const browseButton = screen.getByRole('button');
+  expect(browseButton).toBeInTheDocument();
+  await userEvent.click(browseButton);
+
+  expect(openDialogMock).toHaveBeenCalled();
+
+  expect(onChangeMock).toHaveBeenCalled();
 });

--- a/packages/renderer/src/lib/preferences/item-formats/FileItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/FileItem.svelte
@@ -9,20 +9,11 @@ export let record: IConfigurationPropertyRecordedSchema;
 export let value: string = '';
 export let onChange = async (_id: string, _value: string) => {};
 
-let lastValue: string;
-
 let invalidEntry = false;
 let dialogOptions: OpenDialogOptions = {
   title: `Select ${record.description}`,
   selectors: record.format === 'folder' ? ['openDirectory'] : ['openFile'],
 };
-
-$: if (value !== lastValue) {
-  if (record.id) {
-    onChange(record.id, value).catch((_: unknown) => (invalidEntry = true));
-  }
-  lastValue = value;
-}
 </script>
 
 <div class="w-full flex">
@@ -30,6 +21,11 @@ $: if (value !== lastValue) {
     id="input-standard-{record.id}"
     name={record.id}
     bind:value={value}
+    on:change={(e: CustomEvent<string>) => {
+      if (record.id) {
+        onChange(record.id, e.detail).catch((_: unknown) => (invalidEntry = true));
+      }
+    }}
     readonly={record.readonly ?? true}
     placeholder={record.placeholder}
     options={dialogOptions}

--- a/packages/renderer/src/lib/preferences/item-formats/FileItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/FileItem.svelte
@@ -21,9 +21,9 @@ let dialogOptions: OpenDialogOptions = {
     id="input-standard-{record.id}"
     name={record.id}
     bind:value={value}
-    on:change={(e: CustomEvent<string>) => {
+    onChange={(value: string) => {
       if (record.id) {
-        onChange(record.id, e.detail).catch((_: unknown) => (invalidEntry = true));
+        onChange(record.id, value).catch((_: unknown) => (invalidEntry = true));
       }
     }}
     readonly={record.readonly ?? true}

--- a/packages/renderer/src/lib/preferences/item-formats/FileItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/FileItem.svelte
@@ -14,6 +14,12 @@ let dialogOptions: OpenDialogOptions = {
   title: `Select ${record.description}`,
   selectors: record.format === 'folder' ? ['openDirectory'] : ['openFile'],
 };
+
+function onChangeFileInput(value: string): void {
+  if (record.id) {
+    onChange(record.id, value).catch((_: unknown) => (invalidEntry = true));
+  }
+}
 </script>
 
 <div class="w-full flex">
@@ -21,11 +27,7 @@ let dialogOptions: OpenDialogOptions = {
     id="input-standard-{record.id}"
     name={record.id}
     bind:value={value}
-    onChange={(value: string) => {
-      if (record.id) {
-        onChange(record.id, value).catch((_: unknown) => (invalidEntry = true));
-      }
-    }}
+    onChange={onChangeFileInput}
     readonly={record.readonly ?? true}
     placeholder={record.placeholder}
     options={dialogOptions}

--- a/packages/renderer/src/lib/ui/FileInput.spec.ts
+++ b/packages/renderer/src/lib/ui/FileInput.spec.ts
@@ -20,13 +20,11 @@ import '@testing-library/jest-dom/vitest';
 
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
-import * as svelte from 'svelte';
 import { beforeAll, expect, test, vi } from 'vitest';
 
 import FileInput from './FileInput.svelte';
 
 const openDialogMock = vi.fn();
-const dispatchMock = vi.fn();
 
 beforeAll(() => {
   (window as any).openDialog = openDialogMock;
@@ -44,12 +42,12 @@ test('Expect clicking the button opens file dialog', async () => {
   expect(openDialogMock).toHaveBeenCalled();
 });
 
-test('Expect value to change when selecting via file dialog', async () => {
-  vi.spyOn(svelte, 'createEventDispatcher').mockReturnValue(dispatchMock);
+test('Expect onChange function called with new value when selecting via file dialog', async () => {
   const filename = 'somefile';
   openDialogMock.mockResolvedValue([filename]);
 
-  render(FileInput, {});
+  const onChangeMock = vi.fn();
+  render(FileInput, { options: { title: 'title' }, onChange: onChangeMock });
 
   const browseButton = screen.getByRole('button');
   expect(browseButton).toBeInTheDocument();
@@ -61,5 +59,5 @@ test('Expect value to change when selecting via file dialog', async () => {
   expect(input).toBeInTheDocument();
   expect(input).toHaveValue(filename);
 
-  expect(dispatchMock).toHaveBeenCalledWith('change', filename);
+  expect(onChangeMock).toHaveBeenCalledWith(filename);
 });

--- a/packages/renderer/src/lib/ui/FileInput.spec.ts
+++ b/packages/renderer/src/lib/ui/FileInput.spec.ts
@@ -61,3 +61,42 @@ test('Expect onChange function called with new value when selecting via file dia
 
   expect(onChangeMock).toHaveBeenCalledWith(filename);
 });
+
+test('Expect onChange function called if user types', async () => {
+  const filename = 'somefile';
+  const onChangeMock = vi.fn();
+  render(FileInput, { options: { title: 'title' }, onChange: onChangeMock });
+
+  const browseButton = screen.getByRole('button');
+  expect(browseButton).toBeInTheDocument();
+  await userEvent.click(browseButton);
+
+  expect(openDialogMock).toHaveBeenCalled();
+
+  const input = screen.getByRole('textbox');
+  expect(input).toBeInTheDocument();
+
+  await userEvent.type(input, filename);
+
+  expect(onChangeMock).toHaveBeenCalledWith(filename);
+});
+
+test('Expect onChange function called if user paste content', async () => {
+  const filename = 'somefile';
+  const onChangeMock = vi.fn();
+  render(FileInput, { options: { title: 'title' }, onChange: onChangeMock });
+
+  const browseButton = screen.getByRole('button');
+  expect(browseButton).toBeInTheDocument();
+  await userEvent.click(browseButton);
+
+  expect(openDialogMock).toHaveBeenCalled();
+
+  const input = screen.getByRole('textbox');
+  expect(input).toBeInTheDocument();
+
+  await userEvent.click(input);
+  await userEvent.paste(filename);
+
+  expect(onChangeMock).toHaveBeenCalledWith(filename);
+});

--- a/packages/renderer/src/lib/ui/FileInput.spec.ts
+++ b/packages/renderer/src/lib/ui/FileInput.spec.ts
@@ -20,11 +20,13 @@ import '@testing-library/jest-dom/vitest';
 
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
+import * as svelte from 'svelte';
 import { beforeAll, expect, test, vi } from 'vitest';
 
 import FileInput from './FileInput.svelte';
 
 const openDialogMock = vi.fn();
+const dispatchMock = vi.fn();
 
 beforeAll(() => {
   (window as any).openDialog = openDialogMock;
@@ -43,6 +45,7 @@ test('Expect clicking the button opens file dialog', async () => {
 });
 
 test('Expect value to change when selecting via file dialog', async () => {
+  vi.spyOn(svelte, 'createEventDispatcher').mockReturnValue(dispatchMock);
   const filename = 'somefile';
   openDialogMock.mockResolvedValue([filename]);
 
@@ -57,4 +60,6 @@ test('Expect value to change when selecting via file dialog', async () => {
   const input = screen.getByRole('textbox');
   expect(input).toBeInTheDocument();
   expect(input).toHaveValue(filename);
+
+  expect(dispatchMock).toHaveBeenCalledWith('change', filename);
 });

--- a/packages/renderer/src/lib/ui/FileInput.svelte
+++ b/packages/renderer/src/lib/ui/FileInput.svelte
@@ -19,6 +19,11 @@ async function openDialog() {
     onChange(value);
   }
 }
+
+function onInput(event: Event): void {
+  const inputEvent = event as Event & { target: HTMLInputElement };
+  onChange(inputEvent.target.value);
+}
 </script>
 
 <div class="flex flex-row grow space-x-1.5">
@@ -27,7 +32,7 @@ async function openDialog() {
     name={name}
     class={$$props.class || ''}
     bind:value={value}
-    on:input
+    on:input={onInput}
     on:keypress
     placeholder={placeholder}
     readonly={readonly}

--- a/packages/renderer/src/lib/ui/FileInput.svelte
+++ b/packages/renderer/src/lib/ui/FileInput.svelte
@@ -2,7 +2,6 @@
 import { faFolderOpen } from '@fortawesome/free-solid-svg-icons';
 import type { OpenDialogOptions } from '@podman-desktop/api';
 import { Button, Input } from '@podman-desktop/ui-svelte';
-import { createEventDispatcher } from 'svelte';
 
 export let placeholder: string | undefined = undefined;
 export let id: string | undefined = undefined;
@@ -11,14 +10,13 @@ export let value: string | undefined = undefined;
 export let options: OpenDialogOptions;
 export let readonly: boolean = false;
 export let required: boolean = false;
-
-const dispatch = createEventDispatcher<{ change: string }>();
+export let onChange: (value: string) => void = () => {};
 
 async function openDialog() {
   const result = await window.openDialog(options);
   if (result?.[0]) {
     value = result[0];
-    dispatch('change', value);
+    onChange(value);
   }
 }
 </script>

--- a/packages/renderer/src/lib/ui/FileInput.svelte
+++ b/packages/renderer/src/lib/ui/FileInput.svelte
@@ -2,6 +2,7 @@
 import { faFolderOpen } from '@fortawesome/free-solid-svg-icons';
 import type { OpenDialogOptions } from '@podman-desktop/api';
 import { Button, Input } from '@podman-desktop/ui-svelte';
+import { createEventDispatcher } from 'svelte';
 
 export let placeholder: string | undefined = undefined;
 export let id: string | undefined = undefined;
@@ -11,10 +12,13 @@ export let options: OpenDialogOptions;
 export let readonly: boolean = false;
 export let required: boolean = false;
 
+const dispatch = createEventDispatcher<{ change: string }>();
+
 async function openDialog() {
   const result = await window.openDialog(options);
   if (result?.[0]) {
     value = result[0];
+    dispatch('change', value);
   }
 }
 </script>


### PR DESCRIPTION
### What does this PR do?

This PR updates how the fileItem onChange function is called. Before there was a reactive clause which was triggered even when the component got loaded, which was wrong because there was no need to save the value (it was given by the parent). Now it behaves more naturally, when the on:change gets triggered, the onChange gets called. This prevents from having a first useless call which caused some misbehavior when working on the create new page with hyperv (following https://github.com/containers/podman-desktop/pull/8985)

### Screenshot / video of UI

From a user perspective nothing changes
N/A

### What issues does this PR fix or reference?

it is part of the hyperv/wsl work

### How to test this PR?

1. run tests

- [x] Tests are covering the bug fix or the new feature
