### PR TITLE
chore: do not display any release notes widget if there is nothing to show

### DIFF
--- a/packages/renderer/src/lib/dashboard/ReleaseNotesBox.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ReleaseNotesBox.spec.ts
@@ -113,3 +113,19 @@ test('expect clicking on close button to not show banner anymore', async () => {
   expect(screen.queryByText(responseJSON.title)).not.toBeInTheDocument();
   expect(screen.queryByText(responseJSON.summary)).not.toBeInTheDocument();
 });
+
+test('expect no release notes widget if no notesUrl as well', async () => {
+  podmanDesktopGetReleaseNotesMock.mockResolvedValue({
+    releaseNotesAvailable: false,
+  });
+
+  render(ReleaseNotesBox);
+  await waitFor(() => expect(podmanDesktopGetReleaseNotesMock).toBeCalled());
+  await tick();
+  expect(screen.queryByText(responseJSON.title)).not.toBeInTheDocument();
+  expect(screen.queryByText(responseJSON.summary)).not.toBeInTheDocument();
+  expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  expect(
+    screen.queryByText('Release notes are currently unavailable, please check again later or try this'),
+  ).not.toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/dashboard/ReleaseNotesBox.svelte
+++ b/packages/renderer/src/lib/dashboard/ReleaseNotesBox.svelte
@@ -81,7 +81,7 @@ onDestroy(async () => {
         </div>
       </div>
     </div>
-  {:else}
+  {:else if notesURL}
     <div class="flex bg-[var(--pd-content-card-bg)] rounded-md p-5 flex-col flex-nowrap h-auto items-center">
       <div class="flex flex-row items-center justify-between w-full">
         <p class="text-[var(--pd-content-card-header-text)] font-bold text-lg w-full items-center">


### PR DESCRIPTION
### What does this PR do?
If we don't have internet connection, it was saying "check later" but there is no way to trigger the refresh, etc.

so remove the display of the widget in this case.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/9224


### How to test this PR?

Launch Podman Desktop without an internet connection.

- [x] Tests are covering the bug fix or the new feature
