### PR TITLE
chore: reduce size of kubernetes navigation

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -117,7 +117,12 @@ window.events?.receive('navigate', (navigationRequest: unknown) => {
       {/if}
       {#each $navigationRegistry.filter(item => item.type === 'submenu') as navigationRegistryItem}
         {#if meta.url.startsWith(navigationRegistryItem.link)}
-          <SubmenuNavigation meta={meta} title={navigationRegistryItem.tooltip} items={navigationRegistryItem.items} />
+          <!-- If the meta url starts with "kubernetes" we will pass mini=true to the submenu navigation to reduce the size of it for less whitespace -->
+          <SubmenuNavigation
+            meta={meta}
+            title={navigationRegistryItem.tooltip}
+            items={navigationRegistryItem.items}
+            mini={meta.url.startsWith('/kubernetes')} />
         {/if}
       {/each}
 

--- a/packages/renderer/src/SubmenuNavigation.spec.ts
+++ b/packages/renderer/src/SubmenuNavigation.spec.ts
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import '@testing-library/jest-dom';
+
 import { SettingsNavItem } from '@podman-desktop/ui-svelte';
 import { render, screen } from '@testing-library/svelte';
 import type { TinroRouteMeta } from 'tinro';
@@ -62,4 +64,30 @@ test('SubmenuNavigation displays a title and builds SettingsNavItem components',
     href: '/link2',
     selected: false,
   });
+});
+
+test('if mini=true is passed to SubmenuNavigation, it should render a mini version', async () => {
+  render(SubmenuNavigation, {
+    title: 'A title',
+    items: [
+      {
+        tooltip: 'entry 1',
+        link: '/link1',
+      } as unknown as NavigationRegistryEntry,
+      {
+        tooltip: 'entry 2',
+        link: '/link2',
+      } as unknown as NavigationRegistryEntry,
+    ],
+    meta: {
+      url: '/link1/subpath',
+    } as TinroRouteMeta,
+    mini: true,
+  });
+
+  // Expect w-minileftsidebar min-w-minileftsidebar classes to be present
+  // since 'mini' was passed as true
+  const miniLeftSidebar = screen.getByLabelText('A title Navigation Bar');
+  expect(miniLeftSidebar).toHaveClass('w-minileftsidebar');
+  expect(miniLeftSidebar).toHaveClass('min-w-minileftsidebar');
 });

--- a/packages/renderer/src/SubmenuNavigation.svelte
+++ b/packages/renderer/src/SubmenuNavigation.svelte
@@ -7,10 +7,13 @@ import type { NavigationRegistryEntry } from './stores/navigation/navigation-reg
 export let title: string;
 export let items: NavigationRegistryEntry[] | undefined;
 export let meta: TinroRouteMeta;
+export let mini: boolean = false;
 </script>
 
 <nav
-  class="z-1 w-leftsidebar min-w-leftsidebar flex-col justify-between flex transition-all duration-500 ease-in-out bg-[var(--pd-secondary-nav-bg)] border-[var(--pd-global-nav-bg-border)] border-r-[1px]"
+  class="z-1 {mini
+    ? 'w-minileftsidebar min-w-minileftsidebar'
+    : 'w-leftsidebar min-w-leftsidebar'} flex-col justify-between flex transition-all duration-500 ease-in-out bg-[var(--pd-secondary-nav-bg)] border-[var(--pd-global-nav-bg-border)] border-r-[1px]"
   aria-label={title + ' Navigation Bar'}>
   <div class="flex items-center">
     <div class="pt-4 px-3 mb-10">
@@ -20,7 +23,7 @@ export let meta: TinroRouteMeta;
       </p>
     </div>
   </div>
-  <div class="h-full overflow-hidden hover:overflow-y-auto" style="margin-bottom:auto">
+  <div class="h-full overflow-hidden hover:overflow-y-auto text-sm" style="margin-bottom:auto">
     {#each items ?? [] as item}
       <SettingsNavItem title={item.tooltip} href={item.link} selected={meta.url.startsWith(item.link)}
       ></SettingsNavItem>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -34,10 +34,12 @@ module.exports = {
       width: {
         leftnavbar: '48px',
         leftsidebar: '225px',
+        minileftsidebar: '150px',
       },
       minWidth: {
         leftnavbar: '48px',
         leftsidebar: '225px',
+        minileftsidebar: '150px',
       },
     },
     fontSize: {


### PR DESCRIPTION
chore: reduce size of kubernetes navigation

### What does this PR do?

* Reduces the size of the navigation menu to 'mini' version that's passed
into SubmenuNavigation.
* Adds "mini" version which is just a reduced width version of the
  submenu

Font improvements in the future (if needed) for the "mini" version which
may come in handy with other submenu components in the future that need
that whitespace.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

Before:
![Screenshot 2024-09-25 at 10 12 31 AM](https://github.com/user-attachments/assets/a075d4fd-9eaa-4b33-9c18-ef029157c65d)

After:
![Screenshot 2024-09-25 at 10 02 10 AM](https://github.com/user-attachments/assets/3ea0a547-3e39-4657-a02b-00fc96d42e59)



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/8771

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
