### PR TITLE
fix: remove timeout for async

### DIFF
--- a/extensions/kubectl-cli/src/extension.ts
+++ b/extensions/kubectl-cli/src/extension.ts
@@ -226,11 +226,9 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
 
   // Push the CLI tool as well (but it will do it postActivation so it does not block the activate() function)
   // Post activation
-  setTimeout(() => {
-    postActivate(extensionContext, kubectlDownload).catch((error: unknown) => {
-      console.error('Error activating extension', error);
-    });
-  }, 0);
+  postActivate(extensionContext, kubectlDownload).catch((error: unknown) => {
+    console.error('Error activating extension', String(error));
+  });
 }
 
 interface CliFinder {

--- a/extensions/kubectl-cli/src/extension.ts
+++ b/extensions/kubectl-cli/src/extension.ts
@@ -227,7 +227,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   // Push the CLI tool as well (but it will do it postActivation so it does not block the activate() function)
   // Post activation
   postActivate(extensionContext, kubectlDownload).catch((error: unknown) => {
-    console.error('Error activating extension', String(error));
+    console.error('Error activating extension', error);
   });
 }
 


### PR DESCRIPTION
### What does this PR do?

Removes timeout for async call, which is not required, because async call returns promise without blocking extension activation.
Used Error to String type coercion to convert error to string for the message

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Extracted from #9205.

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
