### PR TITLE
chore: prevent default button action (submitting form)

### DIFF
--- a/packages/ui/src/lib/dropdown/Dropdown.spec.ts
+++ b/packages/ui/src/lib/dropdown/Dropdown.spec.ts
@@ -17,9 +17,9 @@
  ***********************************************************************/
 import '@testing-library/jest-dom/vitest';
 
-import { render, screen } from '@testing-library/svelte';
+import { createEvent, fireEvent, render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 
 import Dropdown from './Dropdown.svelte';
 import DropdownTest from './DropdownTest.svelte';
@@ -39,6 +39,18 @@ test('initial value is visible', async () => {
   const input = screen.getByRole('button');
   expect(input).toBeInTheDocument();
   expect(input).toHaveTextContent('a value');
+});
+
+test('opening dropdown does not submit forms (prevents default button action)', async () => {
+  render(Dropdown);
+
+  const input = screen.getByRole('button');
+  expect(input).toBeInTheDocument();
+
+  const event = createEvent.click(input);
+  event.preventDefault = vi.fn();
+  await fireEvent(input, event);
+  expect(event.preventDefault).toHaveBeenCalled();
 });
 
 test('disabling changes state and styling', async () => {

--- a/packages/ui/src/lib/dropdown/Dropdown.svelte
+++ b/packages/ui/src/lib/dropdown/Dropdown.svelte
@@ -131,12 +131,13 @@ function onSelect(e: Event, newValue: unknown): void {
   e.preventDefault();
 }
 
-function toggleOpen(): void {
+function toggleOpen(e: Event): void {
   if (opened) {
     close();
   } else {
     open();
   }
+  e.preventDefault();
 }
 
 function open(): void {


### PR DESCRIPTION
### What does this PR do?

Dropdown uses a button to open, and buttons auto-submit any form they're in when you click. Just needs a preventDefault to avoid this.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #9490.

### How to test this PR?

Just make sure you can create a Kind or Podman instance normally, without the dropdown triggering the form.

- [x] Tests are covering the bug fix or the new feature