### PR TITLE
fix(ui): aligned task indicator

### DIFF
--- a/packages/renderer/src/lib/statusbar/TaskIndicator.svelte
+++ b/packages/renderer/src/lib/statusbar/TaskIndicator.svelte
@@ -23,14 +23,16 @@ function toggleTaskManager(): void {
 </script>
 
 {#if runningTasks.length > 0}
-  <Tooltip top tip={title}>
-    <button aria-label="Toggle Task Manager" onclick={toggleTaskManager}>
-      <div class="flex items-center gap-x-2">
-        <span role="status" class="max-w-32 text-ellipsis overflow-hidden whitespace-nowrap">{title}</span>
-        {#if (progress ?? 0) >= 0}
-          <ProgressBar height="h-1" width="w-20" progress={progress} />
-        {/if}
-      </div>
-    </button>
-  </Tooltip>
+  <div class="flex items-center">
+    <Tooltip top tip={title}>
+      <button aria-label="Toggle Task Manager" onclick={toggleTaskManager}>
+        <div class="flex items-center gap-x-2">
+          <span role="status" class="max-w-32 text-ellipsis overflow-hidden whitespace-nowrap">{title}</span>
+          {#if (progress ?? 0) >= 0}
+            <ProgressBar height="h-1" width="w-20" progress={progress} />
+          {/if}
+        </div>
+      </button>
+    </Tooltip>
+  </div>
 {/if}


### PR DESCRIPTION
### What does this PR do?

I did not notice after adding the tooltip, that the task indicator was not centred anymore 

### Screenshot / video of UI

**Before**

![image](https://github.com/user-attachments/assets/74d93f33-e25a-4d77-93e6-377fb97c855c)

**After**

![image](https://github.com/user-attachments/assets/80023868-3878-41a0-8288-cadcd4908cf8)

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature

**Testing manually**

Enable the status bar settings `tasks.StatusBar: true` in the `settings.json`
 