### PR TITLE
fix(tests): not all update e2e tests were run

### DIFF
--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -148,8 +148,6 @@ jobs:
           echo ("PODMAN_DESKTOP_BINARY=" + $path) >> $env:GITHUB_ENV
 
       - name: Run E2E Update test
-        env:
-          UPDATE_PODMAN_DESKTOP: true
         run: |
           echo "${{ env.PODMAN_DESKTOP_BINARY }}"
           pnpm test:e2e:update:run

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -393,8 +393,6 @@ jobs:
           echo ("PODMAN_DESKTOP_BINARY=" + $path) >> $env:GITHUB_ENV
 
       - name: Run E2E Update test
-        env:
-          UPDATE_PODMAN_DESKTOP: true
         run: |
           echo "${{ env.PODMAN_DESKTOP_BINARY }}"
           pnpm test:e2e:update:run

--- a/tests/playwright/src/specs/installation/update-install.spec.ts
+++ b/tests/playwright/src/specs/installation/update-install.spec.ts
@@ -27,7 +27,7 @@ let sBar: StatusBar;
 let updateAvailableDialog: Locator;
 let updateDialog: Locator;
 let updateDownloadedDialog: Locator;
-const performUpdate = process.env.UPDATE_PODMAN_DESKTOP !== undefined && process.env.UPDATE_PODMAN_DESKTOP === 'true';
+const performUpdate = process.env.UPDATE_PODMAN_DESKTOP === 'true';
 
 test.skip(isLinux, 'Update is not supported on Linux');
 
@@ -44,27 +44,21 @@ test.afterAll(async ({ runner }) => {
   await runner.close();
 });
 
