### PR TITLE
feat: hide Kubernetes menu when kubernetes empty page is displayed

### DIFF
--- a/packages/renderer/src/App.spec.ts
+++ b/packages/renderer/src/App.spec.ts
@@ -27,7 +27,7 @@ import type { ContextGeneralState } from '/@api/kubernetes-contexts-states';
 import { NO_CURRENT_CONTEXT_ERROR } from '/@api/kubernetes-contexts-states';
 
 import App from './App.svelte';
-import { navigationRegistry } from './stores/navigation/navigation-registry';
+import { navigationRegistry, type NavigationRegistryEntry } from './stores/navigation/navigation-registry';
 
 const mocks = vi.hoisted(() => ({
   DashboardPage: vi.fn(),
@@ -151,6 +151,7 @@ test('opens submenu when a `submenu` menu is opened', async () => {
       get counter() {
         return 0;
       },
+      items: [{} as NavigationRegistryEntry],
     },
   ]);
   render(App);
@@ -168,7 +169,7 @@ test('do not display kubernetes empty screen if current context', async () => {
   expect(mocks.DeploymentsList).toHaveBeenCalled();
 });
 
-test('displays kubernetes empty screen if no current context', async () => {
+test('displays kubernetes empty screen if no current context, without Kubernetes menu', async () => {
   vi.mocked(kubeContextStore).kubernetesCurrentContextState = readable({
     reachable: false,
     error: NO_CURRENT_CONTEXT_ERROR,
@@ -180,4 +181,5 @@ test('displays kubernetes empty screen if no current context', async () => {
   await tick();
   expect(mocks.KubernetesEmptyPage).toHaveBeenCalled();
   expect(mocks.DeploymentsList).not.toHaveBeenCalled();
+  expect(mocks.SubmenuNavigation).not.toHaveBeenCalled();
 });

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -116,7 +116,7 @@ window.events?.receive('navigate', (navigationRequest: unknown) => {
         <PreferencesNavigation meta={meta} />
       {/if}
       {#each $navigationRegistry.filter(item => item.type === 'submenu') as navigationRegistryItem}
-        {#if meta.url.startsWith(navigationRegistryItem.link)}
+        {#if meta.url.startsWith(navigationRegistryItem.link) && navigationRegistryItem.items?.length}
           <SubmenuNavigation meta={meta} title={navigationRegistryItem.tooltip} items={navigationRegistryItem.items} />
         {/if}
       {/each}

--- a/packages/renderer/src/AppNavigation.spec.ts
+++ b/packages/renderer/src/AppNavigation.spec.ts
@@ -26,6 +26,7 @@ import { beforeAll, expect, test, vi } from 'vitest';
 
 import * as kubeContextStore from '/@/stores/kubernetes-contexts-state';
 import type { ContributionInfo } from '/@api/contribution-info';
+import type { ContextGeneralState } from '/@api/kubernetes-contexts-states';
 
 import AppNavigation from './AppNavigation.svelte';
 import { contributions } from './stores/contribs';
@@ -58,6 +59,7 @@ test('Test rendering of the navigation bar with empty items', async () => {
   vi.mocked(kubeContextStore).kubernetesCurrentContextConfigMaps = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextSecrets = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextPersistentVolumeClaims = readable<KubernetesObject[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextState = readable<ContextGeneralState>({} as ContextGeneralState);
 
   // init navigation registry
   await fetchNavigationRegistries();

--- a/packages/renderer/src/stores/navigation/navigation-registry-kubernetes.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-kubernetes.svelte.spec.ts
@@ -17,20 +17,24 @@
  ***********************************************************************/
 
 import type { KubernetesObject } from '@kubernetes/client-node';
+import { readable } from 'svelte/store';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import KubeIcon from '/@/lib/images/KubeIcon.svelte';
+import { type ContextGeneralState, NO_CURRENT_CONTEXT_ERROR } from '/@api/kubernetes-contexts-states';
 
+import * as kubeContextStore from '../kubernetes-contexts-state';
 import { createNavigationKubernetesGroup } from './navigation-registry-kubernetes.svelte';
+
+vi.mock('../kubernetes-contexts-state', async () => {
+  return {};
+});
 
 beforeEach(() => {
   vi.resetAllMocks();
-  (window as any).kubernetesRegisterGetCurrentContextResources = kubernetesRegisterGetCurrentContextResourcesMock;
 });
 
-const kubernetesRegisterGetCurrentContextResourcesMock = vi.fn();
-
-test('createNavigationImageEntry', async () => {
+test('createNavigationImageEntry with current context', async () => {
   const nodes: KubernetesObject[] = [
     {
       apiVersion: 'v1',
@@ -47,7 +51,15 @@ test('createNavigationImageEntry', async () => {
       },
     },
   ];
-  kubernetesRegisterGetCurrentContextResourcesMock.mockResolvedValue(nodes);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextState = readable<ContextGeneralState>({} as ContextGeneralState);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextNodes = readable<KubernetesObject[]>(nodes);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextDeployments = readable<KubernetesObject[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextServices = readable<KubernetesObject[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextIngresses = readable<KubernetesObject[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextRoutes = readable<KubernetesObject[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextConfigMaps = readable<KubernetesObject[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextSecrets = readable<KubernetesObject[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextPersistentVolumeClaims = readable<KubernetesObject[]>([]);
 
   const entry = createNavigationKubernetesGroup();
 
@@ -58,5 +70,30 @@ test('createNavigationImageEntry', async () => {
   // should have 6 items
   await vi.waitFor(() => {
     expect(entry.items?.length).toBe(6);
+  });
+});
+
+test('createNavigationImageEntry without current context', async () => {
+  vi.mocked(kubeContextStore).kubernetesCurrentContextState = readable<ContextGeneralState>({
+    error: NO_CURRENT_CONTEXT_ERROR,
+  } as ContextGeneralState);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextNodes = readable<KubernetesObject[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextDeployments = readable<KubernetesObject[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextServices = readable<KubernetesObject[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextIngresses = readable<KubernetesObject[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextRoutes = readable<KubernetesObject[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextConfigMaps = readable<KubernetesObject[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextSecrets = readable<KubernetesObject[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextPersistentVolumeClaims = readable<KubernetesObject[]>([]);
+
+  const entry = createNavigationKubernetesGroup();
+
+  expect(entry).toBeDefined();
+  expect(entry.name).toBe('Kubernetes');
+  expect(entry.icon.iconComponent).toBe(KubeIcon);
+
+  // should have 0 items
+  await vi.waitFor(() => {
+    expect(entry.items?.length).toBe(0);
   });
 });

--- a/packages/renderer/src/stores/navigation/navigation-registry-kubernetes.svelte.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-kubernetes.svelte.ts
@@ -17,7 +17,9 @@
  ***********************************************************************/
 
 import KubeIcon from '/@/lib/images/KubeIcon.svelte';
+import { NO_CURRENT_CONTEXT_ERROR } from '/@api/kubernetes-contexts-states';
 
+import { kubernetesCurrentContextState } from '../kubernetes-contexts-state';
 import { createNavigationKubernetesConfigMapSecretsEntry } from './kubernetes/navigation-registry-k8s-configmap-secrets.svelte';
 import { createNavigationKubernetesDeploymentsEntry } from './kubernetes/navigation-registry-k8s-deployments.svelte';
 import { createNavigationKubernetesIngressesRoutesEntry } from './kubernetes/navigation-registry-k8s-ingresses-routes.svelte';
@@ -37,6 +39,10 @@ export function createNavigationKubernetesGroup(): NavigationRegistryEntry {
   newItems.push(createNavigationKubernetesPersistentVolumeEntry());
   newItems.push(createNavigationKubernetesConfigMapSecretsEntry());
   kubernetesNavigationGroupItems = newItems;
+
+  kubernetesCurrentContextState.subscribe(value => {
+    kubernetesNavigationGroupItems = value.error === NO_CURRENT_CONTEXT_ERROR ? [] : newItems;
+  });
 
   const mainGroupEntry: NavigationRegistryEntry = {
     name: 'Kubernetes',

--- a/packages/renderer/src/stores/navigation/navigation-registry-kubernetes.svelte.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-kubernetes.svelte.ts
@@ -28,7 +28,12 @@ import { createNavigationKubernetesPersistentVolumeEntry } from './kubernetes/na
 import { createNavigationKubernetesServicesEntry } from './kubernetes/navigation-registry-k8s-services.svelte';
 import type { NavigationRegistryEntry } from './navigation-registry';
 
+// All the items for the menu
 let kubernetesNavigationGroupItems: NavigationRegistryEntry[] = $state([]);
+// Is there a Kubernetes context?
+let context = $state(true);
+// the items being returned to the caller, depending on the existence of a context
+const displayedItems = $derived(context ? kubernetesNavigationGroupItems : []);
 
 export function createNavigationKubernetesGroup(): NavigationRegistryEntry {
   const newItems: NavigationRegistryEntry[] = [];
@@ -41,7 +46,7 @@ export function createNavigationKubernetesGroup(): NavigationRegistryEntry {
   kubernetesNavigationGroupItems = newItems;
 
   kubernetesCurrentContextState.subscribe(value => {
-    kubernetesNavigationGroupItems = value.error === NO_CURRENT_CONTEXT_ERROR ? [] : newItems;
+    context = value.error !== NO_CURRENT_CONTEXT_ERROR;
   });
 
   const mainGroupEntry: NavigationRegistryEntry = {
@@ -54,7 +59,7 @@ export function createNavigationKubernetesGroup(): NavigationRegistryEntry {
       return 0;
     },
     get items() {
-      return kubernetesNavigationGroupItems;
+      return displayedItems;
     },
   };
 

--- a/packages/renderer/src/stores/navigation/navigation-registry.spec.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry.spec.ts
@@ -25,16 +25,20 @@ import { configurationProperties } from '../configurationProperties';
 import { fetchNavigationRegistries, navigationRegistry } from './navigation-registry';
 
 const kubernetesRegisterGetCurrentContextResourcesMock = vi.fn();
+const kubernetesGetCurrentContextGeneralStateMock = vi.fn();
+
 const getConfigurationValueMock = vi.fn();
 beforeEach(() => {
   vi.resetAllMocks();
   (window as any).kubernetesRegisterGetCurrentContextResources = kubernetesRegisterGetCurrentContextResourcesMock;
+  (window as any).window.kubernetesGetCurrentContextGeneralState = kubernetesGetCurrentContextGeneralStateMock;
   (window as any).getConfigurationValue = getConfigurationValueMock;
   (window as any).sendNavigationItems = vi.fn();
 });
 
 test('check navigation registry items', async () => {
   kubernetesRegisterGetCurrentContextResourcesMock.mockResolvedValue([]);
+  kubernetesGetCurrentContextGeneralStateMock.mockResolvedValue({});
   await fetchNavigationRegistries();
   const registries = get(navigationRegistry);
   // expect 7 items in the registry


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Hide Kubernetes menu when kubernetes empty page is displayed

### Screenshot / video of UI

https://github.com/user-attachments/assets/8d130a9a-05e9-4b1e-a2b9-0d6512ec3ac8



### What issues does this PR fix or reference?

Part of #8571 

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
