### PR TITLE
feat: refresh button in Kubernetes empty pages

### DIFF
--- a/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretEmptyScreen.svelte
+++ b/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretEmptyScreen.svelte
@@ -2,9 +2,13 @@
 import { EmptyScreen } from '@podman-desktop/ui-svelte';
 
 import ConfigMapSecretIcon from '../images/ConfigMapSecretIcon.svelte';
+import KubernetesCheckConnection from '../ui/KubernetesCheckConnection.svelte';
 </script>
 
 <EmptyScreen
   icon={ConfigMapSecretIcon}
   title="No configmaps or secrets"
-  message="Try switching to a different context or namespace" />
+  message="Try switching to a different context or namespace">
+  <KubernetesCheckConnection />
+</EmptyScreen>
+

--- a/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretEmptyScreen.svelte
+++ b/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretEmptyScreen.svelte
@@ -1,14 +1,10 @@
 <script lang="ts">
-import { EmptyScreen } from '@podman-desktop/ui-svelte';
-
 import ConfigMapSecretIcon from '../images/ConfigMapSecretIcon.svelte';
-import KubernetesCheckConnection from '../ui/KubernetesCheckConnection.svelte';
+import KubernetesEmptyScreen from '../kube/KubernetesEmptyScreen.svelte';
 </script>
 
-<EmptyScreen
+<KubernetesEmptyScreen
   icon={ConfigMapSecretIcon}
   title="No configmaps or secrets"
-  message="Try switching to a different context or namespace">
-  <KubernetesCheckConnection />
-</EmptyScreen>
+  message="Try switching to a different context or namespace" />
 

--- a/packages/renderer/src/lib/deployments/DeploymentEmptyScreen.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentEmptyScreen.svelte
@@ -1,11 +1,7 @@
 <script lang="ts">
-import { EmptyScreen } from '@podman-desktop/ui-svelte';
-
 import DeploymentIcon from '../images/DeploymentIcon.svelte';
-import KubernetesCheckConnection from '../ui/KubernetesCheckConnection.svelte';
+import KubernetesEmptyScreen from '../kube/KubernetesEmptyScreen.svelte';
 </script>
 
-<EmptyScreen icon={DeploymentIcon} title="No deployments" message="Try switching to a different context or namespace">
-  <KubernetesCheckConnection />
-</EmptyScreen>
+<KubernetesEmptyScreen icon={DeploymentIcon} title="No deployments" message="Try switching to a different context or namespace" />
 

--- a/packages/renderer/src/lib/deployments/DeploymentEmptyScreen.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentEmptyScreen.svelte
@@ -2,6 +2,10 @@
 import { EmptyScreen } from '@podman-desktop/ui-svelte';
 
 import DeploymentIcon from '../images/DeploymentIcon.svelte';
+import KubernetesCheckConnection from '../ui/KubernetesCheckConnection.svelte';
 </script>
 
-<EmptyScreen icon={DeploymentIcon} title="No deployments" message="Try switching to a different context or namespace" />
+<EmptyScreen icon={DeploymentIcon} title="No deployments" message="Try switching to a different context or namespace">
+  <KubernetesCheckConnection />
+</EmptyScreen>
+

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteEmptyScreen.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteEmptyScreen.svelte
@@ -1,14 +1,10 @@
 <script lang="ts">
-import { EmptyScreen } from '@podman-desktop/ui-svelte';
-
 import IngressRouteIcon from '../images/IngressRouteIcon.svelte';
-import KubernetesCheckConnection from '../ui/KubernetesCheckConnection.svelte';
+import KubernetesEmptyScreen from '../kube/KubernetesEmptyScreen.svelte';
 </script>
 
-<EmptyScreen
+<KubernetesEmptyScreen
   icon={IngressRouteIcon}
   title="No ingresses or routes"
-  message="Try switching to a different context or namespace">
-  <KubernetesCheckConnection />
-</EmptyScreen>
+  message="Try switching to a different context or namespace" />
 

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteEmptyScreen.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteEmptyScreen.svelte
@@ -2,9 +2,13 @@
 import { EmptyScreen } from '@podman-desktop/ui-svelte';
 
 import IngressRouteIcon from '../images/IngressRouteIcon.svelte';
+import KubernetesCheckConnection from '../ui/KubernetesCheckConnection.svelte';
 </script>
 
 <EmptyScreen
   icon={IngressRouteIcon}
   title="No ingresses or routes"
