### PR TITLE
feat: widget to display resource/data of the owner of the docker system socket

### DIFF
--- a/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityRendering.spec.ts
@@ -19,9 +19,20 @@
 import '@testing-library/jest-dom/vitest';
 
 import { render, screen } from '@testing-library/svelte';
-import { expect, test } from 'vitest';
+import { beforeAll, expect, test, vi } from 'vitest';
 
 import PreferencesDockerCompatibilityRendering from './PreferencesDockerCompatibilityRendering.svelte';
+
+beforeAll(() => {
+  vi.resetAllMocks();
+  Object.defineProperty(global, 'window', {
+    value: {
+      getOsPlatform: vi.fn(),
+      getSystemDockerSocketMappingStatus: vi.fn(),
+    },
+    writable: true,
+  });
+});
 
 test('Expect title is displayed', async () => {
   render(PreferencesDockerCompatibilityRendering);

--- a/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityRendering.svelte
+++ b/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityRendering.svelte
@@ -1,10 +1,17 @@
 <script lang="ts">
 import SettingsPage from '../SettingsPage.svelte';
+import PreferencesDockerCompatibilitySocketMappingStatus from './PreferencesDockerCompatibilitySocketMappingStatus.svelte';
 </script>
 
 <SettingsPage title="Docker compatibility">
   <div slot="subtitle" class="text-sm font-thin mt-2">
     Podman Desktop provides compatibility with Docker, allowing you to use your existing Docker commands, images and
     workflows.
+  </div>
+  <div class="flex flex-col space-y-4">
+    <div class="container" role="list">
+      Docker Preferences
+      <PreferencesDockerCompatibilitySocketMappingStatus />
+    </div>
   </div>
 </SettingsPage>

--- a/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityRendering.svelte
+++ b/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityRendering.svelte
@@ -4,10 +4,10 @@ import PreferencesDockerCompatibilitySocketMappingStatus from './PreferencesDock
 </script>
 
 <SettingsPage title="Docker compatibility">
-  <div slot="subtitle" class="text-sm font-thin mt-2">
+  <svelte:fragment slot="subtitle">
     Podman Desktop provides compatibility with Docker, allowing you to use your existing Docker commands, images and
     workflows.
-  </div>
+  </svelte:fragment>
   <div class="flex flex-col space-y-4">
     <div class="container" role="list">
       Docker Preferences

--- a/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilitySocketMappingStatus.spec.ts
+++ b/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilitySocketMappingStatus.spec.ts
@@ -1,0 +1,224 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { router } from 'tinro';
+import { beforeEach, expect, type Mock, test, vi } from 'vitest';
+
+import type { DockerSocketMappingStatusInfo, DockerSocketServerInfoType } from '/@api/docker-compatibility-info';
+
+import PreferencesDockerCompatibilitySocketMappingStatus from './PreferencesDockerCompatibilitySocketMappingStatus.svelte';
+
+const podmanServerInfo = {
+  type: 'podman' as DockerSocketServerInfoType,
+  serverVersion: '1.0.0',
+  operatingSystem: 'Linux',
+  osType: 'linux',
+  architecture: 'arm64',
+};
+
+const dockerServerInfo = {
+  type: 'docker' as DockerSocketServerInfoType,
+  serverVersion: '1.0.0',
+  operatingSystem: 'Linux',
+  osType: 'linux',
+  architecture: 'x86_64',
+};
+
+const podmanConnectionInfo = {
+  provider: {
+    id: 'fooId',
+    name: 'foo name',
+  },
+  link: 'providerLink',
+  name: 'connection name',
+  displayName: 'My awesome connection',
+};
+
+// mock the router
+vi.mock('tinro', () => {
+  return {
+    router: {
+      goto: vi.fn(),
+    },
+  };
+});
+
+const getOsPlatformMock: Mock<() => Promise<string>> = vi.fn();
+const getSystemDockerSocketMappingStatusMock: Mock<() => Promise<DockerSocketMappingStatusInfo>> = vi.fn();
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  Object.defineProperty(global, 'window', {
+    value: {
+      getOsPlatform: getOsPlatformMock,
+      getSystemDockerSocketMappingStatus: getSystemDockerSocketMappingStatusMock,
+    },
+    writable: true,
+  });
+});
+
+test('socket running', async () => {
+  getSystemDockerSocketMappingStatusMock.mockResolvedValue({
+    status: 'running',
+    serverInfo: podmanServerInfo,
+  });
+
+  render(PreferencesDockerCompatibilitySocketMappingStatus);
+
+  // wait for the promise to resolve
+  await vi.waitFor(() => expect(getSystemDockerSocketMappingStatusMock).toBeCalled());
+
+  expect(screen.getByText('podman is listening')).toBeInTheDocument();
+});
+
+test('socket unreachable', async () => {
+  getSystemDockerSocketMappingStatusMock.mockResolvedValue({
+    status: 'unreachable',
+  });
+
+  render(PreferencesDockerCompatibilitySocketMappingStatus);
+
+  // wait for the promise to resolve
+  await vi.waitFor(() => expect(getSystemDockerSocketMappingStatusMock).toBeCalled());
+
+  expect(screen.getByText('socket not reachable')).toBeInTheDocument();
+});
+
+test('socket status link on Windows', async () => {
+  getOsPlatformMock.mockResolvedValue('win32');
+  getSystemDockerSocketMappingStatusMock.mockResolvedValue({
+    status: 'running',
+  });
+
+  render(PreferencesDockerCompatibilitySocketMappingStatus);
+
+  // wait for the promise to resolve
+  await vi.waitFor(() => expect(getSystemDockerSocketMappingStatusMock).toBeCalled());
+
+  // get div description of the status
+  const description = screen.getByRole('status', { name: 'description of the status' });
+  expect(description).toBeInTheDocument();
+  expect(description).toHaveTextContent('Status of the system //./pipe/docker_engine');
+});
+
+test('socket status link on macOS', async () => {
+  getOsPlatformMock.mockResolvedValue('darwin');
+  getSystemDockerSocketMappingStatusMock.mockResolvedValue({
+    status: 'running',
+    serverInfo: dockerServerInfo,
+  });
+
+  render(PreferencesDockerCompatibilitySocketMappingStatus);
+
+  // wait for the promise to resolve
+  await vi.waitFor(() => expect(getSystemDockerSocketMappingStatusMock).toBeCalled());
+
+  // get div description of the status
+  const description = screen.getByRole('status', { name: 'description of the status' });
+  expect(description).toBeInTheDocument();
+  expect(description).toHaveTextContent('Status of the system /var/run/docker.sock socket');
+});
+
+test('socket status link on Linux', async () => {
+  getOsPlatformMock.mockResolvedValue('linux');
+  getSystemDockerSocketMappingStatusMock.mockResolvedValue({
+    status: 'running',
+    serverInfo: dockerServerInfo,
+  });
+
+  render(PreferencesDockerCompatibilitySocketMappingStatus);
+
+  // wait for the promise to resolve
+  await vi.waitFor(() => expect(getSystemDockerSocketMappingStatusMock).toBeCalled());
+
+  // get div description of the status
+  const description = screen.getByRole('status', { name: 'description of the status' });
+  expect(description).toBeInTheDocument();
+  expect(description).toHaveTextContent('Status of the system /var/run/docker.sock socket');
+});
+
+test('podman text', async () => {
+  getOsPlatformMock.mockResolvedValue('linux');
+  getSystemDockerSocketMappingStatusMock.mockResolvedValue({
+    status: 'running',
+    serverInfo: podmanServerInfo,
+  });
+
+  render(PreferencesDockerCompatibilitySocketMappingStatus);
+
+  // wait for the promise to resolve
+  await vi.waitFor(() => expect(getSystemDockerSocketMappingStatusMock).toBeCalled());
+
+  // check we have text for podman if podman engine
+  expect(
+    screen.getByText('Any docker commands using this socket are redirected to the Podman Engine instead'),
+  ).toBeInTheDocument();
+});
+
+test('check connection info', async () => {
+  getOsPlatformMock.mockResolvedValue('darwin');
+  getSystemDockerSocketMappingStatusMock.mockResolvedValue({
+    status: 'running',
+    serverInfo: podmanServerInfo,
+    connectionInfo: podmanConnectionInfo,
+  });
+
+  render(PreferencesDockerCompatibilitySocketMappingStatus);
+
+  // wait for the promise to resolve
+  await vi.waitFor(() => expect(getSystemDockerSocketMappingStatusMock).toBeCalled());
+
+  // check we have the connection link
+  const connectionInfo = screen.getByRole('status', { name: 'Connection information' });
+  expect(connectionInfo).toBeInTheDocument();
+
+  // check we have the connection link
+  const connectionLink = screen.getByRole('button', { name: 'foo name details' });
+  expect(connectionLink).toBeInTheDocument();
+
+  // click on the link
+  await fireEvent.click(connectionLink);
+  // check clicked
+  expect(router.goto).toBeCalledWith('providerLink');
+});
+
+test('check server info grid', async () => {
+  getOsPlatformMock.mockResolvedValue('win32');
+  getSystemDockerSocketMappingStatusMock.mockResolvedValue({
+    status: 'running',
+    serverInfo: podmanServerInfo,
+  });
+
+  render(PreferencesDockerCompatibilitySocketMappingStatus);
+
+  // wait for the promise to resolve
+  await vi.waitFor(() => expect(getSystemDockerSocketMappingStatusMock).toBeCalled());
+
+  // check we have the connection link
+  const serverInfo = screen.getByRole('status', { name: 'Server information' });
+  expect(serverInfo).toBeInTheDocument();
+
+  // check we have the properties
+  expect(serverInfo).toHaveTextContent('Operating System');
+  expect(serverInfo).toHaveTextContent('linux/arm64');
+  expect(serverInfo).toHaveTextContent('Server');
+  expect(serverInfo).toHaveTextContent('Version');
+});

