### PR TITLE
fix: remove extra v from release notes link

### DIFF
--- a/packages/main/src/plugin/updater.spec.ts
+++ b/packages/main/src/plugin/updater.spec.ts
@@ -600,6 +600,10 @@ test('open release notes from podman-desktop.io', async () => {
   expect(shell.openExternal).toBeCalledWith('appHomepage/blog/podman-desktop-release-1.1');
   await updater.openReleaseNotes('latest');
   expect(shell.openExternal).toBeCalledWith('appHomepage/blog/podman-desktop-release-1.2');
+  await updater.openReleaseNotes('v0.1.1');
+  expect(shell.openExternal).toBeCalledWith('appHomepage/blog/podman-desktop-release-0.1');
+  await updater.openReleaseNotes('0.2.1');
+  expect(shell.openExternal).toBeCalledWith('appHomepage/blog/podman-desktop-release-0.2');
 });
 
 test('open release notes from GitHub', async () => {
@@ -627,6 +631,10 @@ test('open release notes from GitHub', async () => {
   expect(shell.openExternal).toBeCalledWith('appRepo/releases/tag/v0.20.0');
   await updater.openReleaseNotes('latest');
   expect(shell.openExternal).toBeCalledWith('appRepo/releases/tag/v0.21.0');
+  await updater.openReleaseNotes('v1.1.1');
+  expect(shell.openExternal).toBeCalledWith('appRepo/releases/tag/v1.1.1');
+  await updater.openReleaseNotes('1.1.2');
+  expect(shell.openExternal).toBeCalledWith('appRepo/releases/tag/v1.1.2');
 });
 
 test('get release notes', async () => {

--- a/packages/main/src/plugin/updater.ts
+++ b/packages/main/src/plugin/updater.ts
@@ -72,8 +72,13 @@ export class Updater {
     if (version === 'current') {
       version = app.getVersion();
     } else if (version === 'latest') {
-      version = this.#nextVersion?.substring(1) ?? '';
+      version = this.#nextVersion ?? '';
     }
+
+    if (version.startsWith('v')) {
+      version = version.substring(1);
+    }
+
     const urlVersionFormat = version.split('.', 2).join('.');
     let notesURL = `${homepage}/blog/podman-desktop-release-${urlVersionFormat}`;
     https.get(notesURL, res => {


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR fixes the release notes link when there is an extra or unwanted v before the version number

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/containers/podman-desktop/issues/9447

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
