### PR TITLE
chore: add a way to get status information for mac/linux/windows docker system socket

### DIFF
--- a/packages/api/src/docker-compatibility-info.ts
+++ b/packages/api/src/docker-compatibility-info.ts
@@ -20,3 +20,25 @@ export enum ExperimentalSettings {
   SectionName = 'dockerCompatibility',
   Enabled = 'enabled',
 }
+
+export type DockerSocketServerInfoType = 'podman' | 'docker' | 'unknown';
+
+export interface DockerSocketMappingStatusInfo {
+  status: 'running' | 'unreachable';
+  connectionInfo?: {
+    provider: {
+      id: string;
+      name: string;
+    };
+    link: string;
+    name: string;
+    displayName: string;
+  };
+  serverInfo?: {
+    type: DockerSocketServerInfoType;
+    serverVersion: string;
+    operatingSystem: string;
+    osType: string;
+    architecture: string;
+  };
+}

--- a/packages/main/src/plugin/docker/docker-compatibility.spec.ts
+++ b/packages/main/src/plugin/docker/docker-compatibility.spec.ts
@@ -45,7 +45,7 @@ const providerRegistry: ProviderRegistry = {
 export class TestDockerCompatibility extends DockerCompatibility {
   public override getTypeFromServerInfo(
     info: { OperatingSystem?: string },
-    podmanInfo: unknown,
+    podmanInfo?: unknown,
   ): DockerSocketServerInfoType {
     return super.getTypeFromServerInfo(info, podmanInfo);
   }
@@ -108,10 +108,7 @@ describe('getTypeFromServerInfo', async () => {
     const serverInfo = {
       OperatingSystem: 'Docker Desktop',
     };
-
-    const podmanInfo = {};
-
-    expect(dockerCompatibility.getTypeFromServerInfo(serverInfo, podmanInfo)).toBe('docker');
+    expect(dockerCompatibility.getTypeFromServerInfo(serverInfo)).toBe('docker');
   });
 
   test('check podman OS without podman info', async () => {
@@ -131,7 +128,9 @@ describe('getTypeFromServerInfo', async () => {
       OperatingSystem: 'foo',
     };
 
-    const podmanInfo = {};
+    const podmanInfo = {
+      ServerVersion: '1.0.0',
+    };
 
     expect(dockerCompatibility.getTypeFromServerInfo(serverInfo, podmanInfo)).toBe('podman');
   });

--- a/packages/main/src/plugin/docker/docker-compatibility.spec.ts
+++ b/packages/main/src/plugin/docker/docker-compatibility.spec.ts
@@ -18,14 +18,66 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { beforeAll, expect, test, vi } from 'vitest';
+import type { Stats } from 'node:fs';
+import { promises } from 'node:fs';
 
+import type { ProviderContainerConnection } from '@podman-desktop/api';
+import type { Mock } from 'vitest';
+import { beforeAll, describe, expect, test, vi } from 'vitest';
+
+import type { DockerSocketServerInfoType } from '/@api/docker-compatibility-info.js';
+import type { ProviderInfo } from '/@api/provider-info.js';
+
+import * as util from '../../util.js';
 import type { ApiSenderType } from '../api.js';
 import { ConfigurationRegistry } from '../configuration-registry.js';
 import type { Directories } from '../directories.js';
+import type { ProviderRegistry } from '../provider-registry.js';
 import { DockerCompatibility } from './docker-compatibility.js';
 
 let configurationRegistry: ConfigurationRegistry;
+
+const providerRegistry: ProviderRegistry = {
+  getContainerConnections: vi.fn(),
+  getProviderInfos: vi.fn(),
+} as unknown as ProviderRegistry;
+
+export class TestDockerCompatibility extends DockerCompatibility {
+  public override getTypeFromServerInfo(
+    info: { OperatingSystem?: string },
+    podmanInfo: unknown,
+  ): DockerSocketServerInfoType {
+    return super.getTypeFromServerInfo(info, podmanInfo);
+  }
+}
+
+// mock exists sync
+vi.mock('node:fs');
+
+const dockerodeInfoMock = vi.fn();
+const dockerodePodmanInfoMock = vi.fn();
+
+vi.mock('dockerode', async () => {
+  class Dockerode {
+    async info(): Promise<Mock<any>> {
+      return dockerodeInfoMock();
+    }
+    async podmanInfo(): Promise<Mock<any>> {
+      return dockerodePodmanInfoMock();
+    }
+  }
+
+  return { default: Dockerode };
+});
+
+vi.mock('../../util', () => {
+  return {
+    isWindows: vi.fn(),
+    isMac: vi.fn(),
+    isLinux: vi.fn(),
+    exec: vi.fn(),
+  };
+});
 
 /* eslint-disable @typescript-eslint/no-empty-function */
 beforeAll(() => {
@@ -35,7 +87,7 @@ beforeAll(() => {
 });
 
 test('should register a configuration', async () => {
-  const dockerCompatibility = new DockerCompatibility(configurationRegistry);
+  const dockerCompatibility = new TestDockerCompatibility(configurationRegistry, providerRegistry);
   dockerCompatibility.init();
 
   expect(configurationRegistry.registerConfigurations).toBeCalled();
@@ -44,8 +96,204 @@ test('should register a configuration', async () => {
   expect(configurationNode?.title).toBe('Experimental (Docker Compatibility)');
   expect(configurationNode?.properties).toBeDefined();
   expect(Object.keys(configurationNode?.properties ?? {}).length).toBe(1);
-  expect(configurationNode?.properties?.[DockerCompatibility.ENABLED_FULL_KEY]).toBeDefined();
-  expect(configurationNode?.properties?.[DockerCompatibility.ENABLED_FULL_KEY]?.type).toBe('boolean');
-  expect(configurationNode?.properties?.[DockerCompatibility.ENABLED_FULL_KEY]?.default).toBeFalsy();
-  expect(configurationNode?.properties?.[DockerCompatibility.ENABLED_FULL_KEY]?.hidden).toBeTruthy();
+  expect(configurationNode?.properties?.[TestDockerCompatibility.ENABLED_FULL_KEY]).toBeDefined();
+  expect(configurationNode?.properties?.[TestDockerCompatibility.ENABLED_FULL_KEY]?.type).toBe('boolean');
+  expect(configurationNode?.properties?.[TestDockerCompatibility.ENABLED_FULL_KEY]?.default).toBeFalsy();
+  expect(configurationNode?.properties?.[TestDockerCompatibility.ENABLED_FULL_KEY]?.hidden).toBeTruthy();
+});
+
+describe('getTypeFromServerInfo', async () => {
+  test('Docker Desktop', async () => {
+    const dockerCompatibility = new TestDockerCompatibility(configurationRegistry, providerRegistry);
+    const serverInfo = {
+      OperatingSystem: 'Docker Desktop',
+    };
+
+    const podmanInfo = {};
+
+    expect(dockerCompatibility.getTypeFromServerInfo(serverInfo, podmanInfo)).toBe('docker');
+  });
+
+  test('check podman OS without podman info', async () => {
+    const dockerCompatibility = new TestDockerCompatibility(configurationRegistry, providerRegistry);
+    const serverInfo = {
+      OperatingSystem: 'podman',
+    };
+
+    const podmanInfo = undefined;
+
+    expect(dockerCompatibility.getTypeFromServerInfo(serverInfo, podmanInfo)).toBe('podman');
+  });
+
+  test('check podman OS with podman info', async () => {
+    const dockerCompatibility = new TestDockerCompatibility(configurationRegistry, providerRegistry);
+    const serverInfo = {
+      OperatingSystem: 'foo',
+    };
+
+    const podmanInfo = {};
+
+    expect(dockerCompatibility.getTypeFromServerInfo(serverInfo, podmanInfo)).toBe('podman');
+  });
+
+  test('check unknown', async () => {
+    const dockerCompatibility = new TestDockerCompatibility(configurationRegistry, providerRegistry);
+    const serverInfo = {
+      OperatingSystem: 'random',
+    };
+
+    const podmanInfo = undefined;
+
+    expect(dockerCompatibility.getTypeFromServerInfo(serverInfo, podmanInfo)).toBe('unknown');
+  });
+});
+
+describe('resolveLinkIfAny', async () => {
+  test('on Windows return same path', async () => {
+    const dockerCompatibility = new TestDockerCompatibility(configurationRegistry, providerRegistry);
+
+    vi.spyOn(util, 'isWindows').mockImplementation(() => true);
+    const path = '/var/run/docker.sock';
+    expect(await dockerCompatibility.resolveLinkIfAny(path)).toBe(path);
+  });
+
+  test('on macOS or Linux without symlink return same path', async () => {
+    vi.spyOn(util, 'isWindows').mockImplementation(() => false);
+    const isSymbolicLink = vi.fn();
+    vi.spyOn(promises, 'lstat').mockResolvedValue({
+      isSymbolicLink,
+    } as unknown as Stats);
+    vi.mocked(isSymbolicLink).mockReturnValue(false);
+    const dockerCompatibility = new TestDockerCompatibility(configurationRegistry, providerRegistry);
+
+    const path = '/var/run/docker.sock';
+    expect(await dockerCompatibility.resolveLinkIfAny(path)).toBe(path);
+  });
+
+  test('on macOS or Linux with a symlink return different path', async () => {
+    const path = '/var/run/docker.sock';
+    const newPath = '/var/run/docker.sock2';
+
+    vi.spyOn(util, 'isWindows').mockImplementation(() => false);
+    const isSymbolicLink = vi.fn();
+    vi.spyOn(promises, 'lstat').mockResolvedValue({
+      isSymbolicLink,
+    } as unknown as Stats);
+    // mock readlink
+    vi.spyOn(promises, 'readlink').mockResolvedValue(newPath);
+    // symbolic link first and then not a symbolic link
+    vi.mocked(isSymbolicLink).mockReturnValueOnce(true);
+    vi.mocked(isSymbolicLink).mockReturnValueOnce(false);
+    const dockerCompatibility = new TestDockerCompatibility(configurationRegistry, providerRegistry);
+
+    expect(await dockerCompatibility.resolveLinkIfAny(path)).toBe(newPath);
+
+    // check if readlink is called
+    expect(promises.readlink).toBeCalledWith(path);
+  });
+});
+
+describe('getSystemDockerSocketMappingStatus', async () => {
+  test('on Windows', async () => {
+    const dockerCompatibility = new TestDockerCompatibility(configurationRegistry, providerRegistry);
+
+    vi.spyOn(dockerCompatibility, 'getTypeFromServerInfo').mockReturnValue('docker');
+    vi.spyOn(util, 'isWindows').mockImplementation(() => true);
+
+    dockerodePodmanInfoMock.mockResolvedValue({
+      ServerVersion: '1.0.0',
+    });
+
+    dockerodeInfoMock.mockResolvedValue({
+      ServerVersion: '1.0.0',
+      OperatingSystem: 'podman',
+      OSType: 'foo',
+      Architecture: 'bar',
+    });
+
+    expect(await dockerCompatibility.getSystemDockerSocketMappingStatus()).toEqual({
+      serverInfo: {
+        architecture: 'bar',
+        operatingSystem: 'podman',
+        osType: 'foo',
+        serverVersion: '1.0.0',
+        type: 'docker',
+      },
+      status: 'running',
+    });
+  });
+
+  test('error on dockerode call', async () => {
+    const dockerCompatibility = new TestDockerCompatibility(configurationRegistry, providerRegistry);
+
+    vi.spyOn(util, 'isWindows').mockImplementation(() => true);
+
+    dockerodeInfoMock.mockRejectedValue(new Error('test error'));
+
+    expect(await dockerCompatibility.getSystemDockerSocketMappingStatus()).toEqual({
+      status: 'unreachable',
+    });
+  });
+
+  test('on macOS', async () => {
+    const dockerCompatibility = new TestDockerCompatibility(configurationRegistry, providerRegistry);
+
+    vi.spyOn(dockerCompatibility, 'getTypeFromServerInfo').mockReturnValue('docker');
+    vi.spyOn(util, 'isWindows').mockImplementation(() => false);
+    vi.spyOn(util, 'isMac').mockImplementation(() => true);
+
+    // mock resolveLinkIfAny
+    vi.spyOn(dockerCompatibility, 'resolveLinkIfAny').mockResolvedValue(DockerCompatibility.UNIX_SOCKET_PATH);
+
+    // connection
+    const connection = {
+      providerId: 'fooProvider',
+      connection: {
+        name: 'myDummyConnection',
+
+        endpoint: {
+          socketPath: DockerCompatibility.UNIX_SOCKET_PATH,
+        },
+      },
+    } as unknown as ProviderContainerConnection;
+    vi.mocked(providerRegistry.getContainerConnections).mockReturnValue([connection]);
+
+    const providerInfo = {
+      id: 'fooProvider',
+      name: 'Foo Provider',
+      internalId: 'fooProviderInternalId',
+    } as unknown as ProviderInfo;
+    vi.mocked(providerRegistry.getProviderInfos).mockReturnValue([providerInfo]);
+
+    dockerodePodmanInfoMock.mockResolvedValue({
+      ServerVersion: '1.0.0',
+    });
+
+    dockerodeInfoMock.mockResolvedValue({
+      ServerVersion: '1.0.0',
+      OperatingSystem: 'podman',
+      OSType: 'foo',
+      Architecture: 'bar',
+    });
+
+    expect(await dockerCompatibility.getSystemDockerSocketMappingStatus()).toEqual({
+      connectionInfo: {
+        displayName: 'myDummyConnection',
+        link: '/preferences/container-connection/view/fooProviderInternalId/bXlEdW1teUNvbm5lY3Rpb24=/L3Zhci9ydW4vZG9ja2VyLnNvY2s=/summary',
+        name: 'myDummyConnection',
+        provider: {
+          id: 'fooProvider',
+          name: 'Foo Provider',
+        },
+      },
+      serverInfo: {
+        architecture: 'bar',
+        operatingSystem: 'podman',
+        osType: 'foo',
+        serverVersion: '1.0.0',
+        type: 'docker',
+      },
+      status: 'running',
+    });
+  });
 });

--- a/packages/main/src/plugin/docker/docker-compatibility.ts
+++ b/packages/main/src/plugin/docker/docker-compatibility.ts
@@ -86,10 +86,16 @@ export class DockerCompatibility {
     return path;
   }
 
+  /**
+   * Try to connect to the docker socket if on Linux or macOS or
+   * to the named pipe if on Windows.
+   * If the connection is successful, return the status as running.
+   * Also return some extra information about the server.
+   * If the socket path is an alias to a provider, return the connection information.
+   * If the connection is not successful, return the status as unreachable.
+   * @returns the status plus some extra information if the connection is successful
+   */
   async getSystemDockerSocketMappingStatus(): Promise<DockerSocketMappingStatusInfo> {
-    // first, try to connect to the docker socket if on Linux or macOS
-    // if the connection is successful, return @the status as running
-
     const socketPath = isWindows() ? DockerCompatibility.WINDOWS_NPIPE : DockerCompatibility.UNIX_SOCKET_PATH;
 
     const dockerode = new Dockerode({ socketPath });
@@ -130,7 +136,7 @@ export class DockerCompatibility {
         // search if we have a connection with the same socket path
         const foundConnection = currentConnections.find(c => c.connection.endpoint.socketPath === socketPath);
 
-        // provider is
+        // provider is the one that has the same id as the connection
         const allProviders = this.#providerRegistry.getProviderInfos();
         // search by provider id
         const provider = allProviders.find(p => p.id === foundConnection?.providerId);

--- a/packages/main/src/plugin/docker/docker-compatibility.ts
+++ b/packages/main/src/plugin/docker/docker-compatibility.ts
@@ -61,7 +61,10 @@ export class DockerCompatibility {
     this.#configurationRegistry.registerConfigurations([dockerCompatibilityConfiguration]);
   }
 
-  protected getTypeFromServerInfo(info: { OperatingSystem?: string }, podmanInfo: unknown): DockerSocketServerInfoType {
+  protected getTypeFromServerInfo(
+    info: { OperatingSystem?: string },
+    podmanInfo?: unknown,
+  ): DockerSocketServerInfoType {
     if (info.OperatingSystem === 'Docker Desktop') {
       return 'docker';
     } else if (info.OperatingSystem === 'podman' || podmanInfo) {

--- a/packages/main/src/plugin/docker/docker-compatibility.ts
+++ b/packages/main/src/plugin/docker/docker-compatibility.ts
@@ -16,17 +16,31 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { promises } from 'node:fs';
+
+import Dockerode from 'dockerode';
+
+import { isMac, isWindows } from '/@/util.js';
+import type { DockerSocketMappingStatusInfo, DockerSocketServerInfoType } from '/@api/docker-compatibility-info.js';
 import { ExperimentalSettings } from '/@api/docker-compatibility-info.js';
 
 import type { ConfigurationRegistry, IConfigurationNode } from '../configuration-registry.js';
+import type { LibPod } from '../dockerode/libpod-dockerode.js';
+import type { ProviderRegistry } from '../provider-registry.js';
 
 export class DockerCompatibility {
+  static readonly WINDOWS_NPIPE = '//./pipe/docker_engine';
+  static readonly UNIX_SOCKET_PATH = '/var/run/docker.sock';
+
   static readonly ENABLED_FULL_KEY = `${ExperimentalSettings.SectionName}.${ExperimentalSettings.Enabled}`;
 
   #configurationRegistry: ConfigurationRegistry;
 
-  constructor(configurationRegistry: ConfigurationRegistry) {
+  #providerRegistry: ProviderRegistry;
+
+  constructor(configurationRegistry: ConfigurationRegistry, providerRegistry: ProviderRegistry) {
     this.#configurationRegistry = configurationRegistry;
+    this.#providerRegistry = providerRegistry;
   }
 
   init(): void {
@@ -45,5 +59,107 @@ export class DockerCompatibility {
     };
 
     this.#configurationRegistry.registerConfigurations([dockerCompatibilityConfiguration]);
+  }
+
+  protected getTypeFromServerInfo(info: { OperatingSystem?: string }, podmanInfo: unknown): DockerSocketServerInfoType {
+    if (info.OperatingSystem === 'Docker Desktop') {
+      return 'docker';
+    } else if (info.OperatingSystem === 'podman' || podmanInfo) {
+      // if podman info is available, then it is podman
+      return 'podman';
+    }
+    return 'unknown';
+  }
+
+  async resolveLinkIfAny(path: string): Promise<string> {
+    // do not resolve on Windows
+    if (isWindows()) {
+      return path;
+    }
+
+    const lstat = await promises.lstat(path);
+    if (lstat.isSymbolicLink()) {
+      const resolved = await promises.readlink(path);
+      return this.resolveLinkIfAny(resolved);
+    }
+
+    return path;
+  }
+
+  async getSystemDockerSocketMappingStatus(): Promise<DockerSocketMappingStatusInfo> {
+    // first, try to connect to the docker socket if on Linux or macOS
+    // if the connection is successful, return @the status as running
+
+    const socketPath = isWindows() ? DockerCompatibility.WINDOWS_NPIPE : DockerCompatibility.UNIX_SOCKET_PATH;
+
+    const dockerode = new Dockerode({ socketPath });
+    // check if we can also use a podman API
+    const libpodDockerode = dockerode as unknown as LibPod;
+
+    try {
+      const compatInfo = await dockerode.info();
+      let podmanInfo = undefined;
+
+      let serverVersion = compatInfo.ServerVersion;
+      try {
+        podmanInfo = await libpodDockerode.podmanInfo();
+        serverVersion = podmanInfo.version.Version;
+      } catch (error: unknown) {
+        // podman API is not available
+      }
+
+      const status: DockerSocketMappingStatusInfo = {
+        status: 'running',
+        serverInfo: {
+          type: this.getTypeFromServerInfo(compatInfo, podmanInfo),
+          serverVersion,
+          operatingSystem: compatInfo.OperatingSystem,
+          osType: compatInfo.OSType,
+          architecture: compatInfo.Architecture,
+        },
+      };
+
+      // now, try to see if the socket path is an alias to a podman machine
+      if (isMac()) {
+        // is UNIX_SOCKET_PATH a symbolic link ?
+        const socketPath = await this.resolveLinkIfAny(DockerCompatibility.UNIX_SOCKET_PATH);
+
+        // do we have a matching provider for the socket path ?
+        const currentConnections = this.#providerRegistry.getContainerConnections();
+
+        // search if we have a connection with the same socket path
+        const foundConnection = currentConnections.find(c => c.connection.endpoint.socketPath === socketPath);
+
+        // provider is
+        const allProviders = this.#providerRegistry.getProviderInfos();
+        // search by provider id
+        const provider = allProviders.find(p => p.id === foundConnection?.providerId);
+
+        if (provider && foundConnection) {
+          const link = `/preferences/container-connection/view/${provider.internalId}/${Buffer.from(
+            foundConnection.connection.name,
+          ).toString(
+            'base64',
+          )}/${Buffer.from(foundConnection.connection.endpoint.socketPath).toString('base64')}/summary`;
+
+          // extra data to pass
+          status.connectionInfo = {
+            provider: {
+              id: provider.id,
+              name: provider.name,
+            },
+            link,
+            name: foundConnection?.connection.name,
+            displayName: foundConnection.connection.displayName ?? foundConnection.connection.name,
+          };
+        }
+      }
+
+      return status;
+    } catch (error: unknown) {
+      // unable to connect to the system socket
+      // in that case, need to return the status as not reachable
+      return { status: 'unreachable' };
+    }
   }
 }

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -76,6 +76,7 @@ import type {
 import type { ContainerInspectInfo } from '/@api/container-inspect-info.js';
 import type { ContainerStatsInfo } from '/@api/container-stats-info.js';
 import type { ContributionInfo } from '/@api/contribution-info.js';
+import type { DockerSocketMappingStatusInfo } from '/@api/docker-compatibility-info.js';
 import type { ExtensionInfo } from '/@api/extension-info.js';
 import type { HistoryInfo } from '/@api/history-info.js';
 import type { IconInfo } from '/@api/icon-info.js';
@@ -496,7 +497,7 @@ export class PluginSystem {
     const closeBehaviorConfiguration = new CloseBehavior(configurationRegistry);
     await closeBehaviorConfiguration.init();
 
-    const dockerCompatibility = new DockerCompatibility(configurationRegistry);
+    const dockerCompatibility = new DockerCompatibility(configurationRegistry, providerRegistry);
     dockerCompatibility.init();
 
     const messageBox = new MessageBox(apiSender);
@@ -2693,6 +2694,13 @@ export class PluginSystem {
     this.ipcHandle(
       'context:collectAllValues',
       async (): Promise<Record<string, unknown>> => context.collectAllValues(),
+    );
+
+    this.ipcHandle(
+      'docker-compatibility:getSystemDockerSocketMappingStatus',
+      async (): Promise<DockerSocketMappingStatusInfo> => {
+        return dockerCompatibility.getSystemDockerSocketMappingStatus();
+      },
     );
 
     const dockerDesktopInstallation = new DockerDesktopInstallation(

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -56,6 +56,7 @@ import type {
 import type { ContainerInspectInfo } from '/@api/container-inspect-info';
 import type { ContainerStatsInfo } from '/@api/container-stats-info';
 import type { ContributionInfo } from '/@api/contribution-info';
+import type { DockerSocketMappingStatusInfo } from '/@api/docker-compatibility-info';
 import type { ExtensionInfo } from '/@api/extension-info';
 import type { HistoryInfo } from '/@api/history-info';
 import type { IconInfo } from '/@api/icon-info';
@@ -2239,6 +2240,13 @@ export function initExposure(): void {
   contextBridge.exposeInMainWorld('contextCollectAllValues', async (): Promise<Record<string, unknown>> => {
     return ipcInvoke('context:collectAllValues');
   });
+
+  contextBridge.exposeInMainWorld(
+    'getSystemDockerSocketMappingStatus',
+    async (): Promise<DockerSocketMappingStatusInfo> => {
+      return ipcInvoke('docker-compatibility:getSystemDockerSocketMappingStatus');
+    },
+  );
 }
 
 // expose methods


### PR DESCRIPTION
### What does this PR do?
This is the backend part of https://github.com/containers/podman-desktop/issues/9025

query /var/run/docker.sock or npipe and provide info on the connection to the frontend
correlating for macOS the provider serving this connection


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to #9025 

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
