### PR TITLE
feat: add ability to switch the docker CLI context

### DIFF
--- a/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityDockerContext.spec.ts
+++ b/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityDockerContext.spec.ts
@@ -1,0 +1,138 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { tick } from 'svelte';
+import { beforeEach, expect, type Mock, test, vi } from 'vitest';
+
+import type { DockerContextInfo } from '/@api/docker-compatibility-info';
+
+import PreferencesDockerCompatibilityDockerContext from '././PreferencesDockerCompatibilityDockerContext.svelte';
+
+const contextInfos = [
+  {
+    name: 'default',
+    isCurrentContext: false,
+    metadata: { description: 'default context' },
+    endpoints: {
+      docker: {
+        host: 'unix:///var/run/docker.sock',
+      },
+    },
+  },
+  {
+    name: 'podman',
+    isCurrentContext: true,
+    metadata: { description: 'podman context' },
+    endpoints: {
+      docker: {
+        host: 'unix:///var/podman.sock',
+      },
+    },
+  },
+];
+
+const getDockerContextsMock: Mock<() => Promise<DockerContextInfo[]>> = vi.fn();
+const switchDockerContextMock: Mock<(contextName: string) => Promise<void>> = vi.fn();
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  Object.defineProperty(global, 'window', {
+    value: {
+      navigator: {
+        clipboard: {
+          writeText: vi.fn(),
+        },
+      },
+      getDockerContexts: getDockerContextsMock,
+      switchDockerContext: switchDockerContextMock,
+    },
+    writable: true,
+  });
+});
+
+test('only default context', async () => {
+  getDockerContextsMock.mockResolvedValue([
+    {
+      name: 'default',
+      isCurrentContext: true,
+      metadata: { description: 'default context' },
+      endpoints: {
+        docker: {
+          host: 'unix:///var/run/docker.sock',
+        },
+      },
+    },
+  ]);
+
+  render(PreferencesDockerCompatibilityDockerContext);
+
+  // wait for the promise to resolve
+  await vi.waitFor(() => expect(getDockerContextsMock).toBeCalled());
+  await tick();
+
+  expect(screen.getByText('default (unix:///var/run/docker.sock)')).toBeInTheDocument();
+});
+
+test('multiple contexts', async () => {
+  getDockerContextsMock.mockResolvedValue(contextInfos);
+
+  render(PreferencesDockerCompatibilityDockerContext);
+
+  // wait for the promise to resolve
+  await vi.waitFor(() => expect(getDockerContextsMock).toBeCalled());
+  await tick();
+
+  // default should be there
+  expect(screen.getByText('default (unix:///var/run/docker.sock)')).toBeInTheDocument();
+
+  // podman should be there
+  expect(screen.getByText('podman (unix:///var/podman.sock)')).toBeInTheDocument();
+
+  // get selected context from select component with id dockerContextChoice
+  const select = screen.getByRole('combobox', { name: 'Docker Context selection' });
+  expect(select).toBeInTheDocument();
+});
+
+test('change context', async () => {
+  getDockerContextsMock.mockResolvedValue(contextInfos);
+  switchDockerContextMock.mockResolvedValue();
+  render(PreferencesDockerCompatibilityDockerContext);
+
+  // wait for the promise to resolve
+  await vi.waitFor(() => expect(getDockerContextsMock).toBeCalled());
+  await tick();
+
+  // select another item in the combo box
+  const select = screen.getByRole('combobox', { name: 'Docker Context selection' });
+  expect(select).toBeInTheDocument();
+
+  // find default option
+  const defaultOption = screen.getByRole('option', { name: 'default (unix:///var/run/docker.sock)' });
+  expect(defaultOption).toBeInTheDocument();
+
+  // click on the select
+  await userEvent.selectOptions(select, defaultOption);
+
+  // expect we got a call to switchDockerContext
+  expect(switchDockerContextMock).toBeCalledWith('default');
+});

--- a/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityDockerContext.spec.ts
+++ b/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityDockerContext.spec.ts
@@ -27,6 +27,8 @@ import type { DockerContextInfo } from '/@api/docker-compatibility-info';
 
 import PreferencesDockerCompatibilityDockerContext from '././PreferencesDockerCompatibilityDockerContext.svelte';
 
