### PR TITLE
chore: add release notes to dashboard page - renderer

### DIFF
--- a/packages/renderer/src/lib/dashboard/DashboardPage.svelte
+++ b/packages/renderer/src/lib/dashboard/DashboardPage.svelte
@@ -15,6 +15,7 @@ import ProviderNotInstalled from './ProviderNotInstalled.svelte';
 import ProviderReady from './ProviderReady.svelte';
 import ProviderStarting from './ProviderStarting.svelte';
 import ProviderStopped from './ProviderStopped.svelte';
+import ReleaseNotesBox from './ReleaseNotesBox.svelte';
 
 const providerInitContexts = new Map<string, InitializationContext>();
 
@@ -42,6 +43,7 @@ function getInitializationContext(id: string): InitializationContext {
     <div class="min-w-full flex-1">
       <NotificationsBox />
       <div class="px-5 space-y-5 h-full">
+        <ReleaseNotesBox />
         <!-- Provider is ready display a box to indicate some information -->
         {#if providersReady.length > 0}
           {#each providersReady as providerReady (providerReady.internalId)}

--- a/packages/renderer/src/lib/dashboard/ReleaseNotesBox.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ReleaseNotesBox.spec.ts
@@ -1,0 +1,115 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen, waitFor } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { tick } from 'svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import ReleaseNotesBox from './ReleaseNotesBox.svelte';
+
+const podmanDesktopUpdateAvailableMock = vi.fn();
+const getPodmanDesktopVersionMock = vi.fn();
+const podmanDesktopOpenReleaseNotesMock = vi.fn();
+const updatePodmanDesktopMock = vi.fn();
+const updateConfigurationValueMock = vi.fn();
+const getConfigurationValueMock = vi.fn();
+const podmanDesktopGetReleaseNotesMock = vi.fn();
+const responsJSON = { image: 'image1.png', title: 'Release 1.1', summary: 'some info about v1.1.0 release' };
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  (window as any).podmanDesktopUpdateAvailable = podmanDesktopUpdateAvailableMock.mockResolvedValue(false);
+  (window as any).getPodmanDesktopVersion = getPodmanDesktopVersionMock.mockResolvedValue('1.1.0');
+  (window as any).podmanDesktopOpenReleaseNotes = podmanDesktopOpenReleaseNotesMock;
+  (window as any).podmanDesktopGetReleaseNotes = podmanDesktopGetReleaseNotesMock.mockResolvedValue({
+    releaseNotesAvailable: true,
+    notesURL: `appHomepage/blog/podman-desktop-release-1.1`,
+    notes: responsJSON,
+  });
+  (window as any).updatePodmanDesktop = updatePodmanDesktopMock;
+  (window as any).updateConfigurationValue = updateConfigurationValueMock;
+  (window as any).getConfigurationValue = getConfigurationValueMock.mockResolvedValue('show');
+  (window.events as unknown) = {
+    receive: vi.fn().mockImplementation(() => {
+      return {
+        dispose: vi.fn(),
+      };
+    }),
+  };
+});
+
+test('expect banner to be visible', async () => {
+  render(ReleaseNotesBox);
+  await tick();
+  expect(getConfigurationValueMock).toBeCalledWith('releaseNotesBanner.show');
+  expect(podmanDesktopGetReleaseNotesMock).toBeCalled();
+  await tick();
+  expect(screen.getByText(responsJSON.title)).toBeInTheDocument();
+  expect(screen.getAllByText(responsJSON.summary)[0]).toBeInTheDocument();
+  expect(screen.getByRole('img')).toBeInTheDocument();
+  expect(screen.getByRole('img')).toHaveAttribute('src', responsJSON.image);
+});
+
+test('expect no release notes available', async () => {
+  podmanDesktopGetReleaseNotesMock.mockResolvedValue({
+    releaseNotesAvailable: false,
+    notesURL: `appRepo/release-summary`,
+  });
+
+  render(ReleaseNotesBox);
+  await waitFor(() => expect(podmanDesktopGetReleaseNotesMock).toBeCalled());
+  await tick();
+  expect(screen.queryByText(responsJSON.title)).not.toBeInTheDocument();
+  expect(screen.queryByText(responsJSON.summary)).not.toBeInTheDocument();
+  expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  expect(
+    screen.getByText('Release notes are currently unavailable, please check again later or try this'),
+  ).toBeInTheDocument();
+});
+
+test('expect update button to show when there is an update', async () => {
+  podmanDesktopUpdateAvailableMock.mockResolvedValue(true);
+  render(ReleaseNotesBox);
+  await waitFor(() => expect(podmanDesktopGetReleaseNotesMock));
+  await tick();
+  await waitFor(() => expect(screen.queryByRole('button', { name: 'Update' })).toBeInTheDocument());
+  const updateButton = screen.getByRole('button', { name: 'Update' });
+  await userEvent.click(updateButton);
+  expect(updatePodmanDesktopMock).toHaveBeenCalled();
+});
+
+test('expect update button to not show when there is no update', async () => {
+  render(ReleaseNotesBox);
+  await waitFor(() => expect(podmanDesktopGetReleaseNotesMock).toBeCalled());
+  await tick();
+  expect(screen.queryByRole('button', { name: 'Update' })).not.toBeInTheDocument();
+});
+
+test('expect clicking on close button to not show banner anymore', async () => {
+  render(ReleaseNotesBox);
+  await waitFor(() => expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument);
+  const closeButton = screen.getByRole('button', { name: 'Close' });
+  await userEvent.click(closeButton);
+  await tick();
+  expect(updateConfigurationValueMock).toBeCalledWith('releaseNotesBanner.show', '1.1.0');
+  expect(screen.queryByText(responsJSON.title)).not.toBeInTheDocument();
+  expect(screen.queryByText(responsJSON.summary)).not.toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/dashboard/ReleaseNotesBox.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ReleaseNotesBox.spec.ts
@@ -27,7 +27,7 @@ import ReleaseNotesBox from './ReleaseNotesBox.svelte';
 
 const podmanDesktopUpdateAvailableMock = vi.fn();
 const getPodmanDesktopVersionMock = vi.fn();
-const podmanDesktopOpenReleaseNotesMock = vi.fn();
+const openExternalMock = vi.fn();
 const updatePodmanDesktopMock = vi.fn();
 const updateConfigurationValueMock = vi.fn();
 const getConfigurationValueMock = vi.fn();
@@ -38,7 +38,7 @@ beforeEach(() => {
   vi.resetAllMocks();
   (window as any).podmanDesktopUpdateAvailable = podmanDesktopUpdateAvailableMock.mockResolvedValue(false);
   (window as any).getPodmanDesktopVersion = getPodmanDesktopVersionMock.mockResolvedValue('1.1.0');
-  (window as any).podmanDesktopOpenReleaseNotes = podmanDesktopOpenReleaseNotesMock;
+  (window as any).openExternal = openExternalMock;
   (window as any).podmanDesktopGetReleaseNotes = podmanDesktopGetReleaseNotesMock.mockResolvedValue({
     releaseNotesAvailable: true,
     notesURL: `appHomepage/blog/podman-desktop-release-1.1`,

--- a/packages/renderer/src/lib/dashboard/ReleaseNotesBox.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ReleaseNotesBox.spec.ts
@@ -60,7 +60,7 @@ test('expect banner to be visible', async () => {
   render(ReleaseNotesBox);
   await tick();
   expect(getConfigurationValueMock).toBeCalledWith('releaseNotesBanner.show');
-  expect(podmanDesktopGetReleaseNotesMock).toBeCalled();
+  await waitFor(() => expect(podmanDesktopGetReleaseNotesMock).toBeCalled());
   await tick();
   expect(screen.getByText(responseJSON.title)).toBeInTheDocument();
   expect(screen.getAllByText(responseJSON.summary)[0]).toBeInTheDocument();
@@ -77,8 +77,8 @@ test('expect no release notes available', async () => {
   render(ReleaseNotesBox);
   await waitFor(() => expect(podmanDesktopGetReleaseNotesMock).toBeCalled());
   await tick();
-  expect(screen.queryByText(responsJSON.title)).not.toBeInTheDocument();
-  expect(screen.queryByText(responsJSON.summary)).not.toBeInTheDocument();
+  expect(screen.queryByText(responseJSON.title)).not.toBeInTheDocument();
+  expect(screen.queryByText(responseJSON.summary)).not.toBeInTheDocument();
   expect(screen.queryByRole('img')).not.toBeInTheDocument();
   expect(
     screen.getByText('Release notes are currently unavailable, please check again later or try this'),
@@ -110,6 +110,6 @@ test('expect clicking on close button to not show banner anymore', async () => {
   await userEvent.click(closeButton);
   await tick();
   expect(updateConfigurationValueMock).toBeCalledWith('releaseNotesBanner.show', '1.1.0');
-  expect(screen.queryByText(responsJSON.title)).not.toBeInTheDocument();
-  expect(screen.queryByText(responsJSON.summary)).not.toBeInTheDocument();
+  expect(screen.queryByText(responseJSON.title)).not.toBeInTheDocument();
+  expect(screen.queryByText(responseJSON.summary)).not.toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/dashboard/ReleaseNotesBox.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ReleaseNotesBox.spec.ts
@@ -32,7 +32,7 @@ const updatePodmanDesktopMock = vi.fn();
 const updateConfigurationValueMock = vi.fn();
 const getConfigurationValueMock = vi.fn();
 const podmanDesktopGetReleaseNotesMock = vi.fn();
-const responsJSON = { image: 'image1.png', title: 'Release 1.1', summary: 'some info about v1.1.0 release' };
+const responseJSON = { image: 'image1.png', title: 'Release 1.1', summary: 'some info about v1.1.0 release' };
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -42,7 +42,7 @@ beforeEach(() => {
   (window as any).podmanDesktopGetReleaseNotes = podmanDesktopGetReleaseNotesMock.mockResolvedValue({
     releaseNotesAvailable: true,
     notesURL: `appHomepage/blog/podman-desktop-release-1.1`,
-    notes: responsJSON,
+    notes: responseJSON,
   });
   (window as any).updatePodmanDesktop = updatePodmanDesktopMock;
   (window as any).updateConfigurationValue = updateConfigurationValueMock;
@@ -62,10 +62,10 @@ test('expect banner to be visible', async () => {
   expect(getConfigurationValueMock).toBeCalledWith('releaseNotesBanner.show');
   expect(podmanDesktopGetReleaseNotesMock).toBeCalled();
   await tick();
-  expect(screen.getByText(responsJSON.title)).toBeInTheDocument();
-  expect(screen.getAllByText(responsJSON.summary)[0]).toBeInTheDocument();
+  expect(screen.getByText(responseJSON.title)).toBeInTheDocument();
+  expect(screen.getAllByText(responseJSON.summary)[0]).toBeInTheDocument();
   expect(screen.getByRole('img')).toBeInTheDocument();
-  expect(screen.getByRole('img')).toHaveAttribute('src', responsJSON.image);
+  expect(screen.getByRole('img')).toHaveAttribute('src', responseJSON.image);
 });
 
 test('expect no release notes available', async () => {

--- a/packages/renderer/src/lib/dashboard/ReleaseNotesBox.svelte
+++ b/packages/renderer/src/lib/dashboard/ReleaseNotesBox.svelte
@@ -3,6 +3,8 @@ import { faCircleArrowUp } from '@fortawesome/free-solid-svg-icons';
 import { Button, CloseButton, Link } from '@podman-desktop/ui-svelte';
 import { onDestroy, onMount } from 'svelte';
 
+import type { ReleaseNotes } from '/@api/release-notes-info';
+
 import Markdown from '../markdown/Markdown.svelte';
 
 let showBanner = false;
@@ -10,13 +12,7 @@ let notesAvailable = false;
 let updateAvilable = false;
 let notesURL: string;
 let currentVersion: string;
-let notesInfo: NotesInfo | undefined;
-interface NotesInfo {
-  image: string;
-  blog: string;
-  title: string;
-  summary: string;
-}
+let notesInfo: ReleaseNotes | undefined;
 const receiveShowReleaseNotes = window.events?.receive('show-release-notes', () => {
   showBanner = true;
 });

--- a/packages/renderer/src/lib/dashboard/ReleaseNotesBox.svelte
+++ b/packages/renderer/src/lib/dashboard/ReleaseNotesBox.svelte
@@ -1,0 +1,98 @@
+<script lang="ts">
+import { faCircleArrowUp } from '@fortawesome/free-solid-svg-icons';
+import { Button, CloseButton, Link } from '@podman-desktop/ui-svelte';
+import { onDestroy, onMount } from 'svelte';
+
+import Markdown from '../markdown/Markdown.svelte';
+
+let showBanner = false;
+let notesAvailable = false;
+let updateAvilable = false;
+let notesURL: string;
+let currentVersion: string;
+let notesInfo: NotesInfo | undefined;
+interface NotesInfo {
+  image: string;
+  blog: string;
+  title: string;
+  summary: string;
+}
+const receiveShowReleaseNotes = window.events?.receive('show-release-notes', () => {
+  showBanner = true;
+});
+function openReleaseNotes() {
+  window.podmanDesktopOpenReleaseNotes('current');
+}
+function updatePodmanDesktop() {
+  window.updatePodmanDesktop();
+}
+async function getInfoFromNotes() {
+  let getNotes = await window.podmanDesktopGetReleaseNotes();
+  notesAvailable = getNotes.releaseNotesAvailable;
+  if (notesAvailable) {
+    notesInfo = getNotes.notes;
+  }
+  notesURL = getNotes.notesURL;
+}
+function onClose() {
+  window.updateConfigurationValue(`releaseNotesBanner.show`, currentVersion);
+  showBanner = false;
+}
+onMount(async () => {
+  currentVersion = await window.getPodmanDesktopVersion();
+  showBanner = (await window.getConfigurationValue(`releaseNotesBanner.show`)) !== currentVersion ? true : false;
+  window
+    .podmanDesktopUpdateAvailable()
+    .then(available => (updateAvilable = available))
+    .catch(() => {
+      console.log('Cannot check for update');
+    });
+  await getInfoFromNotes();
+});
+onDestroy(async () => {
+  receiveShowReleaseNotes.dispose();
+});
+</script>
+
+{#if showBanner}
+  {#if notesAvailable}
+    <div class="flex bg-[var(--pd-content-card-bg)] rounded-md p-5 gap-3 flex-row flex-nowrap h-[200px] items-center">
+      {#if notesInfo?.image}
+        <img
+          src={notesInfo.image}
+          class="max-h-[100%] w-auto max-w-[20%] object-contain rounded-md self-start"
+          alt={`Podman Desktop ${currentVersion} release image`} />
+      {/if}
+      <div class="flex flex-col flex-1 h-100% self-start">
+        <div class="flex flex-row items-center justify-between">
+          <p class="text-[var(--pd-content-card-header-text)] font-bold text-xl ml-2">
+            {notesInfo?.title ?? ''}
+          </p>
+          <CloseButton on:click={onClose} />
+        </div>
+        {#if notesInfo?.summary}
+          <div
+            class="text-[var(--pd-content-card-text)] trunace text-ellipsis overflow-hidden whitespace-pre-line line-clamp-6">
+            <Markdown markdown={notesInfo?.summary}></Markdown>
+          </div>
+        {/if}
+        <div class="flex flex-row justify-end items-center gap-3 mt-2">
+          <Link on:click={openReleaseNotes}>Learn more</Link>
+          <Button on:click={updatePodmanDesktop} hidden={!updateAvilable} icon={faCircleArrowUp}>Update</Button>
+        </div>
+      </div>
+    </div>
+  {:else}
+    <div class="flex bg-[var(--pd-content-card-bg)] rounded-md p-5 flex-col flex-nowrap h-auto items-center">
+      <div class="flex flex-row items-center justify-between w-full">
+        <p class="text-[var(--pd-content-card-header-text)] font-bold text-lg w-full items-center">
+          Release notes are currently unavailable, please check again later
+          {#if notesURL}
+            or try this <a href={notesURL} class="text-[var(--pd-link)]">link</a>
+          {/if}
+        </p>
+        <CloseButton on:click={onClose} />
+      </div>
+    </div>
+  {/if}
+{/if}

--- a/packages/renderer/src/lib/dashboard/ReleaseNotesBox.svelte
+++ b/packages/renderer/src/lib/dashboard/ReleaseNotesBox.svelte
@@ -23,26 +23,23 @@ function updatePodmanDesktop() {
   window.updatePodmanDesktop();
 }
 async function getInfoFromNotes() {
-  let getNotes = await window.podmanDesktopGetReleaseNotes();
-  notesAvailable = getNotes.releaseNotesAvailable;
-  if (notesAvailable) {
-    notesInfo = getNotes.notes;
-  }
-  notesURL = getNotes.notesURL;
+  const releaseNotes = await window.podmanDesktopGetReleaseNotes();
+  notesAvailable = releaseNotes.releaseNotesAvailable;
+  notesInfo = releaseNotes?.notes;
+  notesURL = releaseNotes.notesURL;
 }
-function onClose() {
-  window.updateConfigurationValue(`releaseNotesBanner.show`, currentVersion);
+async function onClose() {
+  await window.updateConfigurationValue(`releaseNotesBanner.show`, currentVersion);
   showBanner = false;
 }
 onMount(async () => {
   currentVersion = await window.getPodmanDesktopVersion();
   showBanner = (await window.getConfigurationValue(`releaseNotesBanner.show`)) !== currentVersion ? true : false;
-  window
-    .podmanDesktopUpdateAvailable()
-    .then(available => (updateAvilable = available))
-    .catch(() => {
-      console.log('Cannot check for update');
-    });
+  try {
+    updateAvilable = await window.podmanDesktopUpdateAvailable();
+  } catch (e) {
+    console.log('Cannot check for update');
+  }
   await getInfoFromNotes();
 });
 onDestroy(async () => {
@@ -68,7 +65,7 @@ onDestroy(async () => {
         </div>
         {#if notesInfo?.summary}
           <div
-            class="text-[var(--pd-content-card-text)] trunace text-ellipsis overflow-hidden whitespace-pre-line line-clamp-6">
+            class="text-[var(--pd-content-card-text)] truncate text-ellipsis overflow-hidden whitespace-pre-line line-clamp-6">
             <Markdown markdown={notesInfo?.summary}></Markdown>
           </div>
         {/if}

--- a/packages/renderer/src/lib/dashboard/ReleaseNotesBox.svelte
+++ b/packages/renderer/src/lib/dashboard/ReleaseNotesBox.svelte
@@ -16,22 +16,27 @@ let notesInfo: ReleaseNotes | undefined;
 const receiveShowReleaseNotes = window.events?.receive('show-release-notes', () => {
   showBanner = true;
 });
+
 function openReleaseNotes() {
   window.openExternal(notesURL);
 }
+
 function updatePodmanDesktop() {
   window.updatePodmanDesktop();
 }
+
 async function getInfoFromNotes() {
   const releaseNotes = await window.podmanDesktopGetReleaseNotes();
-  notesAvailable = releaseNotes.releaseNotesAvailable;
   notesInfo = releaseNotes?.notes;
+  notesAvailable = notesInfo !== undefined;
   notesURL = releaseNotes.notesURL;
 }
+
 async function onClose() {
   await window.updateConfigurationValue(`releaseNotesBanner.show`, currentVersion);
   showBanner = false;
 }
+
 onMount(async () => {
   currentVersion = await window.getPodmanDesktopVersion();
   showBanner = (await window.getConfigurationValue(`releaseNotesBanner.show`)) !== currentVersion ? true : false;
@@ -42,6 +47,7 @@ onMount(async () => {
   }
   await getInfoFromNotes();
 });
+
 onDestroy(async () => {
   receiveShowReleaseNotes.dispose();
 });

--- a/packages/renderer/src/lib/dashboard/ReleaseNotesBox.svelte
+++ b/packages/renderer/src/lib/dashboard/ReleaseNotesBox.svelte
@@ -27,7 +27,7 @@ function updatePodmanDesktop() {
 
 async function getInfoFromNotes() {
   const releaseNotes = await window.podmanDesktopGetReleaseNotes();
-  notesInfo = releaseNotes?.notes;
+  notesInfo = releaseNotes.notes;
   notesAvailable = notesInfo !== undefined;
   notesURL = releaseNotes.notesURL;
 }

--- a/packages/renderer/src/lib/dashboard/ReleaseNotesBox.svelte
+++ b/packages/renderer/src/lib/dashboard/ReleaseNotesBox.svelte
@@ -21,7 +21,7 @@ const receiveShowReleaseNotes = window.events?.receive('show-release-notes', () 
   showBanner = true;
 });
 function openReleaseNotes() {
-  window.podmanDesktopOpenReleaseNotes('current');
+  window.openExternal(notesURL);
 }
 function updatePodmanDesktop() {
   window.updatePodmanDesktop();
@@ -88,7 +88,7 @@ onDestroy(async () => {
         <p class="text-[var(--pd-content-card-header-text)] font-bold text-lg w-full items-center">
           Release notes are currently unavailable, please check again later
           {#if notesURL}
-            or try this <a href={notesURL} class="text-[var(--pd-link)]">link</a>
+            or try this <Link on:click={openReleaseNotes}>link</Link>
           {/if}
         </p>
         <CloseButton on:click={onClose} />


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
As part of the dashboard revamp, this PR adds the release notes to the dashboard page. This PR follows https://github.com/containers/podman-desktop/pull/8753, and uses the changes that have been made in the backend side to show the release notes on the dashboard page 

- By default, the release notes banner shows at the top of the dashboard page
- Clicking the close button will close this banner
- The `update` button shows up when an update is available
- The `learn more` button sends the user to the full release notes on `podman-desktop.io` (or GitHub if `podman-desktop.io` is unavilable )

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

![Screenshot from 2024-09-30 12-16-56](https://github.com/user-attachments/assets/833142a8-a2e1-4a98-a90b-3060a933c02b)


If update is unavailable:
![Screenshot from 2024-09-30 11-27-10](https://github.com/user-attachments/assets/40d53be2-b231-4e04-812c-1c620a580a9b)


Notes are unavailable, but GitHub summary is available:
![Screenshot from 2024-09-30 12-16-13](https://github.com/user-attachments/assets/fbbda78b-96ee-4ecc-b3fe-d4d0f49d50d1)

Notes are unavailable also on GitHub:
![Screenshot from 2024-10-03 10-08-11](https://github.com/user-attachments/assets/9d026269-1e75-4d67-a732-a35fb46e13f7)


### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->
Related to https://github.com/containers/podman-desktop/issues/8521

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->
Open the dashboard page and check if the release notes are visible
- [x] Tests are covering the bug fix or the new feature
