### PR TITLE
fix: do not add again an existing Kubernetes resource

### DIFF
--- a/packages/main/src/plugin/kubernetes/contexts-manager.spec.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager.spec.ts
@@ -235,8 +235,13 @@ describe('update', async () => {
         deployments: DEPLOYMENTS_NS1,
       },
     });
-    expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith('pods', Array(PODS_NS1).fill({}));
-    expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith('deployments', Array(DEPLOYMENTS_NS1).fill({}));
+    expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith('pods', [{ metadata: { uid: '0' } }]);
+    expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith('deployments', [
+      { metadata: { uid: '0' } },
+      { metadata: { uid: '1' } },
+      { metadata: { uid: '2' } },
+      { metadata: { uid: '3' } },
+    ]);
 
     const expectedCheckMap = new Map<string, CheckingState>();
     expectedCheckMap.set('context1', { state: 'waiting' });
@@ -329,8 +334,13 @@ describe('update', async () => {
         deployments: DEPLOYMENTS_NS1,
       },
     });
-    expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith('pods', Array(PODS_NS1).fill({}));
-    expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith('deployments', Array(DEPLOYMENTS_NS1).fill({}));
+    expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith('pods', [{ metadata: { uid: '0' } }]);
+    expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith('deployments', [
+      { metadata: { uid: '0' } },
+      { metadata: { uid: '1' } },
+      { metadata: { uid: '2' } },
+      { metadata: { uid: '3' } },
+    ]);
   });
 
   test('should check current context if contexts are > 10', async () => {
@@ -860,7 +870,10 @@ describe('update', async () => {
       },
     });
     expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith('pods', []);
-    expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith('deployments', [{}, {}]);
+    expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith('deployments', [
+      { metadata: { uid: '0' } },
+      { metadata: { uid: '1' } },
+    ]);
 
     vi.advanceTimersToNextTimer(); // error event
     vi.advanceTimersToNextTimer(); // dispatches
@@ -1038,7 +1051,7 @@ describe('update', async () => {
           deployments: 0,
         },
       });
-      expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith(resource, [{}]);
+      expect(dispatchCurrentContextResourceSpy).toHaveBeenCalledWith(resource, [{ metadata: { uid: '0' } }]);
     });
 
     test('createInformer should send data for deleted and updated resource', async () => {

--- a/packages/main/src/plugin/kubernetes/contexts-manager.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager.ts
@@ -392,8 +392,8 @@ export class ContextsManager {
           currentContext: this.kubeConfig.currentContext,
           resources: { pods: true },
           update: state => {
-            if (state.resources.pods.filter(o => o.metadata?.uid !== obj.metadata?.uid).length) {
-              console.debug(`==> resource ${obj.metadata?.name} already added`);
+            if (state.resources.pods.some(o => o.metadata?.uid !== obj.metadata?.uid)) {
+              console.debug(`pod ${obj.metadata?.name} already added in context ${this.kubeConfig.currentContext}`);
             }
             state.resources.pods = state.resources.pods.filter(o => o.metadata?.uid !== obj.metadata?.uid);
             state.resources.pods.push(obj);

--- a/packages/main/src/plugin/kubernetes/contexts-manager.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager.ts
@@ -391,7 +391,13 @@ export class ContextsManager {
           sendGeneral: true,
           currentContext: this.kubeConfig.currentContext,
           resources: { pods: true },
-          update: state => state.resources.pods.push(obj),
+          update: state => {
+            if (state.resources.pods.filter(o => o.metadata?.uid !== obj.metadata?.uid).length) {
+              console.debug(`==> resource ${obj.metadata?.name} already added`);
+            }
+            state.resources.pods = state.resources.pods.filter(o => o.metadata?.uid !== obj.metadata?.uid);
+            state.resources.pods.push(obj);
+          },
         });
       },
       onUpdate: obj => {

--- a/packages/main/src/plugin/kubernetes/test-informer.ts
+++ b/packages/main/src/plugin/kubernetes/test-informer.ts
@@ -57,7 +57,7 @@ export class TestInformer {
     }
     if (this.connectResponse === undefined) {
       for (let i = 0; i < this.resourcesCount; i++) {
-        this.onCb.get('add')?.({});
+        this.onCb.get('add')?.({ metadata: { uid: `${i}` } });
       }
       this.events.forEach(event => {
         setTimeout(() => {

--- a/packages/main/src/plugin/kubernetes/test-informer.ts
+++ b/packages/main/src/plugin/kubernetes/test-informer.ts
@@ -57,7 +57,7 @@ export class TestInformer {
     }
     if (this.connectResponse === undefined) {
       for (let i = 0; i < this.resourcesCount; i++) {
-        this.onCb.get('add')?.({ metadata: { uid: `${i}` } });
+        this.onCb.get('add')?.({ metadata: { uid: i.toString() } });
       }
       this.events.forEach(event => {
         setTimeout(() => {


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Adds a debug log when a Kubernetes resource is added again to the state, and prevent from having the same resource displayed several times in the frontend.

This should not happen, as this should be handled by the informer, but it some circumstances it actually happens. This will help debug why it happens.

### What issues does this PR fix or reference?

Part of #9156 

### How to test this PR?

Start, stop clusters, change current context, etc.

When navigating to the Kubernetes resources pages, the resources should not be duplicated.

- [x] Tests are covering the bug fix or the new feature