+const UNIX_OR_MAC_HOST = 'unix:///var/run/docker.sock';
+
 const contextInfos = [
   {
     name: 'default',
@@ -34,7 +36,7 @@ const contextInfos = [
     metadata: { description: 'default context' },
     endpoints: {
       docker: {
-        host: 'unix:///var/run/docker.sock',
+        host: UNIX_OR_MAC_HOST,
       },
     },
   },
@@ -44,7 +46,7 @@ const contextInfos = [
     metadata: { description: 'podman context' },
     endpoints: {
       docker: {
-        host: 'unix:///var/podman.sock',
+        host: UNIX_OR_MAC_HOST,
       },
     },
   },
@@ -78,7 +80,7 @@ test('only default context', async () => {
       metadata: { description: 'default context' },
       endpoints: {
         docker: {
-          host: 'unix:///var/run/docker.sock',
+          host: UNIX_OR_MAC_HOST,
         },
       },
     },
@@ -90,7 +92,7 @@ test('only default context', async () => {
   await vi.waitFor(() => expect(getDockerContextsMock).toBeCalled());
   await tick();
 
-  expect(screen.getByText('default (unix:///var/run/docker.sock)')).toBeInTheDocument();
+  expect(screen.getByText(`default (${UNIX_OR_MAC_HOST})`)).toBeInTheDocument();
 });
 
 test('multiple contexts', async () => {
@@ -103,10 +105,10 @@ test('multiple contexts', async () => {
   await tick();
 
   // default should be there
-  expect(screen.getByText('default (unix:///var/run/docker.sock)')).toBeInTheDocument();
+  expect(screen.getByText(`default (${UNIX_OR_MAC_HOST})`)).toBeInTheDocument();
 
   // podman should be there
-  expect(screen.getByText('podman (unix:///var/podman.sock)')).toBeInTheDocument();
+  expect(screen.getByText(`podman (${UNIX_OR_MAC_HOST})`)).toBeInTheDocument();
 
   // get selected context from select component with id dockerContextChoice
   const select = screen.getByRole('combobox', { name: 'Docker Context selection' });
@@ -127,7 +129,7 @@ test('change context', async () => {
   expect(select).toBeInTheDocument();
 
   // find default option
-  const defaultOption = screen.getByRole('option', { name: 'default (unix:///var/run/docker.sock)' });
+  const defaultOption = screen.getByRole('option', { name: `default (${UNIX_OR_MAC_HOST})` });
   expect(defaultOption).toBeInTheDocument();
 
   // click on the select

--- a/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityDockerContext.svelte
+++ b/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityDockerContext.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+import { Tooltip } from '@podman-desktop/ui-svelte';
+import { onMount } from 'svelte';
+
+import type { DockerContextInfo } from '/@api/docker-compatibility-info';
+
+let dockerContexts: DockerContextInfo[] = $state([]);
+
+let selectedContext: DockerContextInfo | undefined = $state(undefined);
+
+async function refreshDockerContext(): Promise<void> {
+  const items = await window.getDockerContexts();
+  selectedContext = items.find(context => context.isCurrentContext);
+  // update the list after selected context has been set
+  dockerContexts = items;
+}
+
+onMount(async () => {
+  // ask once to get the result, then it'll be triggered by the user clicking on refresh
+  await refreshDockerContext();
+});
+
+$effect(() => {
+  // get current selected context
+  const currentSelectedContext = dockerContexts.find(context => context.isCurrentContext);
+  if (!selectedContext || (currentSelectedContext && selectedContext?.name === currentSelectedContext.name)) {
+    // do nothing if we're not changing the context
+    return;
+  }
+
+  // set the selected context
+  window.switchDockerContext(selectedContext.name).catch((error: unknown) => {
+    console.error(`Failing to switch docket context to ${selectedContext?.name}`, error);
+  });
+});
+</script>
+
+<div
+  class="bg-[var(--pd-invert-content-card-bg)] rounded-md mt-2 ml-2 divide-x divide-gray-900 flex flex-col lg:flex-row">
+  <div class="flex flex-row grow px-2 py-2 justify-between text-[color:var(--pd-invert-content-card-text)]">
+    <div class="flex flex-col">
+      <div class="flex flex-row items-center text-[color:var(--pd-invert-content-card-text)]">
+        Docker Context
+
+        <div class="mx-2">
+          <Tooltip tip="Refresh the context">
+            <button aria-label="refresh context" class="text-xs text-violet-500" onclick={() => refreshDockerContext()}>
+              <i class="fas fa-undo" aria-hidden="true"></i>
+            </button>
+          </Tooltip>
+        </div>
+      </div>
+      {#if dockerContexts.length === 0}
+        <div class="mt-2">No Docker context found</div>
+      {:else}
+        <div class="mt-2">
+          Display and select between your different Docker-compatible socket contexts.
+          <select
+            class="w-full p-2 outline-none bg-[var(--pd-select-bg)] rounded-sm text-[var(--pd-content-text)]"
+            name="Docker Context selection"
+            id="dockerContextChoice"
+            bind:value={selectedContext}>
+            {#each dockerContexts as dockerContext}
+              <option selected={dockerContext.isCurrentContext} value={dockerContext}
+                >{dockerContext.name} ({dockerContext.endpoints.docker.host})</option>
+            {/each}
+          </select>
+        </div>
+      {/if}
+    </div>
+  </div>
+</div>

--- a/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityDockerContext.svelte
+++ b/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityDockerContext.svelte
@@ -53,7 +53,7 @@ $effect(() => {
           Display and select between your different Docker-compatible socket contexts.
           <select
             class="w-full p-2 outline-none bg-[var(--pd-select-bg)] rounded-sm text-[var(--pd-content-text)]"
-            name="Docker Context selection"
+            aria-label="Docker Context selection"
             id="dockerContextChoice"
             bind:value={selectedContext}>
             {#each dockerContexts as dockerContext}

--- a/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityDockerContext.svelte
+++ b/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityDockerContext.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-import { Tooltip } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 
+import RefreshButton from '/@/lib/ui/RefreshButton.svelte';
 import type { DockerContextInfo } from '/@api/docker-compatibility-info';
 
 let dockerContexts: DockerContextInfo[] = $state([]);
@@ -36,18 +36,14 @@ $effect(() => {
 </script>
 
 <div
-  class="bg-[var(--pd-invert-content-card-bg)] rounded-md mt-2 ml-2 divide-x divide-gray-900 flex flex-col lg:flex-row">
+  class="bg-[var(--pd-invert-content-card-bg)] rounded-md mt-2 ml-2 divide-x divide-[var(--pd-content-divider)] flex flex-col lg:flex-row">
   <div class="flex flex-row grow px-2 py-2 justify-between text-[color:var(--pd-invert-content-card-text)]">
     <div class="flex flex-col">
       <div class="flex flex-row items-center text-[color:var(--pd-invert-content-card-text)]">
         Docker Context
 
         <div class="mx-2">
-          <Tooltip tip="Refresh the context">
-            <button aria-label="refresh context" class="text-xs text-violet-500" onclick={() => refreshDockerContext()}>
-              <i class="fas fa-undo" aria-hidden="true"></i>
-            </button>
-          </Tooltip>
+          <RefreshButton label="Refresh the context" onclick={refreshDockerContext} />
         </div>
       </div>
       {#if dockerContexts.length === 0}

--- a/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityDockerContext.svelte
+++ b/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityDockerContext.svelte
@@ -38,7 +38,7 @@ $effect(() => {
 <div
   class="bg-[var(--pd-invert-content-card-bg)] rounded-md mt-2 ml-2 divide-x divide-[var(--pd-content-divider)] flex flex-col lg:flex-row">
   <div class="flex flex-row grow px-2 py-2 justify-between text-[color:var(--pd-invert-content-card-text)]">
-    <div class="flex flex-col">
+    <div class="flex flex-col w-full">
       <div class="flex flex-row items-center text-[color:var(--pd-invert-content-card-text)]">
         Docker Context
 
@@ -46,21 +46,21 @@ $effect(() => {
           <RefreshButton label="Refresh the context" onclick={refreshDockerContext} />
         </div>
       </div>
-      {#if dockerContexts.length === 0}
-        <div class="mt-2">No Docker context found</div>
-      {:else}
-        <div class="mt-2">
-          Display and select between your different Docker-compatible socket contexts.
-          <select
-            class="w-full p-2 outline-none bg-[var(--pd-select-bg)] rounded-sm text-[var(--pd-content-text)]"
-            aria-label="Docker Context selection"
-            id="dockerContextChoice"
-            bind:value={selectedContext}>
-            {#each dockerContexts as dockerContext}
-              <option selected={dockerContext.isCurrentContext} value={dockerContext}
-                >{dockerContext.name} ({dockerContext.endpoints.docker.host})</option>
-            {/each}
-          </select>
+      {#if dockerContexts.length > 0}
+        <div class="mt-2 flex flex-row items-center">
+          <div class="text-sm">Select the active Docker CLI context:</div>
+          <div class="ml-2 grow">
+            <select
+              class="w-full p-2 outline-none bg-[var(--pd-select-bg)] border-b-[var(--pd-input-field-stroke)] border-b rounded-sm text-[var(--pd-content-text)]"
+              aria-label="Docker Context selection"
+              id="dockerContextChoice"
+              bind:value={selectedContext}>
+              {#each dockerContexts as dockerContext}
+                <option selected={dockerContext.isCurrentContext} value={dockerContext}
+                  >{dockerContext.name} ({dockerContext.endpoints.docker.host})</option>
+              {/each}
+            </select>
+          </div>
         </div>
       {/if}
     </div>

--- a/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityDockerContext.svelte
+++ b/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityDockerContext.svelte
@@ -30,7 +30,7 @@ $effect(() => {
 
   // set the selected context
   window.switchDockerContext(selectedContext.name).catch((error: unknown) => {
-    console.error(`Failing to switch docket context to ${selectedContext?.name}`, error);
+    console.error(`Failing switching docker context to ${selectedContext?.name}`, error);
   });
 });
 </script>

--- a/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityRendering.spec.ts
@@ -29,6 +29,7 @@ beforeAll(() => {
     value: {
       getOsPlatform: vi.fn(),
       getSystemDockerSocketMappingStatus: vi.fn(),
+      getDockerContexts: vi.fn().mockResolvedValue([]),
     },
     writable: true,
   });

--- a/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityRendering.svelte
+++ b/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityRendering.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import SettingsPage from '../SettingsPage.svelte';
-import PreferencesDockerCompatibilitySocketMappingStatus from './PreferencesDockerCompatibilitySocketMappingStatus.svelte';
 import PreferencesDockerCompatibilityDockerContext from './PreferencesDockerCompatibilityDockerContext.svelte';
+import PreferencesDockerCompatibilitySocketMappingStatus from './PreferencesDockerCompatibilitySocketMappingStatus.svelte';
 </script>
 
 <SettingsPage title="Docker compatibility">
@@ -11,13 +11,11 @@ import PreferencesDockerCompatibilityDockerContext from './PreferencesDockerComp
   </svelte:fragment>
   <div class="flex flex-col space-y-4">
     <div class="container" role="list">
-      Docker Preferences
+      <div class="text-lg font-medium first-letter:uppercase">Docker Preferences</div>
       <PreferencesDockerCompatibilitySocketMappingStatus />
     </div>
-  </div>
-  <div class="flex flex-col space-y-4">
     <div class="container" role="list">
-      Docker CLI Context
+      <div class="text-lg font-medium first-letter:uppercase">Docker CLI Context</div>
       <PreferencesDockerCompatibilityDockerContext />
     </div>
   </div>

--- a/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityRendering.svelte
+++ b/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityRendering.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import SettingsPage from '../SettingsPage.svelte';
 import PreferencesDockerCompatibilitySocketMappingStatus from './PreferencesDockerCompatibilitySocketMappingStatus.svelte';
+import PreferencesDockerCompatibilityDockerContext from './PreferencesDockerCompatibilityDockerContext.svelte';
 </script>
 
 <SettingsPage title="Docker compatibility">
@@ -12,6 +13,12 @@ import PreferencesDockerCompatibilitySocketMappingStatus from './PreferencesDock
     <div class="container" role="list">
       Docker Preferences
       <PreferencesDockerCompatibilitySocketMappingStatus />
+    </div>
+  </div>
+  <div class="flex flex-col space-y-4">
+    <div class="container" role="list">
+      Docker CLI Context
+      <PreferencesDockerCompatibilityDockerContext />
     </div>
   </div>
 </SettingsPage>


### PR DESCRIPTION
### What does this PR do?
add ability to switch the docker CLI context

- [x] : Depends on https://github.com/containers/podman-desktop/pull/9197

### Screenshot / video of UI

![image](https://github.com/user-attachments/assets/022fd892-02b0-41ff-b75c-a0f64c7f09b3)


### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/9026

### How to test this PR?

1. Add `"dockerCompatibility.enabled": true` in `~/.local/share/containers/podman-desktop/configuration/settings.json` file
1. go to the settings / Docker compatibility page
1. see the dropdown to select the docker contexts
- [x] Tests are covering the bug fix or the new feature
