### PR TITLE
fix: electron build config to include podman ext assets

### DIFF
--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -90,18 +90,18 @@ const config = {
       context.appOutDir.endsWith('mac-universal-arm64-temp')
     ) {
       context.packager.config.extraResources = DEFAULT_ASSETS;
-      context.packager.config.extraResources.push('extensions/podman/assets/podman-installer-macos-universal*.pkg');
+      context.packager.config.extraResources.push('extensions/podman/packages/extension/assets/podman-installer-macos-universal*.pkg');
       return;
     }
 
     if (context.arch === Arch.arm64 && context.electronPlatformName === 'darwin') {
-      context.packager.config.extraResources.push('extensions/podman/assets/podman-installer-macos-aarch64-*.pkg');
-      context.packager.config.extraResources.push('extensions/podman/assets/podman-image-arm64.zst');
+      context.packager.config.extraResources.push('extensions/podman/packages/extension/assets/podman-installer-macos-aarch64-*.pkg');
+      context.packager.config.extraResources.push('extensions/podman/packages/extension/assets/podman-image-arm64.zst');
     }
 
     if (context.arch === Arch.x64 && context.electronPlatformName === 'darwin') {
-      context.packager.config.extraResources.push('extensions/podman/assets/podman-installer-macos-amd64-*.pkg');
-      context.packager.config.extraResources.push('extensions/podman/assets/podman-image-x64.zst');
+      context.packager.config.extraResources.push('extensions/podman/packages/extension/assets/podman-installer-macos-amd64-*.pkg');
+      context.packager.config.extraResources.push('extensions/podman/packages/extension/assets/podman-image-x64.zst');
     }
 
     if (context.electronPlatformName === 'win32') {
@@ -111,13 +111,13 @@ const config = {
         to: 'win-ca/roots.exe',
       });
       // add podman installer
-      context.packager.config.extraResources.push('extensions/podman/assets/podman-*.exe');
+      context.packager.config.extraResources.push('extensions/podman/packages/extension/assets/podman-*.exe');
     }
     if (context.arch === Arch.x64 && context.electronPlatformName === 'win32') {
-      context.packager.config.extraResources.push('extensions/podman/assets/podman-image-x64.tar.zst');
+      context.packager.config.extraResources.push('extensions/podman/packages/extension/assets/podman-image-x64.tar.zst');
     }
     if (context.arch === Arch.arm64 && context.electronPlatformName === 'win32') {
-      context.packager.config.extraResources.push('extensions/podman/assets/podman-image-arm64.tar.zst');
+      context.packager.config.extraResources.push('extensions/podman/packages/extension/assets/podman-image-arm64.tar.zst');
     }
   },
   afterPack: async context => {


### PR DESCRIPTION
### What does this PR do?

PR updates location of podman extension assets to new location `extensions/podman/packages/extension/assets`

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Fix #9123.

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

See #9123 to test.

- [ ] Tests are covering the bug fix or the new feature
