### PR TITLE
fix: enable 'Update' for kubectl CLI

### DIFF
--- a/extensions/kubectl-cli/src/extension.ts
+++ b/extensions/kubectl-cli/src/extension.ts
@@ -382,7 +382,7 @@ async function postActivate(
       releaseVersionToInstall = selected.tag.slice(1);
       return releaseVersionToInstall;
     },
-    doInstall: async () => {
+    doInstall: async (_logger) => {
       if (currentVersion) {
         throw new Error(`Cannot install ${kubectlCliName}. Version ${currentVersion} is already installed.`);
       }

--- a/extensions/kubectl-cli/src/extension.ts
+++ b/extensions/kubectl-cli/src/extension.ts
@@ -340,9 +340,15 @@ async function postActivate(
   // check if there is a new version to be installed and register the updater
   let releaseToUpdateTo: KubectlGithubReleaseArtifactMetadata | undefined;
   let releaseVersionToUpdateTo: string | undefined;
-  const latestAsset = await kubectlDownload.getLatestVersionAsset();
+  let latestAsset: KubectlGithubReleaseArtifactMetadata | undefined;
+  try {
+    latestAsset = await kubectlDownload.getLatestVersionAsset();
+  } catch (error: unknown) {
+    console.error('Error when downloading kubectl CLI latest release information.', String(error));
+  }
+
   const update = {
-    version: latestAsset.tag.slice(1) !== kubectlCliTool.version ? latestAsset.tag.slice(1) : undefined,
+    version: latestAsset?.tag.slice(1) !== kubectlCliTool.version ? latestAsset?.tag.slice(1) : undefined,
     selectVersion: async (): Promise<string> => {
       const selected = await kubectlDownload.promptUserForVersion(currentVersion);
       releaseToUpdateTo = selected;
@@ -369,7 +375,7 @@ async function postActivate(
       if (releaseToUpdateTo === latestAsset) {
         delete update.version;
       } else {
-        update.version = latestAsset.tag.slice(1);
+        update.version = latestAsset?.tag.slice(1);
       }
       releaseVersionToUpdateTo = undefined;
       releaseToUpdateTo = undefined;

--- a/extensions/kubectl-cli/src/extension.ts
+++ b/extensions/kubectl-cli/src/extension.ts
@@ -382,7 +382,7 @@ async function postActivate(
       releaseVersionToInstall = selected.tag.slice(1);
       return releaseVersionToInstall;
     },
-    doInstall: async (_logger) => {
+    doInstall: async _logger => {
       if (currentVersion) {
         throw new Error(`Cannot install ${kubectlCliName}. Version ${currentVersion} is already installed.`);
       }

--- a/extensions/kubectl-cli/src/extension.ts
+++ b/extensions/kubectl-cli/src/extension.ts
@@ -226,9 +226,11 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
 
   // Push the CLI tool as well (but it will do it postActivation so it does not block the activate() function)
   // Post activation
-  postActivate(extensionContext, kubectlDownload).catch((error: unknown) => {
-    console.error('Error activating extension', error);
-  });
+  setTimeout(() => {
+    postActivate(extensionContext, kubectlDownload).catch((error: unknown) => {
+      console.error('Error activating extension', error);
+    });
+  }, 0);
 }
 
 interface CliFinder {

--- a/extensions/kubectl-cli/src/extension.ts
+++ b/extensions/kubectl-cli/src/extension.ts
@@ -392,18 +392,11 @@ async function postActivate(
       // download, install system wide and update cli version
       const binaryPath = await kubectlDownload.download(releaseToInstall);
       await installBinaryToSystem(binaryPath, 'kubectl');
-      const destinationPath = getSystemBinaryPath('kubectl');
       kubectlCliTool?.updateVersion({
         version: releaseVersionToInstall,
         installationSource: 'extension',
-        path: destinationPath,
       });
       currentVersion = releaseVersionToInstall;
-      if (releaseToInstall === latestAsset) {
-        delete update.version;
-      } else {
-        update.version = latestAsset.tag.slice(1);
-      }
       releaseVersionToInstall = undefined;
       releaseToInstall = undefined;
     },


### PR DESCRIPTION
### What does this PR do?

PR updates kubectl CLI lifecycle so it shows 'Update' command when current installed version is older than latest available. 

### Screenshot / video of UI

Before: there is always 'Upgrade/Downgrade' visible, but never 'Update', even after startup if there is update, it would not be visible on CLI page.

https://github.com/user-attachments/assets/0ac1c7c7-4db6-4e49-99ed-574d032842fb

After: if there is newer version available, 'Update' link shown.

https://github.com/user-attachments/assets/e4523e7b-a50f-4a07-a09c-2a0fc4f8daa5

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Part 1 out of 3 to fix #8838.
Two more fixes for compose and kind should be implemented to close the issue.

### How to test this PR?

Pull PR and try to install/update/upgrade/uninstall kubectl-cli tool.

PR adds:
1. Downloading latest meta for CLI in post activation

Known limitation (probably require new issues to be opened):
1. Install does not install latest kubectl by default, but ask to select specific verison (probably should be additional command `Install Specific version ...`)
2. If latest version is installed, the you will see `Upgrade/Downgrade` (if there is `Install Specific Version ...` command that would not needed
3. If not latest version is installed, then you see 'Update' link that install latest available release and `Upgrade/Downgrade` is not available ( if there is `Install Specific Version ...` always available it would let install any version if latest is not an option)

Known issues (will open follow up as well):
1. version list is not sorted  (at least for kubecli #9221, but should be checked if sorted for other CLIs)
2. version list contains 'Kubernetes' and sorted incorrectly #9221
3. cancel selection of version to install should not show an error, because it it is what user requested #9222
4. `Path` tooltip is empty after installation #9220.


<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
