### PR TITLE
feat: display a spinner when connectivity is being checked in Kubernetes pages 

### DIFF
--- a/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.svelte
+++ b/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.svelte
@@ -21,7 +21,7 @@ function getClassColor(state?: ContextGeneralState): string {
 }
 
 $: text = getText($kubernetesCurrentContextState);
-$: currentContextName = $kubernetesContexts.find(c => c.currentContext)?.name;
+$: currentContextName = $kubernetesContexts?.find(c => c.currentContext)?.name;
 </script>
 
 {#if $kubernetesCurrentContextState}

--- a/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.svelte
+++ b/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
-import { kubernetesCurrentContextState } from '/@/stores/kubernetes-contexts-state';
+import { Spinner } from '@podman-desktop/ui-svelte';
+
+import { kubernetesContexts } from '/@/stores/kubernetes-contexts';
+import {
+  kubernetesContextsCheckingStateDelayed,
+  kubernetesCurrentContextState,
+} from '/@/stores/kubernetes-contexts-state';
 import type { ContextGeneralState } from '/@api/kubernetes-contexts-states';
 
 import Label from './Label.svelte';
@@ -15,9 +21,15 @@ function getClassColor(state?: ContextGeneralState): string {
 }
 
 $: text = getText($kubernetesCurrentContextState);
+$: currentContextName = $kubernetesContexts.find(c => c.currentContext)?.name;
 </script>
 
 {#if $kubernetesCurrentContextState}
-  <Label role="status" name={text} tip={$kubernetesCurrentContextState.error}
-    ><div class="w-2 h-2 {getClassColor($kubernetesCurrentContextState)} rounded-full mx-1"></div></Label>
+  <div class="flex items-center flex-row">
+    {#if !!currentContextName && $kubernetesContextsCheckingStateDelayed?.get(currentContextName)}
+      <div class="mr-1"><Spinner size="12px"></Spinner></div>
+    {/if}
+    <Label role="status" name={text} tip={$kubernetesCurrentContextState.error}
+      ><div class="w-2 h-2 {getClassColor($kubernetesCurrentContextState)} rounded-full mx-1"></div></Label>  
+  </div>
 {/if}

--- a/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.svelte
+++ b/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.svelte
@@ -21,6 +21,7 @@ function getClassColor(state?: ContextGeneralState): string {
 }
 
 $: text = getText($kubernetesCurrentContextState);
+let currentContextName: string | undefined;
 $: currentContextName = $kubernetesContexts?.find(c => c.currentContext)?.name;
 </script>
 


### PR DESCRIPTION
### What does this PR do?

Display a spinner when connectivity is being checked in Kubernetes pages.

Similarly to what is done in the page Settings > Kubernetes

### Screenshot / video of UI

https://github.com/user-attachments/assets/45ae9401-3716-4464-a240-80e5a90615df

### What issues does this PR fix or reference?

Part of #8341 

### How to test this PR?

Have a non reachable context, and go to the different Kubernetes pages, to check that the spinner is displayed regularly

- [x] Tests are covering the bug fix or the new feature
