### PR TITLE
docs: fix two typos on windows-install documentation

### DIFF
--- a/website/docs/installation/windows-install/index.md
+++ b/website/docs/installation/windows-install/index.md
@@ -153,7 +153,7 @@ hyperv
 # [System.Environment]::SetEnvironmentVariable('CONTAINERS_MACHINE_PROVIDER','hyperv')
 # [System.Environment]::GetEnvironmentVariable('CONTAINERS_MACHINE_PROVIDER)
 
-podman machin init
+podman machine init
 podman machine start
 ```
 

--- a/website/docs/installation/windows-install/index.md
+++ b/website/docs/installation/windows-install/index.md
@@ -145,7 +145,7 @@ time="2023-05-09T21:16:08+03:00" level=debug msg="Using Podman machine with `hyp
 Full example then could looks like this, open powershell with admin provileges:
 
 ```
-PS C:\Windows\system32> $env:ACONTAINERS_MACHINE_PROVIDER = 'hyperv'
+PS C:\Windows\system32> $env:CONTAINERS_MACHINE_PROVIDER = 'hyperv'
 PS C:\Windows\system32> $env:CONTAINERS_MACHINE_PROVIDER
 hyperv
 


### PR DESCRIPTION
Fix typo

### What does this PR do?
Fix typo on page: https://podman-desktop.io/docs/installation/windows-install
"machin" -> machine

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
