### PR TITLE
fix: correct selection borders for Kube Play

### DIFF
--- a/packages/renderer/src/lib/kube/KubePlayYAML.spec.ts
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.spec.ts
@@ -196,3 +196,33 @@ test('expect done button is there at the end and redirects to pods', async () =>
 
   expect(router.goto).toHaveBeenCalledWith(`/pods`);
 });
+
+test('expect runtime boxes have the correct selection borders', async () => {
+  (window as any).playKube = vi.fn().mockResolvedValue({
+    Pods: [],
+  });
+
+  setup();
+  render(KubePlayYAML, {});
+
+  // check the current borders
+  const podmanOption = screen.getByText('Podman container engine');
+  expect(podmanOption).toBeInTheDocument();
+  expect(podmanOption.parentElement?.parentElement).toHaveClass('border-[var(--pd-content-card-border-selected)]');
+  expect(podmanOption.parentElement?.parentElement).not.toHaveClass('border-[var(--pd-content-card-border)]');
+
+  const kubeOption = screen.getByText('Kubernetes cluster');
+  expect(kubeOption).toBeInTheDocument();
+  expect(kubeOption.parentElement?.parentElement).not.toHaveClass('border-[var(--pd-content-card-border-selected)]');
+  expect(kubeOption.parentElement?.parentElement).toHaveClass('border-[var(--pd-content-card-border)]');
+
+  // now switch selection to Kubernetes
+  await userEvent.click(kubeOption);
+
+  // and expect opposite selection borders
+  expect(podmanOption.parentElement?.parentElement).not.toHaveClass('border-[var(--pd-content-card-border-selected)]');
+  expect(podmanOption.parentElement?.parentElement).toHaveClass('border-[var(--pd-content-card-border)]');
+
+  expect(kubeOption.parentElement?.parentElement).toHaveClass('border-[var(--pd-content-card-border-selected)]');
+  expect(kubeOption.parentElement?.parentElement).not.toHaveClass('border-[var(--pd-content-card-border)]');
+});

--- a/packages/renderer/src/lib/kube/KubePlayYAML.svelte
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.svelte
@@ -243,6 +243,8 @@ function goBackToPodsPage(): void {
           class="border-2 rounded-md p-5 cursor-pointer bg-[var(--pd-content-card-inset-bg)]"
           aria-label="Kubernetes Cluster Runtime"
           aria-pressed={userChoice === 'kubernetes' ? 'true' : 'false'}
+          class:border-[var(--pd-content-card-border-selected)]={userChoice === 'kubernetes'}
+          class:border-[var(--pd-content-card-border)]={userChoice !== 'kubernetes'}
           on:click={() => {
             userChoice = 'kubernetes';
           }}>


### PR DESCRIPTION
### What does this PR do?

Just adds the same border styling to the Kubernetes option as the Podman option already had.

### Screenshot / video of UI

https://github.com/user-attachments/assets/c6a37ba6-5b57-4ac1-9407-93b72bb98661

### What issues does this PR fix or reference?

Fixes #9243.

### How to test this PR?

Go to Pods > Play Kube.

- [x] Tests are covering the bug fix or the new feature