### PR TITLE
chore: add methods to read or set docker contexts

### DIFF
--- a/packages/api/src/docker-compatibility-info.ts
+++ b/packages/api/src/docker-compatibility-info.ts
@@ -42,3 +42,16 @@ export interface DockerSocketMappingStatusInfo {
     architecture: string;
   };
 }
+
+export interface DockerContextInfo {
+  name: string;
+  isCurrentContext: boolean;
+  metadata: {
+    description: string;
+  };
+  endpoints: {
+    docker: {
+      host: string;
+    };
+  };
+}

--- a/packages/api/src/docker-compatibility-info.ts
+++ b/packages/api/src/docker-compatibility-info.ts
@@ -43,6 +43,8 @@ export interface DockerSocketMappingStatusInfo {
   };
 }
 
+// handle the context information of the docker contexts
+// https://docs.docker.com/engine/manage-resources/contexts/
 export interface DockerContextInfo {
   name: string;
   isCurrentContext: boolean;

--- a/packages/main/src/plugin/docker/docker-compatibility.ts
+++ b/packages/main/src/plugin/docker/docker-compatibility.ts
@@ -21,12 +21,17 @@ import { promises } from 'node:fs';
 import Dockerode from 'dockerode';
 
 import { isMac, isWindows } from '/@/util.js';
-import type { DockerSocketMappingStatusInfo, DockerSocketServerInfoType } from '/@api/docker-compatibility-info.js';
+import type {
+  DockerContextInfo,
+  DockerSocketMappingStatusInfo,
+  DockerSocketServerInfoType,
+} from '/@api/docker-compatibility-info.js';
 import { ExperimentalSettings } from '/@api/docker-compatibility-info.js';
 
 import type { ConfigurationRegistry, IConfigurationNode } from '../configuration-registry.js';
 import type { LibPod } from '../dockerode/libpod-dockerode.js';
 import type { ProviderRegistry } from '../provider-registry.js';
+import { DockerContextHandler } from './docker-context-handler.js';
 
 export class DockerCompatibility {
   static readonly WINDOWS_NPIPE = '//./pipe/docker_engine';
@@ -38,9 +43,12 @@ export class DockerCompatibility {
 
   #providerRegistry: ProviderRegistry;
 
+  #dockerContextHandler: DockerContextHandler;
+
   constructor(configurationRegistry: ConfigurationRegistry, providerRegistry: ProviderRegistry) {
     this.#configurationRegistry = configurationRegistry;
     this.#providerRegistry = providerRegistry;
+    this.#dockerContextHandler = new DockerContextHandler();
   }
 
   init(): void {
@@ -170,5 +178,13 @@ export class DockerCompatibility {
       // in that case, need to return the status as not reachable
       return { status: 'unreachable' };
     }
+  }
+
+  async listDockerContexts(): Promise<DockerContextInfo[]> {
+    return this.#dockerContextHandler.listContexts();
+  }
+
+  async switchDockerContext(contextName: string): Promise<void> {
+    return this.#dockerContextHandler.switchContext(contextName);
   }
 }

--- a/packages/main/src/plugin/docker/docker-context-handler.spec.ts
+++ b/packages/main/src/plugin/docker/docker-context-handler.spec.ts
@@ -1,0 +1,268 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import * as fs from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import * as util from '../../util.js';
+import type { DockerContextParsingInfo } from './docker-context-handler.js';
+import { DockerContextHandler } from './docker-context-handler.js';
+
+export class TestDockerContextHandler extends DockerContextHandler {
+  override getDockerConfigPath(): string {
+    return super.getDockerConfigPath();
+  }
+
+  override getCurrentContext(): Promise<string> {
+    return super.getCurrentContext();
+  }
+
+  override getContexts(): Promise<DockerContextParsingInfo[]> {
+    return super.getContexts();
+  }
+}
+
+// mock exists sync
+vi.mock('node:fs');
+
+const originalConsoleError = console.error;
+let dockerContextHandler: TestDockerContextHandler;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  console.error = vi.fn();
+  dockerContextHandler = new TestDockerContextHandler();
+});
+
+afterEach(() => {
+  console.error = originalConsoleError;
+});
+
+test('getDockerConfigPath', async () => {
+  const configPath = dockerContextHandler.getDockerConfigPath();
+  expect(configPath).toEqual(join(homedir(), '.docker', 'config.json'));
+});
+
+describe('getCurrentContext', () => {
+  test('should return default if docker config does not exist', async () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+
+    const currentContext = await dockerContextHandler.getCurrentContext();
+    expect(currentContext).toBe('default');
+  });
+
+  test('should return context if docker config exist', async () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    vi.spyOn(fs.promises, 'readFile').mockResolvedValue(JSON.stringify({ currentContext: 'test-context' }));
+
+    const currentContext = await dockerContextHandler.getCurrentContext();
+    expect(currentContext).toBe('test-context');
+  });
+
+  test('should return default if docker config exist but fails to parse it', async () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    vi.spyOn(fs.promises, 'readFile').mockResolvedValue('not a JSON');
+
+    const currentContext = await dockerContextHandler.getCurrentContext();
+    expect(currentContext).toBe('default');
+    expect(console.error).toBeCalledWith('Error parsing docker config file', expect.any(Error));
+  });
+});
+
+describe('switchContext', () => {
+  test('should report an error if file does not exists', async () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+
+    await expect(() => dockerContextHandler.switchContext('foo')).rejects.toThrowError('does not exist');
+  });
+
+  test('should throw error if context does not exists', async () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+
+    vi.spyOn(dockerContextHandler, 'getContexts').mockResolvedValue([]);
+
+    await expect(() => dockerContextHandler.switchContext('foo')).rejects.toThrowError('Context foo not found');
+  });
+
+  test('should write the content', async () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    vi.spyOn(dockerContextHandler, 'getContexts').mockResolvedValue([
+      { name: 'foo' } as unknown as DockerContextParsingInfo,
+      { name: 'bar' } as unknown as DockerContextParsingInfo,
+    ]);
+    vi.spyOn(fs.promises, 'readFile').mockResolvedValue(JSON.stringify({ currentContext: 'bar' }));
+    await dockerContextHandler.switchContext('foo');
+    // check using the correct indentation
+    expect(fs.promises.writeFile).toBeCalledWith(
+      expect.any(String),
+      JSON.stringify({ currentContext: 'foo' }, null, '\t'),
+    );
+  });
+
+  test('should remove the entry when switching to default', async () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    vi.spyOn(dockerContextHandler, 'getContexts').mockResolvedValue([
+      { name: 'default' } as unknown as DockerContextParsingInfo,
+      { name: 'dummy' } as unknown as DockerContextParsingInfo,
+    ]);
+    vi.spyOn(fs.promises, 'readFile').mockResolvedValue(JSON.stringify({ currentContext: 'dummy' }));
+    await dockerContextHandler.switchContext('default');
+    // check no currentContext field as we remove it
+    expect(fs.promises.writeFile).toBeCalledWith(expect.any(String), JSON.stringify({}, null, '\t'));
+  });
+
+  test('should throw error if JSON is invalid', async () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    vi.spyOn(dockerContextHandler, 'getContexts').mockResolvedValue([
+      { name: 'foo' } as unknown as DockerContextParsingInfo,
+      { name: 'bar' } as unknown as DockerContextParsingInfo,
+    ]);
+    vi.spyOn(fs.promises, 'readFile').mockResolvedValue('not a json');
+
+    await expect(() => dockerContextHandler.switchContext('foo')).rejects.toThrowError(
+      'Error parsing docker config file',
+    );
+  });
+});
+
+describe('listContexts', () => {
+  test('should add the extra isCurrentContext', async () => {
+    vi.spyOn(dockerContextHandler, 'getCurrentContext').mockResolvedValue('bar');
+    vi.spyOn(dockerContextHandler, 'getContexts').mockResolvedValue([
+      { name: 'foo' } as unknown as DockerContextParsingInfo,
+      { name: 'bar' } as unknown as DockerContextParsingInfo,
+    ]);
+
+    const contexts = await dockerContextHandler.listContexts();
+    expect(contexts).toEqual([
+      { name: 'foo', isCurrentContext: false },
+      { name: 'bar', isCurrentContext: true },
+    ]);
+  });
+});
+
+describe('getContexts', () => {
+  test('should return contexts if directory does not exists', async () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+    const contexts = await dockerContextHandler.getContexts();
+
+    // expect no error
+    expect(console.error).not.toBeCalled();
+    // no read file
+    expect(fs.promises.readFile).not.toBeCalled();
+    expect(contexts.length).toBe(1); // default context in addition
+    expect(contexts.find(c => c.name === 'default')).toBeDefined();
+  });
+
+  test('check default on Windows', async () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+    vi.spyOn(util, 'isWindows').mockImplementation(() => true);
+
+    const contexts = await dockerContextHandler.getContexts();
+
+    const defaultContext = contexts.find(c => c.name === 'default');
+    expect(defaultContext).toBeDefined();
+    // check the path
+    expect(defaultContext?.endpoints.docker.host).toBe('npipe:////./pipe/docker_engine');
+  });
+
+  test('should return contexts if error reading JSON', async () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    vi.spyOn(fs.promises, 'readdir').mockResolvedValue([
+      {
+        isDirectory: () => true,
+        name: 'fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9',
+      } as fs.Dirent,
+      {
+        isDirectory: () => true,
+        name: '2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae',
+      } as fs.Dirent,
+    ]);
+
+    vi.spyOn(fs.promises, 'readFile').mockResolvedValueOnce('invalid JSON');
+    vi.spyOn(fs.promises, 'readFile').mockResolvedValueOnce(
+      JSON.stringify({ Name: 'bar', Endpoints: { docker: { Host: 'foo' } } }),
+    );
+
+    const contexts = await dockerContextHandler.getContexts();
+
+    // expect error while parsing
+    expect(console.error).toBeCalledWith('Error parsing docker context meta file', expect.any(Error));
+    expect(contexts.length).toBe(2); // default context in addition
+    expect(contexts.find(c => c.name === 'default')).toBeDefined();
+    expect(contexts.find(c => c.name === 'bar')).toBeDefined();
+    // not there due to the error
+    expect(contexts.find(c => c.name === 'foo')).toBeUndefined();
+  });
+
+  test('should return contexts if directory exists', async () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    vi.spyOn(fs.promises, 'readdir').mockResolvedValue([
+      {
+        isDirectory: () => true,
+        name: 'fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9',
+      } as fs.Dirent,
+      {
+        isDirectory: () => true,
+        name: '2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae',
+      } as fs.Dirent,
+    ]);
+
+    vi.spyOn(fs.promises, 'readFile').mockResolvedValueOnce(JSON.stringify({ Name: 'foo' }));
+    vi.spyOn(fs.promises, 'readFile').mockResolvedValueOnce(JSON.stringify({ Name: 'bar' }));
+
+    const contexts = await dockerContextHandler.getContexts();
+
+    // expect no error
+    expect(console.error).not.toBeCalled();
+    expect(contexts.length).toBe(3); // default context in addition
+    expect(contexts.find(c => c.name === 'default')).toBeDefined();
+    expect(contexts.find(c => c.name === 'foo')).toBeDefined();
+    expect(contexts.find(c => c.name === 'bar')).toBeDefined();
+  });
+
+  test('should filter contexts if invalid sha', async () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    vi.spyOn(fs.promises, 'readdir').mockResolvedValue([
+      { isDirectory: () => true, name: 'invalidsha' } as fs.Dirent,
+      {
+        isDirectory: () => true,
+        name: '2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae',
+      } as fs.Dirent,
+    ]);
+
+    vi.spyOn(fs.promises, 'readFile').mockResolvedValueOnce(JSON.stringify({ Name: 'foo' }));
+    vi.spyOn(fs.promises, 'readFile').mockResolvedValueOnce(JSON.stringify({ Name: 'bar' }));
+
+    const contexts = await dockerContextHandler.getContexts();
+
+    // expect error
+    expect(console.error).toBeCalledWith(
+      'Context name bar does not match the directory name invalidsha. Found fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9',
+    );
+
+    // only 2 contexts as the one is filtered
+    expect(contexts.length).toBe(2);
+    expect(contexts.find(c => c.name === 'default')).toBeDefined();
+    expect(contexts.find(c => c.name === 'foo')).toBeDefined();
+    expect(contexts.find(c => c.name === 'bar')).not.toBeDefined();
+  });
+});

