### PR TITLE
chore: use dropdown component in Kube terminal

### DIFF
--- a/packages/renderer/src/lib/pod/KubernetesTerminalBrowser.svelte
+++ b/packages/renderer/src/lib/pod/KubernetesTerminalBrowser.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { EmptyScreen } from '@podman-desktop/ui-svelte';
+import { Dropdown, EmptyScreen } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 
 import NoLogIcon from '/@/lib/ui/NoLogIcon.svelte';
@@ -53,16 +53,16 @@ function handleSelectionChange(event: Event) {
     </label>
     <div class="w-full">
       {#if pod.containers.length > 1}
-        <select
+        <Dropdown
           on:change={handleSelectionChange}
-          aria-labelledby="listbox-label"
-          class="block w-48 p-1 outline-none text-sm bg-charcoal-800 rounded-sm text-gray-700 placeholder-gray-700"
+          class="w-48"
           name={pod.name}
-          id="input-standard-{pod.name}">
-          {#each pod.containers as container}
-            <option value={container.Names}>{container.Names}</option>
-          {/each}
-        </select>
+          id="input-standard-{pod.name}"
+          options={pod.containers.map(container => ({
+            label: container.Names,
+            value: container.Names,
+          }))}>
+        </Dropdown>
       {:else}
         <span
           id="input-standard-{pod.name}"


### PR DESCRIPTION
### What does this PR do?

Switches the select in the Kube terminal to a Dropdown.

The select control automatically selects the first value if none is provided. Dropdown wasn't doing that so I added the appropriate line, hoping it is small enough to justify including it here.

Remove redundant aria-labelledby (label already points to control).

### Screenshot / video of UI

<img width="385" alt="Screenshot 2024-10-21 at 3 36 06 PM" src="https://github.com/user-attachments/assets/ab387b3e-c8b2-4d53-a2c8-c8aadd2404a6">

### What issues does this PR fix or reference?

Part of #6199.

### How to test this PR?

Deploy a pod to Kubernetes with more than one container, go to pod's Terminal tab.

- [x] Tests are covering the bug fix or the new feature