### PR TITLE
fix: done button in DeployPodToKube

### DIFF
--- a/packages/renderer/src/lib/pod/DeployPodToKube.svelte
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.svelte
@@ -7,6 +7,7 @@ import { onDestroy, onMount } from 'svelte';
 import { router } from 'tinro';
 
 import { ensureRestrictedSecurityContext } from '/@/lib/pod/pod-utils';
+import { lastPage } from '/@/stores/breadcrumb';
 import type { V1Route } from '/@api/openshift-types';
 
 import MonacoEditor from '../editor/MonacoEditor.svelte';
@@ -134,7 +135,7 @@ onDestroy(() => {
 });
 
 function goBackToHistory(): void {
-  window.history.go(-1);
+  router.goto($lastPage.path);
 }
 
 function openPodDetails(): void {


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Fixes the Done button in the DeployPodToKube page so that it would go back to the previous page
(In 1.13.x branch)
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Closes https://github.com/containers/podman-desktop/issues/9295

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
Go to the DeployPodToKube page, finish the pod deployment process, click the Done button, and check that it goes back to the previous page

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
