### PR TITLE
chore: reduce width and font size subnavigation

### DIFF
--- a/packages/renderer/src/PreferencesNavigation.svelte
+++ b/packages/renderer/src/PreferencesNavigation.svelte
@@ -56,9 +56,9 @@ onMount(async () => {
   class="z-1 w-leftsidebar min-w-leftsidebar flex-col justify-between flex transition-all duration-500 ease-in-out bg-[var(--pd-secondary-nav-bg)] border-[var(--pd-global-nav-bg-border)] border-r-[1px]"
   aria-label="PreferencesNavigation">
   <div class="flex items-center">
-    <div class="pt-4 px-3 mb-10">
+    <div class="pt-4 px-3 mb-5">
       <p
-        class="text-2xl font-semibold text-[color:var(--pd-secondary-nav-header-text)] border-l-[4px] border-transparent">
+        class="text-xl font-semibold text-[color:var(--pd-secondary-nav-header-text)] border-l-[4px] border-transparent">
         Settings
       </p>
     </div>

--- a/packages/renderer/src/SubmenuNavigation.svelte
+++ b/packages/renderer/src/SubmenuNavigation.svelte
@@ -13,9 +13,9 @@ export let meta: TinroRouteMeta;
   class="z-1 w-leftsidebar min-w-leftsidebar flex-col justify-between flex transition-all duration-500 ease-in-out bg-[var(--pd-secondary-nav-bg)] border-[var(--pd-global-nav-bg-border)] border-r-[1px]"
   aria-label={title + ' Navigation Bar'}>
   <div class="flex items-center">
-    <div class="pt-4 px-3 mb-10">
+    <div class="pt-4 px-3 mb-5">
       <p
-        class="text-2xl font-semibold text-[color:var(--pd-secondary-nav-header-text)] border-l-[4px] border-transparent">
+        class="text-xl font-semibold text-[color:var(--pd-secondary-nav-header-text)] border-l-[4px] border-transparent">
         {title}
       </p>
     </div>

--- a/packages/ui/src/lib/settingsNavItem/SettingsNavItem.svelte
+++ b/packages/ui/src/lib/settingsNavItem/SettingsNavItem.svelte
@@ -39,7 +39,7 @@ function click(): void {
     class:pl-3={!child}
     class:pl-6={child}
     class:leading-none={child}
-    class:text-lg={!child}
+    class:text-md={!child}
     class:font-medium={!child}
     class:bg-[var(--pd-secondary-nav-selected-bg)]={selected}
     class:border-[var(--pd-secondary-nav-bg)]={!selected}
@@ -59,12 +59,12 @@ function click(): void {
       <div class="px-2 relative w-4 h-4 text-[color:var(--pd-secondary-nav-expander)]">
         {#if expanded}
           <i
-            class="fas fa-angle-down text-lg absolute left-0 top-0"
+            class="fas fa-angle-down text-md absolute left-0 top-0.5"
             aria-hidden="true"
             in:rotate={{ clockwise: false }}
             out:rotate={{ clockwise: false }}></i>
         {:else}
-          <i class="fas fa-angle-right text-lg absolute left-0 top-0" aria-hidden="true" in:rotate={{}} out:rotate={{}}
+          <i class="fas fa-angle-right text-md absolute left-0 top-0.5" aria-hidden="true" in:rotate={{}} out:rotate={{}}
           ></i>
         {/if}
       </div>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -33,11 +33,11 @@ module.exports = {
       },
       width: {
         leftnavbar: '48px',
-        leftsidebar: '225px',
+        leftsidebar: '170px',
       },
       minWidth: {
         leftnavbar: '48px',
-        leftsidebar: '225px',
+        leftsidebar: '170px',
       },
     },
     fontSize: {


### PR DESCRIPTION
chore: reduce width and font size subnavigation

### What does this PR do?

Reduces the width and font size of the subnavigation for Kubernetes and
settings menus (and other components using the UI).

It does the following:
- Reduces from large to medium font
- Reduces the width of navigation menu
- Decreases spacing between the section name (Kubernetes / Preferences)
  and menu items to match similarly to how it was before with large
  font.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

Before:

![Screenshot 2024-10-10 at 12 21 50 PM](https://github.com/user-attachments/assets/58212ffe-dccf-47ae-bdc9-c3d3cd2fe038)
![Screenshot 2024-10-10 at 12 21 54 PM](https://github.com/user-attachments/assets/d4280453-6fba-4254-a696-0d893e042404)

After:
![Screenshot 2024-10-10 at 12 20 49 PM](https://github.com/user-attachments/assets/e8ad3ec4-bc12-4f89-9519-6c5efbf7cee9)
![Screenshot 2024-10-10 at 12 20 53 PM](https://github.com/user-attachments/assets/1751ebfa-5f74-42d0-9ce8-8088bcd1a12e)




### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/9299

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

N/A, minor UI change

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
