### PR TITLE
feat: make Kubernetes informers cancellable

### DIFF
--- a/packages/main/src/plugin/kubernetes/contexts-informers-registry.spec.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-informers-registry.spec.ts
@@ -20,6 +20,7 @@ import type { Informer, KubernetesObject } from '@kubernetes/client-node';
 import { describe, expect, test } from 'vitest';
 
 import { ContextsInformersRegistry } from './contexts-informers-registry.js';
+import type { CancellableInformer } from './contexts-states-registry.js';
 import { TestInformer } from './test-informer.js';
 
 describe('ContextsInformers tests', () => {
@@ -27,7 +28,15 @@ describe('ContextsInformers tests', () => {
     const client = new ContextsInformersRegistry();
     client.setInformers(
       'context1',
-      new Map([['pods', new TestInformer('context1', '/path/to/resource', 0, undefined, [], [])]]),
+      new Map([
+        [
+          'pods',
+          {
+            informer: new TestInformer('context1', '/path/to/resource', 0, undefined, [], []),
+            cancel: (): void => {},
+          },
+        ],
+      ]),
     );
     expect(client.hasInformer('context1', 'pods')).toBeTruthy();
     expect(client.hasInformer('context1', 'deployments')).toBeFalsy();
@@ -39,11 +48,27 @@ describe('ContextsInformers tests', () => {
     const client = new ContextsInformersRegistry();
     client.setInformers(
       'context1',
-      new Map([['pods', new TestInformer('context1', '/path/to/resource', 0, undefined, [], [])]]),
+      new Map([
+        [
+          'pods',
+          {
+            informer: new TestInformer('context1', '/path/to/resource', 0, undefined, [], []),
+            cancel: (): void => {},
+          },
+        ],
+      ]),
     );
     client.setInformers(
       'context2',
-      new Map([['pods', new TestInformer('context2', '/path/to/resource', 0, undefined, [], [])]]),
+      new Map([
+        [
+          'pods',
+          {
+            informer: new TestInformer('context2', '/path/to/resource', 0, undefined, [], []),
+            cancel: (): void => {},
+          },
+        ],
+      ]),
     );
     expect(Array.from(client.getContextsNames())).toEqual(['context1', 'context2']);
   });
@@ -66,12 +91,12 @@ describe('ContextsInformers tests', () => {
     expect(states.hasInformer('ctx1', 'services')).toBeTruthy();
     expect(states.hasInformer('ctx1', 'pods')).toBeFalsy();
 
-    states.setResourceInformer('ctx1', 'pods', {} as Informer<KubernetesObject>);
+    states.setResourceInformer('ctx1', 'pods', {} as CancellableInformer);
     expect(states.hasContext('ctx1')).toBeTruthy();
     expect(states.hasInformer('ctx1', 'services')).toBeTruthy();
     expect(states.hasInformer('ctx1', 'pods')).toBeTruthy();
 
-    expect(() => states.setResourceInformer('ctx2', 'pods', {} as Informer<KubernetesObject>)).toThrow(
+    expect(() => states.setResourceInformer('ctx2', 'pods', {} as CancellableInformer)).toThrow(
       'watchers for context ctx2 not found',
     );
   });

--- a/packages/main/src/plugin/kubernetes/contexts-manager.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager.ts
@@ -98,7 +98,7 @@ interface CreateInformerOptions<T> {
 export class ContextsManager {
   private kubeConfig = new KubeConfig();
   protected states: ContextsStatesRegistry;
-  private informers = new ContextsInformersRegistry();
+  protected informers = new ContextsInformersRegistry();
   private currentContext: KubeContext | undefined;
   private secondaryWatchers = new ResourceWatchersRegistry();
 

--- a/packages/main/src/plugin/kubernetes/contexts-states-registry.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-states-registry.ts
@@ -29,8 +29,12 @@ import { NO_CURRENT_CONTEXT_ERROR, secondaryResources } from '/@api/kubernetes-c
 import type { ApiSenderType } from '../api.js';
 import { dispatchTimeout } from './contexts-constants.js';
 
+export interface CancellableInformer {
+  informer: Informer<KubernetesObject>;
+  cancel: () => void;
+}
 // ContextInternalState stores informers for a kube context
-export type ContextInternalState = Map<ResourceName, Informer<KubernetesObject>>;
+export type ContextInternalState = Map<ResourceName, CancellableInformer>;
 
 // ContextState stores information for the user about a kube context: is the cluster reachable, the number
 // of instances of different resources


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

For #6114 , we will need to restart the informers every time we change the current context, to change their backoff configuration.

Working on this, I realized that the informers were not correctly stopped when not necessary anymore. 

This PR makes the informers cancellable, so we can make them stop their infinite loop of retries.

### What issues does this PR fix or reference?

Part of #6114

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
