### PR TITLE
fix: button name in update-install E2E test

### DIFF
--- a/tests/playwright/src/specs/installation/update-install.spec.ts
+++ b/tests/playwright/src/specs/installation/update-install.spec.ts
@@ -49,7 +49,7 @@ test.describe
       await playExpect(updateAvailableDialog).toBeVisible();
       const updateNowButton = updateAvailableDialog.getByRole('button', { name: 'Update Now' });
       await playExpect(updateNowButton).toBeVisible();
-      const doNotshowButton = updateAvailableDialog.getByRole('button', { name: 'Do not show again' });
+      const doNotshowButton = updateAvailableDialog.getByRole('button', { name: `Don't show again` });
       await playExpect(doNotshowButton).toBeVisible();
       const cancelButton = updateAvailableDialog.getByRole('button', { name: 'Cancel' });
       await playExpect(cancelButton).toBeVisible();


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Updates the `Do not show again` button name to `Don't show again` in the `update-install` test

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
