### PR TITLE
refactor: split ContextsStats and ContextsInformers

### DIFF
--- a/packages/main/src/plugin/kubernetes/contexts-informers.spec.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-informers.spec.ts
@@ -1,0 +1,78 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Informer, KubernetesObject } from '@kubernetes/client-node';
+import { describe, expect, test } from 'vitest';
+
+import { ContextsInformers } from './contexts-informers.js';
+import { FakeInformer } from './kubernetes-context-state.spec.js';
+
+describe('ContextsInformers tests', () => {
+  test('hasInformer should check if informer exists for context', () => {
+    const client = new ContextsInformers();
+    client.setInformers(
+      'context1',
+      new Map([['pods', new FakeInformer('context1', '/path/to/resource', 0, undefined, [], [])]]),
+    );
+    expect(client.hasInformer('context1', 'pods')).toBeTruthy();
+    expect(client.hasInformer('context1', 'deployments')).toBeFalsy();
+    expect(client.hasInformer('context2', 'pods')).toBeFalsy();
+    expect(client.hasInformer('context2', 'deployments')).toBeFalsy();
+  });
+
+  test('getContextsNames should return the names of contexts as array', () => {
+    const client = new ContextsInformers();
+    client.setInformers(
+      'context1',
+      new Map([['pods', new FakeInformer('context1', '/path/to/resource', 0, undefined, [], [])]]),
+    );
+    client.setInformers(
+      'context2',
+      new Map([['pods', new FakeInformer('context2', '/path/to/resource', 0, undefined, [], [])]]),
+    );
+    expect(Array.from(client.getContextsNames())).toEqual(['context1', 'context2']);
+  });
+
+  test('informers registry', () => {
+    const states = new ContextsInformers();
+    expect(states.hasContext('ctx1')).toBeFalsy();
+    expect(states.hasInformer('ctx1', 'services')).toBeFalsy();
+    expect(states.getContextsNames()).toMatchObject({});
+
+    states.setInformers('ctx1', new Map());
+    expect(states.hasContext('ctx1')).toBeTruthy();
+    expect(states.hasInformer('ctx1', 'services')).toBeFalsy();
+    expect(states.hasInformer('ctx1', 'pods')).toBeFalsy();
+
+    const informersWithService = new Map();
+    informersWithService.set('services', {} as Informer<KubernetesObject>);
+    states.setInformers('ctx1', informersWithService);
+    expect(states.hasContext('ctx1')).toBeTruthy();
+    expect(states.hasInformer('ctx1', 'services')).toBeTruthy();
+    expect(states.hasInformer('ctx1', 'pods')).toBeFalsy();
+
+    states.setResourceInformer('ctx1', 'pods', {} as Informer<KubernetesObject>);
+    expect(states.hasContext('ctx1')).toBeTruthy();
+    expect(states.hasInformer('ctx1', 'services')).toBeTruthy();
+    expect(states.hasInformer('ctx1', 'pods')).toBeTruthy();
+
+    expect(() => states.setResourceInformer('ctx2', 'pods', {} as Informer<KubernetesObject>)).toThrow(
+      'watchers for context ctx2 not found',
+    );
+  });
+});

--- a/packages/main/src/plugin/kubernetes/contexts-informers.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-informers.ts
@@ -1,0 +1,77 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Informer, KubernetesObject } from '@kubernetes/client-node';
+
+import type { ResourceName } from '/@api/kubernetes-contexts-states.js';
+
+import type { ContextInternalState } from './contexts-states.js';
+import { isSecondaryResourceName } from './contexts-states.js';
+
+export class ContextsInformers {
+  private informers = new Map<string, ContextInternalState>();
+
+  hasContext(name: string): boolean {
+    return this.informers.has(name);
+  }
+
+  hasInformer(context: string, resourceName: ResourceName): boolean {
+    const informers = this.informers.get(context);
+    return !!informers?.get(resourceName);
+  }
+
+  setInformers(name: string, informers: ContextInternalState | undefined): void {
+    if (informers) {
+      this.informers.set(name, informers);
+    }
+  }
+
+  setResourceInformer(contextName: string, resourceName: ResourceName, informer: Informer<KubernetesObject>): void {
+    const informers = this.informers.get(contextName);
+    if (!informers) {
+      throw new Error(`watchers for context ${contextName} not found`);
+    }
+    informers.set(resourceName, informer);
+  }
+
+  getContextsNames(): Iterable<string> {
+    return this.informers.keys();
+  }
+
+  async disposeSecondaryInformers(contextName: string): Promise<void> {
+    const informers = this.informers.get(contextName);
+    if (informers) {
+      for (const [resourceName, informer] of informers) {
+        if (isSecondaryResourceName(resourceName)) {
+          await informer?.stop();
+          informers.delete(resourceName);
+        }
+      }
+    }
+  }
+
+  async dispose(name: string): Promise<void> {
+    const informers = this.informers.get(name);
+    if (informers) {
+      for (const informer of informers.values()) {
+        await informer.stop();
+      }
+    }
+    this.informers.delete(name);
+  }
+}

