### PR TITLE
fix: show kubectl CLI version quick picks in descending order without `Kubernetes`

### DIFF
--- a/extensions/kubectl-cli/src/download.spec.ts
+++ b/extensions/kubectl-cli/src/download.spec.ts
@@ -122,7 +122,7 @@ test('pick the 4th option option in the quickpickmenu and expect it to return th
   const kubectlDownload = new KubectlDownload(extensionContext, kubectlGitHubReleasesMock, os);
   const result = await kubectlDownload.promptUserForVersion();
   expect(result).toBeDefined();
-  expect(result).toEqual(releases[3]); // "4th" option was picked
+  expect(result).toEqual(releases[5]); // "6th" option was picked
 });
 
 test('test download of kubectl passes and that mkdir and executable mocks are called', async () => {

--- a/extensions/kubectl-cli/src/download.spec.ts
+++ b/extensions/kubectl-cli/src/download.spec.ts
@@ -109,7 +109,7 @@ test('expect getLatestVersionAsset to return the latest release from a list of r
   expect(result.tag).toEqual('v1.29.0-rc.1');
 });
 
-test('pick the 4th option option in the quickpickmenu and expect it to return the github release information', async () => {
+test('pick the 6th option option in the quickpickmenu and expect it to return the github release information', async () => {
   grabLatestsReleasesMetadataMock.mockImplementation(() => {
     return releases;
   });

--- a/extensions/kubectl-cli/src/download.ts
+++ b/extensions/kubectl-cli/src/download.ts
@@ -47,6 +47,7 @@ export class KubectlDownload {
   async promptUserForVersion(currentKubectlTag?: string): Promise<KubectlGithubReleaseArtifactMetadata> {
     // Get the latest releases
     let lastReleasesMetadata = await this.kubectlGitHubReleases.grabLatestsReleasesMetadata();
+    lastReleasesMetadata.sort((a, b) => rcompare(a.tag, b.tag));
     // if the user already has an installed version, we remove it from the list
     if (currentKubectlTag) {
       lastReleasesMetadata = lastReleasesMetadata.filter(release => release.tag.slice(1) !== currentKubectlTag);

--- a/extensions/kubectl-cli/src/kubectl-github-releases.ts
+++ b/extensions/kubectl-cli/src/kubectl-github-releases.ts
@@ -50,7 +50,7 @@ export class KubectlGitHubReleases {
       .filter(release => !release.prerelease)
       .map(release => {
         return {
-          label: release.name ?? release.tag_name,
+          label: release.tag_name,
           tag: release.tag_name,
           id: release.id,
         };


### PR DESCRIPTION
### What does this PR do?

Removes `Kubernetes` from version quick pick and sorts version to start with latest one. 

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

Before:
![image](https://github.com/user-attachments/assets/15a7777e-f17f-4cbb-ae6e-08a1fd542d27)

After:
![image](https://github.com/user-attachments/assets/6b03f4ae-90a7-4e6e-84df-7cbd6a0b8084)

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Fix #9221.

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
