### PR TITLE
feat: define HostConfig.Devices with a known type in extension-api.d.ts

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -2600,6 +2600,12 @@ declare module '@podman-desktop/api' {
     Options?: { [key: string]: string };
   }
 
+  interface Device {
+    CgroupPermissions: string;
+    PathInContainer: string;
+    PathOnHost: string;
+  }
+
   interface HostConfig {
     AutoRemove?: boolean;
     Binds?: string[];
@@ -2653,7 +2659,7 @@ declare module '@podman-desktop/api' {
     CpuQuota?: number;
     CpusetCpus?: string;
     CpusetMems?: string;
-    Devices?: unknown;
+    Devices?: Device[];
     DeviceCgroupRules?: string[];
     DeviceRequests?: DeviceRequest[];
     DiskQuota?: number;

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -2600,7 +2600,7 @@ declare module '@podman-desktop/api' {
     Options?: { [key: string]: string };
   }
 
-  interface Device {
+  interface DeviceMapping {
     CgroupPermissions: string;
     PathInContainer: string;
     PathOnHost: string;
@@ -2659,7 +2659,7 @@ declare module '@podman-desktop/api' {
     CpuQuota?: number;
     CpusetCpus?: string;
     CpusetMems?: string;
-    Devices?: Device[];
+    Devices?: DeviceMapping[];
     DeviceCgroupRules?: string[];
     DeviceRequests?: DeviceRequest[];
     DiskQuota?: number;


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Define HostConfig.Devices with a known type in extension-api.d.ts, as defined in 
- https://docs.docker.com/reference/api/engine/version/v1.43/#tag/Container/operation/ContainerCreate
- https://github.com/moby/moby/blob/34950b5ede5fa4dc4e6956655299f26b17b88f51/api/types/container/hostconfig.go#L269-L273



### What issues does this PR fix or reference?

Part of #5989, is needed for #9125 

### How to test this PR?

- [ ] Tests are covering the bug fix or the new feature
