### PR TITLE
fix: handle userModeNetwork visibility even when only one provider is available

### DIFF
--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -2830,15 +2830,15 @@ test('getJSONMachineList should get machines from hyperv and wsl if both are ena
 
 describe('updateWSLHyperVEnabledValue', () => {
   beforeEach(() => {
-    extension.updateWSLHyperVEnabledValue(true);
+    extension.updateWSLHyperVEnabledContextValue(true);
     vi.resetAllMocks();
   });
   test('setValue should be called if new value is different than wslAndHypervEnabled', async () => {
-    extension.updateWSLHyperVEnabledValue(false);
+    extension.updateWSLHyperVEnabledContextValue(false);
     expect(extensionApi.context.setValue).toBeCalledWith(extension.WSL_HYPERV_ENABLED_KEY, false);
   });
   test('setValue should not be called if new value is equal to wslAndHypervEnabled', async () => {
-    extension.updateWSLHyperVEnabledValue(true);
+    extension.updateWSLHyperVEnabledContextValue(true);
     expect(extensionApi.context.setValue).not.toBeCalled();
   });
 });

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -2842,3 +2842,70 @@ describe('updateWSLHyperVEnabledValue', () => {
     expect(extensionApi.context.setValue).not.toBeCalled();
   });
 });
+
+describe('connectionAuditor', () => {
+  test('check if podman.isCreateWSLOptionSelected is set to true if podman.factory.machine.win.provider = wsl', async () => {
+    // be sure isCreateWSLOptionSelected is set to false
+    await extension.connectionAuditor({
+      'podman.factory.machine.win.provider': 'hyperv',
+    });
+
+    // verify isCreateWSLOptionSelected is set to true
+    await extension.connectionAuditor({
+      'podman.factory.machine.win.provider': 'wsl',
+    });
+    expect(extensionApi.context.setValue).toHaveBeenLastCalledWith(
+      extension.CREATE_WSL_MACHINE_OPTION_SELECTED_KEY,
+      true,
+    );
+  });
+  test('check if podman.isCreateWSLOptionSelected is set to true if podman.factory.machine.win.provider is undefined but wsl is enabled', async () => {
+    // be sure isCreateWSLOptionSelected is set to false
+    await extension.connectionAuditor({
+      'podman.factory.machine.win.provider': 'hyperv',
+    });
+
+    // verify isCreateWSLOptionSelected is set to true
+    extension.setWSLEnabled(true);
+
+    await extension.connectionAuditor({
+      'podman.factory.machine.win.provider': undefined,
+    });
+    expect(extensionApi.context.setValue).toHaveBeenLastCalledWith(
+      extension.CREATE_WSL_MACHINE_OPTION_SELECTED_KEY,
+      true,
+    );
+  });
+  test('check if podman.isCreateWSLOptionSelected is set to false if podman.factory.machine.win.provider = hyperv', async () => {
+    // be sure isCreateWSLOptionSelected is set to true
+    await extension.connectionAuditor({
+      'podman.factory.machine.win.provider': 'wsl',
+    });
+
+    // verify isCreateWSLOptionSelected is set to false
+    await extension.connectionAuditor({
+      'podman.factory.machine.win.provider': 'hyperv',
+    });
+    expect(extensionApi.context.setValue).toHaveBeenLastCalledWith(
+      extension.CREATE_WSL_MACHINE_OPTION_SELECTED_KEY,
+      false,
+    );
+  });
+  test('check if podman.isCreateWSLOptionSelected is set to false if podman.factory.machine.win.provider is undefined and wsl is NOT enabled', async () => {
+    // be sure isCreateWSLOptionSelected is set to true
+    await extension.connectionAuditor({
+      'podman.factory.machine.win.provider': 'wsl',
+    });
+
+    // verify isCreateWSLOptionSelected is set to false
+    extension.setWSLEnabled(false);
+
+    await extension.connectionAuditor({
+      'podman.factory.machine.win.provider': undefined,
+    });
+    expect(extensionApi.context.setValue).toHaveBeenLastCalledWith(
+      extension.CREATE_WSL_MACHINE_OPTION_SELECTED_KEY,
+      false,
+    );
+  });
+});

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -98,7 +98,7 @@ const podmanBinaryHelper = new PodmanBinaryLocationHelper();
 const podmanInfoHelper = new PodmanInfoHelper();
 
 let createWSLMachineOptionSelected = false;
-let wslAndHypervEnabled = false;
+let wslAndHypervEnabledContextValue = false;
 let wslEnabled = false;
 
 let shouldNotifySetup = true;
@@ -1283,8 +1283,8 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
     extensionApi.context.setValue(USER_MODE_NETWORKING_SUPPORTED_KEY, isUserModeNetworkingSupported(version));
     extensionApi.context.setValue(PODMAN_PROVIDER_LIBKRUN_SUPPORTED_KEY, isLibkrunSupported(version));
     wslEnabled = await isWSLEnabled();
-    const wslHypervEnabled = wslEnabled && (await isHyperVEnabled());
-    updateWSLHyperVEnabledValue(wslHypervEnabled);
+    const isWslAndHyperEnabled = wslEnabled && (await isHyperVEnabled());
+    updateWSLHyperVEnabledContextValue(isWslAndHyperEnabled);
     isMovedPodmanSocket = isPodmanSocketLocationMoved(version);
   }
 
