### PR TITLE
chore: add experimental flag for docker compatibility

### DIFF
--- a/packages/api/src/docker-compatibility-info.ts
+++ b/packages/api/src/docker-compatibility-info.ts
@@ -1,0 +1,22 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export enum ExperimentalSettings {
+  SectionName = 'dockerCompatibility',
+  Enabled = 'enabled',
+}

--- a/packages/main/src/plugin/docker/docker-compatibility.spec.ts
+++ b/packages/main/src/plugin/docker/docker-compatibility.spec.ts
@@ -35,8 +35,8 @@ beforeAll(() => {
 });
 
 test('should register a configuration', async () => {
-  const appearanceInit = new DockerCompatibility(configurationRegistry);
-  appearanceInit.init();
+  const dockerCompatibility = new DockerCompatibility(configurationRegistry);
+  dockerCompatibility.init();
 
   expect(configurationRegistry.registerConfigurations).toBeCalled();
   const configurationNode = vi.mocked(configurationRegistry.registerConfigurations).mock.calls[0]?.[0][0];

--- a/packages/main/src/plugin/docker/docker-compatibility.spec.ts
+++ b/packages/main/src/plugin/docker/docker-compatibility.spec.ts
@@ -1,0 +1,51 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { beforeAll, expect, test, vi } from 'vitest';
+
+import type { ApiSenderType } from '../api.js';
+import { ConfigurationRegistry } from '../configuration-registry.js';
+import type { Directories } from '../directories.js';
+import { DockerCompatibility } from './docker-compatibility.js';
+
+let configurationRegistry: ConfigurationRegistry;
+
+/* eslint-disable @typescript-eslint/no-empty-function */
+beforeAll(() => {
+  configurationRegistry = new ConfigurationRegistry({} as ApiSenderType, {} as Directories);
+  configurationRegistry.registerConfigurations = vi.fn();
+  configurationRegistry.deregisterConfigurations = vi.fn();
+});
+
+test('should register a configuration', async () => {
+  const appearanceInit = new DockerCompatibility(configurationRegistry);
+  appearanceInit.init();
+
+  expect(configurationRegistry.registerConfigurations).toBeCalled();
+  const configurationNode = vi.mocked(configurationRegistry.registerConfigurations).mock.calls[0]?.[0][0];
+  expect(configurationNode?.id).toBe('preferences.experimental.dockerCompatibility');
+  expect(configurationNode?.title).toBe('Experimental (Docker Compatibility)');
+  expect(configurationNode?.properties).toBeDefined();
+  expect(Object.keys(configurationNode?.properties ?? {}).length).toBe(1);
+  expect(configurationNode?.properties?.[DockerCompatibility.ENABLED_FULL_KEY]).toBeDefined();
+  expect(configurationNode?.properties?.[DockerCompatibility.ENABLED_FULL_KEY]?.type).toBe('boolean');
+  expect(configurationNode?.properties?.[DockerCompatibility.ENABLED_FULL_KEY]?.default).toBeFalsy();
+  expect(configurationNode?.properties?.[DockerCompatibility.ENABLED_FULL_KEY]?.hidden).toBeTruthy();
+});

--- a/packages/main/src/plugin/docker/docker-compatibility.ts
+++ b/packages/main/src/plugin/docker/docker-compatibility.ts
@@ -30,7 +30,7 @@ export class DockerCompatibility {
   }
 
   init(): void {
-    const appearanceConfiguration: IConfigurationNode = {
+    const dockerCompatibilityConfiguration: IConfigurationNode = {
       id: 'preferences.experimental.dockerCompatibility',
       title: 'Experimental (Docker Compatibility)',
       type: 'object',
@@ -44,6 +44,6 @@ export class DockerCompatibility {
       },
     };
 
-    this.#configurationRegistry.registerConfigurations([appearanceConfiguration]);
+    this.#configurationRegistry.registerConfigurations([dockerCompatibilityConfiguration]);
   }
 }

--- a/packages/main/src/plugin/docker/docker-compatibility.ts
+++ b/packages/main/src/plugin/docker/docker-compatibility.ts
@@ -1,0 +1,49 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ExperimentalSettings } from '/@api/docker-compatibility-info.js';
+
+import type { ConfigurationRegistry, IConfigurationNode } from '../configuration-registry.js';
+
+export class DockerCompatibility {
+  static readonly ENABLED_FULL_KEY = `${ExperimentalSettings.SectionName}.${ExperimentalSettings.Enabled}`;
+
+  #configurationRegistry: ConfigurationRegistry;
+
+  constructor(configurationRegistry: ConfigurationRegistry) {
+    this.#configurationRegistry = configurationRegistry;
+  }
+
+  init(): void {
+    const appearanceConfiguration: IConfigurationNode = {
+      id: 'preferences.experimental.dockerCompatibility',
+      title: 'Experimental (Docker Compatibility)',
+      type: 'object',
+      properties: {
+        [DockerCompatibility.ENABLED_FULL_KEY]: {
+          description: 'Enable the section for Docker compatibility.',
+          type: 'boolean',
+          hidden: true,
+          default: false,
+        },
+      },
+    };
+
+    this.#configurationRegistry.registerConfigurations([appearanceConfiguration]);
+  }
+}

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -128,6 +128,7 @@ import { ContributionManager } from './contribution-manager.js';
 import { CustomPickRegistry } from './custompick/custompick-registry.js';
 import { DialogRegistry } from './dialog-registry.js';
 import { Directories } from './directories.js';
+import { DockerCompatibility } from './docker/docker-compatibility.js';
 import { DockerDesktopInstallation } from './docker-extension/docker-desktop-installation.js';
 import { DockerPluginAdapter } from './docker-extension/docker-plugin-adapter.js';
 import type {
@@ -494,6 +495,9 @@ export class PluginSystem {
     await kubernetesClient.init();
     const closeBehaviorConfiguration = new CloseBehavior(configurationRegistry);
     await closeBehaviorConfiguration.init();
+
+    const dockerCompatibility = new DockerCompatibility(configurationRegistry);
+    dockerCompatibility.init();
 
     const messageBox = new MessageBox(apiSender);
 


### PR DESCRIPTION
### What does this PR do?
For being able to hide/show the new screen for compatibility mode

It brings a configuration flag. It is ignored for now (and hidden)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

https://github.com/containers/podman-desktop/issues/8337

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