-  message="Try switching to a different context or namespace" />
+  message="Try switching to a different context or namespace">
+  <KubernetesCheckConnection />
+</EmptyScreen>
+

--- a/packages/renderer/src/lib/kube/KubernetesEmptyScreen.spec.ts
+++ b/packages/renderer/src/lib/kube/KubernetesEmptyScreen.spec.ts
@@ -1,0 +1,49 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { faRefresh } from '@fortawesome/free-solid-svg-icons';
+import * as uiSvelte from '@podman-desktop/ui-svelte';
+import { render } from '@testing-library/svelte';
+import { expect, test, vi } from 'vitest';
+
+import * as kubernetesCheckConnection from '/@/lib/ui/KubernetesCheckConnection.svelte';
+
+import KubernetesEmptyScreen from './KubernetesEmptyScreen.svelte';
+
+test('KubernetesCheckConnection is called', async () => {
+  const kubernetesCheckConnectionSpy = vi.spyOn(kubernetesCheckConnection, 'default');
+  render(KubernetesEmptyScreen);
+  expect(kubernetesCheckConnectionSpy).toHaveBeenCalledWith(expect.anything(), {});
+});
+
+test('EmptyScreen is called with properties', async () => {
+  const emptyScreenSpy = vi.spyOn(uiSvelte, 'EmptyScreen');
+  render(KubernetesEmptyScreen, {
+    icon: faRefresh,
+    title: 'A TITLE',
+    message: 'A MESSAGE',
+  });
+  expect(emptyScreenSpy).toHaveBeenCalledWith(
+    expect.anything(),
+    expect.objectContaining({
+      icon: faRefresh,
+      title: 'A TITLE',
+      message: 'A MESSAGE',
+    }),
+  );
+});

--- a/packages/renderer/src/lib/kube/KubernetesEmptyScreen.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesEmptyScreen.svelte
@@ -1,7 +1,7 @@
 <script lang='ts'>
 import { EmptyScreen } from '@podman-desktop/ui-svelte';
 
-import KubernetesCheckConnection from '../ui/KubernetesCheckConnection.svelte';
+import KubernetesCheckConnection from '/@/lib/ui/KubernetesCheckConnection.svelte';
 
 export let icon: any;
 </script>

--- a/packages/renderer/src/lib/kube/KubernetesEmptyScreen.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesEmptyScreen.svelte
@@ -1,0 +1,11 @@
+<script lang='ts'>
+import { EmptyScreen } from '@podman-desktop/ui-svelte';
+
+import KubernetesCheckConnection from '../ui/KubernetesCheckConnection.svelte';
+
+export let icon: any;
+</script>
+
+<EmptyScreen icon={icon} {...$$props}>
+  <KubernetesCheckConnection />
+</EmptyScreen>

--- a/packages/renderer/src/lib/kube/KubernetesEmptyScreen.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesEmptyScreen.svelte
@@ -1,11 +1,12 @@
 <script lang='ts'>
 import { EmptyScreen } from '@podman-desktop/ui-svelte';
+import type { ComponentProps } from 'svelte';
 
 import KubernetesCheckConnection from '/@/lib/ui/KubernetesCheckConnection.svelte';
 
-export let icon: any;
+let { icon, ...restProps }: ComponentProps<EmptyScreen> = $props();
 </script>
 
-<EmptyScreen icon={icon} {...$$props}>
+<EmptyScreen icon={icon} {...restProps}>
   <KubernetesCheckConnection />
 </EmptyScreen>

--- a/packages/renderer/src/lib/node/NodeEmptyScreen.svelte
+++ b/packages/renderer/src/lib/node/NodeEmptyScreen.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
-import { EmptyScreen } from '@podman-desktop/ui-svelte';
-
 import { kubernetesCurrentContextState } from '/@/stores/kubernetes-contexts-state';
 import type { ContextGeneralState } from '/@api/kubernetes-contexts-states';
 
 import NodeIcon from '../images/NodeIcon.svelte';
-import KubernetesCheckConnection from '../ui/KubernetesCheckConnection.svelte';
+import KubernetesEmptyScreen from '../kube/KubernetesEmptyScreen.svelte';
 
 // If the current context is CONNECTED and we are on this empty screen
 // say that you may not have permission to view the nodes on your cluster.
