### PR TITLE
fix: revert "chore: bump version to 1.14.0" to restart release

### DIFF
--- a/.flatpak-appdata.xml
+++ b/.flatpak-appdata.xml
@@ -42,7 +42,6 @@
   <content_rating type="oars-1.1" />
   <update_contact>fbenoit_at_redhat_com</update_contact>
   <releases>
-    <release version="1.13.0" date="2024-10-08"/>
     <release version="1.12.0" date="2024-08-07"/>
     <release version="1.11.0" date="2024-06-19"/>
     <release version="1.10.0" date="2024-04-25"/>

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -50,9 +50,8 @@ body:
       description: What version of the software are you running?
       options:
         - "1.11.1"
-        - "1.13.0"
-        - "next (development version)"
         - "1.12.0"
+        - "next (development version)"
         - "1.11.0"
         - "1.10.2"
         - "1.10.1"

--- a/extensions/compose/package.json
+++ b/extensions/compose/package.json
@@ -2,7 +2,7 @@
   "name": "compose",
   "displayName": "Compose",
   "description": "Install Compose binary to work with Podman",
-  "version": "1.14.0-next",
+  "version": "1.13.0-next",
   "icon": "icon.png",
   "publisher": "podman-desktop",
   "license": "Apache-2.0",

--- a/extensions/docker/package.json
+++ b/extensions/docker/package.json
@@ -2,7 +2,7 @@
   "name": "docker",
   "displayName": "Docker",
   "description": "Integration for Docker engine",
-  "version": "1.14.0-next",
+  "version": "1.13.0-next",
   "icon": "icon.png",
   "publisher": "podman-desktop",
   "license": "Apache-2.0",

--- a/extensions/kind/package.json
+++ b/extensions/kind/package.json
@@ -2,7 +2,7 @@
   "name": "kind",
   "displayName": "Kind",
   "description": "Integration for Kind: run local Kubernetes clusters using container “nodes”",
-  "version": "1.14.0-next",
+  "version": "1.13.0-next",
   "icon": "icon.png",
   "publisher": "podman-desktop",
   "license": "Apache-2.0",

--- a/extensions/kube-context/package.json
+++ b/extensions/kube-context/package.json
@@ -2,7 +2,7 @@
   "name": "kube-context",
   "displayName": "Kube Context",
   "description": "Easily switch between Kubernetes contexts",
-  "version": "1.14.0-next",
+  "version": "1.13.0-next",
   "icon": "icon.png",
   "publisher": "podman-desktop",
   "license": "Apache-2.0",

--- a/extensions/kubectl-cli/package.json
+++ b/extensions/kubectl-cli/package.json
@@ -2,7 +2,7 @@
   "name": "kubectl-cli",
   "displayName": "kubectl CLI",
   "description": "Install and update kubectl CLI Tools without leaving Podman Desktop",
-  "version": "1.14.0-next",
+  "version": "1.13.0-next",
   "icon": "icon.png",
   "publisher": "podman-desktop",
   "license": "Apache-2.0",

--- a/extensions/lima/package.json
+++ b/extensions/lima/package.json
@@ -2,7 +2,7 @@
   "name": "lima",
   "displayName": "Lima",
   "description": "Integration for Lima: Linux Machines (typically macOS)",
-  "version": "1.14.0-next",
+  "version": "1.13.0-next",
   "icon": "icon.png",
   "publisher": "podman-desktop",
   "license": "Apache-2.0",

--- a/extensions/registries/package.json
+++ b/extensions/registries/package.json
@@ -2,7 +2,7 @@
   "name": "registries",
   "displayName": "Registries",
   "description": "Adds default registries for Quay, DockerHub, GitHub, and Google Container Registry",
-  "version": "1.14.0-next",
+  "version": "1.13.0-next",
   "icon": "icon.png",
   "publisher": "podman-desktop",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "Podman Desktop",
   "repository": "https://github.com/containers/podman-desktop",
   "homepage": "https://www.podman-desktop.io",
-  "version": "1.14.0-next",
+  "version": "1.13.0-next",
   "license": "apache-2.0",
   "type": "module",
   "private": true,


### PR DESCRIPTION
This reverts commit 6e721e9aaf350027102cc7d299fe256e1d0de96f to start rebuilding 1.13.0 after fix for build https://github.com/containers/podman-desktop/pull/9274 id merged.

### What does this PR do?

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
