### PR TITLE
chore: move the refresh icon button fragment to its own component to be reused

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { getInitialValue } from '/@/lib/preferences/Util';
+import RefreshButton from '/@/lib/ui/RefreshButton.svelte';
 
 import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import Markdown from '../markdown/Markdown.svelte';
@@ -70,12 +71,7 @@ $: resetToDefault = false;
       {recordUI.title}
       {#if showResetButton}
         <div class="ml-2">
-          <button
-            class="text-xs text-violet-500"
-            on:click={() => doResetToDefault()}
-            aria-label="Reset to default value">
-            <i class="fas fa-undo" aria-hidden="true"></i>
-          </button>
+          <RefreshButton label="Reset to default value" onclick={doResetToDefault} />
         </div>
       {/if}
     </div>

--- a/packages/renderer/src/lib/ui/RefreshButton.spec.ts
+++ b/packages/renderer/src/lib/ui/RefreshButton.spec.ts
@@ -1,0 +1,52 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { expect, test, vi } from 'vitest';
+
+import RefreshButton from './RefreshButton.svelte';
+
+test('Expect basic styling', async () => {
+  const onclick = vi.fn();
+  const label = 'Refresh test';
+  render(RefreshButton, { onclick, label });
+
+  // get button
+  const button = screen.getByRole('button', { name: label });
+  expect(button).toBeInTheDocument();
+  expect(button).toHaveAttribute('title', label);
+  expect(button).toHaveClass('text-[var(--pd-button-primary-bg)]');
+  expect(button).toHaveClass('hover:text-[var(--pd-button-primary-hover-bg)]');
+});
+
+test('Expect click', async () => {
+  const onclick = vi.fn();
+  const label = 'Refresh test';
+  render(RefreshButton, { onclick, label });
+
+  // get button
+  const button = screen.getByRole('button');
+
+  // click button
+  await fireEvent.click(button);
+
+  // check if onclick was called
+  expect(onclick).toHaveBeenCalled();
+});

--- a/packages/renderer/src/lib/ui/RefreshButton.svelte
+++ b/packages/renderer/src/lib/ui/RefreshButton.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+let { label, onclick }: { label: string; onclick: () => void } = $props();
+</script>
+
+<button
+  onclick={onclick}
+  title={label}
+  class="text-xs text-[var(--pd-button-primary-bg)] hover:text-[var(--pd-button-primary-hover-bg)]"
+  aria-label={label}>
+  <i class="fas fa-undo" aria-hidden="true"></i>
+</button>


### PR DESCRIPTION
### What does this PR do?
During issuing a PR I received feedback that I could not use some colors that are in the codebase. I was copying the fragment.
So extract the fragment to its own component and fix the colors, then I'll be able to reuse that component in my PR.

Apply colors from buttons (and apply hover as well)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
fixes https://github.com/containers/podman-desktop/issues/9207

https://github.com/containers/podman-desktop/pull/9199

### How to test this PR?

Go to the preferences page and change some properties, you have an icon to reset the property value to its original/default value.


- [x] Tests are covering the bug fix or the new feature