@@ -20,6 +18,4 @@ function getText(state: ContextGeneralState | undefined): string {
 $: text = getText($kubernetesCurrentContextState);
 </script>
 
-<EmptyScreen icon={NodeIcon} title="No nodes" message={text}>
-  <KubernetesCheckConnection />
-</EmptyScreen>
+<KubernetesEmptyScreen icon={NodeIcon} title="No nodes" message={text} />

--- a/packages/renderer/src/lib/node/NodeEmptyScreen.svelte
+++ b/packages/renderer/src/lib/node/NodeEmptyScreen.svelte
@@ -5,6 +5,7 @@ import { kubernetesCurrentContextState } from '/@/stores/kubernetes-contexts-sta
 import type { ContextGeneralState } from '/@api/kubernetes-contexts-states';
 
 import NodeIcon from '../images/NodeIcon.svelte';
+import KubernetesCheckConnection from '../ui/KubernetesCheckConnection.svelte';
 
 // If the current context is CONNECTED and we are on this empty screen
 // say that you may not have permission to view the nodes on your cluster.
@@ -19,4 +20,6 @@ function getText(state: ContextGeneralState | undefined): string {
 $: text = getText($kubernetesCurrentContextState);
 </script>
 
-<EmptyScreen icon={NodeIcon} title="No nodes" message={text} />
+<EmptyScreen icon={NodeIcon} title="No nodes" message={text}>
+  <KubernetesCheckConnection />
+</EmptyScreen>

--- a/packages/renderer/src/lib/pvc/PVCEmptyScreen.svelte
+++ b/packages/renderer/src/lib/pvc/PVCEmptyScreen.svelte
@@ -2,6 +2,9 @@
 import { EmptyScreen } from '@podman-desktop/ui-svelte';
 
 import PVCIcon from '../images/PVCIcon.svelte';
+import KubernetesCheckConnection from '../ui/KubernetesCheckConnection.svelte';
 </script>
 
-<EmptyScreen icon={PVCIcon} title="No PVCs" message="Try switching to a different context or namespace" />
+<EmptyScreen icon={PVCIcon} title="No PVCs" message="Try switching to a different context or namespace">
+  <KubernetesCheckConnection />
+</EmptyScreen>

--- a/packages/renderer/src/lib/pvc/PVCEmptyScreen.svelte
+++ b/packages/renderer/src/lib/pvc/PVCEmptyScreen.svelte
@@ -1,10 +1,6 @@
 <script lang="ts">
-import { EmptyScreen } from '@podman-desktop/ui-svelte';
-
 import PVCIcon from '../images/PVCIcon.svelte';
-import KubernetesCheckConnection from '../ui/KubernetesCheckConnection.svelte';
+import KubernetesEmptyScreen from '../kube/KubernetesEmptyScreen.svelte';
 </script>
 
-<EmptyScreen icon={PVCIcon} title="No PVCs" message="Try switching to a different context or namespace">
-  <KubernetesCheckConnection />
-</EmptyScreen>
+<KubernetesEmptyScreen icon={PVCIcon} title="No PVCs" message="Try switching to a different context or namespace" />

--- a/packages/renderer/src/lib/service/ServiceEmptyScreen.svelte
+++ b/packages/renderer/src/lib/service/ServiceEmptyScreen.svelte
@@ -2,6 +2,9 @@
 import { EmptyScreen } from '@podman-desktop/ui-svelte';
 
 import ServiceIcon from '../images/ServiceIcon.svelte';
+import KubernetesCheckConnection from '../ui/KubernetesCheckConnection.svelte';
 </script>
 
-<EmptyScreen icon={ServiceIcon} title="No services" message="Try switching to a different context or namespace" />
+<EmptyScreen icon={ServiceIcon} title="No services" message="Try switching to a different context or namespace">
+  <KubernetesCheckConnection />
+</EmptyScreen>

--- a/packages/renderer/src/lib/service/ServiceEmptyScreen.svelte
+++ b/packages/renderer/src/lib/service/ServiceEmptyScreen.svelte
@@ -1,10 +1,6 @@
 <script lang="ts">
-import { EmptyScreen } from '@podman-desktop/ui-svelte';
-
 import ServiceIcon from '../images/ServiceIcon.svelte';
-import KubernetesCheckConnection from '../ui/KubernetesCheckConnection.svelte';
+import KubernetesEmptyScreen from '../kube/KubernetesEmptyScreen.svelte';
 </script>
 
-<EmptyScreen icon={ServiceIcon} title="No services" message="Try switching to a different context or namespace">
-  <KubernetesCheckConnection />
-</EmptyScreen>
+<KubernetesEmptyScreen icon={ServiceIcon} title="No services" message="Try switching to a different context or namespace" />

--- a/packages/renderer/src/lib/ui/KubernetesCheckConnection.spec.ts
+++ b/packages/renderer/src/lib/ui/KubernetesCheckConnection.spec.ts
@@ -1,0 +1,113 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { writable } from 'svelte/store';
+import { expect, test, vi } from 'vitest';
+
+import * as kubernetesContextsStore from '/@/stores/kubernetes-contexts';
+import * as kubernetesContextsStateStore from '/@/stores/kubernetes-contexts-state';
+import type { KubeContext } from '/@api/kubernetes-context';
+import type { ContextGeneralState } from '/@api/kubernetes-contexts-states';
+
+import KubernetesCheckConnection from './KubernetesCheckConnection.svelte';
+
+vi.mock('/@/stores/kubernetes-contexts-state');
+vi.mock('/@/stores/kubernetes-contexts');
+
+test('button is displayed and active if current context is defined and is not reachable', async () => {
+  vi.mocked(kubernetesContextsStore).kubernetesContexts = writable<KubeContext[]>([
+    {
+      name: 'context1',
+      cluster: 'cluster1',
+      user: 'user1',
+      currentContext: true,
+    },
+  ]);
+  vi.mocked(kubernetesContextsStateStore).kubernetesCurrentContextState = writable<ContextGeneralState>({
+    reachable: false,
+    resources: { pods: 0, deployments: 0 },
+  });
+  vi.mocked(kubernetesContextsStateStore).kubernetesContextsCheckingStateDelayed = writable<Map<string, boolean>>();
+  render(KubernetesCheckConnection);
+  const button = screen.queryByRole('button');
+  expect(button).toBeInTheDocument();
+  expect(button).toHaveProperty('disabled', false);
+});
+
+test('button is not displayed if current context is defined and is reachable', async () => {
+  vi.mocked(kubernetesContextsStore).kubernetesContexts = writable<KubeContext[]>([
+    {
+      name: 'context1',
+      cluster: 'cluster1',
+      user: 'user1',
+      currentContext: true,
+    },
+  ]);
+  vi.mocked(kubernetesContextsStateStore).kubernetesCurrentContextState = writable<ContextGeneralState>({
+    reachable: true,
+    resources: { pods: 0, deployments: 0 },
+  });
+  vi.mocked(kubernetesContextsStateStore).kubernetesContextsCheckingStateDelayed = writable<Map<string, boolean>>();
+  render(KubernetesCheckConnection);
+  const button = screen.queryByRole('button');
+  expect(button).toBeNull();
+});
+
+test('button is not displayed if no current context', async () => {
+  vi.mocked(kubernetesContextsStore).kubernetesContexts = writable<KubeContext[]>([
+    {
+      name: 'context1',
+      cluster: 'cluster1',
+      user: 'user1',
+      currentContext: false,
+    },
+  ]);
+  vi.mocked(kubernetesContextsStateStore).kubernetesCurrentContextState = writable<ContextGeneralState>({
+    reachable: false,
+    resources: { pods: 0, deployments: 0 },
+  });
+  vi.mocked(kubernetesContextsStateStore).kubernetesContextsCheckingStateDelayed = writable<Map<string, boolean>>();
+  render(KubernetesCheckConnection);
+  const button = screen.queryByRole('button');
+  expect(button).toBeNull();
+});
+
+test('button is displayed and disabled if current context is defined, is not reacahble and is being checked', async () => {
+  vi.mocked(kubernetesContextsStore).kubernetesContexts = writable<KubeContext[]>([
+    {
+      name: 'context1',
+      cluster: 'cluster1',
+      user: 'user1',
+      currentContext: true,
+    },
+  ]);
+  vi.mocked(kubernetesContextsStateStore).kubernetesCurrentContextState = writable<ContextGeneralState>({
+    reachable: false,
+    resources: { pods: 0, deployments: 0 },
+  });
+  vi.mocked(kubernetesContextsStateStore).kubernetesContextsCheckingStateDelayed = writable<Map<string, boolean>>(
+    new Map([['context1', true]]),
+  );
+  render(KubernetesCheckConnection);
+  const button = screen.queryByRole('button');
+  expect(button).toBeInTheDocument();
+  expect(button).toHaveProperty('disabled', true);
+});

--- a/packages/renderer/src/lib/ui/KubernetesCheckConnection.svelte
+++ b/packages/renderer/src/lib/ui/KubernetesCheckConnection.svelte
@@ -2,12 +2,11 @@
 import { faRefresh } from '@fortawesome/free-solid-svg-icons';
 import { Button } from '@podman-desktop/ui-svelte';
 
+import { kubernetesContexts } from '/@/stores/kubernetes-contexts';
 import {
   kubernetesContextsCheckingStateDelayed,
   kubernetesCurrentContextState,
 } from '/@/stores/kubernetes-contexts-state';
-
-import { kubernetesContexts } from '../../stores/kubernetes-contexts';
 
 let currentContextName: string | undefined;
 $: currentContextName = $kubernetesContexts.find(c => c.currentContext)?.name;

--- a/packages/renderer/src/lib/ui/KubernetesCheckConnection.svelte
+++ b/packages/renderer/src/lib/ui/KubernetesCheckConnection.svelte
@@ -11,17 +11,23 @@ import { kubernetesContexts } from '../../stores/kubernetes-contexts';
 
 let currentContextName: string | undefined;
 $: currentContextName = $kubernetesContexts.find(c => c.currentContext)?.name;
+let error: string = '';
 
 function refresh(): void {
+  error = '';
   if (currentContextName) {
-    window.kubernetesRefreshContextState(currentContextName);
+    window.kubernetesRefreshContextState(currentContextName).catch((err: unknown) => {
+      error = String(err);
+    });
   }
 }
 </script>
+
 {#if currentContextName && !$kubernetesCurrentContextState.reachable}
   <Button 
     on:click={refresh}
     icon={faRefresh}
     inProgress={$kubernetesContextsCheckingStateDelayed?.get(currentContextName)}
     >Refresh</Button>
+  {#if error}<div class="p-2 text-[var(--pd-state-error)]">{error}</div>{/if}
 {/if}

--- a/packages/renderer/src/lib/ui/KubernetesCheckConnection.svelte
+++ b/packages/renderer/src/lib/ui/KubernetesCheckConnection.svelte
@@ -8,9 +8,8 @@ import {
   kubernetesCurrentContextState,
 } from '/@/stores/kubernetes-contexts-state';
 
-let currentContextName: string | undefined;
-$: currentContextName = $kubernetesContexts.find(c => c.currentContext)?.name;
-let error: string = '';
+let currentContextName = $derived($kubernetesContexts.find(c => c.currentContext)?.name);
+let error = $state('');
 
 function refresh(): void {
   error = '';

--- a/packages/renderer/src/lib/ui/KubernetesCheckConnection.svelte
+++ b/packages/renderer/src/lib/ui/KubernetesCheckConnection.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+import { faRefresh } from '@fortawesome/free-solid-svg-icons';
+import { Button } from '@podman-desktop/ui-svelte';
+
+import {
+  kubernetesContextsCheckingStateDelayed,
+  kubernetesCurrentContextState,
+} from '/@/stores/kubernetes-contexts-state';
+
+import { kubernetesContexts } from '../../stores/kubernetes-contexts';
+
+let currentContextName: string | undefined;
+$: currentContextName = $kubernetesContexts.find(c => c.currentContext)?.name;
+
+function refresh(): void {
+  if (currentContextName) {
+    window.kubernetesRefreshContextState(currentContextName);
+  }
+}
+</script>
+{#if currentContextName && !$kubernetesCurrentContextState.reachable}
+  <Button 
+    on:click={refresh}
+    icon={faRefresh}
+    inProgress={$kubernetesContextsCheckingStateDelayed?.get(currentContextName)}
+    >Refresh</Button>
+{/if}


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Frontend part of #8341 

Adds a `Refresh` button to the Kubernetes page when the context is not reachable.

The button is disabled and in progress when the context connectivity is being checked.

### Screenshot / video of UI


https://github.com/user-attachments/assets/7559d508-d055-44ec-82f4-aa76726170e1


### What issues does this PR fix or reference?

Fixes #8341 

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
