### PR TITLE
feat: set slower backoff for current context

### DIFF
--- a/packages/main/src/plugin/kubernetes/backoff.spec.ts
+++ b/packages/main/src/plugin/kubernetes/backoff.spec.ts
@@ -21,7 +21,7 @@ import { expect, test } from 'vitest';
 import { Backoff } from './backoff.js';
 
 test('backoff increment and limit without jitter', () => {
-  const backoff = new Backoff(100, 2, 500, 0);
+  const backoff = new Backoff({ value: 100, multiplier: 2, max: 500 });
   expect(backoff.get()).toEqual(100);
   expect(backoff.get()).toEqual(200);
   expect(backoff.get()).toEqual(400);
@@ -32,7 +32,7 @@ test('backoff increment and limit without jitter', () => {
 test('backoff with jitter', () => {
   let jitterFound = false;
   let base = 100;
-  let backoff: Backoff = new Backoff(base, 2, 500, 10);
+  let backoff: Backoff = new Backoff({ value: base, multiplier: 2, max: 500, jitter: 10 });
   // run several tests, as we cannot rely on a single one due to the random nature
   for (let i = 0; i < 10; i++) {
     const value = backoff.get();
@@ -40,7 +40,7 @@ test('backoff with jitter', () => {
     expect(value).toBeLessThan(base * 1.1);
     if (value === base) {
       // this can happen, try again
-      backoff = new Backoff(base, 2, 500, 10);
+      backoff = new Backoff({ value: base, multiplier: 2, max: 500, jitter: 10 });
       continue;
     }
     jitterFound = true;
@@ -54,7 +54,7 @@ test('backoff with jitter', () => {
 });
 
 test('backoff reset', () => {
-  const backoff = new Backoff(100, 2, 500, 0);
+  const backoff = new Backoff({ value: 100, multiplier: 2, max: 500 });
   expect(backoff.get()).toBe(100);
   expect(backoff.get()).toBe(200);
   expect(backoff.get()).toBe(400);

--- a/packages/main/src/plugin/kubernetes/backoff.spec.ts
+++ b/packages/main/src/plugin/kubernetes/backoff.spec.ts
@@ -21,7 +21,7 @@ import { expect, test } from 'vitest';
 import { Backoff } from './backoff.js';
 
 test('backoff increment and limit without jitter', () => {
-  const backoff = new Backoff(100, 500, 0);
+  const backoff = new Backoff(100, 2, 500, 0);
   expect(backoff.get()).toEqual(100);
   expect(backoff.get()).toEqual(200);
   expect(backoff.get()).toEqual(400);
@@ -32,7 +32,7 @@ test('backoff increment and limit without jitter', () => {
 test('backoff with jitter', () => {
   let jitterFound = false;
   let base = 100;
-  let backoff: Backoff = new Backoff(base, 500, 10);
+  let backoff: Backoff = new Backoff(base, 2, 500, 10);
   // run several tests, as we cannot rely on a single one due to the random nature
   for (let i = 0; i < 10; i++) {
     const value = backoff.get();
@@ -40,7 +40,7 @@ test('backoff with jitter', () => {
     expect(value).toBeLessThan(base * 1.1);
     if (value === base) {
       // this can happen, try again
-      backoff = new Backoff(base, 500, 10);
+      backoff = new Backoff(base, 2, 500, 10);
       continue;
     }
     jitterFound = true;
@@ -54,7 +54,7 @@ test('backoff with jitter', () => {
 });
 
 test('backoff reset', () => {
-  const backoff = new Backoff(100, 500, 0);
+  const backoff = new Backoff(100, 2, 500, 0);
   expect(backoff.get()).toBe(100);
   expect(backoff.get()).toBe(200);
   expect(backoff.get()).toBe(400);

--- a/packages/main/src/plugin/kubernetes/backoff.ts
+++ b/packages/main/src/plugin/kubernetes/backoff.ts
@@ -20,6 +20,7 @@ export class Backoff {
   private readonly initial: number;
   constructor(
     public value: number,
+    public multiplier: number,
     private readonly max: number,
     private readonly jitter: number,
   ) {
@@ -29,7 +30,7 @@ export class Backoff {
   get(): number {
     const current = this.value;
     if (this.value < this.max) {
-      this.value *= 2;
+      this.value *= this.multiplier;
       this.value += this.getJitter();
     }
     return current;

--- a/packages/main/src/plugin/kubernetes/backoff.ts
+++ b/packages/main/src/plugin/kubernetes/backoff.ts
@@ -16,31 +16,42 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+export interface BackoffOptions {
+  value: number;
+  multiplier: number;
+  max: number;
+  jitter?: number;
+}
+
 export class Backoff {
-  private readonly initial: number;
-  constructor(
-    public value: number,
-    public multiplier: number,
-    private readonly max: number,
-    private readonly jitter: number,
-  ) {
-    this.initial = value;
-    this.value += this.getJitter();
+  #value: number;
+  readonly #initial: number;
+  readonly #multiplier: number;
+  readonly #max: number;
+  readonly #jitter: number;
+
+  constructor(options: BackoffOptions) {
+    this.#initial = options.value;
+    this.#value = options.value;
+    this.#multiplier = options.multiplier;
+    this.#max = options.max;
+    this.#jitter = options.jitter ?? 0;
+    this.#value += this.getJitter();
   }
   get(): number {
-    const current = this.value;
-    if (this.value < this.max) {
-      this.value *= this.multiplier;
-      this.value += this.getJitter();
+    const current = this.#value;
+    if (this.#value < this.#max) {
+      this.#value *= this.#multiplier;
+      this.#value += this.getJitter();
     }
     return current;
   }
   reset(): void {
-    this.value = this.initial + this.getJitter();
+    this.#value = this.#initial + this.getJitter();
   }
 
   private getJitter(): number {
     // eslint-disable-next-line sonarjs/pseudo-random
-    return Math.floor(this.jitter * Math.random());
+    return Math.floor(this.#jitter * Math.random());
   }
 }

--- a/packages/main/src/plugin/kubernetes/contexts-constants.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-constants.ts
@@ -21,8 +21,14 @@
 export const connectTimeout = 1000;
 // initial delay between two connection attempts
 export const backoffInitialValue = 1000;
+// the backoff will be multiplied by this number every time
+export const backoffMultiplier = 2.0;
+// the backoff will be multiplied by this number every time for current context
+export const backoffMultiplierCurrentContext = 1.2;
 // maximum delay between two connection attempts
 export const backoffLimit = 60_000;
+// maximum delay between two connection attempts for current context
+export const backoffLimitCurrentContext = 10_000;
 // jitter to add to the delay between two connection attempts
 export const backoffJitter = 300;
 // the time to wait for any update on the data to dispatch before to send it

--- a/packages/main/src/plugin/kubernetes/contexts-manager.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager.ts
@@ -943,14 +943,19 @@ export class ContextsManager {
 
   private getBackoffForContext(contextName: string): Backoff {
     if (contextName === this.kubeConfig.currentContext) {
-      return new Backoff(
-        backoffInitialValue,
-        backoffMultiplierCurrentContext,
-        backoffLimitCurrentContext,
-        backoffJitter,
-      );
+      return new Backoff({
+        value: backoffInitialValue,
+        multiplier: backoffMultiplierCurrentContext,
+        max: backoffLimitCurrentContext,
+        jitter: backoffJitter,
+      });
     } else {
-      return new Backoff(backoffInitialValue, backoffMultiplier, backoffLimit, backoffJitter);
+      return new Backoff({
+        value: backoffInitialValue,
+        multiplier: backoffMultiplier,
+        max: backoffLimit,
+        jitter: backoffJitter,
+      });
     }
   }
 }

--- a/packages/main/src/plugin/kubernetes/contexts-manager.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager.ts
@@ -56,7 +56,15 @@ import type { V1Route } from '/@api/openshift-types.js';
 
 import type { ApiSenderType } from '../api.js';
 import { Backoff } from './backoff.js';
-import { backoffInitialValue, backoffJitter, backoffLimit, connectTimeout } from './contexts-constants.js';
+import {
+  backoffInitialValue,
+  backoffJitter,
+  backoffLimit,
+  backoffLimitCurrentContext,
+  backoffMultiplier,
+  backoffMultiplierCurrentContext,
+  connectTimeout,
+} from './contexts-constants.js';
 import { ContextsInformersRegistry } from './contexts-informers-registry.js';
 import type { CancellableInformer, ContextInternalState } from './contexts-states-registry.js';
 import { ContextsStatesRegistry, dispatchAllResources, isSecondaryResourceName } from './contexts-states-registry.js';
@@ -285,7 +293,7 @@ export class ContextsManager {
       checkReachable: true,
       resource: 'pods',
       timer: timer,
-      backoff: new Backoff(backoffInitialValue, backoffLimit, backoffJitter),
+      backoff: this.getBackoffForContext(context.name),
       connectionDelay: connectionDelay,
       onAdd: obj => {
         this.states.setStateAndDispatch(context.name, {
@@ -378,7 +386,7 @@ export class ContextsManager {
     return this.createInformer<V1Deployment>(kc, context, path, listFn, {
       resource: 'deployments',
       timer: timer,
-      backoff: new Backoff(backoffInitialValue, backoffLimit, backoffJitter),
+      backoff: this.getBackoffForContext(context.name),
       connectionDelay: connectionDelay,
       onAdd: obj => {
         this.states.setStateAndDispatch(context.name, {
@@ -425,7 +433,7 @@ export class ContextsManager {
     return this.createInformer<V1ConfigMap>(kc, context, path, listFn, {
       resource: 'configmaps',
       timer: timer,
-      backoff: new Backoff(backoffInitialValue, backoffLimit, backoffJitter),
+      backoff: this.getBackoffForContext(context.name),
       connectionDelay: connectionDelay,
       onAdd: obj => {
         this.states.setStateAndDispatch(context.name, {
@@ -467,7 +475,7 @@ export class ContextsManager {
     return this.createInformer<V1Secret>(kc, context, path, listFn, {
       resource: 'secrets',
       timer: timer,
-      backoff: new Backoff(backoffInitialValue, backoffLimit, backoffJitter),
+      backoff: this.getBackoffForContext(context.name),
       connectionDelay: connectionDelay,
       onAdd: obj => {
         this.states.setStateAndDispatch(context.name, {
@@ -512,7 +520,7 @@ export class ContextsManager {
     return this.createInformer<V1PersistentVolumeClaim>(kc, context, path, listFn, {
       resource: 'persistentvolumeclaims',
       timer: timer,
-      backoff: new Backoff(backoffInitialValue, backoffLimit, backoffJitter),
+      backoff: this.getBackoffForContext(context.name),
       connectionDelay: connectionDelay,
       onAdd: obj => {
         this.states.setStateAndDispatch(context.name, {
@@ -556,7 +564,7 @@ export class ContextsManager {
     return this.createInformer<V1Node>(kc, context, path, listFn, {
       resource: 'nodes',
       timer: timer,
-      backoff: new Backoff(backoffInitialValue, backoffLimit, backoffJitter),
+      backoff: this.getBackoffForContext(context.name),
       connectionDelay: connectionDelay,
       onAdd: obj => {
         this.states.setStateAndDispatch(context.name, {
@@ -596,7 +604,7 @@ export class ContextsManager {
     return this.createInformer<V1Service>(kc, context, path, listFn, {
       resource: 'services',
       timer: timer,
-      backoff: new Backoff(backoffInitialValue, backoffLimit, backoffJitter),
+      backoff: this.getBackoffForContext(context.name),
       connectionDelay: connectionDelay,
       onAdd: obj => {
         this.states.setStateAndDispatch(context.name, {
@@ -636,7 +644,7 @@ export class ContextsManager {
     return this.createInformer<V1Ingress>(kc, context, path, listFn, {
       resource: 'ingresses',
       timer: timer,
-      backoff: new Backoff(backoffInitialValue, backoffLimit, backoffJitter),
+      backoff: this.getBackoffForContext(context.name),
       connectionDelay: connectionDelay,
       onAdd: obj => {
         this.states.setStateAndDispatch(context.name, {
@@ -682,7 +690,7 @@ export class ContextsManager {
     return this.createInformer<V1Route>(kc, context, path, listFn, {
       resource: 'routes',
       timer: timer,
-      backoff: new Backoff(backoffInitialValue, backoffLimit, backoffJitter),
+      backoff: this.getBackoffForContext(context.name),
       connectionDelay: connectionDelay,
       onAdd: obj => {
         this.states.setStateAndDispatch(context.name, {
@@ -930,6 +938,19 @@ export class ContextsManager {
     }
     for (const timer of this.connectionDelayTimers.values()) {
       clearTimeout(timer);
+    }
+  }
+
+  private getBackoffForContext(contextName: string): Backoff {
+    if (contextName === this.kubeConfig.currentContext) {
+      return new Backoff(
+        backoffInitialValue,
+        backoffMultiplierCurrentContext,
+        backoffLimitCurrentContext,
+        backoffJitter,
+      );
+    } else {
+      return new Backoff(backoffInitialValue, backoffMultiplier, backoffLimit, backoffJitter);
     }
   }
 }


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Set a slower backoff for current context (multiplier 1.2 instead of 2.0, and limit 10s instead of 60s)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Part of #6114 

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
