### PR TITLE
feat: refresh the state of a specific context by restarting its informers

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -2519,6 +2519,10 @@ export class PluginSystem {
       },
     );
 
+    this.ipcHandle('kubernetes-client:refreshContextState', async (_listener, context: string): Promise<void> => {
+      return kubernetesClient.refreshContextState(context);
+    });
+
     this.ipcHandle('feedback:send', async (_listener, feedbackProperties: unknown): Promise<void> => {
       return telemetry.sendFeedback(feedbackProperties);
     });

--- a/packages/main/src/plugin/kubernetes/contexts-manager.spec.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager.spec.ts
@@ -2930,4 +2930,37 @@ describe('refreshContextState', () => {
     await client.refreshContextState('context1');
     expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-contexts-checking-state-update', expectedMap);
   });
+
+  test('should throw an error if the context does not exist', async () => {
+    vi.mocked(makeInformer).mockImplementation(fakeMakeInformer);
+    const client = new TestContextsManager(apiSender);
+    const kubeConfig = new kubeclient.KubeConfig();
+    const config = {
+      clusters: [
+        {
+          name: 'cluster1',
+          server: 'server1',
+        },
+      ],
+      users: [
+        {
+          name: 'user1',
+        },
+      ],
+      contexts: [
+        {
+          name: `context1`,
+          cluster: 'cluster1',
+          user: 'user1',
+        },
+      ],
+      currentContext: 'context1',
+    };
+
+    kubeConfig.loadFromOptions(config);
+    await client.update(kubeConfig);
+    await expect(async () => await client.refreshContextState('unknown-context')).rejects.toThrowError(
+      'context unknown-context not found',
+    );
+  });
 });

--- a/packages/main/src/plugin/kubernetes/contexts-manager.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager.ts
@@ -977,6 +977,10 @@ export class ContextsManager {
   }
 
   public async refreshContextState(contextName: string): Promise<void> {
+    const context = this.kubeConfig.getContexts().find(c => c.name === contextName);
+    if (!context) {
+      throw new Error(`context ${contextName} not found`);
+    }
     // stop previous ones
     // primaries
     await this.informers.deleteContextInformers(contextName);
@@ -986,10 +990,6 @@ export class ContextsManager {
     await this.states.disposeSecondaryStates(contextName);
 
     // start new ones
-    const context = this.kubeConfig.getContexts().find(c => c.name === contextName);
-    if (!context) {
-      return;
-    }
     const kubeContext: KubeContext = this.getKubeContext(context);
     const informers = this.createKubeContextInformers(kubeContext);
     this.informers.setInformers(contextName, informers);

--- a/packages/main/src/plugin/kubernetes/contexts-manager.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager.ts
@@ -976,6 +976,14 @@ export class ContextsManager {
     return [];
   }
 
+  /**
+   * Ask for getting the state of the context as soon as possible.
+   *
+   * This is done by stopping all the informers for this context
+   * and restarting the primary informers.
+   *
+   * @param contextName the context for which to refresh the state
+   */
   public async refreshContextState(contextName: string): Promise<void> {
     const context = this.kubeConfig.getContexts().find(c => c.name === contextName);
     if (!context) {

--- a/packages/main/src/plugin/kubernetes/contexts-manager.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager.ts
@@ -976,6 +976,25 @@ export class ContextsManager {
     return [];
   }
 
+  public async refreshContextState(contextName: string): Promise<void> {
+    // stop previous ones
+    // primaries
+    await this.informers.deleteContextInformers(contextName);
+    await this.states.deleteContextState(contextName);
+    // secondaries
+    await this.informers.disposeSecondaryInformers(contextName);
+    await this.states.disposeSecondaryStates(contextName);
+
+    // start new ones
+    const context = this.kubeConfig.getContexts().find(c => c.name === contextName);
+    if (!context) {
+      return;
+    }
+    const kubeContext: KubeContext = this.getKubeContext(context);
+    const informers = this.createKubeContextInformers(kubeContext);
+    this.informers.setInformers(contextName, informers);
+  }
+
   // for tests
   public getContextResources(contextName: string, resourceName: ResourceName): KubernetesObject[] {
     return this.states.getContextResources(contextName, resourceName);

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.ts
@@ -1728,7 +1728,7 @@ export class KubernetesClient {
   }
 
   /**
-   * Ask forr getting the state of the context as soon as possible.
+   * Ask for getting the state of the context as soon as possible.
    *
    * Because the connection to a context is tested with a backoff,
    * it can take time to know if a context is reachable or not.

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.ts
@@ -1726,4 +1726,8 @@ export class KubernetesClient {
     // pod.metadata?.labels && 'pod-template-hash' in pod.metadata.labels
     return podMetadata.ownerReferences?.find((ref: V1OwnerReference) => ref.controller === true);
   }
+
+  public async refreshContextState(context: string): Promise<void> {
+    return this.contextsState.refreshContextState(context);
+  }
 }

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.ts
@@ -1727,6 +1727,17 @@ export class KubernetesClient {
     return podMetadata.ownerReferences?.find((ref: V1OwnerReference) => ref.controller === true);
   }
 
+  /**
+   * Ask forr getting the state of the context as soon as possible.
+   *
+   * Because the connection to a context is tested with a backoff,
+   * it can take time to know if a context is reachable or not.
+   * By calling this method, the connection will be tested immediately,
+   * and the result sent as soon as the connection status is known.
+   *
+   * @param context name of the context for which we want to get state ASAP
+   * @returns
+   */
   public async refreshContextState(context: string): Promise<void> {
     return this.contextsState.refreshContextState(context);
   }

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -2026,6 +2026,10 @@ export function initExposure(): void {
     },
   );
 
+  contextBridge.exposeInMainWorld('kubernetesRefreshContextState', async (context: string): Promise<void> => {
+    return ipcInvoke('kubernetes-client:refreshContextState', context);
+  });
+
   contextBridge.exposeInMainWorld(
     'openshiftCreateRoute',
     async (namespace: string, route: V1Route): Promise<V1Route> => {


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Adds a method to `window` to restart informers for a specific context, from the frontend.

(frontend part to be done in another PR)


### What issues does this PR fix or reference?

Part of #8341 

### How to test this PR?

#9491 can be used to test from the frontend

- [x] Tests are covering the bug fix or the new feature
