### PR TITLE
chore(ci): add axes for running e2e tests with production mode of pod…

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -332,15 +332,14 @@ jobs:
           echo "Podman Desktop built binary: $path"
           echo "PODMAN_DESKTOP_BINARY_PATH=$path" >> $GITHUB_ENV
 
-      - name: Run E2E smoke tests
-        if: ${{ matrix.mode == 'development' }}
-        run: pnpm test:e2e:smoke
-
-      - name: Run Smoke E2E tests in Production mode
-        if: ${{ matrix.mode == 'production' }}
+      - name: Run Smoke E2E tests in ${{ matrix.mode }} mode
         env:
           PODMAN_DESKTOP_BINARY: ${{ env.PODMAN_DESKTOP_BINARY_PATH }}
-        run: pnpm test:e2e:smoke
+        run: |
+          if [ ${{ matrix.mode }} == 'production' ]; then
+            export PODMAN_DESKTOP_BINARY=${{ env.PODMAN_DESKTOP_BINARY_PATH }}
+          fi
+          pnpm test:e2e:smoke
 
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -322,7 +322,7 @@ jobs:
       - name: Execute pnpm
         run: pnpm install
 
-      - name: Build Podman Desktop for E2E tests Production Mode
+      - name: Build and Run Podman Desktop E2E tests in Production Mode
         if: ${{ matrix.mode == 'production' }}
         env:
           ELECTRON_ENABLE_INSPECT: true
@@ -330,16 +330,12 @@ jobs:
           pnpm compile:current --linux dir
           path=$(realpath ./dist/linux-unpacked/podman-desktop)
           echo "Podman Desktop built binary: $path"
-          echo "PODMAN_DESKTOP_BINARY_PATH=$path" >> $GITHUB_ENV
-
-      - name: Run Smoke E2E tests in ${{ matrix.mode }} mode
-        env:
-          PODMAN_DESKTOP_BINARY: ${{ env.PODMAN_DESKTOP_BINARY_PATH }}
-        run: |
-          if [ ${{ matrix.mode }} == 'production' ]; then
-            export PODMAN_DESKTOP_BINARY=${{ env.PODMAN_DESKTOP_BINARY_PATH }}
-          fi
+          export PODMAN_DESKTOP_BINARY_PATH=$path
           pnpm test:e2e:smoke
+
+      - name: Run Smoke E2E tests in Development mode
+        if: ${{ matrix.mode == 'development' }}
+        run: pnpm test:e2e:smoke
 
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -287,6 +287,9 @@ jobs:
   smoke-e2e-tests:
     name: smoke e2e tests
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        mode: [production, development]
     steps:
       - uses: actions/checkout@v4
 
@@ -319,13 +322,30 @@ jobs:
       - name: Execute pnpm
         run: pnpm install
 
+      - name: Build Podman Desktop for E2E tests Production Mode
+        if: ${{ matrix.mode == 'production' }}
+        env:
+          ELECTRON_ENABLE_INSPECT: true
+        run: |
+          pnpm compile:current --linux dir
+          path=$(realpath ./dist/linux-unpacked/podman-desktop)
+          echo "Podman Desktop built binary: $path"
+          echo "PODMAN_DESKTOP_BINARY_PATH=$path" >> $GITHUB_ENV
+
       - name: Run E2E smoke tests
+        if: ${{ matrix.mode == 'development' }}
+        run: pnpm test:e2e:smoke
+
+      - name: Run Smoke E2E tests in Production mode
+        if: ${{ matrix.mode == 'production' }}
+        env:
+          PODMAN_DESKTOP_BINARY: ${{ env.PODMAN_DESKTOP_BINARY_PATH }}
         run: pnpm test:e2e:smoke
 
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: smoke-e2e-tests
+          name: ${{ matrix.mode }}-smoke-e2e-tests
           path: |
             ./tests/**/output/
             !./tests/**/traces/raw


### PR DESCRIPTION
…man-desktop in pr check

### What does this PR do?
Makes smoke-e2e-tests job a matrix job, running e2e tests with podman desktop in development mode and in production mode.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#9522 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
The PR check details now should have two smoke-e2e-tests: production and development.
<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
