### PR TITLE
fix: set a podman machine as running only when not starting

### DIFF
--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -1232,6 +1232,7 @@ test('ensure stopped machine reports stopped provider', async () => {
   await extension.updateMachines(provider, podmanConfiguration);
 
   expect(provider.updateStatus).toBeCalledWith('configured');
+  expect(extension.podmanMachinesStatuses.get('podman-machine-default')).toBe('stopped');
 });
 
 test('ensure running and starting machine reports starting provider', async () => {
@@ -1262,6 +1263,7 @@ test('ensure running and starting machine reports starting provider', async () =
   await extension.updateMachines(provider, podmanConfiguration);
 
   expect(provider.updateStatus).toBeCalledWith('starting');
+  expect(extension.podmanMachinesStatuses.get('podman-machine-default')).toBe('starting');
 });
 
 test('ensure running and not starting machine reports ready provider', async () => {
@@ -1292,6 +1294,7 @@ test('ensure running and not starting machine reports ready provider', async () 
   await extension.updateMachines(provider, podmanConfiguration);
 
   expect(provider.updateStatus).toBeCalledWith('ready');
+  expect(extension.podmanMachinesStatuses.get('podman-machine-default')).toBe('started');
 });
 
 test('ensure started machine reports configuration', async () => {

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -250,9 +250,9 @@ export async function updateMachines(
     const running = machine?.Running === true;
     let status: extensionApi.ProviderConnectionStatus = running ? 'started' : 'stopped';
 
-    // update the status to starting if the machine is starting but not yet running
+    // update the status to starting if the machine is running but still starting
     const starting = machine?.Starting === true;
-    if (!running && starting) {
+    if (starting) {
       status = 'starting';
     }
 

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -379,7 +379,7 @@ export async function updateMachines(
         provider.updateStatus('installed');
       }
     } else {
-      const atLeastOneMachineRunning = machines.some(machine => machine.Running);
+      const atLeastOneMachineRunning = machines.some(machine => machine.Running && !machine.Starting);
       const atLeastOneMachineStarting = machines.some(machine => machine.Starting);
       // if a machine is running it's started else it is ready
       if (atLeastOneMachineRunning) {

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -76,7 +76,7 @@ let defaultConnectionNotify = !isLinux();
 let defaultMachineMonitor = true;
 
 // current status of machines
-const podmanMachinesStatuses = new Map<string, extensionApi.ProviderConnectionStatus>();
+export const podmanMachinesStatuses = new Map<string, extensionApi.ProviderConnectionStatus>();
 let podmanProviderStatus: extensionApi.ProviderConnectionStatus = 'started';
 const podmanMachinesInfo = new Map<string, MachineInfo>();
 const currentConnections = new Map<string, extensionApi.Disposable>();

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -379,6 +379,12 @@ export async function updateMachines(
         provider.updateStatus('installed');
       }
     } else {
+      /*
+       * The machine can have 3 states, based on `Starting` and `Running` fields:
+       * - !Running && !Starting -> configured
+       * -  Running &&  Starting -> starting
+       * -  Running && !Starting -> ready
+       */
       const atLeastOneMachineRunning = machines.some(machine => machine.Running && !machine.Starting);
       const atLeastOneMachineStarting = machines.some(machine => machine.Starting);
       // if a machine is running it's started else it is ready


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

The podman machine has 2 fields to indicate its state: `Running` and `Starting`.

The global state of the machine can have 3 values:
- `!Running`
- `Running` && `Starting`
- `Running` && `!Starting`

Previously, the second state was considered as running, but at this point, the `podman machine init` is not finished, it will terminate only when the third state is reached. To help the user know when the `podman machine init` is really finished, this PR changes this second state as `Starting` and not `Running`

### Screenshot / video of UI

### What issues does this PR fix or reference?

Fixes #8984 

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