-test.describe.serial('Podman Desktop Update Update installation offering @update-install', () => {
-  console.log(`process.env.UPDATE_PODMAN_DESKTOP: ${process.env.UPDATE_PODMAN_DESKTOP}`);
-  console.log(`performUpdate: ${performUpdate}`);
-  if (!performUpdate) {
-    console.log('Perform Update gonna be skipped...');
-  } else {
-    console.log('Perform Update gonna run...');
-  }
-  test('Update is offered automatically on startup', async ({ welcomePage }) => {
-    await playExpect(updateAvailableDialog).toBeVisible();
-    const updateNowButton = updateAvailableDialog.getByRole('button', { name: 'Update Now' });
-    await playExpect(updateNowButton).toBeVisible();
-    const doNotshowButton = updateAvailableDialog.getByRole('button', { name: 'Do not show again' });
-    await playExpect(doNotshowButton).toBeVisible();
-    const cancelButton = updateAvailableDialog.getByRole('button', { name: 'Cancel' });
-    await playExpect(cancelButton).toBeVisible();
-    await cancelButton.click();
-    await playExpect(updateAvailableDialog).not.toBeVisible();
-    // handle welcome page now
-    await welcomePage.handleWelcomePage(true);
-  });
+test.describe
+  .serial('Podman Desktop Update Update installation offering @update-install', () => {
+    test('Update is offered automatically on startup', async ({ welcomePage }) => {
+      await playExpect(updateAvailableDialog).toBeVisible();
+      const updateNowButton = updateAvailableDialog.getByRole('button', { name: 'Update Now' });
+      await playExpect(updateNowButton).toBeVisible();
+      const doNotshowButton = updateAvailableDialog.getByRole('button', { name: 'Do not show again' });
+      await playExpect(doNotshowButton).toBeVisible();
+      const cancelButton = updateAvailableDialog.getByRole('button', { name: 'Cancel' });
+      await playExpect(cancelButton).toBeVisible();
+      await cancelButton.click();
+      await playExpect(updateAvailableDialog).not.toBeVisible();
+      // handle welcome page now
+      await welcomePage.handleWelcomePage(true);
+    });
 
     test('Version button is visible', async () => {
       await playExpect(sBar.content).toBeVisible();
@@ -78,7 +72,7 @@ test.describe.serial('Podman Desktop Update Update installation offering @update
     });
   });
 test.describe
-  .serial('Podman Desktop Update installation can be performed', () => {
+  .serial('Podman Desktop Update installation can be performed @update-install', () => {
     test.skip(!performUpdate, 'Update test does not run as UPDATE_PODMAN_DESKTOP env. var. is not set');
     test('Update can be initiated', async () => {
       await sBar.updateButtonTitle.click();

--- a/tests/playwright/src/specs/installation/update-install.spec.ts
+++ b/tests/playwright/src/specs/installation/update-install.spec.ts
@@ -27,7 +27,6 @@ let sBar: StatusBar;
 let updateAvailableDialog: Locator;
 let updateDialog: Locator;
 let updateDownloadedDialog: Locator;
-const performUpdate = process.env.UPDATE_PODMAN_DESKTOP === 'true';
 
 test.skip(isLinux, 'Update is not supported on Linux');
 
@@ -45,7 +44,7 @@ test.afterAll(async ({ runner }) => {
 });
 
 test.describe
-  .serial('Podman Desktop Update Update installation offering @update-install', () => {
+  .serial('Podman Desktop Update installation @update-install', () => {
     test('Update is offered automatically on startup', async ({ welcomePage }) => {
       await playExpect(updateAvailableDialog).toBeVisible();
       const updateNowButton = updateAvailableDialog.getByRole('button', { name: 'Update Now' });
@@ -70,10 +69,7 @@ test.describe
       await sBar.updateButtonTitle.click();
       await handleConfirmationDialog(page, 'Update Available now', false, '', 'Cancel');
     });
-  });
-test.describe
-  .serial('Podman Desktop Update installation can be performed @update-install', () => {
-    test.skip(!performUpdate, 'Update test does not run as UPDATE_PODMAN_DESKTOP env. var. is not set');
+
     test('Update can be initiated', async () => {
       await sBar.updateButtonTitle.click();
       await playExpect(updateAvailableDialog).toBeVisible();

--- a/tests/playwright/src/specs/installation/update-install.spec.ts
+++ b/tests/playwright/src/specs/installation/update-install.spec.ts
@@ -27,7 +27,7 @@ let sBar: StatusBar;
 let updateAvailableDialog: Locator;
 let updateDialog: Locator;
 let updateDownloadedDialog: Locator;
-const performUpdate = process.env.UPDATE_PODMAN_DESKTOP ? process.env.UPDATE_PODMAN_DESKTOP : false;
+const performUpdate = process.env.UPDATE_PODMAN_DESKTOP !== undefined && process.env.UPDATE_PODMAN_DESKTOP === 'true';
 
 test.skip(isLinux, 'Update is not supported on Linux');
 
@@ -44,21 +44,27 @@ test.afterAll(async ({ runner }) => {
   await runner.close();
 });
 
-test.describe
-  .serial('Podman Desktop Update Update installation offering @update-install', () => {
-    test('Update is offered automatically on startup', async ({ welcomePage }) => {
-      await playExpect(updateAvailableDialog).toBeVisible();
-      const updateNowButton = updateAvailableDialog.getByRole('button', { name: 'Update Now' });
-      await playExpect(updateNowButton).toBeVisible();
-      const doNotshowButton = updateAvailableDialog.getByRole('button', { name: 'Do not show again' });
-      await playExpect(doNotshowButton).toBeVisible();
-      const cancelButton = updateAvailableDialog.getByRole('button', { name: 'Cancel' });
-      await playExpect(cancelButton).toBeVisible();
-      await cancelButton.click();
-      await playExpect(updateAvailableDialog).not.toBeVisible();
-      // handle welcome page now
-      await welcomePage.handleWelcomePage(true);
-    });
+test.describe.serial('Podman Desktop Update Update installation offering @update-install', () => {
+  console.log(`process.env.UPDATE_PODMAN_DESKTOP: ${process.env.UPDATE_PODMAN_DESKTOP}`);
+  console.log(`performUpdate: ${performUpdate}`);
+  if (!performUpdate) {
+    console.log('Perform Update gonna be skipped...');
+  } else {
+    console.log('Perform Update gonna run...');
+  }
+  test('Update is offered automatically on startup', async ({ welcomePage }) => {
+    await playExpect(updateAvailableDialog).toBeVisible();
+    const updateNowButton = updateAvailableDialog.getByRole('button', { name: 'Update Now' });
+    await playExpect(updateNowButton).toBeVisible();
+    const doNotshowButton = updateAvailableDialog.getByRole('button', { name: 'Do not show again' });
+    await playExpect(doNotshowButton).toBeVisible();
+    const cancelButton = updateAvailableDialog.getByRole('button', { name: 'Cancel' });
+    await playExpect(cancelButton).toBeVisible();
+    await cancelButton.click();
+    await playExpect(updateAvailableDialog).not.toBeVisible();
+    // handle welcome page now
+    await welcomePage.handleWelcomePage(true);
+  });
 
     test('Version button is visible', async () => {
       await playExpect(sBar.content).toBeVisible();


### PR DESCRIPTION
### What does this PR do?
Update e2e tests are now run always when spec file is run. After a change in adding tag was introduced, portion of tests was omitted and did not catch electron update dependency that broke the functionality.  
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#9361 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
build podman-desktop in version ie. 1.0.0 to initiate an update , also in production version with `ELECTRON_ENABLE_INSPECT` using `pnpm compile:current --win nsis`. set `PODMAN_DESKTOP_BINARY` to point to built `Podman Desktop.exe` and run `pnpm test:e2e:update:run` and check that 6 tests being run. If there is a failure, some tests can be skipped, but total is 6.
<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
