### PR TITLE
chore: add warning for users about short image names

### DIFF
--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -2719,16 +2719,13 @@ export class ContainerProviderRegistry {
   async resolveShortnameImage(
     providerContainerConnectionInfo: ProviderContainerConnectionInfo,
     shortName: string,
-  ): Promise<string | undefined> {
+  ): Promise<string[]> {
     const provider = this.getMatchingContainerProvider(providerContainerConnectionInfo);
-    try {
-      if (provider.libpodApi) {
-        return await provider.libpodApi.resolveShortnameImage(shortName);
-      } else {
-        return shortName;
-      }
-    } catch (e) {
-      console.log('problem :(');
+    if (provider.libpodApi) {
+      const response = await provider.libpodApi.resolveShortnameImage(shortName);
+      return response.Names[0] ? response.Names : [shortName];
+    } else {
+      return [shortName];
     }
   }
 }

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -2715,4 +2715,20 @@ export class ContainerProviderRegistry {
       return Promise.reject(errors);
     }
   }
+
+  async resolveShortnameImage(
+    providerContainerConnectionInfo: ProviderContainerConnectionInfo,
+    shortName: string,
+  ): Promise<string | undefined> {
+    const provider = this.getMatchingContainerProvider(providerContainerConnectionInfo);
+    try {
+      if (provider.libpodApi) {
+        return await provider.libpodApi.resolveShortnameImage(shortName);
+      } else {
+        return shortName;
+      }
+    } catch (e) {
+      console.log('problem :(');
+    }
+  }
 }

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.ts
@@ -364,6 +364,7 @@ export interface LibPod {
   startPod(podId: string): Promise<void>;
   stopPod(podId: string): Promise<void>;
   removePod(podId: string, options?: PodRemoveOptions): Promise<void>;
+  resolveShortnameImage(shortname: string): Promise<string>;
   restartPod(podId: string): Promise<void>;
   generateKube(names: string[]): Promise<string>;
   playKube(yamlContentFilePath: string): Promise<PlayKubeInfo>;
@@ -966,6 +967,29 @@ export class LibpodDockerode {
         options: {},
       };
 
+      return new Promise((resolve, reject) => {
+        this.modem.dial(optsf, (err: unknown, data: unknown) => {
+          if (err) {
+            return reject(err);
+          }
+          resolve(data);
+        });
+      });
+    };
+
+    prototypeOfDockerode.resolveShortnameImage = function (shortname: string): Promise<unknown> {
+      const optsf = {
+        path: `libpod/images/${shortname}/resolve`,
+        method: 'GET',
+        options: {},
+        abortSignal: undefined,
+        isStream: true,
+        statusCodes: {
+          204: true,
+          400: 'bad parameter',
+          500: 'server error',
+        },
+      };
       return new Promise((resolve, reject) => {
         this.modem.dial(optsf, (err: unknown, data: unknown) => {
           if (err) {

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.ts
@@ -364,7 +364,7 @@ export interface LibPod {
   startPod(podId: string): Promise<void>;
   stopPod(podId: string): Promise<void>;
   removePod(podId: string, options?: PodRemoveOptions): Promise<void>;
-  resolveShortnameImage(shortname: string): Promise<string>;
+  resolveShortnameImage(shortname: string): Promise<{ Names: string[] }>;
   restartPod(podId: string): Promise<void>;
   generateKube(names: string[]): Promise<string>;
   playKube(yamlContentFilePath: string): Promise<PlayKubeInfo>;
@@ -979,13 +979,11 @@ export class LibpodDockerode {
 
     prototypeOfDockerode.resolveShortnameImage = function (shortname: string): Promise<unknown> {
       const optsf = {
-        path: `libpod/images/${shortname}/resolve`,
+        path: `/v5.0.0/libpod/images/${shortname}/resolve`,
         method: 'GET',
-        options: {},
-        abortSignal: undefined,
-        isStream: true,
         statusCodes: {
-          204: true,
+          // in the documentation it says code 204, but only code 200 works as intended
+          200: true,
           400: 'bad parameter',
           500: 'server error',
         },

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1038,6 +1038,16 @@ export class PluginSystem {
     );
 
     this.ipcHandle(
+      'container-provider-registry:resolveShortnameImage',
+      async (
+        _listener,
+        providerContainerConnectionInfo: ProviderContainerConnectionInfo,
+        shortName: string,
+      ): Promise<string | undefined> => {
+        return containerProviderRegistry.resolveShortnameImage(providerContainerConnectionInfo, shortName);
+      },
+    );
+    this.ipcHandle(
       'container-provider-registry:pullImage',
       async (
         _listener,

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1043,7 +1043,7 @@ export class PluginSystem {
         _listener,
         providerContainerConnectionInfo: ProviderContainerConnectionInfo,
         shortName: string,
-      ): Promise<string | undefined> => {
+      ): Promise<string[]> => {
         return containerProviderRegistry.resolveShortnameImage(providerContainerConnectionInfo, shortName);
       },
     );

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -385,6 +385,16 @@ export function initExposure(): void {
     },
   );
 
+  contextBridge.exposeInMainWorld(
+    'resolveShortnameImage',
+    async (
+      providerContainerConnectionInfo: ProviderContainerConnectionInfo,
+      shortName: string,
+    ): Promise<string | undefined> => {
+      return ipcInvoke('container-provider-registry:resolveShortnameImage', providerContainerConnectionInfo, shortName);
+    },
+  );
+
   let onDataCallbacksPullImageId = 0;
   const onDataCallbacksPullImage = new Map<number, (event: PullEvent) => void>();
   contextBridge.exposeInMainWorld(

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -387,10 +387,7 @@ export function initExposure(): void {
 
   contextBridge.exposeInMainWorld(
     'resolveShortnameImage',
-    async (
-      providerContainerConnectionInfo: ProviderContainerConnectionInfo,
-      shortName: string,
-    ): Promise<string | undefined> => {
+    async (providerContainerConnectionInfo: ProviderContainerConnectionInfo, shortName: string): Promise<string[]> => {
       return ipcInvoke('container-provider-registry:resolveShortnameImage', providerContainerConnectionInfo, shortName);
     },
   );

--- a/packages/renderer/src/lib/image/PullImage.spec.ts
+++ b/packages/renderer/src/lib/image/PullImage.spec.ts
@@ -265,7 +265,7 @@ describe('PullImage', () => {
   });
 });
 
-test('Expect no docker.io shortname to use Podman FQN', async () => {
+test('Expect if no docker.io shortname to use Podman FQN', async () => {
   resolveShortnameImageMock.mockResolvedValue(['someregistry/test1']);
   setup();
   render(PullImage);
@@ -286,7 +286,26 @@ test('Expect no docker.io shortname to use Podman FQN', async () => {
   expect(imageName).toBe('someregistry/test1');
 });
 
-test('Expect no docker.io shortname to not use Podman FQN', async () => {
+test('Expect if no docker.io shortname but checkbox not checked to use docker hub', async () => {
+  resolveShortnameImageMock.mockResolvedValue(['someregistry/test1']);
+  setup();
+  render(PullImage);
+
+  const textbox = screen.getByRole('textbox', { name: 'Image to Pull' });
+  await userEvent.click(textbox);
+  await userEvent.paste('test1');
+
+  expect(resolveShortnameImageMock).toBeCalled();
+  await tick();
+
+  const pullImagebutton = screen.getByRole('button', { name: 'Pull image' });
+  await userEvent.click(pullImagebutton);
+
+  const imageName = pullImageMock.mock.calls[0][1];
+  expect(imageName).toBe('docker.io/test1');
+});
+
+test('Expect if docker.io shortname exists to not use Podman FQN', async () => {
   resolveShortnameImageMock.mockResolvedValue(['someregistry/test1', 'docker.io/test1']);
   setup();
   render(PullImage);

--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -121,8 +121,10 @@ async function pullImage() {
 
   pullInProgress = true;
   try {
-    if (usePodmanFQN && podmanFQN) {
-      await window.pullImage(selectedProviderConnection, podmanFQN.trim(), callback);
+    if (podmanFQN) {
+      usePodmanFQN
+        ? await window.pullImage(selectedProviderConnection, podmanFQN.trim(), callback)
+        : await window.pullImage(selectedProviderConnection, `docker.io/${imageToPull.trim()}`, callback);
     } else {
       await window.pullImage(selectedProviderConnection, imageToPull.trim(), callback);
     }

--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -39,23 +39,24 @@ const lineNumberPerId = new Map<string, number>();
 let lineIndex = 0;
 
 async function resolveShortname(): Promise<void> {
-  if (selectedProviderConnection && selectedProviderConnection.type === 'podman') {
-    if (imageToPull && !imageToPull.includes('/')) {
-      shortnameImages = (await window.resolveShortnameImage(selectedProviderConnection, imageToPull)) ?? [];
-      // not a shortname
-    } else {
-      podmanFQN = '';
-      shortnameImages = [];
-      usePodmanFQN = false;
-    }
-    // checks if there is no FQN that is from dokcer hub
-    if (!shortnameImages.find(name => name.includes('docker.io'))) {
-      podmanFQN = shortnameImages[0];
-    } else {
-      podmanFQN = '';
-      shortnameImages = [];
-      usePodmanFQN = false;
-    }
+  if (!selectedProviderConnection || selectedProviderConnection.type !== 'podman') {
+    return;
+  }
+  if (imageToPull && !imageToPull.includes('/')) {
+    shortnameImages = (await window.resolveShortnameImage(selectedProviderConnection, imageToPull)) ?? [];
+    // not a shortname
+  } else {
+    podmanFQN = '';
+    shortnameImages = [];
+    usePodmanFQN = false;
+  }
+  // checks if there is no FQN that is from dokcer hub
+  if (!shortnameImages.find(name => name.includes('docker.io'))) {
+    podmanFQN = shortnameImages[0];
+  } else {
+    podmanFQN = '';
+    shortnameImages = [];
+    usePodmanFQN = false;
   }
 }
 

--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-import { faArrowCircleDown, faCog } from '@fortawesome/free-solid-svg-icons';
+import { faArrowCircleDown, faCog, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
 import { Button, ErrorMessage } from '@podman-desktop/ui-svelte';
 import type { Terminal } from '@xterm/xterm';
 import { onMount, tick } from 'svelte';
+import Fa from 'svelte-fa';
 import { router } from 'tinro';
 
 import type { ImageSearchOptions } from '/@api/image-registry';
@@ -76,6 +77,20 @@ function callback(event: PullEvent) {
 }
 
 async function pullImage() {
+  //  option 1
+  if (imageToPull?.split('/').length === 1) {
+    const result = await window.showMessageBox({
+      title: 'Warning',
+      message: 'Shortname images will be pulled from Docker Hub',
+      buttons: ['Continue', 'Cancel'],
+    });
+
+    if (result.response === 1) {
+      return;
+    }
+  }
+  // option 1
+
   if (!selectedProviderConnection) {
     pullError = 'No current provider connection';
     return;
@@ -190,6 +205,12 @@ async function searchImages(value: string): Promise<string[]> {
     <div class="w-full">
       <label for="imageName" class="block mb-2 font-bold text-[var(--pd-content-card-header-text)]"
         >Image to Pull</label>
+      <!-- option 2 -->
+      <div class="flex flex-row mb-2 items-center text-[var(--pd-card-text)] text-sm">
+        <Fa size="1.1x" class="flex text-amber-400 mr-2" icon={faTriangleExclamation} />
+        Shortname images will be pulled from Docker Hub
+      </div>
+      <!-- option 2 -->
       <Typeahead
         id="imageName"
         name="imageName"

--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -30,6 +30,10 @@ $: providerConnections = $providerInfos
   .flat()
   .filter(providerContainerConnection => providerContainerConnection.status === 'started');
 
+$: selectedProviderConnection
+  ? console.log(window.resolveShortnameImage(selectedProviderConnection, imageToPull ?? ''))
+  : '';
+
 let selectedProviderConnection: ProviderContainerConnectionInfo | undefined;
 
 const lineNumberPerId = new Map<string, number>();


### PR DESCRIPTION
### What does this PR do?
Since Podman Desktop uses the Dockerode API (Docker based) to pull images, along with Podman's Docker compatibility, when pulling images with their short names, the images are pulled from Docker Hub instead of following the `shortnames.conf` file as some users might expect based on Podman CLI behavior. 
This PR add a visible warning to users to let them know that shortname images will be pulled from Docker Hub

### Screenshot / video of UI
[Screencast from 2024-10-01 16-52-08.webm](https://github.com/user-attachments/assets/4b34e44a-ce2a-419d-a4cc-cce637cd4770)


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/containers/podman-desktop/issues/8817

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->
Input a shortname for an image to pull, assert that if you check the Podman FQN checkbox, it pulls the image based on `shortname.conf`, and without checking the checkbox, it pulls the image from docker hub

- [X] Tests are covering the bug fix or the new feature
