### PR TITLE
chore(test): add addional handling for popup in case of failure

### DIFF
--- a/tests/playwright/src/specs/podman-machine-rootless.spec.ts
+++ b/tests/playwright/src/specs/podman-machine-rootless.spec.ts
@@ -21,7 +21,12 @@ import { PodmanMachineDetails } from '../model/pages/podman-machine-details-page
 import { ResourceConnectionCardPage } from '../model/pages/resource-connection-card-page';
 import { ResourcesPage } from '../model/pages/resources-page';
 import { expect as playExpect, test } from '../utility/fixtures';
-import { createPodmanMachineFromCLI, deletePodmanMachine, handleConfirmationDialog } from '../utility/operations';
+import {
+  createPodmanMachineFromCLI,
+  deletePodmanMachine,
+  deletePodmanMachineFromCLI,
+  handleConfirmationDialog,
+} from '../utility/operations';
 import { isLinux } from '../utility/platform';
 import { waitForPodmanMachineStartup } from '../utility/wait';
 
@@ -47,15 +52,16 @@ test.beforeAll(async ({ runner, welcomePage, page }) => {
 test.afterAll(async ({ runner, page }) => {
   test.setTimeout(120_000);
 
+  if (test.info().status === 'failed') {
+    await deletePodmanMachineFromCLI(PODMAN_MACHINE_NAME);
+    await createPodmanMachineFromCLI();
+  }
+
   try {
     await handleConfirmationDialog(page, 'Podman', true, 'Yes');
     await handleConfirmationDialog(page, 'Podman', true, 'OK');
   } catch (error) {
     console.log('No handling dialog displayed', error);
-  }
-
-  if (test.info().status === 'failed') {
-    await createPodmanMachineFromCLI();
   }
 
   await runner.close();

--- a/tests/playwright/src/specs/podman-machine-rootless.spec.ts
+++ b/tests/playwright/src/specs/podman-machine-rootless.spec.ts
@@ -44,8 +44,15 @@ test.beforeAll(async ({ runner, welcomePage, page }) => {
   await waitForPodmanMachineStartup(page);
 });
 
-test.afterAll(async ({ runner }) => {
+test.afterAll(async ({ runner, page }) => {
   test.setTimeout(120_000);
+
+  try {
+    await handleConfirmationDialog(page, 'Podman', true, 'Yes');
+    await handleConfirmationDialog(page, 'Podman', true, 'OK');
+  } catch (error) {
+    console.log('No handling dialog displayed', error);
+  }
 
   if (test.info().status === 'failed') {
     await createPodmanMachineFromCLI();

--- a/tests/playwright/src/specs/podman-machine-rootless.spec.ts
+++ b/tests/playwright/src/specs/podman-machine-rootless.spec.ts
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { Locator } from '@playwright/test';
+
 import { CreateMachinePage } from '../model/pages/create-machine-page';
 import { PodmanMachineDetails } from '../model/pages/podman-machine-details-page';
 import { ResourceConnectionCardPage } from '../model/pages/resource-connection-card-page';
@@ -35,6 +37,7 @@ const DEFAULT_PODMAN_MACHINE = 'Podman Machine';
 const DEFAULT_PODMAN_MACHINE_VISIBLE = 'podman-machine-default';
 const RESOURCE_NAME = 'podman';
 const ROOTLESS_PODMAN_MACHINE = 'Podman Machine rootless';
+let dialog: Locator;
 
 test.skip(
   isLinux || process.env.TEST_PODMAN_MACHINE !== 'true',
@@ -47,6 +50,7 @@ test.beforeAll(async ({ runner, welcomePage, page }) => {
 
   await welcomePage.handleWelcomePage(true);
   await waitForPodmanMachineStartup(page);
+  dialog = page.getByRole('dialog', { name: 'Podman', exact: true });
 });
 
 test.afterAll(async ({ runner, page }) => {
@@ -120,14 +124,16 @@ test.describe.serial('Rootless Podman machine Verification', () => {
 
     await playExpect(podmanMachineDetails.podmanMachineStartButton).toBeEnabled();
     await podmanMachineDetails.podmanMachineStartButton.click();
-    await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('RUNNING', { timeout: 50_000 });
 
+    await playExpect(dialog).toBeVisible({ timeout: 60_000 });
     await handleConfirmationDialog(page, 'Podman', true, 'Yes');
     await handleConfirmationDialog(page, 'Podman', true, 'OK');
 
+    await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('RUNNING', { timeout: 60_000 });
+
     await playExpect(podmanMachineDetails.podmanMachineStopButton).toBeEnabled();
     await podmanMachineDetails.podmanMachineStopButton.click();
-    await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('OFF', { timeout: 50_000 });
+    await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('OFF', { timeout: 60_000 });
   });
 
   test('Restart default podman machine', async ({ page, navigationBar }) => {
@@ -151,10 +157,12 @@ test.describe.serial('Rootless Podman machine Verification', () => {
 
     await playExpect(podmanMachineDetails.podmanMachineStartButton).toBeEnabled();
     await podmanMachineDetails.podmanMachineStartButton.click();
-    await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('RUNNING', { timeout: 50_000 });
 
+    await playExpect(dialog).toBeVisible({ timeout: 60_000 });
     await handleConfirmationDialog(page, 'Podman', true, 'Yes');
     await handleConfirmationDialog(page, 'Podman', true, 'OK');
+
+    await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('RUNNING', { timeout: 60_000 });
   });
 
   test('Clean up rootless machine', async ({ page }) => {

--- a/tests/playwright/src/specs/podman-machine-tests.spec.ts
+++ b/tests/playwright/src/specs/podman-machine-tests.spec.ts
@@ -42,8 +42,15 @@ test.beforeAll(async ({ runner, welcomePage, page }) => {
   await waitForPodmanMachineStartup(page);
 });
 
-test.afterAll(async ({ runner }) => {
+test.afterAll(async ({ runner, page }) => {
   test.setTimeout(120_000);
+
+  try {
+    await handleConfirmationDialog(page, 'Podman', true, 'Yes');
+    await handleConfirmationDialog(page, 'Podman', true, 'OK');
+  } catch (error) {
+    console.log('No handling dialog displayed', error);
+  }
 
   if (test.info().status === 'failed') {
     await createPodmanMachineFromCLI();

--- a/tests/playwright/src/specs/podman-machine-tests.spec.ts
+++ b/tests/playwright/src/specs/podman-machine-tests.spec.ts
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { Locator } from '@playwright/test';
+
 import { PodmanMachineDetails } from '../model/pages/podman-machine-details-page';
 import { PodmanOnboardingPage } from '../model/pages/podman-onboarding-page';
 import { ResourceConnectionCardPage } from '../model/pages/resource-connection-card-page';
@@ -35,6 +37,7 @@ const DEFAULT_PODMAN_MACHINE_VISIBLE = 'podman-machine-default';
 const ROOTLESS_PODMAN_MACHINE_VISIBLE = 'podman-machine-rootless';
 const ROOTLESS_PODMAN_MACHINE = 'Podman Machine rootless';
 const RESOURCE_NAME = 'podman';
+let dialog: Locator;
 
 test.skip(
   isLinux || process.env.TEST_PODMAN_MACHINE !== 'true',
@@ -45,6 +48,7 @@ test.beforeAll(async ({ runner, welcomePage, page }) => {
   runner.setVideoAndTraceName('podman-machine-tests');
   await welcomePage.handleWelcomePage(true);
   await waitForPodmanMachineStartup(page);
+  dialog = page.getByRole('dialog', { name: 'Podman', exact: true });
 });
 
 test.afterAll(async ({ runner, page }) => {
@@ -161,11 +165,13 @@ test.describe.serial(`Podman machine switching validation `, () => {
       await test.step('Start rootless podman machine', async () => {
         await playExpect(podmanMachineDetails.podmanMachineStartButton).toBeEnabled();
         await podmanMachineDetails.podmanMachineStartButton.click();
-        await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('RUNNING', { timeout: 50_000 });
-      });
 
-      await handleConfirmationDialog(page, 'Podman', true, 'Yes');
-      await handleConfirmationDialog(page, 'Podman', true, 'OK');
+        await playExpect(dialog).toBeVisible({ timeout: 60_000 });
+        await handleConfirmationDialog(page, 'Podman', true, 'Yes');
+        await handleConfirmationDialog(page, 'Podman', true, 'OK');
+
+        await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('RUNNING', { timeout: 60_000 });
+      });
     });
   });
 
@@ -209,10 +215,12 @@ test.describe.serial(`Podman machine switching validation `, () => {
 
       await playExpect(podmanMachineDetails.podmanMachineStartButton).toBeEnabled();
       await podmanMachineDetails.podmanMachineStartButton.click();
-      await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('RUNNING', { timeout: 50_000 });
 
+      await playExpect(dialog).toBeVisible({ timeout: 60_000 });
       await handleConfirmationDialog(page, 'Podman', true, 'Yes');
       await handleConfirmationDialog(page, 'Podman', true, 'OK');
+
+      await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('RUNNING', { timeout: 60_000 });
     });
   });
 

--- a/tests/playwright/src/specs/podman-machine-tests.spec.ts
+++ b/tests/playwright/src/specs/podman-machine-tests.spec.ts
@@ -21,7 +21,12 @@ import { PodmanOnboardingPage } from '../model/pages/podman-onboarding-page';
 import { ResourceConnectionCardPage } from '../model/pages/resource-connection-card-page';
 import { ResourcesPage } from '../model/pages/resources-page';
 import { expect as playExpect, test } from '../utility/fixtures';
-import { createPodmanMachineFromCLI, deletePodmanMachine, handleConfirmationDialog } from '../utility/operations';
+import {
+  createPodmanMachineFromCLI,
+  deletePodmanMachine,
+  deletePodmanMachineFromCLI,
+  handleConfirmationDialog,
+} from '../utility/operations';
 import { isLinux } from '../utility/platform';
 import { waitForPodmanMachineStartup } from '../utility/wait';
 
@@ -45,15 +50,16 @@ test.beforeAll(async ({ runner, welcomePage, page }) => {
 test.afterAll(async ({ runner, page }) => {
   test.setTimeout(120_000);
 
+  if (test.info().status === 'failed') {
+    await deletePodmanMachineFromCLI(ROOTLESS_PODMAN_MACHINE_VISIBLE);
+    await createPodmanMachineFromCLI();
+  }
+
   try {
     await handleConfirmationDialog(page, 'Podman', true, 'Yes');
     await handleConfirmationDialog(page, 'Podman', true, 'OK');
   } catch (error) {
     console.log('No handling dialog displayed', error);
-  }
-
-  if (test.info().status === 'failed') {
-    await createPodmanMachineFromCLI();
   }
 
   await runner.close();

--- a/tests/playwright/src/utility/operations.ts
+++ b/tests/playwright/src/utility/operations.ts
@@ -384,12 +384,16 @@ export async function createPodmanMachineFromCLI(): Promise<void> {
   await test.step('Create Podman machine from CLI', async () => {
     try {
       // eslint-disable-next-line sonarjs/no-os-command-from-path
-      execSync('podman machine init --rootful --now');
+      execSync('podman machine init --rootful');
     } catch (error) {
       if (error instanceof Error && error.message.includes('VM already exists')) {
         console.log(`Podman machine already exists, skipping creation.`);
         return;
       }
     }
+
+    // eslint-disable-next-line sonarjs/no-os-command-from-path
+    execSync('podman machine start');
+    console.log('Default podman machine started');
   });
 }

--- a/tests/playwright/src/utility/operations.ts
+++ b/tests/playwright/src/utility/operations.ts
@@ -388,7 +388,6 @@ export async function createPodmanMachineFromCLI(): Promise<void> {
     } catch (error) {
       if (error instanceof Error && error.message.includes('VM already exists')) {
         console.log(`Podman machine already exists, skipping creation.`);
-        return;
       }
     }
 

--- a/tests/playwright/src/utility/operations.ts
+++ b/tests/playwright/src/utility/operations.ts
@@ -391,8 +391,25 @@ export async function createPodmanMachineFromCLI(): Promise<void> {
       }
     }
 
-    // eslint-disable-next-line sonarjs/no-os-command-from-path
-    execSync('podman machine start');
-    console.log('Default podman machine started');
+    try {
+      // eslint-disable-next-line sonarjs/no-os-command-from-path
+      execSync('podman machine start');
+      console.log('Default podman machine started');
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('VM already running')) {
+        console.log('Default podman machine already started, skipping start.');
+      }
+    }
   });
+}
+
+export async function deletePodmanMachineFromCLI(podmanMachineName: string): Promise<void> {
+  try {
+    // eslint-disable-next-line sonarjs/os-command
+    execSync(`podman machine rm ${podmanMachineName} -f`);
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('VM does not exist')) {
+      console.log(`Podman machine [${podmanMachineName}] does not exist, skipping deletion.`);
+    }
+  }
 }


### PR DESCRIPTION
### What does this PR do?
Add additional handling for failing e2e tests.

### What issues does this PR fix or reference?
https://github.com/containers/podman-desktop/issues/9237