### PR TITLE
chore: add 'mini' navigation menu option for kubernetes

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -117,7 +117,12 @@ window.events?.receive('navigate', (navigationRequest: unknown) => {
       {/if}
       {#each $navigationRegistry.filter(item => item.type === 'submenu') as navigationRegistryItem}
         {#if meta.url.startsWith(navigationRegistryItem.link) && navigationRegistryItem.items?.length}
-          <SubmenuNavigation meta={meta} title={navigationRegistryItem.tooltip} items={navigationRegistryItem.items} />
+          <!-- If the meta url starts with "kubernetes" we will pass mini=true to the submenu navigation to reduce the size of it for less whitespace -->
+          <SubmenuNavigation
+            meta={meta}
+            title={navigationRegistryItem.tooltip}
+            items={navigationRegistryItem.items}
+            mini={meta.url.startsWith('/kubernetes')} />
         {/if}
       {/each}
 

--- a/packages/renderer/src/SubmenuNavigation.spec.ts
+++ b/packages/renderer/src/SubmenuNavigation.spec.ts
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import '@testing-library/jest-dom';
+
 import { SettingsNavItem } from '@podman-desktop/ui-svelte';
 import { render, screen } from '@testing-library/svelte';
 import type { TinroRouteMeta } from 'tinro';
@@ -62,4 +64,30 @@ test('SubmenuNavigation displays a title and builds SettingsNavItem components',
     href: '/link2',
     selected: false,
   });
+});
+
+test('if mini=true is passed to SubmenuNavigation, it should render a mini version', async () => {
+  render(SubmenuNavigation, {
+    title: 'A title',
+    items: [
+      {
+        tooltip: 'entry 1',
+        link: '/link1',
+      } as unknown as NavigationRegistryEntry,
+      {
+        tooltip: 'entry 2',
+        link: '/link2',
+      } as unknown as NavigationRegistryEntry,
+    ],
+    meta: {
+      url: '/link1/subpath',
+    } as TinroRouteMeta,
+    mini: true,
+  });
+
+  // Expect w-minileftsidebar min-w-minileftsidebar classes to be present
+  // since 'mini' was passed as true
+  const miniLeftSidebar = screen.getByLabelText('A title Navigation Bar');
+  expect(miniLeftSidebar).toHaveClass('w-minileftsidebar');
+  expect(miniLeftSidebar).toHaveClass('min-w-minileftsidebar');
 });

--- a/packages/renderer/src/SubmenuNavigation.svelte
+++ b/packages/renderer/src/SubmenuNavigation.svelte
@@ -18,14 +18,14 @@ export let mini: boolean = false;
   <div class="flex items-center">
     <div class="pt-4 px-3 mb-10">
       <p
-        class="text-2xl font-semibold text-[color:var(--pd-secondary-nav-header-text)] border-l-[4px] border-transparent">
+        class="{mini ? 'text-xl' : 'text-2xl'} font-semibold text-[color:var(--pd-secondary-nav-header-text)] border-l-[4px] border-transparent">
         {title}
       </p>
     </div>
   </div>
   <div class="h-full overflow-hidden hover:overflow-y-auto text-sm" style="margin-bottom:auto">
     {#each items ?? [] as item}
-      <SettingsNavItem title={item.tooltip} href={item.link} selected={meta.url.startsWith(item.link)}
+      <SettingsNavItem title={item.tooltip} href={item.link} selected={meta.url.startsWith(item.link)} mini={mini}
       ></SettingsNavItem>
     {/each}
   </div>

--- a/packages/renderer/src/SubmenuNavigation.svelte
+++ b/packages/renderer/src/SubmenuNavigation.svelte
@@ -7,10 +7,13 @@ import type { NavigationRegistryEntry } from './stores/navigation/navigation-reg
 export let title: string;
 export let items: NavigationRegistryEntry[] | undefined;
 export let meta: TinroRouteMeta;
+export let mini: boolean = false;
 </script>
 
 <nav
-  class="z-1 w-leftsidebar min-w-leftsidebar flex-col justify-between flex transition-all duration-500 ease-in-out bg-[var(--pd-secondary-nav-bg)] border-[var(--pd-global-nav-bg-border)] border-r-[1px]"
+  class="z-1 {mini
+    ? 'w-minileftsidebar min-w-minileftsidebar'
+    : 'w-leftsidebar min-w-leftsidebar'} flex-col justify-between flex transition-all duration-500 ease-in-out bg-[var(--pd-secondary-nav-bg)] border-[var(--pd-global-nav-bg-border)] border-r-[1px]"
   aria-label={title + ' Navigation Bar'}>
   <div class="flex items-center">
     <div class="pt-4 px-3 mb-10">
@@ -20,7 +23,7 @@ export let meta: TinroRouteMeta;
       </p>
     </div>
   </div>
-  <div class="h-full overflow-hidden hover:overflow-y-auto" style="margin-bottom:auto">
+  <div class="h-full overflow-hidden hover:overflow-y-auto text-sm" style="margin-bottom:auto">
     {#each items ?? [] as item}
       <SettingsNavItem title={item.tooltip} href={item.link} selected={meta.url.startsWith(item.link)}
       ></SettingsNavItem>

--- a/packages/ui/src/lib/settingsNavItem/SettingsNavItem.svelte
+++ b/packages/ui/src/lib/settingsNavItem/SettingsNavItem.svelte
@@ -9,6 +9,7 @@ export let expanded = false;
 export let child = false;
 export let selected: boolean = false;
 export let icon: IconDefinition | undefined = undefined;
+export let mini: boolean = false;
 
 function rotate(
   node: unknown,
@@ -39,7 +40,8 @@ function click(): void {
     class:pl-3={!child}
     class:pl-6={child}
     class:leading-none={child}
-    class:text-lg={!child}
+    class:text-lg={!child && !mini}
+    class:text-md={!child && mini}
     class:font-medium={!child}
     class:bg-[var(--pd-secondary-nav-selected-bg)]={selected}
     class:border-[var(--pd-secondary-nav-bg)]={!selected}
@@ -59,12 +61,12 @@ function click(): void {
       <div class="px-2 relative w-4 h-4 text-[color:var(--pd-secondary-nav-expander)]">
         {#if expanded}
           <i
-            class="fas fa-angle-down text-lg absolute left-0 top-0"
+            class="fas fa-angle-down {mini ? 'text-md' : 'text-lg'} absolute left-0 top-0"
             aria-hidden="true"
             in:rotate={{ clockwise: false }}
             out:rotate={{ clockwise: false }}></i>
         {:else}
-          <i class="fas fa-angle-right text-lg absolute left-0 top-0" aria-hidden="true" in:rotate={{}} out:rotate={{}}
+          <i class="fas fa-angle-right {mini ? 'text-md' : 'text-lg'} absolute left-0 top-0" aria-hidden="true" in:rotate={{}} out:rotate={{}}
           ></i>
         {/if}
       </div>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -34,12 +34,12 @@ module.exports = {
       width: {
         leftnavbar: '48px',
         leftsidebar: '225px',
-        minileftsidebar: '150px',
+        minileftsidebar: '170px',
       },
       minWidth: {
         leftnavbar: '48px',
         leftsidebar: '225px',
-        minileftsidebar: '150px',
+        minileftsidebar: '170px',
       },
     },
     fontSize: {

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -34,10 +34,12 @@ module.exports = {
       width: {
         leftnavbar: '48px',
         leftsidebar: '225px',
+        minileftsidebar: '150px',
       },
       minWidth: {
         leftnavbar: '48px',
         leftsidebar: '225px',
+        minileftsidebar: '150px',
       },
     },
     fontSize: {


### PR DESCRIPTION
chore: add 'mini' navigation menu option for kubernetes

### What does this PR do?

- Adds a 'mini' boolean option for navbar items and submenu navigation
- Decreases the font size and spacing
- Meant for sections of Podman Desktop with long names
- Decreases the font size and navigation width

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

Before:

![image](https://github.com/user-attachments/assets/bd3235c9-ffa5-48a3-9a9d-71c4263c519a)


After:
![Screenshot 2024-10-07 at 3 49 36 PM](https://github.com/user-attachments/assets/aa63488e-8bcf-471a-a687-782edd905851)



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/8771

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Go to Kubernetes section and see that the navigation bar is slimmer /
smaller.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
