### PR TITLE
chore: replace colors by using registry colors in carousel, configmaps-secrets, and container

### DIFF
--- a/packages/renderer/src/lib/carousel/CarouselTest.svelte
+++ b/packages/renderer/src/lib/carousel/CarouselTest.svelte
@@ -4,7 +4,7 @@ import Carousel from './Carousel.svelte';
 
 <div>
   <p class="text-lg first-letter:uppercase font-bold pb-5">Learning center:</p>
-  <div class="bg-charcoal-800 p-4 rounded-lg">
+  <div class="bg-[var(--pd-content-card-bg)] p-4 rounded-lg">
     <Carousel cards={['card 1', 'card 2', 'card 3']} cardWidth={340} let:card>
       <p>{card}</p>
     </Carousel>

--- a/packages/renderer/src/lib/configmaps-secrets/ConfigMapDetails.svelte
+++ b/packages/renderer/src/lib/configmaps-secrets/ConfigMapDetails.svelte
@@ -64,7 +64,7 @@ async function loadDetails() {
     <svelte:fragment slot="actions">
       <ConfigMapSecretActions configMapSecret={configMap} detailed={true} on:update={() => (configMap = configMap)} />
     </svelte:fragment>
-    <div slot="detail" class="flex py-2 w-full justify-end text-sm text-gray-700">
+    <div slot="detail" class="flex py-2 w-full justify-end text-sm text-[var(--pd-content-text)]">
       <StateChange state={configMap.status} />
     </div>
     <svelte:fragment slot="tabs">

--- a/packages/renderer/src/lib/configmaps-secrets/ConfigMapDetailsSummary.svelte
+++ b/packages/renderer/src/lib/configmaps-secrets/ConfigMapDetailsSummary.svelte
@@ -22,6 +22,6 @@ basic information -->
     <KubeObjectMetaArtifact artifact={configMap.metadata} />
     <KubeConfigMapArtifact artifact={configMap} />
   {:else}
-    <p class="text-purple-500 font-medium">Loading ...</p>
+    <p class="text-[var(--pd-state-info)] font-medium">Loading ...</p>
   {/if}
 </Table>

--- a/packages/renderer/src/lib/configmaps-secrets/SecretDetails.svelte
+++ b/packages/renderer/src/lib/configmaps-secrets/SecretDetails.svelte
@@ -64,7 +64,7 @@ async function loadDetails() {
     <svelte:fragment slot="actions">
       <ConfigMapSecretActions configMapSecret={secret} detailed={true} on:update={() => (secret = secret)} />
     </svelte:fragment>
-    <div slot="detail" class="flex py-2 w-full justify-end text-sm text-gray-700">
+    <div slot="detail" class="flex py-2 w-full justify-end text-sm text-[var(--pd-content-text)]">
       <StateChange state={secret.status} />
     </div>
     <svelte:fragment slot="tabs">

--- a/packages/renderer/src/lib/configmaps-secrets/SecretDetailsSummary.svelte
+++ b/packages/renderer/src/lib/configmaps-secrets/SecretDetailsSummary.svelte
@@ -22,6 +22,6 @@ basic information -->
     <KubeObjectMetaArtifact artifact={secret.metadata} />
     <KubeSecretArtifact artifact={secret} />
   {:else}
-    <p class="text-purple-500 font-medium">Loading ...</p>
+    <p class="text-[var(--pd-state-info)] font-medium">Loading ...</p>
   {/if}
 </Table>

--- a/packages/renderer/src/lib/container/ContainerColumnNameContainer.svelte
+++ b/packages/renderer/src/lib/container/ContainerColumnNameContainer.svelte
@@ -15,7 +15,7 @@ function openContainerDetails(container: ContainerInfoUI): void {
     <div class="max-w-full">
       <div class="flex flex-nowrap max-w-full">
         <div
-          class="text-[var(--pd-table-body-text-highlight)] overflow-hidden text-ellipsis group-hover:text-violet-400"
+          class="text-[var(--pd-table-body-text-highlight)] overflow-hidden text-ellipsis group-hover:text-[var(--pd-link)]"
           title={object.name}>
           {object.name}
         </div>

--- a/packages/renderer/src/lib/container/ContainerDetails.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetails.svelte
@@ -86,7 +86,7 @@ onMount(() => {
       </div>
       <ContainerActions container={container} detailed={true} on:update={() => (container = container)} />
     </svelte:fragment>
-    <div slot="detail" class="flex py-2 w-full justify-end text-sm text-gray-700">
+    <div slot="detail" class="flex py-2 w-full justify-end text-sm text-[var(--pd-content-text)]">
       <StateChange state={container.state} />
       <ContainerStatistics container={container} />
     </div>


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Updates any bg- and text- hardcoded colors to use the color registry
No modification to the color registry

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
https://github.com/containers/podman-desktop/issues/9080

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
