### PR TITLE
chore: add missing util tests

### DIFF
--- a/packages/renderer/src/lib/ui/Util.spec.ts
+++ b/packages/renderer/src/lib/ui/Util.spec.ts
@@ -20,10 +20,25 @@ import '@testing-library/jest-dom/vitest';
 
 import { expect, test } from 'vitest';
 
-import { capitalize } from './Util';
+import { capitalize, getTabUrl, isTabSelected } from './Util';
 
 test('test capitalize function', () => {
   expect(capitalize('test')).toBe('Test');
   expect(capitalize('Test')).toBe('Test');
   expect(capitalize('TEST')).toBe('TEST');
+});
+
+test('test getTabUrl', () => {
+  expect(getTabUrl('/images', 'images')).toBe('/images');
+  expect(getTabUrl('/images/summary', 'summary')).toBe('/images/summary');
+  expect(getTabUrl('/images/summary', 'logs')).toBe('/images/logs');
+  expect(getTabUrl('/images/image-id/summary', 'logs')).toBe('/images/image-id/logs');
+  expect(getTabUrl('/images/image-id/logs', 'logs')).toBe('/images/image-id/logs');
+});
+
+test('test isTabSelected', () => {
+  expect(isTabSelected('/images/details/summary', 'summary')).toBe(true);
+  expect(isTabSelected('/images/details/logs', 'summary')).toBe(false);
+  expect(isTabSelected('/images/details/', 'images')).toBe(false);
+  expect(isTabSelected('/images/image-id/details/summary', 'summary')).toBe(true);
 });


### PR DESCRIPTION
### What does this PR do?

As part of https://github.com/containers/podman-desktop-extension-bootc/pull/866 it was noticed that the Util class is missing tests for a couple functions, this just adds them.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

`pnpm test:renderer`

- [x] Tests are covering the bug fix or the new feature