--- a/packages/main/src/plugin/docker/docker-context-handler.ts
+++ b/packages/main/src/plugin/docker/docker-context-handler.ts
@@ -1,0 +1,185 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { createHash } from 'node:crypto';
+import { existsSync, promises } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import { isWindows } from '/@/util.js';
+import type { DockerContextInfo } from '/@api/docker-compatibility-info.js';
+
+import { DockerCompatibility } from './docker-compatibility.js';
+
+// omit current context as it is coming from another source
+// disabling the rule as we're not only extending the interface but omitting one field
+// but the rule is not able to understand that
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface DockerContextParsingInfo extends Omit<DockerContextInfo, 'isCurrentContext'> {}
+
+/**
+ * Handle the `docker context`, allowing to list them and switch between them.
+ */
+export class DockerContextHandler {
+  protected getDockerConfigPath(): string {
+    return join(homedir(), '.docker', 'config.json');
+  }
+
+  protected async getCurrentContext(): Promise<string> {
+    let currentContext: string = 'default';
+
+    // if $HOME/.docker/config.json exists, read it and get the current context
+    const dockerConfigExists = existsSync(this.getDockerConfigPath());
+    if (dockerConfigExists) {
+      // read the file and get the current context
+      // if there is a current context, add it to the list
+      const content = await promises.readFile(this.getDockerConfigPath(), 'utf-8');
+      try {
+        const config = JSON.parse(content);
+        // only set the name if it is not empty
+        if (config.currentContext) {
+          currentContext = config.currentContext;
+        }
+      } catch (error) {
+        console.error('Error parsing docker config file', error);
+      }
+    }
+
+    return currentContext;
+  }
+
+  protected async getContexts(): Promise<DockerContextParsingInfo[]> {
+    const contexts: DockerContextParsingInfo[] = [];
+
+    const defaultHostForWindows = `npipe://${DockerCompatibility.WINDOWS_NPIPE}`;
+    const defaultHostForMacOrLinux = `unix://${DockerCompatibility.UNIX_SOCKET_PATH}`;
+
+    // adds the default context
+    contexts.push({
+      name: 'default',
+      metadata: {
+        description: 'Default context',
+      },
+      endpoints: {
+        docker: {
+          host: isWindows() ? defaultHostForWindows : defaultHostForMacOrLinux,
+        },
+      },
+    });
+
+    // now, read the ~/.docker/contexts/meta directory if it exists
+    const dockerContextsMetaPath = join(homedir(), '.docker', 'contexts', 'meta');
+    const dockerContextsMetaExists = existsSync(dockerContextsMetaPath);
+    // no directories, no contexts !
+    if (!dockerContextsMetaExists) {
+      return contexts;
+    }
+    const filesAndDirectories = await promises.readdir(dockerContextsMetaPath, { withFileTypes: true });
+
+    // keep only directories
+    const directories = filesAndDirectories.filter(dirent => dirent.isDirectory());
+
+    // for each directory, read the content of the meta.json file
+    // the directory name is the context name encoded with sha256
+    for (const directory of directories) {
+      const contextSha256Name = directory.name;
+      const metaFilePath = join(dockerContextsMetaPath, contextSha256Name, 'meta.json');
+      const metaFileExists = existsSync(metaFilePath);
+      if (metaFileExists) {
+        const metaContent = await promises.readFile(metaFilePath, 'utf-8');
+        try {
+          const meta = JSON.parse(metaContent);
+          const context: DockerContextParsingInfo = {
+            name: meta.Name,
+            metadata: {
+              description: meta.Description,
+            },
+            endpoints: {
+              docker: {
+                host: meta?.Endpoints?.docker?.Host,
+              },
+            },
+          };
+
+          // check the context.name being the same as the directory name encoded
+          // using sha256 from the context.name
+          const readContextSha256Name = createHash('sha256').update(context.name).digest('hex');
+          if (readContextSha256Name !== contextSha256Name) {
+            console.error(
+              `Context name ${context.name} does not match the directory name ${contextSha256Name}. Found ${readContextSha256Name}`,
+            );
+            continue;
+          }
+          contexts.push(context);
+        } catch (error) {
+          console.error('Error parsing docker context meta file', error);
+        }
+      }
+    }
+
+    return contexts;
+  }
+
+  async listContexts(): Promise<DockerContextInfo[]> {
+    const currentContext = await this.getCurrentContext();
+
+    const readContexts = await this.getContexts();
+    // update the isCurrentContext field
+    return readContexts.map(context => {
+      return {
+        ...context,
+        isCurrentContext: context.name === currentContext,
+      };
+    });
+  }
+
+  async switchContext(contextName: string): Promise<void> {
+    const dockerConfigExists = existsSync(this.getDockerConfigPath());
+    if (!dockerConfigExists) {
+      throw new Error(`Docker config file ${this.getDockerConfigPath()} does not exist`);
+    }
+
+    // check if the context exists
+    const allContexts = await this.getContexts();
+
+    const foundContext = allContexts.find(context => context.name === contextName);
+
+    if (!foundContext) {
+      throw new Error(`Context ${contextName} not found`);
+    }
+
+    // now, write the context name to the ~/.docker/config.json file
+    // read current content
+    const content = await promises.readFile(this.getDockerConfigPath(), 'utf-8');
+    let config;
+    try {
+      config = JSON.parse(content);
+    } catch (error: unknown) {
+      throw new Error(`Error parsing docker config file: ${String(error)}`);
+    }
+    // update the current context or drop the field if it is the default context
+    if (contextName === 'default') {
+      delete config.currentContext;
+    } else {
+      config.currentContext = contextName;
+    }
+
+    // write back the file with the current context and using tabs for indentation
+    await promises.writeFile(this.getDockerConfigPath(), JSON.stringify(config, null, '\t'));
+  }
+}

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -76,7 +76,7 @@ import type {
 import type { ContainerInspectInfo } from '/@api/container-inspect-info.js';
 import type { ContainerStatsInfo } from '/@api/container-stats-info.js';
 import type { ContributionInfo } from '/@api/contribution-info.js';
-import type { DockerSocketMappingStatusInfo } from '/@api/docker-compatibility-info.js';
+import type { DockerContextInfo, DockerSocketMappingStatusInfo } from '/@api/docker-compatibility-info.js';
 import type { ExtensionInfo } from '/@api/extension-info.js';
 import type { HistoryInfo } from '/@api/history-info.js';
 import type { IconInfo } from '/@api/icon-info.js';
@@ -2724,6 +2724,17 @@ export class PluginSystem {
       'docker-compatibility:getSystemDockerSocketMappingStatus',
       async (): Promise<DockerSocketMappingStatusInfo> => {
         return dockerCompatibility.getSystemDockerSocketMappingStatus();
+      },
+    );
+
+    this.ipcHandle('docker-compatibility:listDockerContexts', async (): Promise<DockerContextInfo[]> => {
+      return dockerCompatibility.listDockerContexts();
+    });
+
+    this.ipcHandle(
+      'docker-compatibility:switchDockerContext',
+      async (_listener, dockerContextName: string): Promise<void> => {
+        return dockerCompatibility.switchDockerContext(dockerContextName);
       },
     );
 

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -56,7 +56,7 @@ import type {
 import type { ContainerInspectInfo } from '/@api/container-inspect-info';
 import type { ContainerStatsInfo } from '/@api/container-stats-info';
 import type { ContributionInfo } from '/@api/contribution-info';
-import type { DockerSocketMappingStatusInfo } from '/@api/docker-compatibility-info';
+import type { DockerContextInfo, DockerSocketMappingStatusInfo } from '/@api/docker-compatibility-info';
 import type { ExtensionInfo } from '/@api/extension-info';
 import type { HistoryInfo } from '/@api/history-info';
 import type { IconInfo } from '/@api/icon-info';
@@ -2260,6 +2260,14 @@ export function initExposure(): void {
       return ipcInvoke('docker-compatibility:getSystemDockerSocketMappingStatus');
     },
   );
+
+  contextBridge.exposeInMainWorld('getDockerContexts', async (): Promise<DockerContextInfo[]> => {
+    return ipcInvoke('docker-compatibility:listDockerContexts');
+  });
+
+  contextBridge.exposeInMainWorld('switchDockerContext', async (contextName: string): Promise<DockerContextInfo[]> => {
+    return ipcInvoke('docker-compatibility:switchDockerContext', contextName);
+  });
 }
 
 // expose methods


### PR DESCRIPTION
### What does this PR do?
add methods to list and set the docker contexts
there is always a default context even when there is no files (like .docker/config.json or any .docker/context/** files) on the filesystem, it's what we're calling the system socket path.

unit tests provided

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to #9026

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