--- a/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilitySocketMappingStatus.svelte
+++ b/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilitySocketMappingStatus.svelte
@@ -62,14 +62,14 @@ onMount(async () => {
           </Label>
         {/if}
       </div>
-      <div class="mt-2" role="status" aria-label="description of the status">
+      <div class="flex flex-col mt-2 text-sm" role="status" aria-label="description of the status">
         Status of the system {isLinux || isMac ? '/var/run/docker.sock socket' : ''}{isWindows
           ? '//./pipe/docker_engine'
           : ''}.
+        {#if dockerSocketMappingStatusInfo?.serverInfo?.type === 'podman'}
+          <div>Any docker commands using this socket are redirected to the Podman Engine instead</div>
+        {/if}
       </div>
-      {#if dockerSocketMappingStatusInfo?.serverInfo?.type === 'podman'}
-        <div>Any docker commands using this socket are redirected to the Podman Engine instead</div>
-      {/if}
     </div>
   </div>
 

--- a/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilitySocketMappingStatus.svelte
+++ b/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilitySocketMappingStatus.svelte
@@ -1,0 +1,111 @@
+<script lang="ts">
+import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
+import { Tooltip } from '@podman-desktop/ui-svelte';
+import { onMount } from 'svelte';
+import Fa from 'svelte-fa';
+import { router } from 'tinro';
+
+import type { DockerSocketMappingStatusInfo } from '/@api/docker-compatibility-info';
+
+import Label from '../../ui/Label.svelte';
+import ProviderInfoCircle from '../../ui/ProviderInfoCircle.svelte';
+
+let isMac = $state(false);
+let isWindows = $state(false);
+let isLinux = $state(false);
+
+let dockerSocketMappingStatusInfo: DockerSocketMappingStatusInfo | undefined = $state(undefined);
+
+let engineType: 'kubernetes' | 'podman' | 'docker' | undefined = $state(undefined);
+
+async function refreshSocketMappingStatus(): Promise<void> {
+  dockerSocketMappingStatusInfo = await window.getSystemDockerSocketMappingStatus();
+
+  if (dockerSocketMappingStatusInfo?.serverInfo?.type === 'podman') {
+    engineType = 'podman';
+  } else if (dockerSocketMappingStatusInfo?.serverInfo?.type === 'docker') {
+    engineType = 'docker';
+  } else {
+    engineType = undefined;
+  }
+}
+
+onMount(async () => {
+  const platform = await window.getOsPlatform();
+
+  isMac = platform === 'darwin';
+  isLinux = platform === 'linux';
+  isWindows = platform === 'win32';
+
+  // ask once to get the result
+  await refreshSocketMappingStatus();
+});
+</script>
+
+<div
+  class="bg-[var(--pd-invert-content-card-bg)] rounded-md mt-2 ml-2 divide-x divide-gray-900 flex flex-col lg:flex-row">
+  <div class="flex flex-row grow px-2 py-2 justify-between text-[color:var(--pd-invert-content-card-text)]">
+    <div class="flex flex-col">
+      <div class="flex flex-row items-center text-[color:var(--pd-invert-content-card-text)]">
+        System socket status
+
+        <div class="mx-2">
+          <Tooltip tip="Refresh the status">
+            <button
+              aria-label="refresh status"
+              class="text-xs text-violet-500"
+              onclick={() => refreshSocketMappingStatus()}>
+              <i class="fas fa-undo" aria-hidden="true"></i>
+            </button>
+          </Tooltip>
+        </div>
+        {#if dockerSocketMappingStatusInfo?.status === 'running' && dockerSocketMappingStatusInfo?.serverInfo}
+          <Label name="{dockerSocketMappingStatusInfo.serverInfo.type} is listening">
+            <ProviderInfoCircle type={engineType} />
+          </Label>
+        {:else if dockerSocketMappingStatusInfo?.status === 'unreachable'}
+          <Label name="socket not reachable">
+            <ProviderInfoCircle type={undefined} />
+          </Label>
+        {/if}
+      </div>
+      <div class="mt-2">
+        Status of the system {isLinux || isMac ? '/var/run/docker.sock socket' : ''}{isWindows
+          ? '//./pipe/docker_engine'
+          : ''}.
+      </div>
+    </div>
+  </div>
+
+  {#if dockerSocketMappingStatusInfo?.connectionInfo}
+    {@const connectionInfo = dockerSocketMappingStatusInfo.connectionInfo}
+    <div class="flex flex-row grow divide-gray-900 p-2 max-w-64">
+      <div class="flex flex-col grow">
+        <div>Provided by {connectionInfo.provider.name} ({connectionInfo.displayName})</div>
+        {#if dockerSocketMappingStatusInfo.serverInfo?.type === 'podman'}
+          <div class="font-thin text-xs">
+            Any docker commands using this socket are redirected to the Podman Engine instead
+          </div>
+        {/if}
+      </div>
+
+      <Tooltip bottom tip="{connectionInfo.provider.name} details">
+        <button
+          aria-label="{connectionInfo.provider.name} details"
+          type="button"
+          onclick={() => router.goto(connectionInfo.link)}>
+          <Fa icon={faArrowUpRightFromSquare} />
+        </button>
+      </Tooltip>
+    </div>
+  {:else if dockerSocketMappingStatusInfo?.serverInfo}
+    <div class="flex flex-row divide-gray-900 px-2 m-2 font-thin">
+      <div class="grid grid-cols-2 gap-x-1.5 gap-y-0.5">
+        {#each Array.from(Object.entries(dockerSocketMappingStatusInfo.serverInfo)) as entry}
+          <div class="capitalize">{entry[0]}:</div>
+          <div>{entry[1]}</div>
+        {/each}
+      </div>
+    </div>
+  {/if}
+</div>

--- a/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilitySocketMappingStatus.svelte
+++ b/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilitySocketMappingStatus.svelte
@@ -9,6 +9,7 @@ import type { DockerSocketMappingStatusInfo } from '/@api/docker-compatibility-i
 
 import Label from '../../ui/Label.svelte';
 import ProviderInfoCircle from '../../ui/ProviderInfoCircle.svelte';
+import RefreshButton from '../../ui/RefreshButton.svelte';
 
 let isMac = $state(false);
 let isWindows = $state(false);
@@ -43,21 +44,14 @@ onMount(async () => {
 </script>
 
 <div
-  class="bg-[var(--pd-invert-content-card-bg)] rounded-md mt-2 ml-2 divide-x divide-gray-900 flex flex-col lg:flex-row">
+  class="bg-[var(--pd-invert-content-card-bg)] rounded-md m-2 divide-x divide-[var(--pd-content-divider)] flex flex-col lg:flex-row">
   <div class="flex flex-row grow px-2 py-2 justify-between text-[color:var(--pd-invert-content-card-text)]">
     <div class="flex flex-col">
       <div class="flex flex-row items-center text-[color:var(--pd-invert-content-card-text)]">
         System socket status
 
         <div class="mx-2">
-          <Tooltip tip="Refresh the status">
-            <button
-              aria-label="refresh status"
-              class="text-xs text-violet-500"
-              onclick={() => refreshSocketMappingStatus()}>
-              <i class="fas fa-undo" aria-hidden="true"></i>
-            </button>
-          </Tooltip>
+          <RefreshButton label="Refresh the status" onclick={refreshSocketMappingStatus} />
         </div>
         {#if dockerSocketMappingStatusInfo?.status === 'running' && dockerSocketMappingStatusInfo?.serverInfo}
           <Label name="{dockerSocketMappingStatusInfo.serverInfo.type} is listening">
@@ -74,22 +68,21 @@ onMount(async () => {
           ? '//./pipe/docker_engine'
           : ''}.
       </div>
+      {#if dockerSocketMappingStatusInfo?.serverInfo?.type === 'podman'}
+        <div>Any docker commands using this socket are redirected to the Podman Engine instead</div>
+      {/if}
     </div>
   </div>
 
   {#if dockerSocketMappingStatusInfo?.connectionInfo}
     {@const connectionInfo = dockerSocketMappingStatusInfo.connectionInfo}
-    <div class="flex flex-row grow divide-gray-900 p-2 max-w-64">
+    <div class="flex flex-row grow divide-[var(--pd-content-divider)] m-2 p-2 max-w-64">
       <div class="flex flex-col grow">
-        <div>Provided by {connectionInfo.provider.name} ({connectionInfo.displayName})</div>
-        {#if dockerSocketMappingStatusInfo.serverInfo?.type === 'podman'}
-          <div class="font-thin text-xs">
-            Any docker commands using this socket are redirected to the Podman Engine instead
-          </div>
-        {/if}
+        <div>Provided by {connectionInfo.provider.name}</div>
+        <div class="font-thin text-xs">{connectionInfo.displayName}</div>
       </div>
 
-      <Tooltip bottom tip="{connectionInfo.provider.name} details">
+      <Tooltip class="m-2" bottom tip="{connectionInfo.provider.name} details">
         <button
           aria-label="{connectionInfo.provider.name} details"
           type="button"
@@ -99,7 +92,7 @@ onMount(async () => {
       </Tooltip>
     </div>
   {:else if dockerSocketMappingStatusInfo?.serverInfo}
-    <div class="flex flex-row divide-gray-900 px-2 m-2 font-thin">
+    <div class="flex flex-row divide-[var(--pd-content-divider)] px-2 m-2 font-thin">
       <div class="grid grid-cols-2 gap-x-1.5 gap-y-0.5">
         {#each Array.from(Object.entries(dockerSocketMappingStatusInfo.serverInfo)) as entry}
           <div class="capitalize">{entry[0]}:</div>

--- a/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilitySocketMappingStatus.svelte
+++ b/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilitySocketMappingStatus.svelte
@@ -5,11 +5,10 @@ import { onMount } from 'svelte';
 import Fa from 'svelte-fa';
 import { router } from 'tinro';
 
+import Label from '/@/lib/ui/Label.svelte';
+import ProviderInfoCircle from '/@/lib/ui/ProviderInfoCircle.svelte';
+import RefreshButton from '/@/lib/ui/RefreshButton.svelte';
 import type { DockerSocketMappingStatusInfo } from '/@api/docker-compatibility-info';
-
-import Label from '../../ui/Label.svelte';
-import ProviderInfoCircle from '../../ui/ProviderInfoCircle.svelte';
-import RefreshButton from '../../ui/RefreshButton.svelte';
 
 let isMac = $state(false);
 let isWindows = $state(false);
@@ -63,7 +62,7 @@ onMount(async () => {
           </Label>
         {/if}
       </div>
-      <div class="mt-2">
+      <div class="mt-2" role="status" aria-label="description of the status">
         Status of the system {isLinux || isMac ? '/var/run/docker.sock socket' : ''}{isWindows
           ? '//./pipe/docker_engine'
           : ''}.
@@ -76,7 +75,10 @@ onMount(async () => {
 
   {#if dockerSocketMappingStatusInfo?.connectionInfo}
     {@const connectionInfo = dockerSocketMappingStatusInfo.connectionInfo}
-    <div class="flex flex-row grow divide-[var(--pd-content-divider)] m-2 p-2 max-w-64">
+    <div
+      class="flex flex-row grow divide-[var(--pd-content-divider)] m-2 p-2 max-w-64"
+      role="status"
+      aria-label="Connection information">
       <div class="flex flex-col grow">
         <div>Provided by {connectionInfo.provider.name}</div>
         <div class="font-thin text-xs">{connectionInfo.displayName}</div>
@@ -92,12 +94,24 @@ onMount(async () => {
       </Tooltip>
     </div>
   {:else if dockerSocketMappingStatusInfo?.serverInfo}
-    <div class="flex flex-row divide-[var(--pd-content-divider)] px-2 m-2 font-thin">
-      <div class="grid grid-cols-2 gap-x-1.5 gap-y-0.5">
-        {#each Array.from(Object.entries(dockerSocketMappingStatusInfo.serverInfo)) as entry}
-          <div class="capitalize">{entry[0]}:</div>
-          <div>{entry[1]}</div>
-        {/each}
+    <div
+      class="flex flex-row divide-[var(--pd-content-divider)] px-2 m-2 pl-8 justify-center"
+      role="status"
+      aria-label="Server information">
+      <div class="grid grid-cols-2 gap-x-8 gap-y-2">
+        <div>Server:</div>
+        <div>{dockerSocketMappingStatusInfo.serverInfo.type}</div>
+
+        <div>Version:</div>
+        <div>{dockerSocketMappingStatusInfo.serverInfo.serverVersion}</div>
+
+        <div>Operating System:</div>
+        <div>{dockerSocketMappingStatusInfo.serverInfo.operatingSystem}</div>
+
+        <div>OS/Arch:</div>
+        <div>
+          {dockerSocketMappingStatusInfo.serverInfo.osType}/{dockerSocketMappingStatusInfo.serverInfo.architecture}
+        </div>
       </div>
     </div>
   {/if}


### PR DESCRIPTION
### What does this PR do?
Adds a widget in Docker compatibility page

on macOS, displays the link to the resource providing that mapping
on Windows, it's not possible to know, so it displays only the information (server info)

### Screenshot / video of UI

on macOS:
![image](https://github.com/user-attachments/assets/56301f7e-3803-4ac6-b1cc-31d49b2a3324)

on Windows/Linux it should look like:
![image](https://github.com/user-attachments/assets/03ef8975-cacf-474b-8fbd-f8de239db4ce)



### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/9025

### How to test this PR?

1. Add "dockerCompatibility.enabled": true in ~/.local/share/containers/podman-desktop/configuration/settings.json file
1. go to the settings / Docker compatibility page
1. see the docker system socket state

- [x] Tests are covering the bug fix or the new feature
