### PR TITLE
chore: use another time than the default time for dependabot daily job

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,16 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+      # check at 3am UTC
+      time: "03:00"
     open-pull-requests-limit: 20
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: daily
+      # check at 3am UTC
+      time: "03:00"
     open-pull-requests-limit: 20
     groups:
       storybook:


### PR DESCRIPTION
### What does this PR do?
select a time where it's before european ppl start their day

If https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduletime is saying default is UTC and https://www.worldtimebuddy.com/france-paris-to-utc is working as expected, 3 UTC is 5am paris time

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
