### PR TITLE
fix: add podman version check to hyperv enablement

### DIFF
--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -2036,8 +2036,11 @@ describe('calcPodmanMachineSetting', () => {
     expect(extensionApi.context.setValue).toBeCalledWith(extension.PODMAN_MACHINE_MEMORY_SUPPORTED_KEY, true);
     expect(extensionApi.context.setValue).toBeCalledWith(extension.PODMAN_MACHINE_DISK_SUPPORTED_KEY, true);
   });
-  test('setValue to true if OS is Windows and uses HyperV - set env variable', async () => {
+  test('setValue to true if OS is Windows and uses HyperV', async () => {
     vi.mocked(isWindows).mockReturnValue(true);
+    vi.spyOn(podmanCli, 'getPodmanInstallation').mockResolvedValue({
+      version: '5.2.1',
+    });
     vi.spyOn(extensionApi.process, 'exec').mockImplementation((command, args) => {
       return new Promise<extensionApi.RunResult>(resolve => {
         if (command === 'powershell.exe') {

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -1940,6 +1940,10 @@ describe('registerOnboardingRemoveUnsupportedMachinesCommand', () => {
     });
 
     vi.mocked(extensionApi.process.exec).mockResolvedValueOnce({
+      stdout: 'podman version 5.2.0',
+    } as unknown as extensionApi.RunResult);
+
+    vi.mocked(extensionApi.process.exec).mockResolvedValueOnce({
       stdout: 'True',
       stderr: '',
       command: 'command',
@@ -2369,6 +2373,9 @@ test('isHypervEnabled should return false if hyperv is not enabled', async () =>
 
 test('isHypervEnabled should return true if hyperv is enabled', async () => {
   vi.mocked(isWindows).mockReturnValue(true);
+  vi.spyOn(podmanCli, 'getPodmanInstallation').mockResolvedValue({
+    version: '5.2.1',
+  });
   vi.spyOn(extensionApi.process, 'exec').mockImplementation((command, args) => {
     return new Promise<extensionApi.RunResult>(resolve => {
       if (command === 'powershell.exe') {
@@ -2429,7 +2436,6 @@ test('isWSLEnabled should return true if wsl is enabled', async () => {
 test('getJSONMachineList should only get machines from wsl if hyperv is not enabled', async () => {
   vi.mocked(isWindows).mockReturnValue(true);
   vi.mocked(isMac).mockReturnValue(false);
-  vi.spyOn(config, 'get').mockReturnValue('');
   vi.spyOn(extensionApi.process, 'exec').mockImplementation((command, args) => {
     return new Promise<extensionApi.RunResult>(resolve => {
       if (command !== 'wsl' && args?.[0] === '--version') {
@@ -2494,12 +2500,14 @@ test('getJSONMachineList should only get machines from wsl if hyperv is not enab
 test('getJSONMachineList should only get machines from hyperv if wsl is not enabled', async () => {
   vi.mocked(isWindows).mockReturnValue(true);
   vi.mocked(isMac).mockReturnValue(false);
-  vi.spyOn(config, 'get').mockReturnValue('');
+  vi.spyOn(podmanCli, 'getPodmanInstallation').mockResolvedValue({
+    version: '5.2.1',
+  });
   vi.spyOn(extensionApi.process, 'exec').mockImplementation((command, args) => {
     return new Promise<extensionApi.RunResult>(resolve => {
       if (command !== 'wsl' && args?.[0] === '--version') {
         resolve({
-          stdout: 'podman version 5.1.1',
+          stdout: 'podman version 5.2.1',
         } as extensionApi.RunResult);
       }
       if (command === 'wsl') {
@@ -2558,12 +2566,14 @@ test('getJSONMachineList should only get machines from hyperv if wsl is not enab
 test('getJSONMachineList should get machines from hyperv and wsl if both are enabled', async () => {
   vi.mocked(isWindows).mockReturnValue(true);
   vi.mocked(isMac).mockReturnValue(false);
-  vi.spyOn(config, 'get').mockReturnValue('');
+  vi.spyOn(podmanCli, 'getPodmanInstallation').mockResolvedValue({
+    version: '5.2.1',
+  });
   vi.spyOn(extensionApi.process, 'exec').mockImplementation((command, args) => {
     return new Promise<extensionApi.RunResult>(resolve => {
       if (command !== 'wsl' && args?.[0] === '--version') {
         resolve({
-          stdout: 'podman version 5.1.1',
+          stdout: 'podman version 5.2.1',
         } as extensionApi.RunResult);
       }
       if (command === 'wsl') {

--- a/extensions/podman/packages/extension/src/podman-install.ts
+++ b/extensions/podman/packages/extension/src/podman-install.ts
@@ -821,12 +821,12 @@ export class WSLVersionCheck extends BaseCheck {
 
 export class HyperVCheck extends WindowsCheck {
   title = 'Hyper-V installed';
-  PODMAN_MINIMUM_VERSION_FOR_HYPERV = '5.2.0';
+  static readonly PODMAN_MINIMUM_VERSION_FOR_HYPERV = '5.2.0';
 
   async execute(): Promise<extensionApi.CheckResult> {
     if (!(await this.isPodmanVersionSupported())) {
       return this.createFailureResult({
-        description: `Hyper-V is only supported with podman version >= ${this.PODMAN_MINIMUM_VERSION_FOR_HYPERV}.`,
+        description: `Hyper-V is only supported with podman version >= ${HyperVCheck.PODMAN_MINIMUM_VERSION_FOR_HYPERV}.`,
       });
     }
     if (!(await this.isUserAdmin())) {
@@ -870,7 +870,7 @@ export class HyperVCheck extends WindowsCheck {
   private async isPodmanVersionSupported(): Promise<boolean> {
     const installedPodman = await getPodmanInstallation();
     if (installedPodman?.version) {
-      return compareVersions(installedPodman?.version, this.PODMAN_MINIMUM_VERSION_FOR_HYPERV) >= 0;
+      return compareVersions(installedPodman?.version, HyperVCheck.PODMAN_MINIMUM_VERSION_FOR_HYPERV) >= 0;
     }
     return false;
   }


### PR DESCRIPTION
### What does this PR do?

After talking with @jeffmaury there was a missing piece in the hyperv check - the podman version should be greater than 5.2.0.
This PR just enhances the hyperv part to check if podman has a valid version

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

1. run tests or try to use an older version of podman to see hyperv is not enabled

- [ ] Tests are covering the bug fix or the new feature
