### PR TITLE
feat(website): improve storybook sidebar

### DIFF
--- a/website/storybook.spec.ts
+++ b/website/storybook.spec.ts
@@ -1,0 +1,241 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { describe, expect, test } from 'vitest';
+
+import { StorybookSidebarBuilder } from './storybook';
+
+const BASIC_STORYBOOK_SIDEBAR = {
+  v: 5,
+  entries: {
+    'checkbox--docs': {
+      id: 'checkbox--docs',
+      title: 'Checkbox',
+      name: 'Docs',
+      importPath: './src/stories/Checkbox.stories.svelte',
+      type: 'docs',
+      tags: ['dev', 'test', 'autodocs'],
+      storiesImports: [],
+    },
+    'checkbox--basic': {
+      type: 'story',
+      id: 'checkbox--basic',
+      name: 'Basic',
+      title: 'Checkbox',
+      importPath: './src/stories/Checkbox.stories.svelte',
+      tags: ['dev', 'test', 'autodocs'],
+    },
+    'checkbox--checked': {
+      type: 'story',
+      id: 'checkbox--checked',
+      name: 'Checked',
+      title: 'Checkbox',
+      importPath: './src/stories/Checkbox.stories.svelte',
+      tags: ['dev', 'test', 'autodocs'],
+    },
+  },
+};
+
+const DEEP_STORYBOOK_SIDEBAR = {
+  v: 5,
+  entries: {
+    'checkbox--docs': {
+      id: 'checkbox--docs',
+      title: 'Checkbox',
+      name: 'Docs',
+      importPath: './src/stories/Checkbox.stories.svelte',
+      type: 'docs',
+      tags: ['dev', 'test', 'autodocs'],
+      storiesImports: [],
+    },
+    'progress-linearprogress--docs': {
+      id: 'progress-linearprogress--docs',
+      title: 'Progress/LinearProgress',
+      name: 'Docs',
+      importPath: './src/stories/progress/LinearProgress.stories.svelte',
+      type: 'docs',
+      tags: ['dev', 'test', 'autodocs'],
+      storiesImports: [],
+    },
+    'progress-linearprogress--basic': {
+      type: 'story',
+      id: 'progress-linearprogress--basic',
+      name: 'Basic',
+      title: 'Progress/LinearProgress',
+      importPath: './src/stories/progress/LinearProgress.stories.svelte',
+      tags: ['dev', 'test', 'autodocs'],
+    },
+    'progress-spinner--docs': {
+      id: 'progress-spinner--docs',
+      title: 'Progress/Spinner',
+      name: 'Docs',
+      importPath: './src/stories/progress/Spinner.stories.svelte',
+      type: 'docs',
+      tags: ['dev', 'test', 'autodocs'],
+      storiesImports: [],
+    },
+  },
+};
+describe('StorybookSidebarBuilder', () => {
+  test('malformed object should throw an error', () => {
+    const builder = new StorybookSidebarBuilder();
+    expect(() => {
+      builder.fromStorybookIndex(false).build();
+    }).toThrowError('malformed storybook object');
+  });
+
+  test('missing version in storybook index should throw an error', () => {
+    const builder = new StorybookSidebarBuilder();
+    expect(() => {
+      builder.fromStorybookIndex({}).build();
+    }).toThrowError('missing version in storybook index');
+  });
+
+  test('incompatible version should an error', () => {
+    const builder = new StorybookSidebarBuilder();
+    expect(() => {
+      builder
+        .fromStorybookIndex({
+          v: 6,
+        })
+        .build();
+    }).toThrowError('invalid version number for storybook index');
+  });
+
+  test('missing entries should an error', () => {
+    const builder = new StorybookSidebarBuilder();
+    expect(() => {
+      builder
+        .fromStorybookIndex({
+          v: 5,
+        })
+        .build();
+    }).toThrowError('missing entries in storybook index');
+  });
+
+  test('missing entries should an error', () => {
+    const builder = new StorybookSidebarBuilder();
+    expect(() => {
+      builder
+        .fromStorybookIndex({
+          v: 5,
+        })
+        .build();
+    }).toThrowError('missing entries in storybook index');
+  });
+
+  test('no entries should return an empty array', () => {
+    const builder = new StorybookSidebarBuilder();
+    const result = builder
+      .fromStorybookIndex({
+        v: 5,
+        entries: {},
+      })
+      .build();
+    expect(result).toHaveLength(0);
+  });
+
+  test('basic storybook index', () => {
+    const builder = new StorybookSidebarBuilder();
+    const result = builder.fromStorybookIndex(BASIC_STORYBOOK_SIDEBAR).build();
+    expect(result).toStrictEqual([
+      {
+        collapsed: false,
+        collapsible: true,
+        items: [
+          {
+            href: '/storybook?id=checkbox--docs',
+            label: 'Docs',
+            type: 'link',
+          },
+          {
+            href: '/storybook?id=checkbox--basic',
+            label: 'Basic',
+            type: 'link',
+          },
+          {
+            href: '/storybook?id=checkbox--checked',
+            label: 'Checked',
+            type: 'link',
+          },
+        ],
+        label: 'Checkbox',
+        type: 'category',
+      },
+    ]);
+  });
+
+  test('multi category storybook index', () => {
+    const builder = new StorybookSidebarBuilder();
+    const result = builder.fromStorybookIndex(DEEP_STORYBOOK_SIDEBAR).build();
+    expect(result).toStrictEqual([
+      {
+        collapsed: false,
+        collapsible: true,
+        items: [
+          {
+            href: '/storybook?id=checkbox--docs',
+            label: 'Docs',
+            type: 'link',
+          },
+        ],
+        label: 'Checkbox',
+        type: 'category',
+      },
+      {
+        collapsed: false,
+        collapsible: true,
+        items: [
+          {
+            collapsed: false,
+            collapsible: true,
+            items: [
+              {
+                href: '/storybook?id=progress-linearprogress--docs',
+                label: 'Docs',
+                type: 'link',
+              },
+              {
+                href: '/storybook?id=progress-linearprogress--basic',
+                label: 'Basic',
+                type: 'link',
+              },
+            ],
+            label: 'LinearProgress',
+            type: 'category',
+          },
+          {
+            collapsed: false,
+            collapsible: true,
+            items: [
+              {
+                href: '/storybook?id=progress-spinner--docs',
+                label: 'Docs',
+                type: 'link',
+              },
+            ],
+            label: 'Spinner',
+            type: 'category',
+          },
+        ],
+        label: 'Progress',
+        type: 'category',
+      },
+    ]);
+  });
+});

