### PR TITLE
chore: redirect kubernetes page to /kubernetes/nodes

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -232,6 +232,12 @@ window.events?.receive('navigate', (navigationRequest: unknown) => {
             <KubernetesEmptyPage />
           </Route>
         {:else}
+          <!-- Redirect /kubernetes to nodes if we end up on /kubernetes without a context error 
+           we use router.goto to preserve the navbar remembering the navigation location. 
+           TODO: Remove after https://github.com/containers/podman-desktop/issues/8825 is implemented -->
+          <Route path="/kubernetes" breadcrumb="Kubernetes" navigationHint="root">
+            {router.goto('/kubernetes/nodes')}
+          </Route>
           <Route path="/kubernetes/nodes" breadcrumb="Nodes" navigationHint="root">
             <NodesList />
           </Route>


### PR DESCRIPTION
chore: redirect kubernetes page to /kubernetes/nodes

### What does this PR do?

When clicking on the navigation, it will take you to `kubernetes/nodes`
instead of `/kubernetes` which may lead to a blank page.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

https://github.com/user-attachments/assets/0888033d-b9b7-43b4-a928-fb122f69da22




### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/9189

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

Click on Kubernetes and it'll go to /nodes now.

- [X] Tests are covering the bug fix or the new feature

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
