### PR TITLE
fix: release notes banner update button

### DIFF
--- a/packages/main/src/plugin/updater.ts
+++ b/packages/main/src/plugin/updater.ts
@@ -272,6 +272,7 @@ export class Updater {
         console.error('Something went wrong while executing update command', err);
       });
     }
+    this.apiSender.send('app-update-available', true);
   }
 
   /**
@@ -327,6 +328,7 @@ export class Updater {
 
     // Update the 'version' entry in the status bar to show that no update is available
     this.defaultVersionEntry();
+    this.apiSender.send('app-update-available', false);
   }
 
   /**
@@ -375,6 +377,7 @@ export class Updater {
       return;
     }
     console.error('unable to check for updates', error);
+    this.apiSender.send('app-update-available', false);
   }
 
   /**
@@ -403,7 +406,7 @@ export class Updater {
   }
 
   public updateAvailable(): boolean {
-    return this.#updateCheckResult !== undefined;
+    return this.#updateCheckResult !== undefined && this.#currentVersion !== this.#nextVersion;
   }
 
   public init(): Disposable {

--- a/packages/renderer/src/lib/dashboard/ReleaseNotesBox.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ReleaseNotesBox.spec.ts
@@ -23,6 +23,7 @@ import userEvent from '@testing-library/user-event';
 import { tick } from 'svelte';
 import { beforeEach, expect, test, vi } from 'vitest';
 
+import { updateAvailable } from '../../stores/update-store';
 import ReleaseNotesBox from './ReleaseNotesBox.svelte';
 
 const podmanDesktopUpdateAvailableMock = vi.fn();
@@ -86,7 +87,7 @@ test('expect no release notes available', async () => {
 });
 
 test('expect update button to show when there is an update', async () => {
-  podmanDesktopUpdateAvailableMock.mockResolvedValue(true);
+  updateAvailable.set(true);
   render(ReleaseNotesBox);
   await waitFor(() => expect(podmanDesktopGetReleaseNotesMock));
   await tick();
@@ -97,6 +98,7 @@ test('expect update button to show when there is an update', async () => {
 });
 
 test('expect update button to not show when there is no update', async () => {
+  updateAvailable.set(false);
   render(ReleaseNotesBox);
   await waitFor(() => expect(podmanDesktopGetReleaseNotesMock).toBeCalled());
   await tick();

--- a/packages/renderer/src/lib/dashboard/ReleaseNotesBox.svelte
+++ b/packages/renderer/src/lib/dashboard/ReleaseNotesBox.svelte
@@ -3,13 +3,13 @@ import { faCircleArrowUp } from '@fortawesome/free-solid-svg-icons';
 import { Button, CloseButton, Link } from '@podman-desktop/ui-svelte';
 import { onDestroy, onMount } from 'svelte';
 
+import { updateAvailable } from '/@/stores/update-store';
 import type { ReleaseNotes } from '/@api/release-notes-info';
 
 import Markdown from '../markdown/Markdown.svelte';
 
 let showBanner = false;
 let notesAvailable = false;
-let updateAvailable = false;
 let notesURL: string;
 let currentVersion: string;
 let notesInfo: ReleaseNotes | undefined;
@@ -40,11 +40,6 @@ async function onClose() {
 onMount(async () => {
   currentVersion = await window.getPodmanDesktopVersion();
   showBanner = (await window.getConfigurationValue(`releaseNotesBanner.show`)) !== currentVersion ? true : false;
-  try {
-    updateAvailable = await window.podmanDesktopUpdateAvailable();
-  } catch (e) {
-    console.log('Cannot check for update');
-  }
   await getInfoFromNotes();
 });
 
@@ -77,7 +72,7 @@ onDestroy(async () => {
         {/if}
         <div class="flex flex-row justify-end items-center gap-3 mt-2">
           <Link on:click={openReleaseNotes}>Learn more</Link>
-          <Button on:click={updatePodmanDesktop} hidden={!updateAvailable} icon={faCircleArrowUp}>Update</Button>
+          <Button on:click={updatePodmanDesktop} hidden={!$updateAvailable} icon={faCircleArrowUp}>Update</Button>
         </div>
       </div>
     </div>

--- a/packages/renderer/src/stores/update-store.spec.ts
+++ b/packages/renderer/src/stores/update-store.spec.ts
@@ -18,7 +18,6 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { waitFor } from '@testing-library/dom';
 import { get } from 'svelte/store';
 import { beforeEach, expect, test, vi } from 'vitest';
 
@@ -29,6 +28,7 @@ const receiveMock = vi.fn();
 const podmanDesktopUpdateAvailableMock = vi.fn();
 
 beforeEach(() => {
+  vi.resetAllMocks();
   (window as any).podmanDesktopUpdateAvailable = podmanDesktopUpdateAvailableMock.mockResolvedValue(false);
   (window.events as unknown) = {
     receive: receiveMock.mockImplementation((channel: string, func: any) => {
@@ -38,8 +38,7 @@ beforeEach(() => {
 });
 
 test('updateAvailable starts as podmanDesktopUpdateAvailable value or false if undefined', async () => {
-  setup();
-  await waitFor(() => expect(receiveMock).toBeCalled());
+  await setup();
 
   expect(get(updateAvailable)).toBeFalsy();
 
@@ -55,10 +54,4 @@ test('updateAvailable starts as podmanDesktopUpdateAvailable value or false if u
   message(false);
 
   expect(get(updateAvailable)).toBeFalsy();
-});
-
-test('updateAvailable starts as true', async () => {
-  podmanDesktopUpdateAvailableMock.mockResolvedValue(true);
-  setup();
-  await waitFor(() => expect(receiveMock).toBeCalled());
 });

--- a/packages/renderer/src/stores/update-store.spec.ts
+++ b/packages/renderer/src/stores/update-store.spec.ts
@@ -1,0 +1,64 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { waitFor } from '@testing-library/dom';
+import { get } from 'svelte/store';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { setup, updateAvailable } from './update-store';
+
+const messages = new Map<string, any>();
+const receiveMock = vi.fn();
+const podmanDesktopUpdateAvailableMock = vi.fn();
+
+beforeEach(() => {
+  (window as any).podmanDesktopUpdateAvailable = podmanDesktopUpdateAvailableMock.mockResolvedValue(false);
+  (window.events as unknown) = {
+    receive: receiveMock.mockImplementation((channel: string, func: any) => {
+      messages.set(channel, func);
+    }),
+  };
+});
+
+test('updateAvailable starts as podmanDesktopUpdateAvailable value or false if undefined', async () => {
+  setup();
+  await waitFor(() => expect(receiveMock).toBeCalled());
+
+  expect(get(updateAvailable)).toBeFalsy();
+
+  // now we call the listener
+  const message = messages.get('app-update-available');
+
+  expect(message).toBeDefined();
+
+  message(true);
+
+  expect(get(updateAvailable)).toBeTruthy();
+
+  message(false);
+
+  expect(get(updateAvailable)).toBeFalsy();
+});
+
+test('updateAvailable starts as true', async () => {
+  podmanDesktopUpdateAvailableMock.mockResolvedValue(true);
+  setup();
+  await waitFor(() => expect(receiveMock).toBeCalled());
+});

--- a/packages/renderer/src/stores/update-store.ts
+++ b/packages/renderer/src/stores/update-store.ts
@@ -27,9 +27,9 @@ try {
   console.log('Cannot check for update');
 }
 
-export const updateAvailable = await setup();
+export const updateAvailable = setup();
 
-export async function setup(): Promise<Writable<boolean>> {
+export function setup(): Writable<boolean> {
   const store = writable(podmanDesktopUpdateAvailable);
 
   window.events?.receive('app-update-available', isUpdateAvailable => {

--- a/packages/renderer/src/stores/update-store.ts
+++ b/packages/renderer/src/stores/update-store.ts
@@ -1,0 +1,42 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Writable } from 'svelte/store';
+import { writable } from 'svelte/store';
+
+export const updateAvailable = await setup();
+
+export async function setup(): Promise<Writable<boolean>> {
+  let podmanDesktopUpdateAvailable = false;
+  try {
+    podmanDesktopUpdateAvailable = await window.podmanDesktopUpdateAvailable();
+  } catch (e) {
+    console.log('Cannot check for update');
+  }
+  const store = writable(podmanDesktopUpdateAvailable);
+
+  window.events?.receive('app-update-available', isUpdateAvailable => {
+    if (isUpdateAvailable) {
+      updateAvailable.set(true);
+    } else {
+      updateAvailable.set(false);
+    }
+  });
+
+  return store;
+}

--- a/packages/renderer/src/stores/update-store.ts
+++ b/packages/renderer/src/stores/update-store.ts
@@ -36,12 +36,12 @@ export async function checkForUpdate(eventName: string): Promise<boolean> {
   return false;
 }
 
-const isUpdateAvailable = (...args: unknown[]): Promise<boolean> => {
+const isUpdateAvailable = async (...args: unknown[]): Promise<boolean> => {
   const eventArg = args.length > 0 ? args[0] : false;
   if (typeof eventArg === 'boolean') {
-    return Promise.resolve(eventArg);
+    return eventArg;
   }
-  return Promise.resolve(false);
+  return false;
 };
 
 export const updateEventStore = new EventStore<boolean>(

--- a/packages/renderer/src/stores/update-store.ts
+++ b/packages/renderer/src/stores/update-store.ts
@@ -19,15 +19,17 @@
 import type { Writable } from 'svelte/store';
 import { writable } from 'svelte/store';
 
+let podmanDesktopUpdateAvailable = false;
+
+try {
+  podmanDesktopUpdateAvailable = await window.podmanDesktopUpdateAvailable();
+} catch (e) {
+  console.log('Cannot check for update');
+}
+
 export const updateAvailable = await setup();
 
 export async function setup(): Promise<Writable<boolean>> {
-  let podmanDesktopUpdateAvailable = false;
-  try {
-    podmanDesktopUpdateAvailable = await window.podmanDesktopUpdateAvailable();
-  } catch (e) {
-    console.log('Cannot check for update');
-  }
   const store = writable(podmanDesktopUpdateAvailable);
 
   window.events?.receive('app-update-available', isUpdateAvailable => {


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Fixes the release notes banner update button bug where the update button still shows up even after updating to the latest release.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/containers/podman-desktop/issues/9365
Closes https://github.com/containers/podman-desktop/issues/9352

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
