### PR TITLE
refactor: context checking state as derived store

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
@@ -25,7 +25,7 @@ import { beforeEach, expect, test, vi } from 'vitest';
 import { kubernetesContexts } from '/@/stores/kubernetes-contexts';
 import * as kubernetesContextsState from '/@/stores/kubernetes-contexts-state';
 import type { KubeContext } from '/@api/kubernetes-context';
-import type { CheckingState, ContextGeneralState } from '/@api/kubernetes-contexts-states';
+import type { ContextGeneralState } from '/@api/kubernetes-contexts-states';
 
 import PreferencesKubernetesContextsRendering from './PreferencesKubernetesContextsRendering.svelte';
 
@@ -75,7 +75,7 @@ beforeEach(() => {
 
 test('test that name, cluster and the server is displayed when rendering', async () => {
   vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextGeneralState>>(new Map());
-  vi.mocked(kubernetesContextsState).kubernetesContextsCheckingState = readable<Map<string, CheckingState>>(new Map());
+  vi.mocked(kubernetesContextsState).kubernetesContextsCheckingStateDelayed = readable<Map<string, boolean>>(new Map());
   (window as any).kubernetesGetCurrentContextName = vi.fn().mockResolvedValue('my-current-context');
   render(PreferencesKubernetesContextsRendering, {});
   expect(await screen.findByText('context-name')).toBeInTheDocument();
@@ -86,14 +86,14 @@ test('test that name, cluster and the server is displayed when rendering', async
 
 test('Test that namespace is displayed when available in the context', async () => {
   vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextGeneralState>>(new Map());
-  vi.mocked(kubernetesContextsState).kubernetesContextsCheckingState = readable<Map<string, CheckingState>>(new Map());
+  vi.mocked(kubernetesContextsState).kubernetesContextsCheckingStateDelayed = readable<Map<string, boolean>>(new Map());
   render(PreferencesKubernetesContextsRendering, {});
   expect(await screen.findByText('namespace-name3')).toBeInTheDocument();
 });
 
 test('If nothing is returned for contexts, expect that the page shows a message', async () => {
   vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextGeneralState>>(new Map());
-  vi.mocked(kubernetesContextsState).kubernetesContextsCheckingState = readable<Map<string, CheckingState>>(new Map());
+  vi.mocked(kubernetesContextsState).kubernetesContextsCheckingStateDelayed = readable<Map<string, boolean>>(new Map());
   kubernetesContexts.set([]);
   render(PreferencesKubernetesContextsRendering, {});
   expect(await screen.findByText('No Kubernetes contexts found')).toBeInTheDocument();
@@ -101,7 +101,7 @@ test('If nothing is returned for contexts, expect that the page shows a message'
 
 test('Test that context-name2 is the current context', async () => {
   vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextGeneralState>>(new Map());
-  vi.mocked(kubernetesContextsState).kubernetesContextsCheckingState = readable<Map<string, CheckingState>>(new Map());
+  vi.mocked(kubernetesContextsState).kubernetesContextsCheckingStateDelayed = readable<Map<string, boolean>>(new Map());
   (window as any).kubernetesGetCurrentContextName = vi.fn().mockResolvedValue('context-name2');
   render(PreferencesKubernetesContextsRendering, {});
 
@@ -119,7 +119,7 @@ test('Test that context-name2 is the current context', async () => {
 
 test('when deleting the current context, a popup should ask confirmation', async () => {
   vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextGeneralState>>(new Map());
-  vi.mocked(kubernetesContextsState).kubernetesContextsCheckingState = readable<Map<string, CheckingState>>(new Map());
+  vi.mocked(kubernetesContextsState).kubernetesContextsCheckingStateDelayed = readable<Map<string, boolean>>(new Map());
   const showMessageBoxMock = vi.fn();
   (window as any).showMessageBox = showMessageBoxMock;
   showMessageBoxMock.mockResolvedValue({ result: 1 });
@@ -139,7 +139,7 @@ test('when deleting the current context, a popup should ask confirmation', async
 
 test('when deleting the non current context, no popup should ask confirmation', async () => {
   vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextGeneralState>>(new Map());
-  vi.mocked(kubernetesContextsState).kubernetesContextsCheckingState = readable<Map<string, CheckingState>>(new Map());
+  vi.mocked(kubernetesContextsState).kubernetesContextsCheckingStateDelayed = readable<Map<string, boolean>>(new Map());
   const showMessageBoxMock = vi.fn();
   (window as any).showMessageBox = showMessageBoxMock;
   showMessageBoxMock.mockResolvedValue({ result: 1 });
@@ -174,7 +174,7 @@ test('state and resources counts are displayed in contexts', () => {
     },
   });
   vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextGeneralState>>(state);
-  vi.mocked(kubernetesContextsState).kubernetesContextsCheckingState = readable<Map<string, CheckingState>>(new Map());
+  vi.mocked(kubernetesContextsState).kubernetesContextsCheckingStateDelayed = readable<Map<string, boolean>>(new Map());
   render(PreferencesKubernetesContextsRendering, {});
   const context1 = screen.getAllByRole('row')[0];
   const context2 = screen.getAllByRole('row')[1];


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

In the Settings > Kubernetes page, a spinner is displayed when the connectivity is being checked,to inform the user when the checks happen. A delay of 2 seconds is used, so the spinner is displayed for at least 2 seconds, to make it visible for the user. 

The state used to display the spinner with this delay was computed in the component. This PR moves this computation in a store, so the store can be reused in other pages (in the Kubernetes pages not to name them).

### Screenshot / video of UI


https://github.com/user-attachments/assets/5aaa142f-868b-4c21-85fd-e6b4633dd97a


### What issues does this PR fix or reference?

Part of #8341

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
