### PR TITLE
fix: show correct empty screens when filtering catalog

### DIFF
--- a/packages/renderer/src/lib/extensions/ExtensionList.spec.ts
+++ b/packages/renderer/src/lib/extensions/ExtensionList.spec.ts
@@ -118,3 +118,54 @@ test('Expect to see extensions', async () => {
   const extensionIdBAfterSwitch = screen.getByRole('group', { name: 'B Extension' });
   expect(extensionIdBAfterSwitch).toBeInTheDocument();
 });
+
+test('Expect to see empty screen on extension page only', async () => {
+  catalogExtensionInfos.set([aFakeExtension]);
+  extensionInfos.set([]);
+
+  render(ExtensionList, { searchTerm: 'A' });
+
+  let title = screen.queryByText("No extensions matching 'A' found");
+  expect(title).toBeInTheDocument();
+
+  // click on the catalog
+  const catalogTab = screen.getByRole('button', { name: 'Catalog' });
+  await fireEvent.click(catalogTab);
+
+  title = screen.queryByText("No extensions matching 'A' found");
+  expect(title).not.toBeInTheDocument();
+});
+
+test('Expect to see empty screen on catalog page only', async () => {
+  catalogExtensionInfos.set([]);
+  extensionInfos.set(combined);
+
+  render(ExtensionList, { searchTerm: 'A' });
+
+  let title = screen.queryByText("No extensions matching 'A' found");
+  expect(title).not.toBeInTheDocument();
+
+  // click on the catalog
+  const catalogTab = screen.getByRole('button', { name: 'Catalog' });
+  await fireEvent.click(catalogTab);
+
+  title = screen.queryByText("No extensions matching 'A' found");
+  expect(title).toBeInTheDocument();
+});
+
+test('Expect to see empty screens on both pages', async () => {
+  catalogExtensionInfos.set([]);
+  extensionInfos.set([]);
+
+  render(ExtensionList, { searchTerm: 'foo' });
+
+  let title = screen.getByText("No extensions matching 'foo' found");
+  expect(title).toBeInTheDocument();
+
+  // click on the catalog
+  const catalogTab = screen.getByRole('button', { name: 'Catalog' });
+  await fireEvent.click(catalogTab);
+
+  title = screen.getByText("No extensions matching 'foo' found");
+  expect(title).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/extensions/ExtensionList.spec.ts
+++ b/packages/renderer/src/lib/extensions/ExtensionList.spec.ts
@@ -125,14 +125,14 @@ test('Expect to see empty screen on extension page only', async () => {
 
   render(ExtensionList, { searchTerm: 'A' });
 
-  let title = screen.queryByText("No extensions matching 'A' found");
+  let title = screen.queryByText('No extensions matching \'A\' found');
   expect(title).toBeInTheDocument();
 
   // click on the catalog
   const catalogTab = screen.getByRole('button', { name: 'Catalog' });
   await fireEvent.click(catalogTab);
 
-  title = screen.queryByText("No extensions matching 'A' found");
+  title = screen.queryByText('No extensions matching \'A\' found');
   expect(title).not.toBeInTheDocument();
 });
 
@@ -142,14 +142,14 @@ test('Expect to see empty screen on catalog page only', async () => {
 
   render(ExtensionList, { searchTerm: 'A' });
 
-  let title = screen.queryByText("No extensions matching 'A' found");
+  let title = screen.queryByText('No extensions matching \'A\' found');
   expect(title).not.toBeInTheDocument();
 
   // click on the catalog
   const catalogTab = screen.getByRole('button', { name: 'Catalog' });
   await fireEvent.click(catalogTab);
 
-  title = screen.queryByText("No extensions matching 'A' found");
+  title = screen.queryByText('No extensions matching \'A\' found');
   expect(title).toBeInTheDocument();
 });
 
@@ -159,13 +159,13 @@ test('Expect to see empty screens on both pages', async () => {
 
   render(ExtensionList, { searchTerm: 'foo' });
 
-  let title = screen.getByText("No extensions matching 'foo' found");
+  let title = screen.getByText('No extensions matching \'foo\' found');
   expect(title).toBeInTheDocument();
 
   // click on the catalog
   const catalogTab = screen.getByRole('button', { name: 'Catalog' });
   await fireEvent.click(catalogTab);
 
-  title = screen.getByText("No extensions matching 'foo' found");
+  title = screen.getByText('No extensions matching \'foo\' found');
   expect(title).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/extensions/ExtensionList.spec.ts
+++ b/packages/renderer/src/lib/extensions/ExtensionList.spec.ts
@@ -125,14 +125,14 @@ test('Expect to see empty screen on extension page only', async () => {
 
   render(ExtensionList, { searchTerm: 'A' });
 
-  let title = screen.queryByText('No extensions matching \'A\' found');
+  let title = screen.queryByText(`No extensions matching 'A' found`);
   expect(title).toBeInTheDocument();
 
   // click on the catalog
   const catalogTab = screen.getByRole('button', { name: 'Catalog' });
   await fireEvent.click(catalogTab);
 
-  title = screen.queryByText('No extensions matching \'A\' found');
+  title = screen.queryByText(`No extensions matching 'A' found`);
   expect(title).not.toBeInTheDocument();
 });
 
@@ -142,14 +142,14 @@ test('Expect to see empty screen on catalog page only', async () => {
 
   render(ExtensionList, { searchTerm: 'A' });
 
-  let title = screen.queryByText('No extensions matching \'A\' found');
+  let title = screen.queryByText(`No extensions matching 'A' found`);
   expect(title).not.toBeInTheDocument();
 
   // click on the catalog
   const catalogTab = screen.getByRole('button', { name: 'Catalog' });
   await fireEvent.click(catalogTab);
 
-  title = screen.queryByText('No extensions matching \'A\' found');
+  title = screen.queryByText(`No extensions matching 'A' found`);
   expect(title).toBeInTheDocument();
 });
 
@@ -159,13 +159,13 @@ test('Expect to see empty screens on both pages', async () => {
 
   render(ExtensionList, { searchTerm: 'foo' });
 
-  let title = screen.getByText('No extensions matching \'foo\' found');
+  let title = screen.getByText(`No extensions matching 'foo' found`);
   expect(title).toBeInTheDocument();
 
   // click on the catalog
   const catalogTab = screen.getByRole('button', { name: 'Catalog' });
   await fireEvent.click(catalogTab);
 
-  title = screen.getByText('No extensions matching \'foo\' found');
+  title = screen.getByText(`No extensions matching 'foo' found`);
   expect(title).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/extensions/ExtensionList.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionList.svelte
@@ -107,18 +107,24 @@ let installManualImageModal: boolean = false;
   </svelte:fragment>
 
   <div class="flex min-w-full h-full" slot="content">
-    {#if searchTerm && $filteredInstalledExtensions.length === 0 && $filteredCatalogExtensions.length === 0}
-      <FilteredEmptyScreen
-        icon={ExtensionIcon}
-        kind="extensions"
-        searchTerm={searchTerm}
-        on:resetFilter={() => (searchTerm = '')} />
-    {/if}
-
     {#if screen === 'installed'}
+      {#if searchTerm && $filteredInstalledExtensions.length === 0}
+        <FilteredEmptyScreen
+          icon={ExtensionIcon}
+          kind="extensions"
+          searchTerm={searchTerm}
+          on:resetFilter={() => (searchTerm = '')} />
+      {/if}
       <InstalledExtensionList extensionInfos={$filteredInstalledExtensions} />
     {:else}
-      <CatalogExtensionList catalogExtensions={$filteredCatalogExtensions} />
+      {#if searchTerm && $filteredCatalogExtensions.length === 0}
+        <FilteredEmptyScreen
+          icon={ExtensionIcon}
+          kind="extensions"
+          searchTerm={searchTerm}
+          on:resetFilter={() => (searchTerm = '')} />
+      {/if}
+      <CatalogExtensionList showEmptyScreen={!searchTerm} catalogExtensions={$filteredCatalogExtensions} />
     {/if}
   </div>
 </NavPage>


### PR DESCRIPTION
### What does this PR do?

When searching the extension catalog many of the 'empty screens' were incorrect. This moves the FilteredEmptyScreen down into the installed and catalog sections so that it is displayed correctly for each screen, and reuses the existing showEmptyScreen property on CatalogExtensionList to avoid showing duplicate empty screens.

Fixes three related issues:
- When search term isn't in installed or catalog, show (only) the FilteredEmptyScreen in both. (was duplicate empty screen in catalog)
- When search term is in installed but not in catalog, show the FilteredEmptyScreen in catalog. (was internet connection empty screen)
- When search term is in catalog but not in installed, show the FilteredEmptyScreen in installed. (was blank screen)

### Screenshot / video of UI

Before:

https://github.com/user-attachments/assets/0f6add06-e6de-4c74-825a-8c3bf0c4745c

After:

https://github.com/user-attachments/assets/9f82cae9-1736-4639-9a94-16b39ddfcc07

### What issues does this PR fix or reference?

Fixes #9056.

### How to test this PR?

Try search terms like in the videos to filter to things that are only in one screen or neither.

- [x] Tests are covering the bug fix or the new feature