### PR TITLE
chore: replace the toml library

### DIFF
--- a/extensions/podman/packages/extension/package.json
+++ b/extensions/podman/packages/extension/package.json
@@ -399,10 +399,10 @@
     "watch": "vite build -w"
   },
   "dependencies": {
-    "@ltd/j-toml": "^1.38.0",
     "@podman-desktop/api": "workspace:*",
     "compare-versions": "^6.1.1",
     "ps-list": "^8.1.1",
+    "smol-toml": "1.3.0",
     "ssh2": "^1.16.0"
   },
   "devDependencies": {

--- a/extensions/podman/packages/extension/src/podman-configuration.ts
+++ b/extensions/podman/packages/extension/src/podman-configuration.ts
@@ -20,9 +20,9 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import * as toml from '@ltd/j-toml';
 import type { ProxySettings } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
+import * as toml from 'smol-toml';
 
 import { isLinux, isMac, isWindows } from './util';
 
@@ -134,22 +134,22 @@ export class PodmanConfiguration {
   async updateRosettaSetting(useRosetta: boolean): Promise<void> {
     // Initalize an empty configuration file for us to use
     const containersConfContent = {
-      containers: toml.Section({}),
-      engine: toml.Section({
+      containers: {},
+      engine: {
         env: [] as string[],
-      }),
-      machine: toml.Section({}),
-      network: toml.Section({}),
-      secrets: toml.Section({}),
-      configmaps: toml.Section({}),
+      },
+      machine: {},
+      network: {},
+      secrets: {},
+      configmaps: {},
     };
 
     // If the file does NOT exist and useRosetta is being set as false, we will have to create the file and write rosetta = false
     if (!useRosetta && !fs.existsSync(this.getContainersFileLocation())) {
-      containersConfContent['machine'] = toml.Section({
+      containersConfContent['machine'] = {
         rosetta: false as boolean,
-      });
-      const content = toml.stringify(containersConfContent, { newline: '\n' });
+      };
+      const content = toml.stringify(containersConfContent);
       await fs.promises.writeFile(this.getContainersFileLocation(), content);
     } else if (fs.existsSync(this.getContainersFileLocation())) {
       // Read the file
@@ -179,14 +179,14 @@ export class PodmanConfiguration {
         delete containersConfContent['machine']['rosetta'];
       } else if (!useRosetta && containersConfContent['machine']) {
         // If rosetta key does not exist, we need to add it
-        containersConfContent['machine'] = toml.Section({
+        containersConfContent['machine'] = {
           ...containersConfContent['machine'], // MAKE SURE we copy over the previous configuration
           rosetta: false as boolean,
-        });
+        };
       }
 
       // Write the file
-      const content = toml.stringify(containersConfContent, { newline: '\n' });
+      const content = toml.stringify(containersConfContent);
       await fs.promises.writeFile(this.getContainersFileLocation(), content);
     }
   }
@@ -194,14 +194,14 @@ export class PodmanConfiguration {
   async updateProxySettings(proxySettings: ProxySettings | undefined): Promise<void> {
     // create empty config file
     const containersConfContent = {
-      containers: toml.Section({}),
-      engine: toml.Section({
+      containers: {},
+      engine: {
         env: [] as string[],
-      }),
-      machine: toml.Section({}),
-      network: toml.Section({}),
-      secrets: toml.Section({}),
-      configmaps: toml.Section({}),
+      },
+      machine: {},
+      network: {},
+      secrets: {},
+      configmaps: {},
     };
 
     if (!fs.existsSync(this.getContainersFileLocation())) {
@@ -216,7 +216,7 @@ export class PodmanConfiguration {
       }
 
       // write the file
-      const content = toml.stringify(containersConfContent, { newline: '\n' });
+      const content = toml.stringify(containersConfContent);
       await fs.promises.writeFile(this.getContainersFileLocation(), content);
     } else {
       // read the content of the file
@@ -299,7 +299,7 @@ export class PodmanConfiguration {
 
       containersConfContent['engine'].env = engineEnv;
       // write the file
-      const content = toml.stringify(containersConfContent, { newline: '\n' });
+      const content = toml.stringify(containersConfContent);
       await fs.promises.writeFile(this.getContainersFileLocation(), content);
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -462,9 +462,6 @@ importers:
 
   extensions/podman/packages/extension:
     dependencies:
-      '@ltd/j-toml':
-        specifier: ^1.38.0
-        version: 1.38.0
       '@podman-desktop/api':
         specifier: workspace:*
         version: link:../../../../packages/extension-api
@@ -474,6 +471,9 @@ importers:
       ps-list:
         specifier: ^8.1.1
         version: 8.1.1
+      smol-toml:
+        specifier: 1.3.0
+        version: 1.3.0
       ssh2:
         specifier: ^1.16.0
         version: 1.16.0
@@ -2699,9 +2699,6 @@ packages:
 
   '@leichtgewicht/ip-codec@2.0.5':
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
-
-  '@ltd/j-toml@1.38.0':
-    resolution: {integrity: sha512-lYtBcmvHustHQtg4X7TXUu1Xa/tbLC3p2wLvgQI+fWVySguVZJF60Snxijw5EiohumxZbR10kWYFFebh1zotiw==}
 
   '@lukeed/csprng@1.1.0':
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
@@ -9844,6 +9841,10 @@ packages:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
 
+  smol-toml@1.3.0:
+    resolution: {integrity: sha512-tWpi2TsODPScmi48b/OQZGi2lgUmBCHy6SZrhi/FdnnHiU1GwebbCfuQuxsC3nHaLwtYeJGPrDZDIeodDOc4pA==}
+    engines: {node: '>= 18'}
+
   snake-case@3.0.4:
     resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
 
@@ -13577,8 +13578,6 @@ snapshots:
 
   '@leichtgewicht/ip-codec@2.0.5': {}
 
-  '@ltd/j-toml@1.38.0': {}
-
   '@lukeed/csprng@1.1.0': {}
 
   '@lukeed/uuid@2.0.1':
@@ -15163,14 +15162,6 @@ snapshots:
       magic-string: 0.30.11
     optionalDependencies:
       vite: 5.4.8(@types/node@20.16.11)(terser@5.31.6)
-
-  '@vitest/mocker@2.1.2(@vitest/spy@2.1.2)(vite@5.4.8(@types/node@20.16.2)(terser@5.31.6))':
-    dependencies:
-      '@vitest/spy': 2.1.2
-      estree-walker: 3.0.3
-      magic-string: 0.30.11
-    optionalDependencies:
-      vite: 5.4.8(@types/node@20.16.2)(terser@5.31.6)
 
   '@vitest/pretty-format@2.0.5':
     dependencies:
@@ -22419,6 +22410,8 @@ snapshots:
 
   smart-buffer@4.2.0: {}
 
+  smol-toml@1.3.0: {}
+
   snake-case@3.0.4:
     dependencies:
       dot-case: 3.0.4
@@ -23544,7 +23537,7 @@ snapshots:
   vitest@2.1.2(@types/node@20.16.2)(jsdom@25.0.1)(terser@5.31.6):
     dependencies:
       '@vitest/expect': 2.1.2
-      '@vitest/mocker': 2.1.2(@vitest/spy@2.1.2)(vite@5.4.8(@types/node@20.16.2)(terser@5.31.6))
+      '@vitest/mocker': 2.1.2(@vitest/spy@2.1.2)(vite@5.4.8(@types/node@20.16.11)(terser@5.31.6))
       '@vitest/pretty-format': 2.1.2
       '@vitest/runner': 2.1.2
       '@vitest/snapshot': 2.1.2


### PR DESCRIPTION
### What does this PR do?
current one had LGPL, switch to a BSD-3 one

I took this one as it was allowing both parse and stringify (some of them can only read)
and it's popular (downloads/week) and still maintained

but if you have another idea of library, why not !

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/9173

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

check the change of proxy parameters, or tune the machine provider and see if Podman Desktop is able to read the data, etc.