--- a/packages/main/src/plugin/kubernetes/contexts-states.spec.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-states.spec.ts
@@ -15,86 +15,23 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import type { Informer, KubernetesObject } from '@kubernetes/client-node';
 import { describe, expect, test } from 'vitest';
 
 import { ContextsStates, isSecondaryResourceName } from './contexts-states.js';
-import { FakeInformer } from './kubernetes-context-state.spec.js';
 
 describe('ContextsStates tests', () => {
-  test('hasInformer should check if informer exists for context', () => {
-    const client = new ContextsStates();
-    client.setInformers(
-      'context1',
-      new Map([['pods', new FakeInformer('context1', '/path/to/resource', 0, undefined, [], [])]]),
-    );
-    expect(client.hasInformer('context1', 'pods')).toBeTruthy();
-    expect(client.hasInformer('context1', 'deployments')).toBeFalsy();
-    expect(client.hasInformer('context2', 'pods')).toBeFalsy();
-    expect(client.hasInformer('context2', 'deployments')).toBeFalsy();
-  });
-
-  test('getContextsNames should return the names of contexts as array', () => {
-    const client = new ContextsStates();
-    client.setInformers(
-      'context1',
-      new Map([['pods', new FakeInformer('context1', '/path/to/resource', 0, undefined, [], [])]]),
-    );
-    client.setInformers(
-      'context2',
-      new Map([['pods', new FakeInformer('context2', '/path/to/resource', 0, undefined, [], [])]]),
-    );
-    expect(Array.from(client.getContextsNames())).toEqual(['context1', 'context2']);
-  });
-
-  test('isReachable', () => {
-    const client = new ContextsStates();
-    client.setInformers(
-      'context1',
-      new Map([['pods', new FakeInformer('context1', '/path/to/resource', 0, undefined, [], [])]]),
-    );
-    client.setInformers(
-      'context2',
-      new Map([['pods', new FakeInformer('context2', '/path/to/resource', 0, undefined, [], [])]]),
-    );
-    client.safeSetState('context1', state => (state.reachable = true));
-
-    expect(client.isReachable('context1')).toBeTruthy();
-    expect(client.isReachable('context2')).toBeFalsy();
-    expect(client.isReachable('context3')).toBeFalsy();
-  });
-
   test('isSecondaryResourceName', () => {
     expect(isSecondaryResourceName('pods')).toBeFalsy();
     expect(isSecondaryResourceName('services')).toBeTruthy();
   });
 
-  test('informers registry', () => {
-    const states = new ContextsStates();
-    expect(states.hasContext('ctx1')).toBeFalsy();
-    expect(states.hasInformer('ctx1', 'services')).toBeFalsy();
-    expect(states.getContextsNames()).toMatchObject({});
+  test('isReachable', () => {
+    const client = new ContextsStates();
+    client.safeSetState('context1', state => (state.reachable = true));
 
-    states.setInformers('ctx1', new Map());
-    expect(states.hasContext('ctx1')).toBeTruthy();
-    expect(states.hasInformer('ctx1', 'services')).toBeFalsy();
-    expect(states.hasInformer('ctx1', 'pods')).toBeFalsy();
-
-    const informersWithService = new Map();
-    informersWithService.set('services', {} as Informer<KubernetesObject>);
-    states.setInformers('ctx1', informersWithService);
-    expect(states.hasContext('ctx1')).toBeTruthy();
-    expect(states.hasInformer('ctx1', 'services')).toBeTruthy();
-    expect(states.hasInformer('ctx1', 'pods')).toBeFalsy();
-
-    states.setResourceInformer('ctx1', 'pods', {} as Informer<KubernetesObject>);
-    expect(states.hasContext('ctx1')).toBeTruthy();
-    expect(states.hasInformer('ctx1', 'services')).toBeTruthy();
-    expect(states.hasInformer('ctx1', 'pods')).toBeTruthy();
-
-    expect(() => states.setResourceInformer('ctx2', 'pods', {} as Informer<KubernetesObject>)).toThrow(
-      'watchers for context ctx2 not found',
-    );
+    expect(client.isReachable('context1')).toBeTruthy();
+    expect(client.isReachable('context2')).toBeFalsy();
+    expect(client.isReachable('context3')).toBeFalsy();
   });
 
   test('state', () => {


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?
Move informers out of ContextsStats to have a separate ContextsInformers

### What issues does this PR fix or reference?

Part of #8775 

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
