### PR TITLE
fix: reset extra assets array in beforePack call to avoid including podman vm image for x64 and arm64 in arm64.zip

### DIFF
--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -79,14 +79,16 @@ const config = {
   buildDependenciesFromSource: false,
   npmRebuild: false,
   beforePack: async context => {
-    context.packager.config.extraResources = ['packages/main/src/assets/**'];
+    const DEFAULT_ASSETS = ['packages/main/src/assets/**'];
+    context.packager.config.extraResources = DEFAULT_ASSETS;
+
     // universal build, add both pkg files
     // this is hack to avoid issue https://github.com/electron/universal/issues/36
     if (
       context.appOutDir.endsWith('mac-universal-x64-temp') ||
       context.appOutDir.endsWith('mac-universal-arm64-temp')
     ) {
-      context.packager.config.extraResources = ['packages/main/src/assets/**'];
+      context.packager.config.extraResources = DEFAULT_ASSETS;
       context.packager.config.extraResources.push('extensions/podman/packages/extension/assets/podman-installer-macos-universal*.pkg');
       return;
     }

--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -65,8 +65,6 @@ async function addElectronFuses(context) {
   });
 }
 
-const DEFAULT_ASSETS = ['packages/main/src/assets/**'];
-
 /**
  * @type {import('electron-builder').Configuration}
  * @see https://www.electron.build/configuration/configuration
@@ -81,15 +79,14 @@ const config = {
   buildDependenciesFromSource: false,
   npmRebuild: false,
   beforePack: async context => {
-    context.packager.config.extraResources = DEFAULT_ASSETS;
-
+    context.packager.config.extraResources = ['packages/main/src/assets/**'];
     // universal build, add both pkg files
     // this is hack to avoid issue https://github.com/electron/universal/issues/36
     if (
       context.appOutDir.endsWith('mac-universal-x64-temp') ||
       context.appOutDir.endsWith('mac-universal-arm64-temp')
     ) {
-      context.packager.config.extraResources = DEFAULT_ASSETS;
+      context.packager.config.extraResources = ['packages/main/src/assets/**'];
       context.packager.config.extraResources.push('extensions/podman/packages/extension/assets/podman-installer-macos-universal*.pkg');
       return;
     }


### PR DESCRIPTION
This fix avoid including x64 and arm64 podman vm images to amd64 build

### What does this PR do?

PR removes const array and init extra assets array with new one in every beforfPack call.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
