### PR TITLE
fix: skip podman check on hypervCheck.execute when called as installation preflight

### DIFF
--- a/extensions/podman/packages/extension/src/podman-install.ts
+++ b/extensions/podman/packages/extension/src/podman-install.ts
@@ -460,7 +460,7 @@ export class WinInstaller extends BaseInstaller {
       new OrCheck(
         'Windows virtualization',
         new SequenceCheck('WSL platform', [new WSLVersionCheck(), new WSL2Check(this.extensionContext)]),
-        new HyperVCheck(),
+        new HyperVCheck(true),
       ),
     ];
   }
@@ -823,8 +823,13 @@ export class HyperVCheck extends WindowsCheck {
   title = 'Hyper-V installed';
   static readonly PODMAN_MINIMUM_VERSION_FOR_HYPERV = '5.2.0';
 
+  constructor(private installationPreflightMode: boolean = false) {
+    super();
+  }
+
   async execute(): Promise<extensionApi.CheckResult> {
-    if (!(await this.isPodmanVersionSupported())) {
+    // if the hyperv check is called as an installation preflight we skip the podman version check
+    if (!this.installationPreflightMode && !(await this.isPodmanVersionSupported())) {
       return this.createFailureResult({
         description: `Hyper-V is only supported with podman version >= ${HyperVCheck.PODMAN_MINIMUM_VERSION_FOR_HYPERV}.`,
       });


### PR DESCRIPTION
### What does this PR do?

This PR updates the hypervCheck to skip the podman version check when hypervCheck is called as an installation preflight.

If you are installing podman, the version is unknown, and so the hyperv check will always fail. With this PR we skip that check as not needed in such as situation

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

it resolves #9158 

### How to test this PR?

1. try to install podman from desktop

- [x] Tests are covering the bug fix or the new feature
