### PR TITLE
chore: remove timer to refresh tasks in frontend side

### DIFF
--- a/packages/renderer/src/stores/tasks.ts
+++ b/packages/renderer/src/stores/tasks.ts
@@ -28,11 +28,6 @@ import type { TaskImpl } from '../../../main/src/plugin/tasks/task-impl';
  */
 export const tasksInfo: Writable<TaskInfo[]> = writable([]);
 
-// refresh the array every second
-setInterval(() => {
-  tasksInfo.update(tasks => [...tasks]);
-}, 1000);
-
 // remove element from the store
 export function removeTask(taskId: string): void {
   window.clearTask(taskId);


### PR DESCRIPTION
### What does this PR do?
there is a timer refreshing every second the tasks but AFAIK it's useless as now tasks are managed on the backend side

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

part of #7399

### How to test this PR?

play with tasks being created
- [ ] Tests are covering the bug fix or the new feature
