### PR TITLE
chore: update airgap installer for windows to pull images from quay.io

### DIFF
--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022 Red Hat, Inc.
+ * Copyright (C) 2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -119,14 +119,10 @@ const config = {
       context.packager.config.extraResources.push('extensions/podman/packages/extension/assets/podman-*.exe');
     }
     if (context.arch === Arch.x64 && context.electronPlatformName === 'win32') {
-      context.packager.config.extraResources.push(
-        'extensions/podman/packages/extension/assets/podman-image-x64.tar.zst',
-      );
+      context.packager.config.extraResources.push('extensions/podman/packages/extension/assets/podman-image-x64.zst');
     }
     if (context.arch === Arch.arm64 && context.electronPlatformName === 'win32') {
-      context.packager.config.extraResources.push(
-        'extensions/podman/packages/extension/assets/podman-image-arm64.tar.zst',
-      );
+      context.packager.config.extraResources.push('extensions/podman/packages/extension/assets/podman-image-arm64.zst');
     }
   },
   afterPack: async context => {

--- a/extensions/podman/packages/extension/scripts/podman-download.spec.ts
+++ b/extensions/podman/packages/extension/scripts/podman-download.spec.ts
@@ -18,7 +18,7 @@
 
 import { setupServer, SetupServerApi } from 'msw/node';
 import { beforeEach, afterEach, describe, expect, test, vi } from 'vitest';
-import { Podman5DownloadMachineOS, PodmanDownload, ShaCheck } from './podman-download';
+import { DiskType, Podman5DownloadMachineOS, PodmanDownload, ShaCheck } from './podman-download';
 import * as podman5JSON from '../src/podman5.json';
 import { Readable, Writable } from 'node:stream';
 import { WritableStream } from 'stream/web';
@@ -441,7 +441,12 @@ describe('Podman5DownloadMachineOS', () => {
     server = setupServer(...handlers);
     server.listen({ onUnhandledRequest: 'error' });
 
-    const podman5DownloadMachineOS = new TestPodman5DownloadMachineOS('1.0-fake', shaCheck, '/fake-directory', false);
+    const podman5DownloadMachineOS = new TestPodman5DownloadMachineOS(
+      '1.0-fake',
+      shaCheck,
+      '/fake-directory',
+      DiskType.Applehv,
+    );
 
     vi.spyOn(podman5DownloadMachineOS, 'pipe').mockResolvedValue();
 
@@ -641,15 +646,25 @@ describe('Podman5DownloadMachineOS', () => {
     server = setupServer(...handlers);
     server.listen({ onUnhandledRequest: 'error' });
 
-    const podman5DownloadMachineOS = new TestPodman5DownloadMachineOS('1.0-fake', shaCheck, '/fake-directory', true);
+    const podman5DownloadMachineOS = new TestPodman5DownloadMachineOS(
+      '1.0-fake',
+      shaCheck,
+      '/fake-directory',
+      DiskType.WSL,
+    );
 
     vi.spyOn(podman5DownloadMachineOS, 'pipe').mockResolvedValue();
 
     await podman5DownloadMachineOS.download();
   });
 
-  test('check pipe method', async () => {
-    const podman5DownloadMachineOS = new TestPodman5DownloadMachineOS('1.0-fake', shaCheck, '/fake-directory', false);
+  test('check pipe method on Mac', async () => {
+    const podman5DownloadMachineOS = new TestPodman5DownloadMachineOS(
+      '1.0-fake',
+      shaCheck,
+      '/fake-directory',
+      DiskType.Applehv,
+    );
 
     const myStream = Readable.from('Hello, World!');
 
@@ -667,7 +682,12 @@ describe('Podman5DownloadMachineOS', () => {
   });
 
   test('check pipe method on Windows', async () => {
-    const podman5DownloadMachineOS = new TestPodman5DownloadMachineOS('1.0-fake', shaCheck, '/fake-directory', true);
+    const podman5DownloadMachineOS = new TestPodman5DownloadMachineOS(
+      '1.0-fake',
+      shaCheck,
+      '/fake-directory',
+      DiskType.WSL,
+    );
 
     const myStream = Readable.from('Hello, World!');
 

--- a/extensions/podman/packages/extension/scripts/podman-download.spec.ts
+++ b/extensions/podman/packages/extension/scripts/podman-download.spec.ts
@@ -441,16 +441,11 @@ describe('Podman5DownloadMachineOS', () => {
     server = setupServer(...handlers);
     server.listen({ onUnhandledRequest: 'error' });
 
-    const podman5DownloadMachineOS = new TestPodman5DownloadMachineOS(
-      '1.0-fake',
-      shaCheck,
-      '/fake-directory',
-      DiskType.Applehv,
-    );
+    const podman5DownloadMachineOS = new TestPodman5DownloadMachineOS('1.0-fake', shaCheck, '/fake-directory');
 
     vi.spyOn(podman5DownloadMachineOS, 'pipe').mockResolvedValue();
 
-    await podman5DownloadMachineOS.download();
+    await podman5DownloadMachineOS.setAndDownload('darwin');
   });
 
   test('download all the files and perform checks on Windows', async () => {
@@ -646,25 +641,15 @@ describe('Podman5DownloadMachineOS', () => {
     server = setupServer(...handlers);
     server.listen({ onUnhandledRequest: 'error' });
 
-    const podman5DownloadMachineOS = new TestPodman5DownloadMachineOS(
-      '1.0-fake',
-      shaCheck,
-      '/fake-directory',
-      DiskType.WSL,
-    );
+    const podman5DownloadMachineOS = new TestPodman5DownloadMachineOS('1.0-fake', shaCheck, '/fake-directory');
 
     vi.spyOn(podman5DownloadMachineOS, 'pipe').mockResolvedValue();
 
-    await podman5DownloadMachineOS.download();
+    await podman5DownloadMachineOS.setAndDownload('win32');
   });
 
   test('check pipe method on Mac', async () => {
-    const podman5DownloadMachineOS = new TestPodman5DownloadMachineOS(
-      '1.0-fake',
-      shaCheck,
-      '/fake-directory',
-      DiskType.Applehv,
-    );
+    const podman5DownloadMachineOS = new TestPodman5DownloadMachineOS('1.0-fake', shaCheck, '/fake-directory');
 
     const myStream = Readable.from('Hello, World!');
 
@@ -682,12 +667,7 @@ describe('Podman5DownloadMachineOS', () => {
   });
 
   test('check pipe method on Windows', async () => {
-    const podman5DownloadMachineOS = new TestPodman5DownloadMachineOS(
-      '1.0-fake',
-      shaCheck,
-      '/fake-directory',
-      DiskType.WSL,
-    );
+    const podman5DownloadMachineOS = new TestPodman5DownloadMachineOS('1.0-fake', shaCheck, '/fake-directory');
 
     const myStream = Readable.from('Hello, World!');
 

--- a/extensions/podman/packages/extension/scripts/podman-download.spec.ts
+++ b/extensions/podman/packages/extension/scripts/podman-download.spec.ts
@@ -548,7 +548,7 @@ describe('Podman5DownloadMachineOS', () => {
           digest: 'sha256:c7bbce32d96c44b0db6e05a3f78fa4cb11f578c7d18cec49d23a7d6b40843a05',
           size: 11009,
           platform: {
-            architecture: 'x86_644',
+            architecture: 'x86_64',
             os: 'linux',
           },
         },

--- a/extensions/podman/packages/extension/scripts/podman-download.spec.ts
+++ b/extensions/podman/packages/extension/scripts/podman-download.spec.ts
@@ -18,19 +18,11 @@
 
 import { setupServer, SetupServerApi } from 'msw/node';
 import { beforeEach, afterEach, describe, expect, test, vi } from 'vitest';
-import {
-  DownloadAndCheck,
-  Podman5DownloadFedoraImage,
-  Podman5DownloadMachineOS,
-  PodmanDownload,
-  ShaCheck,
-} from './podman-download';
+import { Podman5DownloadMachineOS, PodmanDownload, ShaCheck } from './podman-download';
 import * as podman5JSON from '../src/podman5.json';
-import { http, HttpResponse } from 'msw';
-import { appendFileSync, existsSync, mkdirSync } from 'node:fs';
-import { Octokit } from 'octokit';
 import { Readable, Writable } from 'node:stream';
 import { WritableStream } from 'stream/web';
+import { http, HttpResponse } from 'msw';
 
 const mockedPodman5 = {
   version: '5.0.0',
@@ -57,20 +49,20 @@ const mockedPodman5 = {
 };
 
 class TestPodmanDownload extends PodmanDownload {
-  public getPodman5DownloadFedoraImage(): Podman5DownloadFedoraImage {
-    return super.getPodman5DownloadFedoraImage();
-  }
-
   public getPodman5DownloadMachineOS(): Podman5DownloadMachineOS {
     return super.getPodman5DownloadMachineOS();
   }
 
-  public getShaCheck(): ShaCheck {
-    return super.getShaCheck();
+  public getArtifactsToDownload(): {
+    version: string;
+    downloadName: string;
+    artifactName: string;
+  }[] {
+    return super.getArtifactsToDownload();
   }
 
-  public getDownloadAndCheck(): DownloadAndCheck {
-    return super.getDownloadAndCheck();
+  public getShaCheck(): ShaCheck {
+    return super.getShaCheck();
   }
 }
 
@@ -104,11 +96,6 @@ describe('macOS platform', () => {
   test('PodmanDownload with real json', async () => {
     const podmanDownload = new TestPodmanDownload(podman5JSON, true);
 
-    // mock downloadAndCheckSha
-    const downloadCheck = podmanDownload.getDownloadAndCheck();
-    const downloadAndCheckShaSpy = vi.spyOn(downloadCheck, 'downloadAndCheckSha');
-    downloadAndCheckShaSpy.mockResolvedValue();
-
     // mock podman5DownloadMachineOS
     const podman5DownloadMachineOS = podmanDownload.getPodman5DownloadMachineOS();
     const podman5DownloadMachineOSSpy = vi.spyOn(podman5DownloadMachineOS, 'download');
@@ -119,57 +106,65 @@ describe('macOS platform', () => {
 
     await podmanDownload.downloadBinaries();
 
-    // check called 2 times
-    expect(downloadAndCheckShaSpy).toHaveBeenCalledTimes(3);
+    const value: {
+      version: string;
+      downloadName: string[];
+      artifactName: string[];
+    } = {
+      version: 'v5.',
+      downloadName: [
+        'podman-installer-macos-amd64',
+        'podman-installer-macos-aarch64',
+        'podman-installer-macos-universal',
+      ],
+      artifactName: [
+        'podman-installer-macos-amd64.pkg',
+        'podman-installer-macos-arm64.pkg',
+        'podman-installer-macos-universal.pkg',
+      ],
+    };
 
     // check called with the correct parameters
-    expect(downloadAndCheckShaSpy).toHaveBeenCalledWith(
-      expect.stringContaining('v5.'),
-      expect.stringContaining('podman-installer-macos-amd64'),
-      'podman-installer-macos-amd64.pkg',
-    );
-    expect(downloadAndCheckShaSpy).toHaveBeenCalledWith(
-      expect.stringContaining('v5.'),
-      expect.stringContaining('podman-installer-macos-aarch64'),
-      'podman-installer-macos-arm64.pkg',
-    );
-
-    // check airgap download
-    expect(podman5DownloadMachineOSSpy).toHaveBeenCalled();
+    const artifactsToDownload = podmanDownload.getArtifactsToDownload();
+    artifactsToDownload.forEach(artifact => {
+      expect(artifact.version).toContain('v5.');
+      expect(value.artifactName).toContain(artifact.artifactName);
+      expect(artifact.downloadName).toSatisfy((fileName: string) =>
+        value.downloadName.some(base => fileName.includes(base)),
+      );
+    });
   });
 
   test('PodmanDownload with mocked json', async () => {
     const podmanDownload = new TestPodmanDownload(mockedPodman5, false);
 
-    // mock downloadAndCheckSha
-    const downloadCheck = podmanDownload.getDownloadAndCheck();
-    const downloadAndCheckShaSpy = vi.spyOn(downloadCheck, 'downloadAndCheckSha');
-    downloadAndCheckShaSpy.mockResolvedValue();
-
     await podmanDownload.downloadBinaries();
 
-    // check called 3 (one for each arch + universal) times
-    expect(downloadAndCheckShaSpy).toHaveBeenCalledTimes(3);
+    const value: {
+      downloadName: string[];
+      artifactName: string[];
+    } = {
+      downloadName: [
+        'podman-installer-macos-amd64-v5.0.0.pkg',
+        'podman-installer-macos-aarch64-v5.0.0.pkg',
+        'podman-installer-macos-universal-v5.0.0.pkg',
+      ],
+      artifactName: [
+        'podman-installer-macos-amd64.pkg',
+        'podman-installer-macos-arm64.pkg',
+        'podman-installer-macos-universal.pkg',
+      ],
+    };
 
     // check called with the correct parameters
-    expect(downloadAndCheckShaSpy).toHaveBeenNthCalledWith(
-      1,
-      'v5.0.0',
-      'podman-installer-macos-amd64-v5.0.0.pkg',
-      'podman-installer-macos-amd64.pkg',
-    );
-    expect(downloadAndCheckShaSpy).toHaveBeenNthCalledWith(
-      2,
-      'v5.0.0',
-      'podman-installer-macos-aarch64-v5.0.0.pkg',
-      'podman-installer-macos-arm64.pkg',
-    );
-    expect(downloadAndCheckShaSpy).toHaveBeenNthCalledWith(
-      3,
-      'v5.0.0',
-      'podman-installer-macos-universal-v5.0.0.pkg',
-      'podman-installer-macos-universal.pkg',
-    );
+    const artifactsToDownload = podmanDownload.getArtifactsToDownload();
+    artifactsToDownload.forEach(artifact => {
+      expect(artifact.version).toContain('v5.0.0');
+      expect(value.artifactName).toContain(artifact.artifactName);
+      expect(artifact.downloadName).toSatisfy((fileName: string) =>
+        value.downloadName.some(base => fileName.includes(base)),
+      );
+    });
   });
 });
 
@@ -194,147 +189,42 @@ describe('windows platform', () => {
   test('PodmanDownload with real data', async () => {
     const podmanDownload = new TestPodmanDownload(podman5JSON, true);
 
-    // mock downloadAndCheckSha
-    const downloadCheck = podmanDownload.getDownloadAndCheck();
-    const downloadAndCheckShaSpy = vi.spyOn(downloadCheck, 'downloadAndCheckSha');
-    downloadAndCheckShaSpy.mockResolvedValue();
+    // mock podman5DownloadMachineOS
+    const podman5DownloadMachineOS = podmanDownload.getPodman5DownloadMachineOS();
+    const podman5DownloadMachineOSSpy = vi.spyOn(podman5DownloadMachineOS, 'download');
+    podman5DownloadMachineOSSpy.mockResolvedValue();
 
     // add env file
     process.env.AIRGAP_DOWNLOAD = 'yes';
 
-    // mock podmanDownloadFedoraImage
-    const podman5DownloadFedoraImage = podmanDownload.getPodman5DownloadFedoraImage();
-    const podman5DownloadFedoraImageSpy = vi.spyOn(podman5DownloadFedoraImage, 'download');
-    podman5DownloadFedoraImageSpy.mockResolvedValue();
-
     await podmanDownload.downloadBinaries();
 
-    // check called once
-    expect(downloadAndCheckShaSpy).toHaveBeenCalled();
-
     // check called with the correct parameters
-    expect(downloadAndCheckShaSpy).toHaveBeenCalledWith(
-      expect.stringContaining('v5.'),
-      expect.stringContaining('-setup.exe'),
-      expect.stringContaining('-setup.exe'),
-    );
-
-    // check airgap download
-    expect(podman5DownloadFedoraImageSpy).toHaveBeenCalled();
-    expect(podman5DownloadFedoraImageSpy).toHaveBeenCalledWith('x64');
-    expect(podman5DownloadFedoraImageSpy).toHaveBeenCalledWith('arm64');
+    const artifactsToDownload = podmanDownload.getArtifactsToDownload();
+    artifactsToDownload.forEach(artifact => {
+      expect(artifact.version).toContain('v5.');
+      expect(artifact.artifactName).toContain('-setup.exe');
+      expect(artifact.downloadName).toContain('-setup.exe');
+    });
   });
 
   test('PodmanDownload with mocked json', async () => {
-    const podmanDownload = new TestPodmanDownload(mockedPodman5, false);
+    const podmanDownload = new TestPodmanDownload(mockedPodman5, true);
 
-    // mock downloadAndCheckSha
-    const downloadCheck = podmanDownload.getDownloadAndCheck();
-    const downloadAndCheckShaSpy = vi.spyOn(downloadCheck, 'downloadAndCheckSha');
-    downloadAndCheckShaSpy.mockResolvedValue();
-
-    const podman5DownloadFedoraImage = podmanDownload.getPodman5DownloadFedoraImage();
-    const podmanDownloadFedoraImageSpy = vi.spyOn(podman5DownloadFedoraImage, 'download');
+    const podman5DownloadMachineOS = podmanDownload.getPodman5DownloadMachineOS();
+    const podman5DownloadMachineOSSpy = vi.spyOn(podman5DownloadMachineOS, 'download');
+    podman5DownloadMachineOSSpy.mockResolvedValue();
 
     await podmanDownload.downloadBinaries();
 
-    // check called
-    expect(downloadAndCheckShaSpy).toHaveBeenCalled();
-
     // check called with the correct parameters
-    expect(downloadAndCheckShaSpy).toHaveBeenNthCalledWith(
-      1,
-      'v5.0.0',
-      'podman-5.0.0-setup.exe',
-      'podman-5.0.0-setup.exe',
-    );
-
-    // check no airgap download
-    expect(podmanDownloadFedoraImageSpy).not.toHaveBeenCalled();
+    const artifactsToDownload = podmanDownload.getArtifactsToDownload();
+    artifactsToDownload.forEach(artifact => {
+      expect(artifact.version).toContain('v5.0.0');
+      expect(artifact.artifactName).toBe('podman-5.0.0-setup.exe');
+      expect(artifact.downloadName).toBe('podman-5.0.0-setup.exe');
+    });
   });
-});
-test('downloadAndCheckSha', async () => {
-  vi.mocked(existsSync).mockReturnValue(false);
-  vi.mocked(mkdirSync).mockReturnValue('');
-
-  const shaCheck = {
-    checkFile: vi.fn(),
-  } as unknown as ShaCheck;
-  // mock GitHub requests
-
-  vi.mocked(shaCheck.checkFile).mockResolvedValue(true);
-
-  const response = {
-    name: 'vFakeVersion',
-    assets: [
-      {
-        url: 'https://api.github.com/repos/containers/podman/releases/assets/456',
-        id: 456,
-        name: 'podman-fake-binary',
-        browser_download_url: 'https://github.com/containers/podman/releases/download/vFakeVersion/podman-binary',
-      },
-
-      {
-        url: 'https://api.github.com/repos/containers/podman/releases/assets/789',
-        id: 789,
-        name: 'shasums',
-        browser_download_url: 'https://github.com/containers/podman/releases/download/vFakeVersion/shasums',
-      },
-    ],
-  };
-  const shasumContent = 'fake-sha podman-fake-binary\n';
-  const podmanBinaryContent = 'fake-binary-content';
-
-  const handlers = [
-    http.get('https://api.github.com/repos/containers/podman/releases/tags/vFakeVersion', () =>
-      HttpResponse.json(response),
-    ),
-
-    http.get(
-      'https://api.github.com/repos/containers/podman/releases/assets/789',
-      () =>
-        new HttpResponse(shasumContent, {
-          status: 200,
-          headers: {
-            'content-type': 'application/octet-stream',
-            'content-length': `${shasumContent.length}`,
-            'content-disposition': 'attachment; filename=binary.zip',
-          },
-        }),
-    ),
-
-    // podman-binary content
-    http.get(
-      'https://api.github.com/repos/containers/podman/releases/assets/456',
-      () =>
-        new HttpResponse(podmanBinaryContent, {
-          status: 200,
-          headers: {
-            'content-type': 'application/octet-stream',
-            'content-length': `${podmanBinaryContent.length}`,
-            'content-disposition': 'attachment; filename=binary.zip',
-          },
-        }),
-    ),
-  ];
-
-  server = setupServer(...handlers);
-  server.listen({ onUnhandledRequest: 'error' });
-
-  const octokit = new Octokit();
-
-  const podmanDownload = new DownloadAndCheck(octokit, shaCheck, 'fake-directory');
-
-  await podmanDownload.downloadAndCheckSha('vFakeVersion', 'podman-fake-binary', 'podman-fake-binary');
-
-  // check we wrote the file
-  expect(appendFileSync).toHaveBeenCalledWith(
-    expect.stringContaining('podman-fake-binary'),
-    Buffer.from(podmanBinaryContent),
-  );
-
-  // check the sha
-  expect(shaCheck.checkFile).toHaveBeenCalledWith(expect.stringContaining('podman-fake-binary'), 'fake-sha');
 });
 
 describe('Podman5DownloadMachineOS', () => {
@@ -358,7 +248,7 @@ describe('Podman5DownloadMachineOS', () => {
     }
   }
 
-  test('download all the files and perform checks', async () => {
+  test('download all the files and perform checks on Mac', async () => {
     // spy Writable.toWeb
     vi.spyOn(Writable, 'toWeb').mockResolvedValue({} as unknown as WritableStream);
 
@@ -551,7 +441,207 @@ describe('Podman5DownloadMachineOS', () => {
     server = setupServer(...handlers);
     server.listen({ onUnhandledRequest: 'error' });
 
-    const podman5DownloadMachineOS = new TestPodman5DownloadMachineOS('1.0-fake', shaCheck, '/fake-directory');
+    const podman5DownloadMachineOS = new TestPodman5DownloadMachineOS('1.0-fake', shaCheck, '/fake-directory', false);
+
+    vi.spyOn(podman5DownloadMachineOS, 'pipe').mockResolvedValue();
+
+    await podman5DownloadMachineOS.download();
+  });
+
+  test('download all the files and perform checks on Windows', async () => {
+    // spy Writable.toWeb
+    vi.spyOn(Writable, 'toWeb').mockResolvedValue({} as unknown as WritableStream);
+
+    // mock manifests
+    const rootManifest = {
+      schemaVersion: 2,
+      mediaType: 'application/vnd.oci.image.index.v1+json',
+      manifests: [
+        {
+          mediaType: 'application/vnd.oci.image.manifest.v1+json',
+          digest: 'sha256:123amd64',
+          size: 481,
+          annotations: {
+            disktype: 'wsl',
+          },
+          platform: {
+            architecture: 'x86_64',
+            os: 'linux',
+          },
+        },
+        {
+          mediaType: 'application/vnd.oci.image.manifest.v1+json',
+          digest: 'sha256:456arm64',
+          size: 482,
+          annotations: {
+            disktype: 'wsl',
+          },
+          platform: {
+            architecture: 'aarch64',
+            os: 'linux',
+          },
+        },
+        {
+          mediaType: 'application/vnd.oci.image.manifest.v1+json',
+          digest: 'sha256:ee45494db66e33525f50835af65c4099db4db7a066b1da9a85fba7e88f95f594',
+          size: 481,
+          annotations: {
+            disktype: 'hyperv',
+          },
+          platform: {
+            architecture: 'x86_64',
+            os: 'linux',
+          },
+        },
+        {
+          mediaType: 'application/vnd.oci.image.manifest.v1+json',
+          digest: 'sha256:56bbdde7b2dc8714a0397f37ae1c8ac1353ed3e4de1b09c1db791d6fa5bc56fa',
+          size: 482,
+          annotations: {
+            disktype: 'hyperv',
+          },
+          platform: {
+            architecture: 'aarch64',
+            os: 'linux',
+          },
+        },
+        {
+          mediaType: 'application/vnd.oci.image.manifest.v1+json',
+          digest: 'sha256:c25ce5ba618f870f88c418c7aa0f176af4a7b32ed39aa328a8e27eae5a497e11',
+          size: 480,
+          annotations: {
+            disktype: 'qemu',
+          },
+          platform: {
+            architecture: 'x86_64',
+            os: 'linux',
+          },
+        },
+        {
+          mediaType: 'application/vnd.oci.image.manifest.v1+json',
+          digest: 'sha256:9a9285bd1a01e5b4c5b27467025cc5da281e250913432a9f92cf8fe1668fec19',
+          size: 481,
+          annotations: {
+            disktype: 'qemu',
+          },
+          platform: {
+            architecture: 'aarch64',
+            os: 'linux',
+          },
+        },
+        {
+          mediaType: 'application/vnd.oci.image.manifest.v1+json',
+          digest: 'sha256:34f21a8b9b8b9ff13fc348f8eba72fa92e74e52caa9984a78b68a7f5822641c7',
+          size: 11003,
+          platform: {
+            architecture: 'aarch64',
+            os: 'linux',
+          },
+        },
+        {
+          mediaType: 'application/vnd.oci.image.manifest.v1+json',
+          digest: 'sha256:c7bbce32d96c44b0db6e05a3f78fa4cb11f578c7d18cec49d23a7d6b40843a05',
+          size: 11009,
+          platform: {
+            architecture: 'x86_644',
+            os: 'linux',
+          },
+        },
+      ],
+    };
+
+    const zstdArchiveFakeContent = 'blablabla-ARM64\n';
+    const fakeContent = 'blablabla-ARM64\n';
+
+    const processArm64File = (): Buffer => {
+      return Buffer.from(fakeContent);
+    };
+
+    const handlers = [
+      http.get('https://quay.io/v2/podman/machine-os-wsl/manifests/1.0-fake', () => HttpResponse.json(rootManifest)),
+
+      // fake digest for amd64
+      http.get('https://quay.io/v2/podman/machine-os-wsl/manifests/sha256:123amd64', () =>
+        HttpResponse.json({
+          schemaVersion: 2,
+          mediaType: 'application/vnd.oci.image.manifest.v1+json',
+          config: {
+            mediaType: 'application/vnd.oci.empty.v1+json',
+            digest: 'sha256:1234',
+            size: 2,
+            data: 'e30=',
+          },
+          layers: [
+            {
+              mediaType: 'application/zstd',
+              digest: 'sha256:zstfakeamd64digest',
+              size: 1233263850,
+              annotations: {
+                'org.opencontainers.image.title': 'podman-machine-daily.amd64.wsl.raw.zst',
+              },
+            },
+          ],
+        }),
+      ),
+
+      // fake digest for arm64
+      http.get('https://quay.io/v2/podman/machine-os-wsl/manifests/sha256:456arm64', () =>
+        HttpResponse.json({
+          schemaVersion: 2,
+          mediaType: 'application/vnd.oci.image.manifest.v1+json',
+          config: {
+            mediaType: 'application/vnd.oci.empty.v1+json',
+            digest: 'sha256:1234',
+            size: 2,
+            data: 'e30=',
+          },
+          layers: [
+            {
+              mediaType: 'application/zstd',
+              digest: 'sha256:zstfakearm64digest',
+              size: 1233263850,
+              annotations: {
+                'org.opencontainers.image.title': 'podman-machine-daily.aarch64.wsl.raw.zst',
+              },
+            },
+          ],
+        }),
+      ),
+
+      // now do the digests for blobs
+      http.get('https://quay.io/v2/podman/machine-os-wsl/blobs/sha256:zstfakeamd64digest', () =>
+        HttpResponse.text('fake-amd64-content'),
+      ),
+
+      http.get(
+        'https://quay.io/v2/podman/machine-os-wsl/blobs/sha256:zstfakearm64digest',
+        () =>
+          new HttpResponse(zstdArchiveFakeContent, {
+            headers: {
+              'content-type': 'application/octet-stream',
+              'content-length': `${zstdArchiveFakeContent.length}`,
+              'content-disposition': 'attachment; filename=binary.zip',
+            },
+          }),
+      ),
+
+      http.get(
+        'https://quay.io/v2/podman/machine-os-wsl/blobs/sha256:zstfakearm64digest',
+        () =>
+          new HttpResponse(processArm64File(), {
+            headers: {
+              'content-type': 'application/octet-stream',
+              'content-length': `${fakeContent.length}`,
+              'content-disposition': 'attachment; filename=foo.raw.std',
+            },
+          }),
+      ),
+    ];
+
+    server = setupServer(...handlers);
+    server.listen({ onUnhandledRequest: 'error' });
+
+    const podman5DownloadMachineOS = new TestPodman5DownloadMachineOS('1.0-fake', shaCheck, '/fake-directory', true);
 
     vi.spyOn(podman5DownloadMachineOS, 'pipe').mockResolvedValue();
 
@@ -559,7 +649,25 @@ describe('Podman5DownloadMachineOS', () => {
   });
 
   test('check pipe method', async () => {
-    const podman5DownloadMachineOS = new TestPodman5DownloadMachineOS('1.0-fake', shaCheck, '/fake-directory');
+    const podman5DownloadMachineOS = new TestPodman5DownloadMachineOS('1.0-fake', shaCheck, '/fake-directory', false);
+
+    const myStream = Readable.from('Hello, World!');
+
+    const readableStream = Readable.toWeb(myStream) as ReadableStream<Uint8Array>;
+
+    const writeMock = vi.fn();
+    const writableStream = new WritableStream({
+      write: writeMock,
+    });
+
+    await podman5DownloadMachineOS.pipe('fake-title', 100, readableStream, writableStream);
+
+    // check we wrote the content
+    expect(writeMock).toHaveBeenCalledWith('Hello, World!', expect.anything());
+  });
+
+  test('check pipe method on Windows', async () => {
+    const podman5DownloadMachineOS = new TestPodman5DownloadMachineOS('1.0-fake', shaCheck, '/fake-directory', true);
 
     const myStream = Readable.from('Hello, World!');
 

--- a/extensions/podman/packages/extension/scripts/podman-download.ts
+++ b/extensions/podman/packages/extension/scripts/podman-download.ts
@@ -117,6 +117,14 @@ export class PodmanDownload {
     return this.#shaCheck;
   }
 
+  protected getArtifactsToDownload(): {
+    version: string;
+    downloadName: string;
+    artifactName: string;
+  }[] {
+    return this.#artifactsToDownload;
+  }
+
   async downloadBinaries(): Promise<void> {
     // fetch binaries in case of AirGap
     await this.downloadAirGapBinaries();

--- a/extensions/podman/packages/extension/scripts/podman-download.ts
+++ b/extensions/podman/packages/extension/scripts/podman-download.ts
@@ -157,7 +157,7 @@ export class Podman5DownloadMachineOS {
   #shaCheck: ShaCheck;
   #assetsFolder: string;
   #diskType: DiskType;
-  #githubProjectName: string;
+  #ociRegistryProjectLink: string;
 
   constructor(
     readonly version: string,
@@ -170,7 +170,7 @@ export class Podman5DownloadMachineOS {
     this.#shaCheck = shaCheck;
     this.#assetsFolder = assetsFolder;
     // Windows uses WSL => machine-os-wsl ; MacOS uses Applehv => machine-os
-    this.#githubProjectName = diskType === DiskType.WSL ? 'machine-os-wsl' : 'machine-os';
+    this.#ociRegistryProjectLink = `https://quay.io/v2/podman/${diskType === DiskType.WSL ? 'machine-os-wsl' : 'machine-os'}`;
   }
 
   async getManifest(manifestUrl: string): Promise<any> {
@@ -215,7 +215,7 @@ export class Podman5DownloadMachineOS {
     filename: string,
     layer: { digest: string; size: number },
   ): Promise<void> {
-    const blobURL = `https://quay.io/v2/podman/${this.#githubProjectName}/blobs/${layer.digest}`;
+    const blobURL = `${this.#ociRegistryProjectLink}/blobs/${layer.digest}`;
 
     const blobResponse = await fetch(blobURL);
     const total = layer.size;
@@ -257,7 +257,7 @@ export class Podman5DownloadMachineOS {
   // For macOS, need to grab images from quay.io/podman/machine-os repository
   // For Windos, need to grab images from quay.io/podman/machine-os-wsl repository
   async download(): Promise<void> {
-    const manifestUrl = `https://quay.io/v2/podman/${this.#githubProjectName}/manifests/${this.#version}`;
+    const manifestUrl = `${this.#ociRegistryProjectLink}/manifests/${this.#version}`;
 
     // get first level of manifests
     const rootManifest = await this.getManifest(manifestUrl);
@@ -293,10 +293,10 @@ export class Podman5DownloadMachineOS {
 
     // now get the zstd entry from the arch manifest
     const amd64ZstdManifest = await this.getManifest(
-      `https://quay.io/v2/podman/${this.#githubProjectName}/manifests/${amd64Manifest.digest}`,
+      `${this.#ociRegistryProjectLink}/manifests/${amd64Manifest.digest}`,
     );
     const arm64ZstdManifest = await this.getManifest(
-      `https://quay.io/v2/podman/${this.#githubProjectName}/manifests/${arm64Manifest.digest}`,
+      `${this.#ociRegistryProjectLink}/manifests/${arm64Manifest.digest}`,
     );
 
     // download the zstd layers

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -2092,14 +2092,7 @@ export async function createMachine(
     }
   } else if (isMac() || extensionApi.env.isWindows) {
     // check if we have an embedded asset for the image path for macOS or Windows
-    let suffix = '';
-    if (extensionApi.env.isWindows) {
-      suffix = `-${process.arch}.tar.zst`;
-    } else if (isMac()) {
-      suffix = `-${process.arch}.zst`;
-    }
-
-    const assetImagePath = path.resolve(getAssetsFolder(), `podman-image${suffix}`);
+    const assetImagePath = path.resolve(getAssetsFolder(), `podman-image-${process.arch}.zst`);
 
     const podmanInstallation = await getPodmanInstallation();
 


### PR DESCRIPTION
### What does this PR do?
Updates airgap installer to fetch podman from quay.io
Related info: https://github.com/containers/podman/pull/23949#issuecomment-2355128723

- [x] rebase after https://github.com/podman-desktop/podman-desktop/pull/9882 will be merged
### What issues does this PR fix or reference?
Closes #8917 

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature

Run command `AIRGAP_DOWNLOAD=1 pnpm compile:current` and you should get 2 .zst files in extensions\podman\packages\extension\assets folder, run the PD using `pnpm watch` command and in the end try to create podman machine with no connection to internet (it should use those 2 files to create the wsl machine)
