### PR TITLE
fix: update Updater button names to fit in message box - 1.13.x

### DIFF
--- a/packages/main/src/plugin/updater.spec.ts
+++ b/packages/main/src/plugin/updater.spec.ts
@@ -419,7 +419,7 @@ describe('expect update command to depends on context', async () => {
 
     expect(messageBoxMock.showMessageBox).toHaveBeenCalledWith({
       cancelId: 2,
-      buttons: ['Update now', "What's new", 'Remind me later', "Don't show again"],
+      buttons: ['Update now', `What's new`, 'Remind me later', `Don't show again`],
       message:
         'A new version v@debug-next of Podman Desktop is available. Do you want to update your current version v@debug?',
       title: 'Update Available now',
@@ -435,7 +435,7 @@ describe('expect update command to depends on context', async () => {
 
     expect(messageBoxMock.showMessageBox).toHaveBeenCalledWith({
       cancelId: 2,
-      buttons: ['Update now', "What's new", 'Cancel'],
+      buttons: ['Update now', `What's new`, 'Cancel'],
       message:
         'A new version v@debug-next of Podman Desktop is available. Do you want to update your current version v@debug?',
       title: 'Update Available now',

--- a/packages/main/src/plugin/updater.spec.ts
+++ b/packages/main/src/plugin/updater.spec.ts
@@ -419,7 +419,7 @@ describe('expect update command to depends on context', async () => {
 
     expect(messageBoxMock.showMessageBox).toHaveBeenCalledWith({
       cancelId: 2,
-      buttons: ['Update now', 'View release notes', 'Remind me later', 'Do not show again'],
+      buttons: ['Update now', "What's new", 'Remind me later', "Don't show again"],
       message:
         'A new version v@debug-next of Podman Desktop is available. Do you want to update your current version v@debug?',
       title: 'Update Available now',
@@ -435,7 +435,7 @@ describe('expect update command to depends on context', async () => {
 
     expect(messageBoxMock.showMessageBox).toHaveBeenCalledWith({
       cancelId: 2,
-      buttons: ['Update now', 'View release notes', 'Cancel'],
+      buttons: ['Update now', "What's new", 'Cancel'],
       message:
         'A new version v@debug-next of Podman Desktop is available. Do you want to update your current version v@debug?',
       title: 'Update Available now',

--- a/packages/main/src/plugin/updater.ts
+++ b/packages/main/src/plugin/updater.ts
@@ -214,9 +214,9 @@ export class Updater {
 
       let buttons: string[];
       if (context === 'startup') {
-        buttons = ['Update now', 'View release notes', 'Remind me later', 'Do not show again'];
+        buttons = ['Update now', "What's new", 'Remind me later', "Don't show again"];
       } else {
-        buttons = ['Update now', 'View release notes', 'Cancel'];
+        buttons = ['Update now', "What's new", 'Cancel'];
       }
 
       const result = await this.messageBox.showMessageBox({

--- a/packages/main/src/plugin/updater.ts
+++ b/packages/main/src/plugin/updater.ts
@@ -214,9 +214,9 @@ export class Updater {
 
       let buttons: string[];
       if (context === 'startup') {
-        buttons = ['Update now', "What's new", 'Remind me later', "Don't show again"];
+        buttons = ['Update now', `What's new`, 'Remind me later', `Don't show again`];
       } else {
-        buttons = ['Update now', "What's new", 'Cancel'];
+        buttons = ['Update now', `What's new`, 'Cancel'];
       }
 
       const result = await this.messageBox.showMessageBox({

--- a/tests/playwright/src/specs/installation/update-install.spec.ts
+++ b/tests/playwright/src/specs/installation/update-install.spec.ts
@@ -49,7 +49,7 @@ test.describe.serial('Podman Desktop Update Update installation offering @update
     await playExpect(updateAvailableDialog).toBeVisible();
     const updateNowButton = updateAvailableDialog.getByRole('button', { name: 'Update Now' });
     await playExpect(updateNowButton).toBeVisible();
-    const doNotshowButton = updateAvailableDialog.getByRole('button', { name: 'Do not show again' });
+    const doNotshowButton = updateAvailableDialog.getByRole('button', { name: `Don't show again` });
     await playExpect(doNotshowButton).toBeVisible();
     const cancelButton = updateAvailableDialog.getByRole('button', { name: 'Cancel' });
     await playExpect(cancelButton).toBeVisible();


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR shortens the text of some of the updater button to fit in the message box

### Screenshot / video of UI
![Screenshot from 2024-10-21 10-00-12](https://github.com/user-attachments/assets/dc95fd31-3153-4b89-893f-5359ca1b92dc)


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
https://github.com/containers/podman-desktop/issues/9393

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
