### PR TITLE
fix: avoid to have proxy arguments when calling the status bar entry command

### DIFF
--- a/packages/renderer/src/lib/statusbar/StatusBarItem.svelte
+++ b/packages/renderer/src/lib/statusbar/StatusBarItem.svelte
@@ -24,10 +24,12 @@ async function executeCommand(entry: StatusBarEntry) {
   if (typeof entry.command === 'undefined') {
     return;
   }
+  const command = entry.command;
+  const commandArgs = entry.commandArgs;
 
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  await window.executeStatusBarEntryCommand(entry.command, entry.commandArgs);
+  // convert args to a plain object and not as proxy of arguments
+  const noProxyCommandArgs = commandArgs ? JSON.parse(JSON.stringify(commandArgs)) : undefined;
+  await window.executeStatusBarEntryCommand(command, noProxyCommandArgs);
 }
 </script>
 


### PR DESCRIPTION
### What does this PR do?
some parameters can't be cloned but we're mostly interested in the values, not the object so grab values before calling the method

it fixes the update workflow clicking in the status bar entry

side effect from https://github.com/containers/podman-desktop/pull/9186

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

fixes https://github.com/containers/podman-desktop/issues/9378

use issue to have steps

- [x] Tests are covering the bug fix or the new feature
