### PR TITLE
fix: patch kubernetes-client-node to be able to handle cluster restart

### DIFF
--- a/package.json
+++ b/package.json
@@ -210,6 +210,9 @@
       "react-router>path-to-regexp": "^1.9.0",
       "serve-handler>path-to-regexp": "^3.3.0",
       "express>cookie": "^0.7.0"
+    },
+    "patchedDependencies": {
+      "@kubernetes/client-node@1.0.0-rc7": "patches/@kubernetes__client-node@1.0.0-rc7.patch"
     }
   },
   "packageManager": "pnpm@9.7.1+sha512.faf344af2d6ca65c4c5c8c2224ea77a81a5e8859cbc4e06b1511ddce2f0151512431dd19e6aff31f2c6a8f5f2aced9bd2273e1fed7dd4de1868984059d2c4247"

--- a/patches/@kubernetes__client-node@1.0.0-rc7.patch
+++ b/patches/@kubernetes__client-node@1.0.0-rc7.patch
@@ -1,0 +1,16 @@
+diff --git a/dist/cache.js b/dist/cache.js
+index 3f7f6d2942d046a375f01a6c5a49d8b5cad8e2a7..f36613e12c280266768f5e7575c0970c53f79bc9 100644
+--- a/dist/cache.js
++++ b/dist/cache.js
+@@ -138,6 +138,11 @@ class ListWatch {
+     }
+     watchHandler(phase, obj, watchObj) {
+         switch (phase) {
++            case 'ERROR':
++                if (obj.code === 410) {
++                    this.resourceVersion = '';
++                }
++                break;
+             case 'ADDED':
+             case 'MODIFIED':
+                 addOrUpdateObject(this.objects, obj, this.callbackCache[informer_1.ADD].slice(), this.callbackCache[informer_1.UPDATE].slice());

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,11 @@ overrides:
   serve-handler>path-to-regexp: ^3.3.0
   express>cookie: ^0.7.0
 
+patchedDependencies:
+  '@kubernetes/client-node@1.0.0-rc7':
+    hash: nvb6em7iqff4wvrdgasjxmjpju
+    path: patches/@kubernetes__client-node@1.0.0-rc7.patch
+
 importers:
 
   .:
@@ -19,7 +24,7 @@ importers:
         version: 0.3.4
       '@kubernetes/client-node':
         specifier: ^1.0.0-rc7
-        version: 1.0.0-rc7(encoding@0.1.13)
+        version: 1.0.0-rc7(patch_hash=nvb6em7iqff4wvrdgasjxmjpju)(encoding@0.1.13)
       '@segment/analytics-node':
         specifier: ^2.2.0
         version: 2.2.0(encoding@0.1.13)
@@ -13657,7 +13662,7 @@ snapshots:
     dependencies:
       jsep: 1.3.9
 
-  '@kubernetes/client-node@1.0.0-rc7(encoding@0.1.13)':
+  '@kubernetes/client-node@1.0.0-rc7(patch_hash=nvb6em7iqff4wvrdgasjxmjpju)(encoding@0.1.13)':
     dependencies:
       '@types/js-yaml': 4.0.9
       '@types/node': 22.7.5
@@ -15271,14 +15276,6 @@ snapshots:
       magic-string: 0.30.11
     optionalDependencies:
       vite: 5.4.9(@types/node@20.16.11)(terser@5.31.6)
-
-  '@vitest/mocker@2.1.2(@vitest/spy@2.1.2)(vite@5.4.9(@types/node@20.16.2)(terser@5.31.6))':
-    dependencies:
-      '@vitest/spy': 2.1.2
-      estree-walker: 3.0.3
-      magic-string: 0.30.11
-    optionalDependencies:
-      vite: 5.4.9(@types/node@20.16.2)(terser@5.31.6)
 
   '@vitest/mocker@2.1.2(@vitest/spy@2.1.2)(vite@5.4.9(@types/node@22.7.5)(terser@5.31.6))':
     dependencies:
@@ -23708,7 +23705,7 @@ snapshots:
   vitest@2.1.2(@types/node@20.16.2)(jsdom@25.0.1)(terser@5.31.6):
     dependencies:
       '@vitest/expect': 2.1.2
-      '@vitest/mocker': 2.1.2(@vitest/spy@2.1.2)(vite@5.4.9(@types/node@20.16.2)(terser@5.31.6))
+      '@vitest/mocker': 2.1.2(@vitest/spy@2.1.2)(vite@5.4.9(@types/node@20.16.11)(terser@5.31.6))
       '@vitest/pretty-format': 2.1.2
       '@vitest/runner': 2.1.2
       '@vitest/snapshot': 2.1.2


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Patches kubernetes-client-node to be able to handle cluster restart

See https://github.com/kubernetes-client/javascript/issues/1933

The fix has missed the release of the library version 1.0-rc7 for a few hours, and the next release is targeted to happen for next Kubernetes release (in a few months) (https://github.com/kubernetes-client/javascript/pull/1937#issuecomment-2416261432).

For the moment, we are patching the library locally with the patch already included for next release (https://github.com/kubernetes-client/javascript/pull/1937). We will need to remove the patch when we use the next release.

### What issues does this PR fix or reference?

Part of #9156 

Fixes #9348

### How to test this PR?

- create a Kind cluster with audit (https://kind.sigs.k8s.io/docs/user/auditing/)
- start the cluster
- start Podman Desktop
- check that the cluster is marked as Reachable
- stop the cluster
- check that the cluster is marked as Unreachable
- restart the cluster
- check that the cluster is marked as Reachable
- check that the cluster is not spammed with watch requests

- [ ] Tests are covering the bug fix or the new feature
