### PR TITLE
chore: use dropdown component in proxy settings

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { faPen } from '@fortawesome/free-solid-svg-icons';
-import { Button, ErrorMessage, Input } from '@podman-desktop/ui-svelte';
+import { Button, Dropdown, ErrorMessage, Input } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 
 import { ProxyState } from '/@api/proxy';
@@ -67,16 +67,17 @@ function validate(event: any) {
   <div class="flex flex-col bg-[var(--pd-invert-content-card-bg)] rounded-md p-3 space-y-2">
     <!-- if proxy is not enabled, display a toggle -->
 
-    <label for="toggle-proxy" class="inline-flex relative items-center mt-1 mb-4 cursor-pointer"
+    <label for="toggle-proxy" class="flex flex-row items-center mt-1 mb-6 cursor-pointer gap-x-4"
       >Proxy configuration
-      <select
-        class="p-2 outline-none text-sm bg-charcoal-600 rounded-sm text-gray-700 placeholder-gray-700"
+      <Dropdown
+        class="text-sm max-w-28"
         id="toggle-proxy"
-        bind:value={proxyState}>
-        <option value={ProxyState.PROXY_SYSTEM}>System</option>
-        <option value={ProxyState.PROXY_MANUAL}>Manual</option>
-        <option value={ProxyState.PROXY_DISABLED}>Disabled</option>
-      </select>
+        bind:value={proxyState}
+        options={[
+          {value: ProxyState.PROXY_SYSTEM, label:'System'},
+          {value: ProxyState.PROXY_MANUAL, label:'Manual'},
+          {value: ProxyState.PROXY_DISABLED, label:'Disabled'}]}>
+      </Dropdown>
     </label>
 
       <div class="space-y-2">


### PR DESCRIPTION
### What does this PR do?

Switches to use the Dropdown component in the Proxy settings.

### Screenshot / video of UI

Before:

<img width="264" alt="Screenshot 2024-10-21 at 4 04 00 PM" src="https://github.com/user-attachments/assets/29f4f891-fb20-458c-8a31-9c5a82dd2677">

After:

<img width="264" alt="Screenshot 2024-10-21 at 4 11 07 PM" src="https://github.com/user-attachments/assets/21fe5fef-f1d3-457b-ac9f-53d7240b7abf">


### What issues does this PR fix or reference?

Part of #6199.

### How to test this PR?

Just go to Proxy settings.