### PR TITLE
chore: update container engine selects to Dropdown component

### DIFF
--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
@@ -3,7 +3,7 @@
 // https://github.com/import-js/eslint-plugin-import/issues/1479
 import { faCube, faMinusCircle, faPlusCircle } from '@fortawesome/free-solid-svg-icons';
 import type { OpenDialogOptions } from '@podman-desktop/api';
-import { Button, Input } from '@podman-desktop/ui-svelte';
+import { Button, Dropdown, Input } from '@podman-desktop/ui-svelte';
 import type { Terminal } from '@xterm/xterm';
 import { onDestroy, onMount } from 'svelte';
 import { get } from 'svelte/store';
@@ -329,21 +329,24 @@ async function abortBuild() {
         placeholder="Image name (e.g. quay.io/namespace/my-custom-image)"
         class="w-full"
         required />
-      {#if providerConnections.length > 1}
-        <label for="providerChoice" class="py-6 block mb-2 font-semibold text-[var(--pd-content-card-header-text)]"
-          >Container Engine
-          <select
-            class="w-full p-2 outline-none bg-[var(--pd-select-bg)] rounded-sm text-[var(--pd-content-text)]"
+    </div>
+
+    {#if providerConnections.length > 1}
+      <div hidden={buildImageInfo?.buildRunning}>
+        <label for="providerChoice" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]"
+          >Container engine</label>
+          <Dropdown
             name="providerChoice"
             id="providerChoice"
-            bind:value={selectedProvider}>
-            {#each providerConnections as providerConnection}
-              <option value={providerConnection}>{providerConnection.name}</option>
-            {/each}
-          </select>
-        </label>
-      {/if}
-    </div>
+            bind:value={selectedProvider}
+            options={providerConnections.map(providerConnection => ({
+              label: providerConnection.name,
+              value: providerConnection,
+            }))}>
+          </Dropdown>
+      </div>
+    {/if}
+
     <div hidden={buildImageInfo?.buildRunning}>
       <label for="inputKey" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]"
         >Build arguments</label>

--- a/packages/renderer/src/lib/image/ImportContainersImages.svelte
+++ b/packages/renderer/src/lib/image/ImportContainersImages.svelte
@@ -2,7 +2,7 @@
 /* eslint-disable import/no-duplicates */
 // https://github.com/import-js/eslint-plugin-import/issues/1479
 import { faMinusCircle, faPlay, faPlusCircle } from '@fortawesome/free-solid-svg-icons';
-import { Button, ErrorMessage, Input } from '@podman-desktop/ui-svelte';
+import { Button, Dropdown, ErrorMessage, Input } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 import { get } from 'svelte/store';
 import { router } from 'tinro';
@@ -104,26 +104,27 @@ async function importContainers() {
   </svelte:fragment>
   <div slot="content" class="space-y-2">
     {#if providerConnections.length > 1}
-      <label for="providerChoice" class="py-6 block mb-2 text-sm font-bold text-[var(--pd-content-card-header-text)]"
-        >Container Engine
-        <select
-          class="w-full p-2 outline-none text-sm bg-[var(--pd-select-bg)] rounded-sm text-[var(--pd-content-card-text)]"
-          name="providerChoice"
-          id="providerChoice"
-          bind:value={selectedProvider}>
-          {#each providerConnections as providerConnection}
-            <option value={providerConnection}>{providerConnection.name}</option>
-          {/each}
-        </select>
-      </label>
+    <div class="mb-4">
+      <label for="providerChoice" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]"
+        >Container engine</label>
+      <Dropdown
+        name="providerChoice"
+        id="providerChoice"
+        bind:value={selectedProvider}
+        options={providerConnections.map(providerConnection => ({
+          label: providerConnection.name,
+          value: providerConnection,
+        }))}>
+      </Dropdown>
+    </div>
     {/if}
 
-    <label for="modalContainersImport" class="block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
-      >Containers to import:</label>
+    <label for="modalContainersImport" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]"
+      >Containers to import</label>
     <Button on:click={addContainersToImport} icon={faPlusCircle} type="link">Add images to import</Button>
     <!-- Display the list of existing containersToImport -->
     {#if containersToImport.length > 0}
-      <div class="flex flex-row justify-center w-full py-1 text-sm font-medium text-[var(--pd-content-card-text)]">
+      <div class="flex flex-row justify-center w-full py-1 text-sm font-semibold text-[var(--pd-content-card-text)]">
         <div class="flex flex-col grow pl-2">Image Path</div>
         <div class="flex flex-col w-2/4 mr-2.5">Image Name when importing (e.g quay.io/podman/hello)</div>
       </div>

--- a/packages/renderer/src/lib/image/LoadImages.svelte
+++ b/packages/renderer/src/lib/image/LoadImages.svelte
@@ -2,7 +2,7 @@
 /* eslint-disable import/no-duplicates */
 // https://github.com/import-js/eslint-plugin-import/issues/1479
 import { faMinusCircle, faPlay, faPlusCircle } from '@fortawesome/free-solid-svg-icons';
-import { Button, ErrorMessage, Input } from '@podman-desktop/ui-svelte';
+import { Button, Dropdown, ErrorMessage, Input } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 import { get } from 'svelte/store';
 import { router } from 'tinro';
@@ -83,24 +83,25 @@ async function loadImages() {
   </svelte:fragment>
   <div slot="content" class="space-y-2">
     {#if providerConnections.length > 1}
-      <label for="providerChoice" class="pt-6 block text-sm font-bold text-[var(--pd-content-card-header-text)]"
-        >Container Engine
-        <select
-          class="w-full p-2 outline-none text-sm bg-[var(--pd-select-bg)] rounded-sm text-[var(--pd-content-card-text)]"
+    <div class="mb-2">
+      <label for="providerChoice" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]"
+        >Container Engine</label>
+        <Dropdown
           name="providerChoice"
           id="providerChoice"
-          bind:value={selectedProvider}>
-          {#each providerConnections as providerConnection}
-            <option value={providerConnection}>{providerConnection.name}</option>
-          {/each}
-        </select>
-      </label>
+          bind:value={selectedProvider}
+          options={providerConnections.map(providerConnection => ({
+            label: providerConnection.name,
+            value: providerConnection,
+          }))}>
+        </Dropdown>
+      </div>
     {/if}
 
     <Button on:click={addArchivesToLoad} icon={faPlusCircle} type="link">Add archive</Button>
     <!-- Display the list of existing imagesToLoad -->
     {#if archivesToLoad.length > 0}
-      <div class="flex flex-row justify-center w-full py-1 text-sm font-medium text-[var(--pd-content-card-text)]">
+      <div class="flex flex-row justify-center w-full py-1 font-semibold text-[var(--pd-content-card-text)]">
         <div class="flex flex-col grow pl-2">Image Archives</div>
       </div>
     {/if}

--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { faArrowCircleDown, faCog, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
-import { Button, Checkbox, ErrorMessage, Tooltip } from '@podman-desktop/ui-svelte';
+import { Button, Checkbox, Dropdown, ErrorMessage, Tooltip } from '@podman-desktop/ui-svelte';
 import type { Terminal } from '@xterm/xterm';
 import { onMount, tick } from 'svelte';
 import Fa from 'svelte-fa';
@@ -220,7 +220,7 @@ async function searchImages(value: string): Promise<string[]> {
 
   <div slot="content" class="space-y-6">
     <div class="w-full">
-      <label for="imageName" class="block mb-2 font-bold text-[var(--pd-content-card-header-text)]"
+      <label for="imageName" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]"
         >Image to Pull</label>
       <div class="flex flex-col">
         <Typeahead
@@ -254,17 +254,17 @@ async function searchImages(value: string): Promise<string[]> {
 
       {#if providerConnections.length > 1}
         <div class="pt-4">
-          <label for="providerChoice" class="block mb-2 font-bold text-[var(--pd-content-card-header-text)]"
-            >Container Engine:</label>
-          <select
+          <label for="providerChoice" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]"
+            >Container Engine</label>
+          <Dropdown
             id="providerChoice"
-            class="w-auto border text-sm rounded-lg focus:ring-purple-500 focus:border-purple-500 block p-2.5 bg-[var(--pd-select-bg)] rounded-sm text-[var(--pd-content-card-text)]"
             name="providerChoice"
-            bind:value={selectedProviderConnection}>
-            {#each providerConnections as providerConnection}
-              <option value={providerConnection}>{providerConnection.name}</option>
-            {/each}
-          </select>
+            bind:value={selectedProviderConnection}
+            options={providerConnections.map(providerConnection => ({
+              label: providerConnection.name,
+              value: providerConnection,
+            }))}>
+          </Dropdown>
         </div>
       {/if}
       {#if providerConnections.length === 1}

--- a/packages/renderer/src/lib/kube/KubePlayYAML.svelte
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.svelte
@@ -9,7 +9,7 @@ let providerUnsubscribe: Unsubscriber;
 import { faCircleCheck } from '@fortawesome/free-solid-svg-icons';
 import type { V1NamespaceList } from '@kubernetes/client-node/dist/api';
 import type { OpenDialogOptions } from '@podman-desktop/api';
-import { Button, ErrorMessage, Input } from '@podman-desktop/ui-svelte';
+import { Button, Dropdown, ErrorMessage, Input } from '@podman-desktop/ui-svelte';
 import Fa from 'svelte-fa';
 
 import { handleNavigation } from '/@/navigation';
@@ -221,17 +221,19 @@ function goBackToPodsPage(): void {
             {#if providerConnections.length > 1}
               <label
                 for="providerConnectionName"
-                class="py-6 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
-                >Container Engine
-                <select
-                  class="w-full p-2 outline-none text-sm bg-[var(--pd-select-bg)] rounded-sm text-[var(--pd-content-text)]"
+                class="block mb-2 font-medium"
+                class:text-[var(--pd-content-card-header-text)]={userChoice === 'podman'}
+                class:text-[var(--pd-input-field-disabled-text)]={userChoice !== 'podman'}
+                >Container Engine</label>
+                <Dropdown
                   name="providerChoice"
-                  bind:value={selectedProvider}>
-                  {#each providerConnections as providerConnection}
-                    <option value={providerConnection}>{providerConnection.name}</option>
-                  {/each}
-                </select>
-              </label>
+                  bind:value={selectedProvider}
+                  disabled={userChoice === 'kubernetes'}
+                  options={providerConnections.map(providerConnection => ({
+                    label: providerConnection.name,
+                    value: providerConnection,
+                  }))}>
+                </Dropdown>
             {/if}
             {#if providerConnections.length === 1 && selectedProviderConnection}
               <input type="hidden" name="providerChoice" readonly bind:value={selectedProviderConnection.name} />
@@ -290,18 +292,16 @@ function goBackToPodsPage(): void {
                 class:text-[var(--pd-content-card-header-text)]={userChoice === 'kubernetes'}
                 class:text-[var(--pd-input-field-disabled-text)]={userChoice !== 'kubernetes'}
                 >Kubernetes namespace:</label>
-              <select
+              <Dropdown
                 disabled={userChoice === 'podman'}
-                class="w-full p-2 outline-none text-sm bg-[var(--pd-select-bg)] rounded-sm text-[var(--pd-content-card-text)]"
-                aria-label="Kubernetes Namespace"
+                ariaLabel="Kubernetes Namespace"
                 name="namespaceChoice"
-                bind:value={currentNamespace}>
-                {#each allNamespaces.items as namespace}
-                  <option value={namespace.metadata?.name}>
-                    {namespace.metadata?.name}
-                  </option>
-                {/each}
-              </select>
+                bind:value={currentNamespace}
+                options={allNamespaces.items.map(namespace => ({
+                  label: namespace.metadata?.name ?? '',
+                  value: namespace.metadata?.name ?? '',
+                }))}>
+              </Dropdown>
             </div>
           {/if}
         </button>

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { Button, Checkbox, ErrorMessage, Input, StatusIcon } from '@podman-desktop/ui-svelte';
+import { Button, Checkbox, Dropdown, ErrorMessage, Input, StatusIcon } from '@podman-desktop/ui-svelte';
 import { ContainerIcon } from '@podman-desktop/ui-svelte/icons';
 import { onDestroy, onMount } from 'svelte';
 import type { Unsubscriber } from 'svelte/store';
@@ -220,7 +220,7 @@ function getWarningText(): string {
           <WarningMessage class="flex flex-row w-full  mb-2" error={getWarningText()} />
         {/if}
         <div class="mb-2">
-          <span class="block text-sm font-semibold rounded text-[var(--pd-content-card-header-text)]"
+          <span class="block font-semibold rounded text-[var(--pd-content-card-header-text)]"
             >Name of the pod:</span>
         </div>
         <div class="mb-4">
@@ -235,7 +235,7 @@ function getWarningText(): string {
 
         <div class="mb-2">
           <span
-            class="block text-sm font-semibold rounded text-[var(--pd-content-card-header-text)]"
+            class="block font-semibold rounded text-[var(--pd-content-card-header-text)]"
             aria-label="Containers">Containers to replicate to the pod:</span>
         </div>
         <div class="w-full bg-[var(--pd-content-card-inset-bg)] mb-4 max-h-40 overflow-y-auto">
@@ -252,7 +252,7 @@ function getWarningText(): string {
         {#if mapPortExposed.size > 0}
           <div class="mb-2">
             <span
-              class="block text-sm font-semibold rounded text-[var(--pd-content-card-header-text)]"
+              class="block font-semibold rounded text-[var(--pd-content-card-header-text)]"
               aria-label="Exposed ports">All selected ports will be exposed:</span>
           </div>
           <div class="bg-[var(--pd-content-card-inset-bg)] mb-4 max-h-40 overflow-y-auto">
@@ -273,16 +273,17 @@ function getWarningText(): string {
       {#if providerConnections.length > 1}
         <label
           for="providerConnectionName"
-          class="block mb-2 text-sm font-medium rounded text-[var(--pd-content-card-header-text)]"
-          >Container Engine</label>
-        <select
-          class="w-full p-2 outline-none text-sm bg-[var(--pd-select-bg)] rounded-sm text-[var(--pd-content-card-text)]"
+          class="block mb-2 font-semibold rounded text-[var(--pd-content-card-header-text)]"
+          >Container engine:</label>
+        <Dropdown
+          class="w-full"
           name="providerChoice"
-          bind:value={selectedProvider}>
-          {#each providerConnections as providerConnection}
-            <option value={providerConnection}>{providerConnection.name}</option>
-          {/each}
-        </select>
+          bind:value={selectedProvider}
+          options={providerConnections.map(providerConnection => ({
+            label: providerConnection.name,
+            value: providerConnection,
+          }))}>
+        </Dropdown>
       {/if}
       {#if providerConnections.length === 1 && selectedProviderConnection?.name}
         <input type="hidden" name="providerChoice" readonly bind:value={selectedProviderConnection.name} />


### PR DESCRIPTION
### What does this PR do?

Updates all the container engine select controls [*] to the Dropdown component, plus another select that was in KubePlayYaml. An odd set, but the code in each of these is almost identical.

I kept this to just the component swap as much as possible, but almost all of these pages had existing formatting inconsistencies, with the container engine standing out the most. In each case I tried to make the minimum formatting change to allow the container engine option to fit in or fix existing formatting to be more consistent. There are still issues here, but doing any less looked odd.

[*] I left out CreateVolume because I'm still deciding how to do the tests, will PR later.

Noticed an issue while using Dropdown: when objects are passed via html parameters like 'option value={obj}', Svelte puts the stringified value in .value and keeps the real value in .__value. Although it hasn't changed in several years, use of this property is not Svelte API (https://github.com/sveltejs/svelte/issues/2734), which means we can't use option child elements when using non-string values. I just switched to the options parameter instead, which is what most third-party components use.

### Screenshot / video of UI

<img width="567" alt="Screenshot 2024-10-17 at 12 20 56 PM" src="https://github.com/user-attachments/assets/ebd7b6e0-4be4-45bb-8f98-ef83d38f0f49">
<img width="567" alt="Screenshot 2024-10-17 at 12 22 13 PM" src="https://github.com/user-attachments/assets/81fcae14-4b8a-4db2-91f3-a480a13f9224">
<img width="567" alt="Screenshot 2024-10-17 at 12 22 39 PM" src="https://github.com/user-attachments/assets/f822b406-0ba4-488e-ba20-bf11b26ea779">
<img width="567" alt="Screenshot 2024-10-17 at 12 23 27 PM" src="https://github.com/user-attachments/assets/0c104b7b-6feb-46a9-b28b-80ec8da579cf">
<img width="567" alt="Screenshot 2024-10-17 at 12 24 36 PM" src="https://github.com/user-attachments/assets/6bd8866e-849b-45ed-8c28-0b629f5909f3">
<img width="567" alt="Screenshot 2024-10-17 at 12 26 01 PM" src="https://github.com/user-attachments/assets/13ad7110-9786-4044-a68b-291ad533c8a3">

### What issues does this PR fix or reference?

Fixes #8283.

### How to test this PR?

Make sure you have two container engines, then go to each of these pages.