### PR TITLE
chore: specify devices when creating a container

### DIFF
--- a/packages/api/src/container-info.ts
+++ b/packages/api/src/container-info.ts
@@ -89,7 +89,7 @@ interface MountSettings {
 
 type MountConfig = MountSettings[];
 
-export interface Device {
+export interface DeviceMapping {
   CgroupPermissions: string;
   PathInContainer: string;
   PathOnHost: string;
@@ -111,7 +111,7 @@ export interface HostConfig {
   ExtraHosts?: string[];
   NetworkMode?: string;
   Mounts?: MountConfig;
-  Devices?: Device[];
+  Devices?: DeviceMapping[];
 }
 
 export interface HealthConfig {

--- a/packages/api/src/container-info.ts
+++ b/packages/api/src/container-info.ts
@@ -89,6 +89,12 @@ interface MountSettings {
 
 type MountConfig = MountSettings[];
 
+export interface Device {
+  CgroupPermissions: string;
+  PathInContainer: string;
+  PathOnHost: string;
+}
+
 export interface HostConfig {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   PortBindings?: any;
@@ -105,6 +111,7 @@ export interface HostConfig {
   ExtraHosts?: string[];
   NetworkMode?: string;
   Mounts?: MountConfig;
+  Devices?: Device[];
 }
 
 export interface HealthConfig {

--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -6,7 +6,7 @@ import { onMount } from 'svelte';
 import { router } from 'tinro';
 
 import { array2String } from '/@/lib/string/string.js';
-import type { ContainerCreateOptions, Device, HostConfig } from '/@api/container-info';
+import type { ContainerCreateOptions, DeviceMapping, HostConfig } from '/@api/container-info';
 import type { ImageInspectInfo } from '/@api/image-inspect-info';
 import type { NetworkInspectInfo } from '/@api/network-info';
 
@@ -336,7 +336,7 @@ async function startContainer() {
   const Tty = useTty;
   const OpenStdin = useInteractive;
 
-  let Devices: Device[] | undefined = devices
+  let Devices: DeviceMapping[] | undefined = devices
     .filter(d => d.host)
     .map(d => ({
       PathOnHost: d.host,

--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -893,9 +893,11 @@ const envDialogOptions: OpenDialogOptions = {
                     placeholder="Container Device (leave blank for same as host device)"
                     class="ml-2"
                     aria-label="device.container.{index}" />
-                  <Checkbox bind:checked={device.read} title="Read" class="ml-2">Read</Checkbox>
-                  <Checkbox bind:checked={device.write} title="Write" class="ml-2">Write</Checkbox>
-                  <Checkbox bind:checked={device.mknod} title="Mknod" class="ml-2">Mknod</Checkbox>
+                  <div class="flex flew-row space-x-4 ml-2 text-sm">
+                    <Checkbox bind:checked={device.read} title="Read">Read</Checkbox>
+                    <Checkbox bind:checked={device.write} title="Write">Write</Checkbox>
+                    <Checkbox bind:checked={device.mknod} title="Mknod">Mknod</Checkbox>
+                  </div>
                   <Button
                     type="link"
                     hidden={index === devices.length - 1}

--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -6,7 +6,7 @@ import { onMount } from 'svelte';
 import { router } from 'tinro';
 
 import { array2String } from '/@/lib/string/string.js';
-import type { ContainerCreateOptions, HostConfig } from '/@api/container-info';
+import type { ContainerCreateOptions, Device, HostConfig } from '/@api/container-info';
 import type { ImageInspectInfo } from '/@api/image-inspect-info';
 import type { NetworkInspectInfo } from '/@api/network-info';
 
@@ -50,6 +50,9 @@ let environmentVariables: { key: string; value: string }[] = [{ key: '', value: 
 let environmentFiles: string[] = [''];
 let volumeMounts: { source: string; target: string }[] = [{ source: '', target: '' }];
 let hostContainerPortMappings: { hostPort: PortInfo; containerPort: string }[] = [];
+let devices: { host: string; container: string; read: boolean; write: boolean; mknod: boolean }[] = [
+  { host: '', container: '', read: false, write: false, mknod: false },
+];
 
 let invalidName = false;
 let invalidPorts = false;
@@ -332,6 +335,19 @@ async function startContainer() {
   const ReadonlyRootfs = readOnly;
   const Tty = useTty;
   const OpenStdin = useInteractive;
+
+  let Devices: Device[] | undefined = devices
+    .filter(d => d.host)
+    .map(d => ({
+      PathOnHost: d.host,
+      PathInContainer: d.container !== '' ? d.container : d.host,
+      CgroupPermissions:
+        !d.read && !d.write && !d.mknod ? 'rwm' : `${d.read ? 'r' : ''}${d.write ? 'w' : ''}${d.mknod ? 'm' : ''}`,
+    }));
+  if (Devices.length === 0) {
+    Devices = undefined;
+  }
+
   const HostConfig: HostConfig = {
     Binds,
     AutoRemove: autoRemove,
@@ -343,6 +359,7 @@ async function startContainer() {
     CapAdd,
     CapDrop,
     NetworkMode,
+    Devices,
   };
 
   const Dns = dnsServers.filter(dns => dns);
@@ -538,6 +555,14 @@ function addExtraHost() {
 
 function deleteExtraHost(index: number) {
   extraHosts = extraHosts.filter((_, i) => i !== index);
+}
+
+function addDevice() {
+  devices = [...devices, { host: '', container: '', read: false, write: false, mknod: false }];
+}
+
+function deleteDevice(index: number) {
+  devices = devices.filter((_, i) => i !== index);
 }
 
 // called when user change the container's name
@@ -850,6 +875,41 @@ const envDialogOptions: OpenDialogOptions = {
                   class="w-24 p-2"
                   disabled={restartPolicyName !== 'on-failure'} />
               </div>
+
+              <!-- devices -->
+              <label
+                for="modalDevices"
+                class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]">Devices:</label>
+              <!-- Display the list of existing devices -->
+              {#each devices as device, index}
+                <div class="flex flex-row justify-center items-center w-full py-1">
+                  <Input
+                    bind:value={device.host}
+                    placeholder="Host Device"
+                    class="w-full"
+                    aria-label="device.host.{index}" />
+                  <Input
+                    bind:value={device.container}
+                    placeholder="Container Device (leave blank for same as host device)"
+                    class="ml-2"
+                    aria-label="device.container.{index}" />
+                  <Checkbox bind:checked={device.read} title="Read" class="ml-2">Read</Checkbox>
+                  <Checkbox bind:checked={device.write} title="Write" class="ml-2">Write</Checkbox>
+                  <Checkbox bind:checked={device.mknod} title="Mknod" class="ml-2">Mknod</Checkbox>
+                  <Button
+                    type="link"
+                    hidden={index === devices.length - 1}
+                    aria-label="Delete device at index {index}"
+                    on:click={() => deleteDevice(index)}
+                    icon={faMinusCircle} />
+                  <Button
+                    type="link"
+                    hidden={index < devices.length - 1}
+                    aria-label="Add device after index {index}"
+                    on:click={addDevice}
+                    icon={faPlusCircle} />
+                </div>
+              {/each}
             </div>
           </Route>
 


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Specify devices when creating a container, equivalent of the `--device` option

A typeahead could help the user, it could be part of a follow-up PR

### Screenshot / video of UI


### What issues does this PR fix or reference?

Fixes #5989

### How to test this PR?

Go to the Container creation form, in Advanced tab, and add devices (should exist in the podman machine), and check in the Inspect tab of the created container that the `HostConfig.Devices` info is present.

- [x] Tests are covering the bug fix or the new feature
