### PR TITLE
 fix: reset extra assets array in beforePack call to avoid including podman vm image for x64 and arm64 in arm64.zip #9274 

### DIFF
--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -65,8 +65,6 @@ async function addElectronFuses(context) {
   });
 }
 
-const DEFAULT_ASSETS = ['packages/main/src/assets/**'];
-
 /**
  * @type {import('electron-builder').Configuration}
  * @see https://www.electron.build/configuration/configuration
@@ -81,6 +79,7 @@ const config = {
   buildDependenciesFromSource: false,
   npmRebuild: false,
   beforePack: async context => {
+    const DEFAULT_ASSETS = ['packages/main/src/assets/**'];
     context.packager.config.extraResources = DEFAULT_ASSETS;
 
     // universal build, add both pkg files


### PR DESCRIPTION
This fix avoid including x64 and arm64 podman vm images to amd64 build

### What does this PR do?

PR moves DEFAULT_ASSETS const inside beforPack callback to avoid including both x64 and arm64 podman vm images into arm64 podman desktop airgap zip.

Original PR for main branch #9274.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
