### PR TITLE
feat: add experimental flag to display toasts when we have notifications

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -60,6 +60,7 @@ import StatusBar from './lib/statusbar/StatusBar.svelte';
 import IconsStyle from './lib/style/IconsStyle.svelte';
 import TaskManager from './lib/task-manager/TaskManager.svelte';
 import ToastHandler from './lib/toast/ToastHandler.svelte';
+import ToastTaskNotifications from './lib/toast/ToastTaskNotifications.svelte';
 import TroubleshootingPage from './lib/troubleshooting/TroubleshootingPage.svelte';
 import TitleBar from './lib/ui/TitleBar.svelte';
 import CreateVolume from './lib/volume/CreateVolume.svelte';
@@ -128,6 +129,7 @@ window.events?.receive('navigate', (navigationRequest: unknown) => {
         <TaskManager />
         <SendFeedback />
         <ToastHandler />
+        <ToastTaskNotifications />
         <Route path="/" breadcrumb="Dashboard Page">
           <DashboardPage />
         </Route>
@@ -232,8 +234,8 @@ window.events?.receive('navigate', (navigationRequest: unknown) => {
             <KubernetesEmptyPage />
           </Route>
         {:else}
-          <!-- Redirect /kubernetes to nodes if we end up on /kubernetes without a context error 
-           we use router.goto to preserve the navbar remembering the navigation location. 
+          <!-- Redirect /kubernetes to nodes if we end up on /kubernetes without a context error
+           we use router.goto to preserve the navbar remembering the navigation location.
            TODO: Remove after https://github.com/containers/podman-desktop/issues/8825 is implemented -->
           <Route path="/kubernetes" breadcrumb="Kubernetes" navigationHint="root">
             {router.goto('/kubernetes/nodes')}

--- a/packages/renderer/src/lib/toast/ToastCustomUi.spec.ts
+++ b/packages/renderer/src/lib/toast/ToastCustomUi.spec.ts
@@ -1,0 +1,177 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { toast } from '@zerodevx/svelte-toast';
+import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
+
+import type { TaskInfo } from '/@api/taskInfo';
+
+import ToastCustomUi from './ToastCustomUi.svelte';
+
+const started = new Date().getTime();
+const onpop = vi.fn();
+const IN_PROGRESS_TASK: TaskInfo = {
+  id: '1',
+  name: 'Running Task 1',
+  state: 'running',
+  status: 'in-progress',
+  started,
+  action: 'Task action',
+};
+
+const SUCCESS_TASK: TaskInfo = {
+  id: '1',
+  name: 'Completed Task 1',
+  state: 'completed',
+  status: 'success',
+  started,
+  action: 'Success action',
+};
+
+const failureTaskError = 'this is the error';
+const FAILURE_TASK: TaskInfo = {
+  id: '1',
+  name: 'Failure Task 1',
+  state: 'completed',
+  status: 'failure',
+  started,
+  error: failureTaskError,
+  action: 'failure action',
+};
+
+beforeAll(() => {
+  Object.defineProperty(window, 'executeTask', {
+    value: vi.fn(),
+  });
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('Check with in-progress', async () => {
+  // spy pop method on toast
+  const toastPopSpy = vi.spyOn(toast, 'pop');
+  const toastId = 1234;
+
+  render(ToastCustomUi, {
+    taskInfo: IN_PROGRESS_TASK,
+    toastId,
+    onpop,
+  });
+  // expect the in-progress is used
+  const status = screen.getByRole('status', { name: 'in-progress' });
+  expect(status).toBeInTheDocument();
+
+  // expect name is there
+  const name = screen.getAllByText(IN_PROGRESS_TASK.name);
+  expect(name).lengthOf(2);
+
+  // should have an action and can click on it
+  const action = screen.getByRole('link', { name: 'Task action' });
+  expect(action).toBeInTheDocument();
+  await fireEvent.click(action);
+
+  // expect we have been calling the method
+  expect(window.executeTask).toHaveBeenCalledWith(IN_PROGRESS_TASK.id);
+
+  // expect we can close the toast
+  const close = screen.getByRole('button', { name: 'Close' });
+  expect(close).toBeInTheDocument();
+  await fireEvent.click(close);
+  expect(onpop).toHaveBeenCalled();
+
+  expect(toastPopSpy).toHaveBeenCalledWith(toastId);
+});
+
+test('Check with success', async () => {
+  // spy pop method on toast
+  const toastPopSpy = vi.spyOn(toast, 'pop');
+  const toastId = 1234;
+
+  render(ToastCustomUi, {
+    taskInfo: SUCCESS_TASK,
+    toastId,
+    onpop,
+  });
+  // expect the in-progress is used
+  const status = screen.getByRole('status', { name: 'success' });
+  expect(status).toBeInTheDocument();
+
+  // expect name is there
+  const name = screen.getAllByText(SUCCESS_TASK.name);
+  expect(name).lengthOf(2);
+
+  // should have an action and can click on it
+  const action = screen.getByRole('link', { name: 'Success action' });
+  expect(action).toBeInTheDocument();
+  await fireEvent.click(action);
+
+  // expect we have been calling the method
+  expect(window.executeTask).toHaveBeenCalledWith(SUCCESS_TASK.id);
+
+  // expect we can close the toast
+  const close = screen.getByRole('button', { name: 'Close' });
+  expect(close).toBeInTheDocument();
+  await fireEvent.click(close);
+  expect(onpop).toHaveBeenCalled();
+
+  expect(toastPopSpy).toHaveBeenCalledWith(toastId);
+});
+
+test('Check with failure', async () => {
+  // spy pop method on toast
+  const toastPopSpy = vi.spyOn(toast, 'pop');
+  const toastId = 1234;
+
+  render(ToastCustomUi, {
+    taskInfo: FAILURE_TASK,
+    toastId,
+    onpop,
+  });
+  // expect the in-progress is used
+  const status = screen.getByRole('status', { name: 'failure' });
+  expect(status).toBeInTheDocument();
+
+  // expect name is there
+  const name = screen.getByText(FAILURE_TASK.name);
+  expect(name).toBeInTheDocument();
+
+  // expect error to be displayed
+  const error = screen.getByText(failureTaskError);
+  expect(error).toBeInTheDocument();
+
+  // should have an action and can click on it
+  const action = screen.getByRole('link', { name: 'failure action' });
+  expect(action).toBeInTheDocument();
+  await fireEvent.click(action);
+
+  // expect we have been calling the method
+  expect(window.executeTask).toHaveBeenCalledWith(FAILURE_TASK.id);
+
+  // expect we can close the toast
+  const close = screen.getByRole('button', { name: 'Close' });
+  expect(close).toBeInTheDocument();
+  await fireEvent.click(close);
+  expect(onpop).toHaveBeenCalled();
+
+  expect(toastPopSpy).toHaveBeenCalledWith(toastId);
+});

--- a/packages/renderer/src/lib/toast/ToastCustomUi.svelte
+++ b/packages/renderer/src/lib/toast/ToastCustomUi.svelte
@@ -1,12 +1,18 @@
 <script lang="ts">
-import { faCheckCircle, faCircleExclamation, faSpinner } from '@fortawesome/free-solid-svg-icons';
-import { CloseButton, Link } from '@podman-desktop/ui-svelte';
+import { faCheckCircle, faCircleExclamation } from '@fortawesome/free-solid-svg-icons';
+import { CloseButton, Link, Spinner } from '@podman-desktop/ui-svelte';
 import { toast } from '@zerodevx/svelte-toast';
 import Fa from 'svelte-fa';
 
 import type { TaskInfo } from '/@api/taskInfo';
 
-let { toastId, taskInfo, onpop = () => {} }: { toastId: number; taskInfo: TaskInfo; onpop?: () => void } = $props();
+interface Props {
+  toastId: number;
+  taskInfo: TaskInfo;
+  onpop?: () => void;
+}
+
+let { toastId, taskInfo, onpop = () => {} }: Props = $props();
 
 const closeAction = (): void => {
   toast.pop(toastId);
@@ -19,7 +25,8 @@ const executeAction = (): void => {
 </script>
 
 <div
-  class="flex min-h-10 max-h-30 flex-col p-2 border-[var(--pd-button-tab-border-selected)] border rounded-md bg-[var(--pd-modal-bg)]"
+  class="flex min-h-10 cursor-default max-h-30 max-w-[var(--toastWidth)] flex-col p-2 border-[var(--pd-button-tab-border-selected)] border rounded-md bg-[var(--pd-modal-bg)]"
+  title={taskInfo.name}
 >
   <div class="mb-1 flex flex-row items-center">
     <div
@@ -28,7 +35,7 @@ const executeAction = (): void => {
       aria-label={taskInfo.status}
     >
       {#if taskInfo.status === 'in-progress'}
-        <Fa class="animate-spin" icon={faSpinner} />
+        <Spinner size="1em"/>
       {:else if taskInfo.status === 'success'}
         <Fa icon={faCheckCircle} />
       {:else if taskInfo.status === 'failure'}
@@ -36,7 +43,7 @@ const executeAction = (): void => {
       {/if}
     </div>
 
-    <div class="font-bold text-ellipsis line-clamp-1 max-w-32">
+    <div class="font-bold text-ellipsis line-clamp-1 overflow-hidden">
       {taskInfo.name}
     </div>
 
@@ -48,13 +55,15 @@ const executeAction = (): void => {
       <CloseButton on:click={closeAction} />
     </div>
   </div>
-  <div class="flex flex-row items-center italic">
+  <div class="flex flex-row items-center italic line-clamp-4">
     {#if taskInfo.error}
       <p class="flex-1 text-sm line-clamp-4 text-[var(--pd-state-error)]">
         {taskInfo.error}
       </p>
     {:else}
+    <p class="flex-1 text-sm text-ellipsis overflow-hidden">
       {taskInfo.name}
+    </p>
     {/if}
   </div>
   {#if taskInfo.action}

--- a/packages/renderer/src/lib/toast/ToastCustomUi.svelte
+++ b/packages/renderer/src/lib/toast/ToastCustomUi.svelte
@@ -1,4 +1,3 @@
-
 <script lang="ts">
 import { faCheckCircle, faCircleExclamation, faSpinner } from '@fortawesome/free-solid-svg-icons';
 import { CloseButton, Link } from '@podman-desktop/ui-svelte';
@@ -19,46 +18,48 @@ const executeAction = (): void => {
 };
 </script>
 
-<div class="flex min-h-10 max-h-30 flex-col p-2 border-[var(--pd-button-tab-border-selected)] border rounded-md bg-[var(--pd-modal-bg)]">
+<div
+  class="flex min-h-10 max-h-30 flex-col p-2 border-[var(--pd-button-tab-border-selected)] border rounded-md bg-[var(--pd-modal-bg)]"
+>
   <div class="mb-1 flex flex-row items-center">
-
-    <div class="mr-1 text-purple-500" role="status" aria-label="{taskInfo.status}">
+    <div
+      class="mr-1 text-purple-500"
+      role="status"
+      aria-label={taskInfo.status}
+    >
       {#if taskInfo.status === 'in-progress'}
         <Fa class="animate-spin" icon={faSpinner} />
-        {:else if taskInfo.status === 'success'}
-          <Fa icon={faCheckCircle} />
-        {:else if taskInfo.status === 'failure'}
-          <Fa icon={faCircleExclamation} class="text-[var(--pd-state-error)]" />
+      {:else if taskInfo.status === 'success'}
+        <Fa icon={faCheckCircle} />
+      {:else if taskInfo.status === 'failure'}
+        <Fa icon={faCircleExclamation} class="text-[var(--pd-state-error)]" />
       {/if}
-      </div>
+    </div>
 
+    <div class="font-bold text-ellipsis line-clamp-1 max-w-32">
+      {taskInfo.name}
+    </div>
 
-    <div class="font-bold text-ellipsis line-clamp-1 max-w-32">{taskInfo.name}</div>
-
-      {#if taskInfo.progress && taskInfo.status === 'in-progress'}
-        <span class="ml-1">{taskInfo.progress}%</span>
-      {/if}
-
+    {#if taskInfo.progress && taskInfo.status === 'in-progress'}
+      <span class="ml-1">{taskInfo.progress}%</span>
+    {/if}
 
     <div class="flex flex-grow flex-col items-end">
       <CloseButton on:click={clicked} />
     </div>
-
   </div>
-<div class="flex flex-row items-center italic">
-  {#if taskInfo.error}
-  <p class="flex-1 text-sm line-clamp-4 text-[var(--pd-state-error)]">{taskInfo.error}</p>
-  {:else}
-  {taskInfo.name}
-  {/if}
+  <div class="flex flex-row items-center italic">
+    {#if taskInfo.error}
+      <p class="flex-1 text-sm line-clamp-4 text-[var(--pd-state-error)]">
+        {taskInfo.error}
+      </p>
+    {:else}
+      {taskInfo.name}
+    {/if}
   </div>
   <div class="text-right text-xs text-[var(--pd-content-text)]">
-  {#if taskInfo.action}
-  <Link onclick={executeAction}>{taskInfo.action}</Link>
-  {/if}
-
-</div>
-
-
-
+    {#if taskInfo.action}
+      <Link onclick={executeAction}>{taskInfo.action}</Link>
+    {/if}
+  </div>
 </div>

--- a/packages/renderer/src/lib/toast/ToastCustomUi.svelte
+++ b/packages/renderer/src/lib/toast/ToastCustomUi.svelte
@@ -1,0 +1,64 @@
+
+<script lang="ts">
+import { faCheckCircle, faCircleExclamation, faSpinner } from '@fortawesome/free-solid-svg-icons';
+import { CloseButton, Link } from '@podman-desktop/ui-svelte';
+import { toast } from '@zerodevx/svelte-toast';
+import Fa from 'svelte-fa';
+
+import type { TaskInfo } from '/@api/taskInfo';
+
+let { toastId, taskInfo, onpop = () => {} }: { toastId: number; taskInfo: TaskInfo; onpop?: () => void } = $props();
+
+const clicked = (): void => {
+  toast.pop(toastId);
+  onpop();
+};
+
+const executeAction = (): void => {
+  window.executeTask(taskInfo.id);
+};
+</script>
+
+<div class="flex min-h-10 max-h-30 flex-col p-2 border-[var(--pd-button-tab-border-selected)] border rounded-md bg-[var(--pd-modal-bg)]">
+  <div class="mb-1 flex flex-row items-center">
+
+    <div class="mr-1 text-purple-500" role="status" aria-label="{taskInfo.status}">
+      {#if taskInfo.status === 'in-progress'}
+        <Fa class="animate-spin" icon={faSpinner} />
+        {:else if taskInfo.status === 'success'}
+          <Fa icon={faCheckCircle} />
+        {:else if taskInfo.status === 'failure'}
+          <Fa icon={faCircleExclamation} class="text-[var(--pd-state-error)]" />
+      {/if}
+      </div>
+
+
+    <div class="font-bold text-ellipsis line-clamp-1 max-w-32">{taskInfo.name}</div>
+
+      {#if taskInfo.progress && taskInfo.status === 'in-progress'}
+        <span class="ml-1">{taskInfo.progress}%</span>
+      {/if}
+
+
+    <div class="flex flex-grow flex-col items-end">
+      <CloseButton on:click={clicked} />
+    </div>
+
+  </div>
+<div class="flex flex-row items-center italic">
+  {#if taskInfo.error}
+  <p class="flex-1 text-sm line-clamp-4 text-[var(--pd-state-error)]">{taskInfo.error}</p>
+  {:else}
+  {taskInfo.name}
+  {/if}
+  </div>
+  <div class="text-right text-xs text-[var(--pd-content-text)]">
+  {#if taskInfo.action}
+  <Link onclick={executeAction}>{taskInfo.action}</Link>
+  {/if}
+
+</div>
+
+
+
+</div>

--- a/packages/renderer/src/lib/toast/ToastCustomUi.svelte
+++ b/packages/renderer/src/lib/toast/ToastCustomUi.svelte
@@ -8,7 +8,7 @@ import type { TaskInfo } from '/@api/taskInfo';
 
 let { toastId, taskInfo, onpop = () => {} }: { toastId: number; taskInfo: TaskInfo; onpop?: () => void } = $props();
 
-const clicked = (): void => {
+const closeAction = (): void => {
   toast.pop(toastId);
   onpop();
 };
@@ -45,7 +45,7 @@ const executeAction = (): void => {
     {/if}
 
     <div class="flex flex-grow flex-col items-end">
-      <CloseButton on:click={clicked} />
+      <CloseButton on:click={closeAction} />
     </div>
   </div>
   <div class="flex flex-row items-center italic">
@@ -57,9 +57,9 @@ const executeAction = (): void => {
       {taskInfo.name}
     {/if}
   </div>
-  <div class="text-right text-xs text-[var(--pd-content-text)]">
-    {#if taskInfo.action}
+  {#if taskInfo.action}
+    <div class="text-right text-xs text-[var(--pd-content-text)]">
       <Link onclick={executeAction}>{taskInfo.action}</Link>
-    {/if}
-  </div>
+    </div>
+  {/if}
 </div>

--- a/packages/renderer/src/lib/toast/ToastHandler.svelte
+++ b/packages/renderer/src/lib/toast/ToastHandler.svelte
@@ -5,6 +5,7 @@
   --toastMsgPadding: '0';
   --toastMinHeight: 2rem;
   --toastBorderRadius: 0.3rem;
+  --toastWidth: 16rem;
   --toastContainerTop: auto;
   --toastContainerRight: 0.8rem;
   --toastContainerBottom: 1rem;

--- a/packages/renderer/src/lib/toast/ToastHandler.svelte
+++ b/packages/renderer/src/lib/toast/ToastHandler.svelte
@@ -1,8 +1,15 @@
 <style>
 .svelte-toast-wrapper {
   font-size: 0.8rem;
+  --toastPadding: '0';
+  --toastMsgPadding: '0';
   --toastMinHeight: 2rem;
-  --toastBorderRadius: 0.2rem;
+  --toastBorderRadius: 0.3rem;
+  --toastContainerTop: auto;
+  --toastContainerRight: 0.8rem;
+  --toastContainerBottom: 1rem;
+  --toastContainerLeft: auto;
+  --toastBackground: var(--pd-modal-bg);
 }
 </style>
 

--- a/packages/renderer/src/lib/toast/ToastTaskNotifications.spec.ts
+++ b/packages/renderer/src/lib/toast/ToastTaskNotifications.spec.ts
@@ -1,0 +1,142 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, waitFor } from '@testing-library/svelte';
+import { toast } from '@zerodevx/svelte-toast';
+import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
+
+import { tasksInfo } from '/@/stores/tasks';
+import type { TaskInfo } from '/@api/taskInfo';
+
+import ToastTaskNotifications from './ToastTaskNotifications.svelte';
+
+beforeAll(() => {
+  Object.defineProperty(window, 'getConfigurationValue', {
+    value: vi.fn(),
+  });
+});
+
+vi.mock('@zerodevx/svelte-toast', async () => {
+  return {
+    toast: {
+      push: vi.fn(),
+      pop: vi.fn(),
+      set: vi.fn(),
+    },
+  };
+});
+
+const started = new Date().getTime();
+
+const IN_PROGRESS_TASK: TaskInfo = {
+  id: '1',
+  name: 'Running Task 1',
+  state: 'running',
+  status: 'in-progress',
+  started,
+  action: 'Task action',
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('Check a toast is being created when there is a task created', async () => {
+  // make it enabled
+  vi.mocked(window.getConfigurationValue).mockResolvedValue(true);
+
+  tasksInfo.set([IN_PROGRESS_TASK]);
+
+  render(ToastTaskNotifications, {});
+
+  // check we have called toast library to create a toast
+  await waitFor(() => expect(toast.push).toHaveBeenCalled());
+  expect(toast.push).toHaveBeenCalledWith(
+    IN_PROGRESS_TASK.name,
+    expect.objectContaining({
+      initial: 0,
+      dismissable: false,
+      component: {
+        props: expect.objectContaining({
+          taskInfo: IN_PROGRESS_TASK,
+        }),
+        sendIdTo: 'toastId',
+        src: expect.anything(),
+      },
+    }),
+  );
+});
+
+test('Check no toast is being if disabled', async () => {
+  // make it disabled
+  vi.mocked(window.getConfigurationValue).mockResolvedValue(false);
+
+  tasksInfo.set([]);
+
+  render(ToastTaskNotifications, {});
+
+  // check we have called toast library to create a toast
+  await waitFor(() => expect(toast.push).not.toHaveBeenCalled());
+});
+
+test('Check a toast is being updated after a task is updated', async () => {
+  // make it enabled
+  vi.mocked(window.getConfigurationValue).mockResolvedValue(true);
+
+  // return a toast id when we create one
+  const dummyToastId = 1256;
+  vi.mocked(toast.push).mockReturnValue(dummyToastId);
+
+  tasksInfo.set([IN_PROGRESS_TASK]);
+
+  render(ToastTaskNotifications, {});
+
+  // check we have called toast library to create a toast
+  await waitFor(() => expect(toast.push).toHaveBeenCalled());
+
+  // ok, now update the task to go from in-progress to success
+  const updatedTask: TaskInfo = {
+    ...IN_PROGRESS_TASK,
+    status: 'success',
+    state: 'completed',
+  };
+  // reset call to toast.set
+  vi.mocked(toast.set).mockClear();
+  tasksInfo.set([updatedTask]);
+
+  // check we have called toast library to create a toast
+  await waitFor(() => expect(toast.set).toHaveBeenCalled());
+
+  // check we have called toast library to update the toast
+  expect(toast.set).toHaveBeenCalledWith(
+    dummyToastId,
+    expect.objectContaining({
+      initial: 0,
+      dismissable: false,
+      component: {
+        props: expect.objectContaining({
+          taskInfo: updatedTask,
+        }),
+        sendIdTo: 'toastId',
+        src: expect.anything(),
+      },
+    }),
+  );
+});

--- a/packages/renderer/src/lib/toast/ToastTaskNotifications.spec.ts
+++ b/packages/renderer/src/lib/toast/ToastTaskNotifications.spec.ts
@@ -84,15 +84,15 @@ test('Check a toast is being created when there is a task created', async () => 
   );
 });
 
-test('Check no toast is being if disabled', async () => {
+test('Check no toast is being created if disabled', async () => {
   // make it disabled
   vi.mocked(window.getConfigurationValue).mockResolvedValue(false);
 
-  tasksInfo.set([]);
+  tasksInfo.set([IN_PROGRESS_TASK]);
 
   render(ToastTaskNotifications, {});
 
-  // check we have called toast library to create a toast
+  // check we have not called toast library to create a toast
   await waitFor(() => expect(toast.push).not.toHaveBeenCalled());
 });
 

--- a/packages/renderer/src/lib/toast/ToastTaskNotifications.svelte
+++ b/packages/renderer/src/lib/toast/ToastTaskNotifications.svelte
@@ -1,0 +1,111 @@
+<script lang="ts">
+import { type SvelteToastOptions, toast } from '@zerodevx/svelte-toast';
+import { type ComponentType, onMount } from 'svelte';
+
+import { onDidChangeConfiguration } from '/@/stores/configurationProperties';
+import { tasksInfo } from '/@/stores/tasks';
+import type { TaskInfo } from '/@api/taskInfo';
+import { ExperimentalTasksSettings } from '/@api/tasks-preferences';
+
+import ToastCustomUi from './ToastCustomUi.svelte';
+
+// extends TaskInfo by adding the toast id
+interface TaskInfoWithToastId extends TaskInfo {
+  toastId: number;
+}
+
+const CONFIGURATION_KEY = `${ExperimentalTasksSettings.SectionName}.${ExperimentalTasksSettings.Toast}`;
+
+// keep a local copy of the tasks with their toast id
+const currentTasks: TaskInfoWithToastId[] = $state([]);
+
+// is that the configuration is enabled or not, will be updated by configuration
+let enabled = $state(false);
+
+// Responsible to display the toast notifications in case of tasks
+// subscribe to the tasks and keep a local copy there
+// it allows to compare when tasks are updated
+
+function handleTasks(tasks: TaskInfo[]): void {
+  // grab the tasks that are not in the currentTasks
+  const newTasks = tasks.filter(task => !currentTasks.find(currentTask => currentTask.id === task.id));
+
+  // get the existing one that we should update
+  const toUpdateTasks = tasks.filter(task => currentTasks.find(currentTask => currentTask.id === task.id));
+
+  // get deleted tasks
+  const toDeleteTasks = currentTasks.filter(currentTask => !tasks.find(task => task.id === currentTask.id));
+
+  console;
+  // for the new one, create the notification
+  for (const taskInfo of newTasks) {
+    const number = displayNewToast(taskInfo);
+    currentTasks.push({ ...taskInfo, toastId: number });
+  }
+
+  // for the existing one, update the toast
+  for (const taskInfo of toUpdateTasks) {
+    const currentTask = currentTasks.find(currentTask => currentTask.id === taskInfo.id);
+
+    if (currentTask) {
+      // replace the task in the currentTasks
+      currentTasks.splice(currentTasks.indexOf(currentTask), 1, { ...taskInfo, toastId: currentTask.toastId });
+      toast.set(currentTask.toastId, createToastOptions(taskInfo));
+    }
+  }
+
+  // remove from currentTasks all the items from deletedTasks
+  for (const taskInfo of toDeleteTasks) {
+    currentTasks.splice(currentTasks.indexOf(taskInfo), 1);
+    toast.pop(taskInfo.toastId);
+  }
+}
+
+// create a toast with a custom UI
+function createToastOptions(taskInfo: TaskInfo): SvelteToastOptions {
+  const src = ToastCustomUi as unknown as ComponentType;
+
+  return {
+    component: {
+      src,
+      props: {
+        taskInfo,
+      },
+      sendIdTo: 'toastId',
+    },
+    dismissable: false,
+    initial: 0,
+  };
+}
+
+function displayNewToast(taskInfo: TaskInfo): number {
+  const toastOptions = createToastOptions(taskInfo);
+  return toast.push(taskInfo.name, toastOptions);
+}
+
+onMount(async () => {
+  // read initial value
+  enabled = (await window.getConfigurationValue<boolean>(CONFIGURATION_KEY)) ?? false;
+
+  // update the enabled flag each time the configuration properties is updated
+  onDidChangeConfiguration.addEventListener(CONFIGURATION_KEY, obj => {
+    if ('detail' in obj) {
+      const detail = obj.detail as { key: string; value: boolean };
+      if (CONFIGURATION_KEY === detail?.key) {
+        enabled = detail.value;
+        if (!enabled) {
+          toast.pop(0);
+          currentTasks.length = 0;
+        }
+      }
+    }
+  });
+
+  // create/update toasts when tasks are updated
+  tasksInfo.subscribe(tasks => {
+    if (enabled) {
+      handleTasks(tasks);
+    }
+  });
+});
+</script>

--- a/packages/renderer/src/lib/toast/ToastTaskNotifications.svelte
+++ b/packages/renderer/src/lib/toast/ToastTaskNotifications.svelte
@@ -36,7 +36,6 @@ function handleTasks(tasks: TaskInfo[]): void {
   // get deleted tasks
   const toDeleteTasks = currentTasks.filter(currentTask => !tasks.find(task => task.id === currentTask.id));
 
-  console;
   // for the new one, create the notification
   for (const taskInfo of newTasks) {
     const number = displayNewToast(taskInfo);


### PR DESCRIPTION
### What does this PR do?
Allow to display a toast when tasks are created

### Screenshot / video of UI


https://github.com/user-attachments/assets/b1a8ceed-b975-4252-86d0-f295bcb0b2ad



### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/7399

### How to test this PR?

Enable the flag in preferences screen then open long taks with progress (like bootc build image) or stuff from AI Lab

- [x] Tests are covering the bug fix or the new feature