@@ -1797,7 +1797,7 @@ export async function getJSONMachineList(): Promise<MachineJSONListOutput> {
     containerMachineProviders.push('hyperv');
   }
   // update context "wsl-hyperv enabled" value
-  updateWSLHyperVEnabledValue(wslEnabled && hypervEnabled);
+  updateWSLHyperVEnabledContextValue(wslEnabled && hypervEnabled);
 
   if (containerMachineProviders.length === 0) {
     // in all other cases we set undefined so that it executes normally by using the default container provider
@@ -2229,9 +2229,9 @@ export async function handleCompatibilityModeSetting(): Promise<void> {
   }
 }
 
-export function updateWSLHyperVEnabledValue(value: boolean): void {
-  if (wslAndHypervEnabled !== value) {
-    wslAndHypervEnabled = value;
+export function updateWSLHyperVEnabledContextValue(value: boolean): void {
+  if (wslAndHypervEnabledContextValue !== value) {
+    wslAndHypervEnabledContextValue = value;
     extensionApi.context.setValue(WSL_HYPERV_ENABLED_KEY, value);
   }
 }

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -99,6 +99,7 @@ const podmanInfoHelper = new PodmanInfoHelper();
 
 let createWSLMachineOptionSelected = false;
 let wslAndHypervEnabled = false;
+let wslEnabled = false;
 
 let shouldNotifySetup = true;
 const setupPodmanNotification: extensionApi.NotificationOptions = {
@@ -1281,7 +1282,8 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
     extensionApi.context.setValue(START_NOW_MACHINE_INIT_SUPPORTED_KEY, isStartNowAtMachineInitSupported(version));
     extensionApi.context.setValue(USER_MODE_NETWORKING_SUPPORTED_KEY, isUserModeNetworkingSupported(version));
     extensionApi.context.setValue(PODMAN_PROVIDER_LIBKRUN_SUPPORTED_KEY, isLibkrunSupported(version));
-    const wslHypervEnabled = (await isWSLEnabled()) && (await isHyperVEnabled());
+    wslEnabled = await isWSLEnabled();
+    const wslHypervEnabled = wslEnabled && (await isHyperVEnabled());
     updateWSLHyperVEnabledValue(wslHypervEnabled);
     isMovedPodmanSocket = isPodmanSocketLocationMoved(version);
   }
@@ -1693,7 +1695,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   };
 }
 
-async function connectionAuditor(items: extensionApi.AuditRequestItems): Promise<extensionApi.AuditResult> {
+export async function connectionAuditor(items: extensionApi.AuditRequestItems): Promise<extensionApi.AuditResult> {
   const records: extensionApi.AuditRecord[] = [];
 
   if (items['podman.factory.machine.image-uri'] && items['podman.factory.machine.image-path']) {
@@ -1704,7 +1706,9 @@ async function connectionAuditor(items: extensionApi.AuditRequestItems): Promise
   }
 
   const winProvider = items['podman.factory.machine.win.provider'];
-  const isWSL = winProvider === 'wsl';
+  // set createWSLMachineOptionSelected if the user actively selected wsl from the list in the UI, or
+  // if the list is not visible (so only one provider is active) and the provider is wsl
+  const isWSL = winProvider === 'wsl' || (winProvider === undefined && wslEnabled);
   if (createWSLMachineOptionSelected !== isWSL) {
     createWSLMachineOptionSelected = isWSL;
     extensionApi.context.setValue(CREATE_WSL_MACHINE_OPTION_SELECTED_KEY, createWSLMachineOptionSelected);
@@ -1780,12 +1784,14 @@ export async function getJSONMachineList(): Promise<MachineJSONListOutput> {
     containerMachineProviders.push(...['applehv', 'libkrun']);
   }
 
-  let wslEnabled = false;
   let hypervEnabled = false;
   if (await isWSLEnabled()) {
     wslEnabled = true;
     containerMachineProviders.push('wsl');
+  } else {
+    wslEnabled = false;
   }
+
   if (await isHyperVEnabled()) {
     hypervEnabled = true;
     containerMachineProviders.push('hyperv');
@@ -1856,6 +1862,11 @@ const PODMAN_MINIMUM_VERSION_FOR_LIBKRUN_SUPPORT = '5.2.0-rc1';
 // Checks if libkrun is supported. Only Mac platform allows this parameter to be tuned
 export function isLibkrunSupported(podmanVersion: string): boolean {
   return isMac() && compareVersions(podmanVersion, PODMAN_MINIMUM_VERSION_FOR_LIBKRUN_SUPPORT) >= 0;
+}
+
+// Set wslEnabled. Used for testing purposes
+export function setWSLEnabled(enabled: boolean): void {
+  wslEnabled = enabled;
 }
 
 export async function isWSLEnabled(): Promise<boolean> {


### PR DESCRIPTION
### What does this PR do?

https://github.com/containers/podman-desktop/pull/9105 introduced a dropdownlist to select wsl or hyperv (when both are available) to specify the proider to use when creating a new machine. 
Based on the choice the user-mode-networking option is visible or not (wsl=visible, hyperv=hidden).

However, there was a use case not handled. When only one provider is enabled, the user-mode-network is always hidden. But if the provider is wsl it should be visible.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

N/A, raised on slack

### How to test this PR?

1. run tests or have only one provider enabled

- [x] Tests are covering the bug fix or the new feature
