### PR TITLE
fix: disable `Create` button if properties audit returns errors

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
@@ -333,6 +333,44 @@ describe.each([
     const showLogsButton = screen.getByRole('button', { name: 'Show Logs' });
     expect(showLogsButton).toBeInTheDocument();
   });
+
+  test(`Expect ${label} button to be disabled if itemsAudit returns errors`, async () => {
+    const callback = vi.fn();
+    vi.spyOn(window as any, 'auditConnectionParameters').mockResolvedValue({
+      records: [
+        {
+          type: 'error',
+          record: 'error message',
+        },
+      ],
+    });
+    // eslint-disable-next-line @typescript-eslint/await-thenable
+    render(PreferencesConnectionCreationOrEditRendering, {
+      properties: [
+        {
+          title: 'FactoryProperty',
+          parentId: '',
+          scope: 'ContainerProviderConnectionFactory',
+          id: 'test.factoryProperty',
+          type: 'number',
+          description: 'test.factoryProperty',
+        },
+      ],
+      providerInfo,
+      connectionInfo,
+      propertyScope,
+      callback,
+      pageIsLoading: false,
+      taskId,
+    });
+    await vi.waitUntil(() => screen.queryByRole('textbox', { name: 'test.factoryProperty' }));
+    const inputElement = screen.queryByRole('textbox', { name: 'test.factoryProperty' });
+    await fireEvent.change(inputElement as Element, { target: { value: '1' } });
+    await vi.waitFor(() => expect(vi.mocked(window as any).auditConnectionParameters).toBeCalled());
+    const createButton = screen.getByRole('button', { name: `${label}` });
+    expect(createButton).toBeInTheDocument();
+    await vi.waitFor(() => expect(createButton).toBeDisabled());
+  });
 });
 
 test(`Expect create with unchecked and checked checkboxes`, async () => {

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
@@ -236,7 +236,7 @@ describe.each([
       // keep reference
       providedKeyLogger = keyLogger;
     });
-
+    (window as any).getCancellableTokenSource.mockReturnValue(Date.now());
     render(PreferencesConnectionCreationOrEditRendering, {
       properties,
       providerInfo,

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
@@ -216,7 +216,7 @@ async function handleValidComponent() {
 
   try {
     const auditResult = await window.auditConnectionParameters(providerInfo.internalId, data as AuditRequestItems);
-    isValid = auditResult?.records?.filter(record => record.type === 'error')?.length === 0;
+    isValid = auditResult.records.filter(record => record.type === 'error').length === 0;
     connectionAuditResult = auditResult;
   } catch (err: unknown) {
     if (err instanceof Error) {

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
@@ -223,6 +223,8 @@ async function handleValidComponent() {
       console.warn(String(err));
     }
   }
+  const auditErrors = connectionAuditResult?.records?.filter(record => record.type === 'error');
+  isValid = auditErrors !== undefined && auditErrors.length === 0;
 }
 
 function internalSetConfigurationValue(id: string, modified: boolean, value: string | boolean | number) {

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
@@ -215,7 +215,9 @@ async function handleValidComponent() {
   }
 
   try {
-    connectionAuditResult = await window.auditConnectionParameters(providerInfo.internalId, data as AuditRequestItems);
+    const auditResult = await window.auditConnectionParameters(providerInfo.internalId, data as AuditRequestItems);
+    isValid = auditResult?.records?.filter(record => record.type === 'error')?.length === 0;
+    connectionAuditResult = auditResult;
   } catch (err: unknown) {
     if (err instanceof Error) {
       console.warn(err.message);
@@ -223,8 +225,6 @@ async function handleValidComponent() {
       console.warn(String(err));
     }
   }
-  const auditErrors = connectionAuditResult?.records?.filter(record => record.type === 'error');
-  isValid = auditErrors !== undefined && auditErrors.length === 0;
 }
 
 function internalSetConfigurationValue(id: string, modified: boolean, value: string | boolean | number) {


### PR DESCRIPTION
### What does this PR do?

PR disables 'Create' button in new resource form if audit returned record with type 'error'.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

https://github.com/user-attachments/assets/c82dcf6b-f317-4499-99c5-51459472137e

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Fix #9118

### How to test this PR?

Try to create kind cluster with the same name

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
