### PR TITLE
chore: display latest release notes in development mode

### DIFF
--- a/packages/main/src/plugin/updater.ts
+++ b/packages/main/src/plugin/updater.ts
@@ -84,7 +84,20 @@ export class Updater {
   }
 
   public async getReleaseNotes(): Promise<ReleaseNotesInfo> {
-    const version = app.getVersion();
+    let version = app.getVersion();
+    if (import.meta.env.DEV && version.endsWith('-next')) {
+      // use the latest release version published on GitHub
+      const response = await fetch('https://api.github.com/repos/containers/podman-desktop/releases/latest');
+      if (response.ok) {
+        const latestRelease = await response.json();
+        version = latestRelease.tag_name;
+        // remove the 'v' prefix from the version
+        if (version.startsWith('v')) {
+          version = version.substring(1);
+        }
+      }
+    }
+
     const urlVersionFormat = version.split('.', 2).join('.');
 
     const notesURL = `${homepage}/release-notes/${urlVersionFormat}.json`;


### PR DESCRIPTION
### What does this PR do?
In development mode I always see "Error while getting release notes" on the dashboard widget
to provide a better feedback to the component, always display the release notes from the latest stable release.

### Screenshot / video of UI

![image](https://github.com/user-attachments/assets/f4e1f6c2-1850-47f9-8b66-3f1169a15e2a)


### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
