### PR TITLE
chore: add redirect for core-values

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -294,6 +294,10 @@ const config = {
               '/docs/extensions/write/adding-icons',
             ],
           },
+          {
+            to: '/',
+            from: '/core-values',
+          },
         ],
       },
     ],


### PR DESCRIPTION
### What does this PR do?

Core values was removed, this just adds a redirect to the homepage to avoid 404s.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #9084.

### How to test this PR?

Use `pnpm website:prod`, changing the url to `/core-values` should redirect to the homepage.