--- a/website/storybook.ts
+++ b/website/storybook.ts
@@ -19,7 +19,7 @@
 import fs from 'node:fs';
 import { join } from 'node:path';
 
-import type { PropSidebarItem } from '@docusaurus/plugin-content-docs';
+import type { PropSidebarItem, PropSidebarItemCategory, PropSidebarItemLink } from '@docusaurus/plugin-content-docs';
 import type { LoadContext, Plugin, PluginOptions as DocusaurusOptions } from '@docusaurus/types';
 
 export interface PluginOptions extends DocusaurusOptions {
@@ -39,32 +39,101 @@ export interface StorybookItem {
   tags: string[];
 }
 
-function populate(folder: string, storybookStatic: string): void {
-  const index = require(join(storybookStatic, 'index.json'));
+export class StorybookSidebarBuilder {
+  private items: StorybookItem[] = [];
 
-  if (index['v'] !== 5)
-    throw new Error(`index version is not compatible with current script. Expected 5 got ${index['v']}.`);
+  public fromStorybookIndex(index: unknown): StorybookSidebarBuilder {
+    if (!index || typeof index !== 'object') {
+      throw new Error('malformed storybook object');
+    }
 
-  const groups = new Map<string, PropSidebarItem[]>();
+    if (!('v' in index)) {
+      throw new Error('missing version in storybook index');
+    }
 
-  for (const item of Object.values(index['entries']) as StorybookItem[]) {
-    groups.set(item.title, [
-      ...(groups.get(item.title) ?? []),
-      {
-        type: 'link',
-        label: item.name,
-        href: `/storybook?id=${item.id}`,
-      },
-    ]);
+    if (typeof index['v'] !== 'number' || index['v'] !== 5) {
+      throw new Error('invalid version number for storybook index');
+    }
+
+    if (!('entries' in index)) {
+      throw new Error('missing entries in storybook index');
+    }
+
+    Object.entries(index['entries']).forEach(([_, value]) => {
+      if (!('id' in value)) {
+        throw new Error('missing id in storybook entry');
+      }
+
+      if (!('title' in value)) {
+        throw new Error('missing title in storybook entry');
+      }
+
+      if (!('name' in value)) {
+        throw new Error('missing name in storybook entry');
+      }
+
+      this.items.push(value);
+    });
+
+    return this;
   }
 
-  const sidebar: PropSidebarItem[] = Array.from(groups.entries()).map(([key, value]) => ({
-    type: 'category',
-    label: key,
-    items: value,
-    collapsed: false,
-    collapsible: true,
-  }));
+  public build(): PropSidebarItemCategory[] {
+    const output: Map<string, PropSidebarItemCategory> = new Map();
+
+    for (const item of this.items) {
+      const keys: string[] = item.title.split('/');
+
+      let top: PropSidebarItemCategory;
+      if (output.has(keys[0])) {
+        top = output.get(keys[0]);
+      } else {
+        top = this.createCategory(keys[0]);
+        output.set(keys[0], top);
+      }
+
+      let current: PropSidebarItemCategory = top;
+      for (let i = 1; i < keys.length; i++) {
+        let category: PropSidebarItemCategory | undefined = current.items.find(
+          (item): item is PropSidebarItemCategory => item.type === 'category' && item.label === keys[i],
+        );
+
+        if (!category) {
+          category = this.createCategory(keys[i]);
+          current.items.push(category);
+        }
+
+        current = category;
+      }
+
+      current.items.push(this.createLink(item.name, item.id));
+    }
+
+    return Array.from(output.values());
+  }
+
+  private createCategory(label: string): PropSidebarItemCategory {
+    return {
+      type: 'category',
+      items: [],
+      collapsed: false,
+      collapsible: true,
+      label,
+    };
+  }
+
+  private createLink(label: string, id: string): PropSidebarItemLink {
+    return {
+      type: 'link',
+      label: label,
+      href: `/storybook?id=${id}`,
+    };
+  }
+}
+
+function populate(folder: string, storybookStatic: string): void {
+  const index = require(join(storybookStatic, 'index.json'));
+  const sidebar: PropSidebarItem[] = new StorybookSidebarBuilder().fromStorybookIndex(index).build();
 
   // Write the generate sidebar to the output directory
   fs.writeFileSync(join(folder, 'sidebar.cjs'), `module.exports = ${JSON.stringify(sidebar)};`);


### PR DESCRIPTION
### What does this PR do?

Give more depth to the Storybook sidebar on the docusaurus website. E.g. Before `Progress/LinearProgress` and `Progress/Spinner` was at the same level, now there are a new subcategory `Progress` with LinearProgress and `Spinner` under it.

It uses the `/` as separator, to create the hierarchy.

### Screenshot / video of UI

| before | after |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/8eb94f8d-d08c-452e-a612-a9ba7338c06c) | ![image](https://github.com/user-attachments/assets/ec5f195e-c2b5-44e0-a413-de7367f54d43) |

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/8846

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
