### PR TITLE
fix: work on related context, not current context

### DIFF
--- a/packages/main/src/plugin/kubernetes/contexts-manager.spec.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager.spec.ts
@@ -35,6 +35,8 @@ const PODS_DEFAULT = 3;
 const DEPLOYMENTS_NS1 = 4;
 const DEPLOYMENTS_NS2 = 5;
 const DEPLOYMENTS_DEFAULT = 6;
+const NODES_CONTEXT1 = 1;
+const NODES_CONTEXT2 = 2;
 
 class TestContextsManager extends ContextsManager {
   getStates(): ContextsStatesRegistry {
@@ -77,6 +79,14 @@ function fakeMakeInformer(
       return buildFakeInformer(DEPLOYMENTS_NS2);
     case '/apis/apps/v1/namespaces/default/deployments':
       return buildFakeInformer(DEPLOYMENTS_DEFAULT);
+
+    case '/api/v1/nodes':
+      switch (kubeconfig.currentContext) {
+        case 'context1':
+          return buildFakeInformer(NODES_CONTEXT1);
+        case 'context2':
+          return buildFakeInformer(NODES_CONTEXT2);
+      }
   }
   return buildFakeInformer(0);
 }
@@ -2307,7 +2317,75 @@ describe('update', async () => {
       expect.anything(),
     );
   });
+
+  test('switch from non reachable to reachable context should send correct data for second informers', async () => {
+    vi.mocked(makeInformer).mockImplementation(fakeMakeInformer);
+    client = new TestContextsManager(apiSender);
+
+    // nodes informer are registered from frontend
+    client.registerGetCurrentContextResources('nodes');
+
+    const kubeConfig = new kubeclient.KubeConfig();
+    const config = {
+      clusters: [
+        {
+          name: 'cluster1',
+          server: 'server1',
+        },
+        {
+          name: 'cluster2',
+          server: 'server2',
+        },
+      ],
+      users: [
+        {
+          name: 'user1',
+        },
+        {
+          name: 'user2',
+        },
+      ],
+      contexts: [
+        {
+          name: `context1`,
+          cluster: 'cluster1',
+          user: 'user1',
+        },
+        {
+          name: `context2`,
+          cluster: 'cluster2',
+          user: 'user2',
+        },
+      ],
+      currentContext: 'context1',
+    };
+
+    // Start with a non reachable context
+    kubeConfig.loadFromOptions(config);
+    await client.update(kubeConfig);
+    vi.advanceTimersToNextTimer();
+    vi.advanceTimersToNextTimer();
+    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-nodes-update', []);
+    apiSenderSendMock.mockClear();
+
+    // Switch to reachable context
+
+    config.currentContext = 'context2';
+    const kubeConfig2 = new KubeConfig();
+    kubeConfig2.loadFromOptions(config);
+    await client.update(kubeConfig2);
+    vi.advanceTimersToNextTimer();
+    vi.advanceTimersToNextTimer();
+    expect(apiSenderSendMock).not.toHaveBeenCalledWith('kubernetes-current-context-nodes-update', []);
+    expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-current-context-nodes-update', [
+      { metadata: { uid: '0' } },
+      { metadata: { uid: '1' } },
+    ]);
+    vi.advanceTimersByTime(100_000);
+    expect(apiSenderSendMock).not.toHaveBeenCalledWith('kubernetes-current-context-nodes-update', []);
+  });
 });
+
 describe('isContextInKubeconfig', () => {
   let client: ContextsManager;
   beforeAll(async () => {

--- a/packages/main/src/plugin/kubernetes/contexts-manager.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager.ts
@@ -294,7 +294,7 @@ export class ContextsManager {
           resources: { pods: true },
           update: state => {
             if (state.resources.pods.some(o => o.metadata?.uid !== obj.metadata?.uid)) {
-              console.debug(`pod ${obj.metadata?.name} already added in context ${this.kubeConfig.currentContext}`);
+              console.debug(`pod ${obj.metadata?.name} already added in context ${context.name}`);
             }
             state.resources.pods = state.resources.pods.filter(o => o.metadata?.uid !== obj.metadata?.uid);
             state.resources.pods.push(obj);
@@ -334,24 +334,20 @@ export class ContextsManager {
             if (reachable) {
               for (const resourceName of secondaryResources) {
                 if (this.secondaryWatchers.hasSubscribers(resourceName)) {
-                  this.startResourceInformer(this.kubeConfig.currentContext, resourceName);
+                  this.startResourceInformer(context.name, resourceName);
                 }
               }
             } else {
               // Delete secondary informers
               this.informers
-                .disposeSecondaryInformers(this.kubeConfig.currentContext)
+                .disposeSecondaryInformers(context.name)
                 .catch((err: unknown) =>
-                  console.error(
-                    `error disposing secondary informers for context ${this.kubeConfig.currentContext}: ${String(err)}`,
-                  ),
+                  console.error(`error disposing secondary informers for context ${context.name}: ${String(err)}`),
                 );
               this.states
-                .disposeSecondaryStates(this.kubeConfig.currentContext)
+                .disposeSecondaryStates(context.name)
                 .catch((err: unknown) =>
-                  console.error(
-                    `error disposing secondary states for context ${this.kubeConfig.currentContext}: ${String(err)}`,
-                  ),
+                  console.error(`error disposing secondary states for context ${context.name}: ${String(err)}`),
                 );
             }
           },


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

#9443 introduced a problem, the secondary informers were deleted in the current context at the time of stopping them, not on the context the informers were created for. In case the user switches from a non reachable context to a reachable one, the informers for the now accessible current context were deleted.


### What issues does this PR fix or reference?

Part od #6114 

### How to test this PR?

Have 2 contexts, one reachable and the other non reachable.
Switch from 1 context to the other, and check that the resources (nodes, ...) for the reachable one remain visible.

- [x] Tests are covering the bug fix or the new feature
