### PR TITLE
fix: rm packages/main/src/assets from extra resources to get included into app.asar

### DIFF
--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -79,7 +79,7 @@ const config = {
   buildDependenciesFromSource: false,
   npmRebuild: false,
   beforePack: async context => {
-    const DEFAULT_ASSETS = ['packages/main/src/assets/**'];
+    const DEFAULT_ASSETS = [];
     context.packager.config.extraResources = DEFAULT_ASSETS;
 
     // universal build, add both pkg files


### PR DESCRIPTION
Apparently extra resources have higher priority and files included in extra resource are getting dropped out of reqular resources included into  app.asar file.

### What does this PR do?

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

#9507.

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
