### PR TITLE
fix: update cancelId to fix failing windows update e2e test

### DIFF
--- a/packages/main/src/plugin/updater.spec.ts
+++ b/packages/main/src/plugin/updater.spec.ts
@@ -418,7 +418,7 @@ describe('expect update command to depends on context', async () => {
     await mListener?.('startup');
 
     expect(messageBoxMock.showMessageBox).toHaveBeenCalledWith({
-      cancelId: 1,
+      cancelId: 2,
       buttons: ['Update now', 'View release notes', 'Remind me later', 'Do not show again'],
       message:
         'A new version v@debug-next of Podman Desktop is available. Do you want to update your current version v@debug?',
@@ -434,7 +434,7 @@ describe('expect update command to depends on context', async () => {
     await mListener?.('status-bar-entry');
 
     expect(messageBoxMock.showMessageBox).toHaveBeenCalledWith({
-      cancelId: 1,
+      cancelId: 2,
       buttons: ['Update now', 'View release notes', 'Cancel'],
       message:
         'A new version v@debug-next of Podman Desktop is available. Do you want to update your current version v@debug?',
@@ -685,6 +685,7 @@ test('get release notes in dev mode', async () => {
       statusBarRegistryMock,
       commandRegistryMock,
       taskManagerMock,
+      apiSenderMock,
     );
 
     vi.spyOn(global, 'fetch').mockResolvedValueOnce({

--- a/packages/main/src/plugin/updater.ts
+++ b/packages/main/src/plugin/updater.ts
@@ -224,7 +224,7 @@ export class Updater {
         title: 'Update Available now',
         message: `A new version ${updateVersion} of Podman Desktop is available. Do you want to update your current version ${this.#currentVersion}?`,
         buttons: buttons,
-        cancelId: 1,
+        cancelId: 2,
       });
       if (result.response === 3) {
         this.updateConfigurationValue('never');


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Updates the update buttons cancelId to pass the failing windows update e2e test

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
