### PR TITLE
feat: add telemetry on Kubernetes empty page

### DIFF
--- a/packages/renderer/src/lib/extensions/CatalogExtension.svelte
+++ b/packages/renderer/src/lib/extensions/CatalogExtension.svelte
@@ -8,8 +8,11 @@ import FeaturedExtensionDownload from '../featured/FeaturedExtensionDownload.sve
 import type { CatalogExtensionInfoUI } from './catalog-extension-info-ui';
 
 export let catalogExtensionUI: CatalogExtensionInfoUI;
+export let oninstall: (extensionId: string) => void = () => {};
+export let ondetails: (extensionId: string) => void = () => {};
 
 function openExtensionDetails() {
+  ondetails(catalogExtensionUI.id);
   router.goto(`/extensions/details/${catalogExtensionUI.id}/`);
 }
 </script>
@@ -56,7 +59,7 @@ function openExtensionDetails() {
         </div>
       {:else if catalogExtensionUI.fetchable}
         <div class="flex flex-1 justify-items-end w-18 flex-col items-end place-content-center">
-          <FeaturedExtensionDownload extension={catalogExtensionUI} />
+          <FeaturedExtensionDownload oninstall={oninstall} extension={catalogExtensionUI} />
         </div>
       {/if}
     </div>

--- a/packages/renderer/src/lib/extensions/CatalogExtensionList.svelte
+++ b/packages/renderer/src/lib/extensions/CatalogExtensionList.svelte
@@ -8,6 +8,8 @@ import CatalogExtension from './CatalogExtension.svelte';
 export let catalogExtensions: CatalogExtensionInfoUI[];
 export let title: string = 'Available extensions';
 export let showEmptyScreen: boolean = true;
+export let oninstall: (extensionId: string) => void = () => {};
+export let ondetails: (extensionId: string) => void = () => {};
 
 async function fetchCatalog() {
   try {
@@ -48,7 +50,7 @@ async function fetchCatalog() {
       role="region"
       aria-label="Catalog Extensions">
       {#each catalogExtensions as catalogExtension (catalogExtension.id)}
-        <CatalogExtension catalogExtensionUI={catalogExtension} />
+        <CatalogExtension ondetails={ondetails} oninstall={oninstall} catalogExtensionUI={catalogExtension} />
       {/each}
     </div>
   </div>

--- a/packages/renderer/src/lib/extensions/EmbeddableCatalogExtensionList.svelte
+++ b/packages/renderer/src/lib/extensions/EmbeddableCatalogExtensionList.svelte
@@ -14,6 +14,8 @@ export let category: string | undefined = undefined;
 export let keywords: string[] = [];
 export let title = 'Available extensions';
 export let showEmptyScreen: boolean = true;
+export let oninstall: (extensionId: string) => void = () => {};
+export let ondetails: (extensionId: string) => void = () => {};
 
 // show installed extensions
 export let showInstalled: boolean = true;
@@ -52,5 +54,10 @@ const catalogExtensions: Readable<CatalogExtensionInfoUI[]> = derived(
 </script>
 
 <div class="flex bg-[var(--pd-content-bg)] text-left">
-  <CatalogExtensionList title={title} showEmptyScreen={showEmptyScreen} catalogExtensions={$catalogExtensions} />
+  <CatalogExtensionList
+    oninstall={oninstall}
+    ondetails={ondetails}
+    title={title}
+    showEmptyScreen={showEmptyScreen}
+    catalogExtensions={$catalogExtensions} />
 </div>

--- a/packages/renderer/src/lib/featured/FeaturedExtensionDownload.svelte
+++ b/packages/renderer/src/lib/featured/FeaturedExtensionDownload.svelte
@@ -11,6 +11,7 @@ export let extension: {
   displayName: string;
   fetchable: boolean;
 };
+export let oninstall: (extensionId: string) => void = () => {};
 
 let installInProgress = false;
 
@@ -20,6 +21,7 @@ let errorInstall = '';
 let percentage = '0%';
 
 async function installExtension() {
+  oninstall(extension.id);
   errorInstall = '';
   console.log('User asked to install the extension with the following properties', extension);
   logs = [];

--- a/packages/renderer/src/lib/kube/KubernetesEmptyPage.spec.ts
+++ b/packages/renderer/src/lib/kube/KubernetesEmptyPage.spec.ts
@@ -42,6 +42,8 @@ vi.mock('tinro', () => {
   };
 });
 
+(window as any).telemetryTrack = vi.fn();
+
 test('expect to call EmbeddableCatalogExtensionList for Kubernetes providers local and remote', () => {
   render(KubernetesEmptyPage);
   expect(mocks.EmbeddableCatalogExtensionList).toHaveBeenCalledTimes(2);
@@ -78,9 +80,27 @@ test('expect to call EmbeddableCatalogExtensionList for Kubernetes providers loc
   );
 });
 
+test('expect to send telemetry when extension is installed or details viewed', () => {
+  mocks.EmbeddableCatalogExtensionList.mockImplementation((_, props) => {
+    if (props.keywords.includes('local')) {
+      props.oninstall('extension-local');
+    } else {
+      props.ondetails('extension-remote');
+    }
+  });
+  render(KubernetesEmptyPage);
+  expect(vi.mocked(window.telemetryTrack)).toHaveBeenCalledWith('kubernetes.nocontext.installExtension', {
+    extension: 'extension-local',
+  });
+  expect(vi.mocked(window.telemetryTrack)).toHaveBeenCalledWith('kubernetes.nocontext.showExtensionDetails', {
+    extension: 'extension-remote',
+  });
+});
+
 test('expect to have links for each Kubernetes provider', async () => {
   providerInfos.set([
     {
+      id: 'provider1',
       internalId: '101',
       name: 'Name 1',
       kubernetesProviderConnectionCreation: true,
@@ -88,11 +108,13 @@ test('expect to have links for each Kubernetes provider', async () => {
       kubernetesProviderConnectionCreationButtonTitle: 'Go create',
     } as unknown as ProviderInfo,
     {
+      id: 'provider2',
       internalId: '102',
       name: 'Name 2',
       kubernetesProviderConnectionCreation: true,
     } as unknown as ProviderInfo,
     {
+      id: 'provider3',
       internalId: '103',
       name: 'Name 3',
     } as unknown as ProviderInfo,
@@ -105,10 +127,16 @@ test('expect to have links for each Kubernetes provider', async () => {
   const link1 = screen.getByLabelText('Go create Provider 1...');
   await fireEvent.click(link1);
   expect(router.goto).toHaveBeenCalledWith('/preferences/provider/101');
+  expect(vi.mocked(window.telemetryTrack)).toHaveBeenCalledWith('kubernetes.nocontext.createNew', {
+    provider: 'provider1',
+  });
 
   const link2 = screen.getByLabelText('Create new Name 2...');
   await fireEvent.click(link2);
   expect(router.goto).toHaveBeenCalledWith('/preferences/provider/102');
+  expect(vi.mocked(window.telemetryTrack)).toHaveBeenCalledWith('kubernetes.nocontext.createNew', {
+    provider: 'provider2',
+  });
 
   expect(screen.queryByLabelText(/Name 3/)).toBeNull();
 

--- a/packages/renderer/src/lib/kube/KubernetesEmptyPage.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesEmptyPage.svelte
@@ -2,9 +2,30 @@
 import { Link } from '@podman-desktop/ui-svelte';
 import { router } from 'tinro';
 
+import type { ProviderInfo } from '/@api/provider-info';
+
 import { providerInfos } from '../../stores/providers';
 import EmbeddableCatalogExtensionList from '../extensions/EmbeddableCatalogExtensionList.svelte';
 import KubeIcon from '../images/KubeIcon.svelte';
+
+async function createNew(provider: ProviderInfo) {
+  await window.telemetryTrack('kubernetes.nocontext.createNew', {
+    provider: provider.id,
+  });
+  router.goto(`/preferences/provider/${provider.internalId}`);
+}
+
+async function oninstall(extensionId: string) {
+  await window.telemetryTrack('kubernetes.nocontext.installExtension', {
+    extension: extensionId,
+  });
+}
+
+async function ondetails(extensionId: string) {
+  await window.telemetryTrack('kubernetes.nocontext.showExtensionDetails', {
+    extension: extensionId,
+  });
+}
 </script>
 
 <div class="mt-8 flex justify-center overflow-auto">
@@ -20,18 +41,22 @@ import KubeIcon from '../images/KubeIcon.svelte';
     <div class="w-full justify-center flex flex-row space-x-3">
       {#each $providerInfos.filter(p => p.kubernetesProviderConnectionCreation) as provider}
         {@const label = `${provider.kubernetesProviderConnectionCreationButtonTitle ?? 'Create new'} ${provider.kubernetesProviderConnectionCreationDisplayName ?? provider.name}...`}
-        <Link onclick={() => router.goto(`/preferences/provider/${provider.internalId}`)} aria-label={label}>
+        <Link onclick={() => createNew(provider)} aria-label={label}>
           {label}
         </Link>
       {/each}
     </div>
     <EmbeddableCatalogExtensionList
+      oninstall={oninstall}
+      ondetails={ondetails}
       showEmptyScreen={false}
       title="Extensions to help you deploy Kubernetes clusters on your machine"
       category="Kubernetes"
       keywords={['provider', 'local']}
       showInstalled={false} />
     <EmbeddableCatalogExtensionList
+      oninstall={oninstall}
+      ondetails={ondetails}
       showEmptyScreen={false}
       title="Extensions to help you connect to remote Kubernetes clusters"
       category="Kubernetes"


### PR DESCRIPTION
### What does this PR do?

Adds events for telemetry:

- `kubernetes.nocontext.createNew` when a link is clicked to create a new cluster
- `kubernetes.nocontext.installExtension` when an extension is installed (by clicking the download button on the extension card)
- `kubernetes.nocontext.showExtensionDetails` when the user clicks on the "More details" link of an extension card. 

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Part of #8571 

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
