### PR TITLE
fix: exited quick pick should resolve to undefined

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1668,9 +1668,12 @@ export class PluginSystem {
       },
     );
 
-    this.ipcHandle('showQuickPick:values', async (_listener, id: number, indexes: number[]): Promise<void> => {
-      return inputQuickPickRegistry.onQuickPickValuesSelected(id, indexes);
-    });
+    this.ipcHandle(
+      'showQuickPick:values',
+      async (_listener, id: number, indexes: number[] | undefined): Promise<void> => {
+        return inputQuickPickRegistry.onQuickPickValuesSelected(id, indexes);
+      },
+    );
 
     this.ipcHandle(
       'showInputBox:validate',

--- a/packages/main/src/plugin/input-quickpick/input-quickpick-registry.spec.ts
+++ b/packages/main/src/plugin/input-quickpick/input-quickpick-registry.spec.ts
@@ -1,0 +1,37 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import { beforeAll, expect, test, vi } from 'vitest';
+
+import type { ApiSenderType } from '../api.js';
+import { InputQuickPickRegistry } from './input-quickpick-registry.js';
+
+let inputQuickPickRegistry: InputQuickPickRegistry;
+
+/* eslint-disable @typescript-eslint/no-empty-function */
+beforeAll(() => {
+  inputQuickPickRegistry = new InputQuickPickRegistry({
+    send: vi.fn(),
+    receive: vi.fn(),
+  } as ApiSenderType);
+});
+
+test('Expect no quick pick selection to resolve the promise as undefined', async () => {
+  const result = inputQuickPickRegistry.showQuickPick(['a', 'b']);
+  inputQuickPickRegistry.onQuickPickValuesSelected(1, undefined);
+  expect(await result).toBe(undefined);
+});

--- a/packages/main/src/plugin/input-quickpick/input-quickpick-registry.spec.ts
+++ b/packages/main/src/plugin/input-quickpick/input-quickpick-registry.spec.ts
@@ -22,7 +22,6 @@ import { InputQuickPickRegistry } from './input-quickpick-registry.js';
 
 let inputQuickPickRegistry: InputQuickPickRegistry;
 
-/* eslint-disable @typescript-eslint/no-empty-function */
 beforeAll(() => {
   inputQuickPickRegistry = new InputQuickPickRegistry({
     send: vi.fn(),
@@ -32,6 +31,6 @@ beforeAll(() => {
 
 test('Expect no quick pick selection to resolve the promise as undefined', async () => {
   const result = inputQuickPickRegistry.showQuickPick(['a', 'b']);
-  inputQuickPickRegistry.onQuickPickValuesSelected(1, undefined);
+  inputQuickPickRegistry.onQuickPickValuesSelected(1);
   expect(await result).toBe(undefined);
 });

--- a/packages/main/src/plugin/input-quickpick/input-quickpick-registry.ts
+++ b/packages/main/src/plugin/input-quickpick/input-quickpick-registry.ts
@@ -110,7 +110,7 @@ export class InputQuickPickRegistry {
   }
 
   // this method is called by the frontend when the user has selected a value in QuickPick
-  onQuickPickValuesSelected(id: number, indexes: number[] | undefined): void {
+  onQuickPickValuesSelected(id: number, indexes?: number[]): void {
     // get the callback
     const callback = this.callbacksQuickPicks.get(id);
 

--- a/packages/main/src/plugin/input-quickpick/input-quickpick-registry.ts
+++ b/packages/main/src/plugin/input-quickpick/input-quickpick-registry.ts
@@ -110,13 +110,16 @@ export class InputQuickPickRegistry {
   }
 
   // this method is called by the frontend when the user has selected a value in QuickPick
-  onQuickPickValuesSelected(id: number, indexes: number[]): void {
+  onQuickPickValuesSelected(id: number, indexes: number[] | undefined): void {
     // get the callback
     const callback = this.callbacksQuickPicks.get(id);
 
     // if there is a callback
     if (callback) {
-      if (callback.options?.canPickMany) {
+      if (!indexes) {
+        // no selection
+        callback.deferred.resolve(undefined);
+      } else if (callback.options?.canPickMany) {
         const allItems = indexes.map(index => callback.items[index]);
         // resolve the promise
         callback.deferred.resolve(allItems);

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1619,7 +1619,7 @@ export function initExposure(): void {
 
   contextBridge.exposeInMainWorld(
     'sendShowQuickPickValues',
-    async (quickPickId: number, selectedIndexes: number[]): Promise<void> => {
+    async (quickPickId: number, selectedIndexes: number[] | undefined): Promise<void> => {
       return ipcInvoke('showQuickPick:values', quickPickId, selectedIndexes);
     },
   );

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1619,7 +1619,7 @@ export function initExposure(): void {
 
   contextBridge.exposeInMainWorld(
     'sendShowQuickPickValues',
-    async (quickPickId: number, selectedIndexes: number[] | undefined): Promise<void> => {
+    async (quickPickId: number, selectedIndexes?: number[]): Promise<void> => {
       return ipcInvoke('showQuickPick:values', quickPickId, selectedIndexes);
     },
   );

--- a/packages/renderer/src/lib/dialogs/QuickPickInput.spec.ts
+++ b/packages/renderer/src/lib/dialogs/QuickPickInput.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,7 +66,7 @@ describe('QuickPickInput', () => {
     await userEvent.keyboard('{Escape}');
 
     // check we received the answer for showQuickPick
-    expect(sendShowQuickPickValuesMock).toBeCalledWith(idRequest, []);
+    expect(sendShowQuickPickValuesMock).toBeCalledWith(idRequest);
 
     // and not for showInputBox
     expect(sendShowInputBoxValueMock).not.toBeCalled();

--- a/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
+++ b/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
@@ -131,7 +131,7 @@ const onClose = () => {
     return;
   }
   if (mode === 'QuickPick') {
-    window.sendShowQuickPickValues(currentId, []);
+    window.sendShowQuickPickValues(currentId, undefined);
   } else if (mode === 'InputBox') {
     window.sendShowInputBoxValue(currentId, undefined, undefined);
   }

--- a/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
+++ b/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
@@ -131,7 +131,7 @@ const onClose = () => {
     return;
   }
   if (mode === 'QuickPick') {
-    window.sendShowQuickPickValues(currentId, undefined);
+    window.sendShowQuickPickValues(currentId);
   } else if (mode === 'InputBox') {
     window.sendShowInputBoxValue(currentId, undefined, undefined);
   }


### PR DESCRIPTION
### What does this PR do?

The documentation for quick picks says: `@return A promise that resolves to the selected items or 'undefined'` but instead it rejected the promise as 'no item' if the user escapes or exits the popup.

This adds an explicit undefined back from the renderer and resolves to undefined to match the spec.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #9167.

### How to test this PR?

See #9167, just open a quick pick and then click outside the popup and make sure no error is thrown in the log.

- [x] Tests are covering the bug fix or the new feature