### PR TITLE
feat: display deployments and nodes conditions in a table

### DIFF
--- a/packages/renderer/src/lib/kube/details/ConditionsTable.spec.ts
+++ b/packages/renderer/src/lib/kube/details/ConditionsTable.spec.ts
@@ -1,0 +1,50 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen, within } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import ConditionsTable from './ConditionsTable.svelte';
+
+test('conditions are displayed in a table', async () => {
+  render(ConditionsTable, {
+    conditions: [
+      {
+        type: 'Ready',
+        status: 'True',
+        lastTransitionTime: new Date(),
+        reason: 'Kubelet ready',
+        message: 'kubelet is posting ready status',
+      },
+    ],
+  });
+
+  const table = screen.getByRole('table');
+  expect(table).toBeInTheDocument();
+  const rows = within(table).getAllByRole('row');
+  // the first row is the header
+  expect(rows.length).toBe(2);
+  const row = rows[1];
+  within(row).getByText('Ready');
+  within(row).getByText('True');
+  within(row).getByText('0 seconds');
+  within(row).getByText('Kubelet ready');
+  within(row).getByText('kubelet is posting ready status');
+});

--- a/packages/renderer/src/lib/kube/details/ConditionsTable.svelte
+++ b/packages/renderer/src/lib/kube/details/ConditionsTable.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+import humanizeDuration from 'humanize-duration';
+import moment from 'moment';
+
+import Table from '/@/lib/details/DetailsTable.svelte';
+
+export let conditions: {
+  type: string;
+  status: string;
+  lastTransitionTime?: Date;
+  reason?: string;
+  message?: string;
+}[];
+</script>
+
+<tr>
+  <td colspan="2">
+    <Table>
+      <tr>
+        <th align="left">Type</th><th align="left">Status</th><th align="left">Updated</th><th align="left">Reason</th><th align="left">Message</th>
+      </tr>
+      {#each conditions as condition}
+        <tr>
+          <td>{condition.type}</td>
+          <td>{condition.status}</td>
+          <td>{humanizeDuration(moment().diff(condition.lastTransitionTime), { round: true, largest: 1 })}</td>
+          <td>{condition.reason}</td>
+          <td>{condition.message}</td>
+        </tr>
+      {/each}
+    </Table>
+  </td>
+</tr>

--- a/packages/renderer/src/lib/kube/details/KubeDeploymentStatusArtifact.svelte
+++ b/packages/renderer/src/lib/kube/details/KubeDeploymentStatusArtifact.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
 import type { V1DeploymentStatus } from '@kubernetes/client-node';
+import humanizeDuration from 'humanize-duration';
+import moment from 'moment';
 
 import Cell from '/@/lib/details/DetailsCell.svelte';
-import Subtitle from '/@/lib/details/DetailsSubtitle.svelte';
+import Table from '/@/lib/details/DetailsTable.svelte';
 import Title from '/@/lib/details/DetailsTitle.svelte';
 
 export let artifact: V1DeploymentStatus | undefined;
@@ -23,26 +25,23 @@ export let artifact: V1DeploymentStatus | undefined;
     <tr>
       <Title>Conditions</Title>
     </tr>
-    {#each artifact.conditions as condition}
-      <tr>
-        <Subtitle>{condition.reason}</Subtitle>
-      </tr>
-      <tr>
-        <Cell>Type</Cell>
-        <Cell>{condition.type}</Cell>
-      </tr>
-      <tr>
-        <Cell>Status</Cell>
-        <Cell>{condition.status}</Cell>
-      </tr>
-      <tr>
-        <Cell>Reason</Cell>
-        <Cell>{condition.reason}</Cell>
-      </tr>
-      <tr>
-        <Cell>Message</Cell>
-        <Cell>{condition.message}</Cell>
-      </tr>
-    {/each}
+    <tr>
+      <td colspan="2">
+        <Table>
+          <tr>
+            <th align="left">Type</th><th align="left">Status</th><th align="left">Updated</th><th align="left">Reason</th><th align="left">Message</th>
+          </tr>
+          {#each artifact.conditions as condition}
+            <tr>
+              <td>{condition.type}</td>
+              <td>{condition.status}</td>
+              <td>{humanizeDuration(moment().diff(condition.lastTransitionTime), { round: true, largest: 1 })}</td>
+              <td>{condition.reason}</td>
+              <td>{condition.message}</td>
+            </tr>
+          {/each}
+        </Table>
+      </td>
+    </tr>
   {/if}
 {/if}

--- a/packages/renderer/src/lib/kube/details/KubeDeploymentStatusArtifact.svelte
+++ b/packages/renderer/src/lib/kube/details/KubeDeploymentStatusArtifact.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
 import type { V1DeploymentStatus } from '@kubernetes/client-node';
-import humanizeDuration from 'humanize-duration';
-import moment from 'moment';
 
 import Cell from '/@/lib/details/DetailsCell.svelte';
-import Table from '/@/lib/details/DetailsTable.svelte';
 import Title from '/@/lib/details/DetailsTitle.svelte';
+
+import ConditionsTable from './ConditionsTable.svelte';
 
 export let artifact: V1DeploymentStatus | undefined;
 </script>
@@ -25,23 +24,6 @@ export let artifact: V1DeploymentStatus | undefined;
     <tr>
       <Title>Conditions</Title>
     </tr>
-    <tr>
-      <td colspan="2">
-        <Table>
-          <tr>
-            <th align="left">Type</th><th align="left">Status</th><th align="left">Updated</th><th align="left">Reason</th><th align="left">Message</th>
-          </tr>
-          {#each artifact.conditions as condition}
-            <tr>
-              <td>{condition.type}</td>
-              <td>{condition.status}</td>
-              <td>{humanizeDuration(moment().diff(condition.lastTransitionTime), { round: true, largest: 1 })}</td>
-              <td>{condition.reason}</td>
-              <td>{condition.message}</td>
-            </tr>
-          {/each}
-        </Table>
-      </td>
-    </tr>
+    <ConditionsTable conditions={artifact.conditions} />
   {/if}
 {/if}

--- a/packages/renderer/src/lib/kube/details/KubeNodeStatusArtifact.svelte
+++ b/packages/renderer/src/lib/kube/details/KubeNodeStatusArtifact.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
 import type { V1NodeStatus } from '@kubernetes/client-node';
+import humanizeDuration from 'humanize-duration';
+import moment from 'moment';
 
 import Cell from '/@/lib/details/DetailsCell.svelte';
-import Subtitle from '/@/lib/details/DetailsSubtitle.svelte';
+import Table from '/@/lib/details/DetailsTable.svelte';
 import Title from '/@/lib/details/DetailsTitle.svelte';
 
 export let artifact: V1NodeStatus | undefined;
@@ -61,27 +63,24 @@ export let artifact: V1NodeStatus | undefined;
     <tr>
       <Title>Conditions</Title>
     </tr>
-    {#each artifact.conditions as condition}
-      <tr>
-        <Subtitle>{condition.reason}</Subtitle>
-      </tr>
-      <tr>
-        <Cell>Type</Cell>
-        <Cell>{condition.type}</Cell>
-      </tr>
-      <tr>
-        <Cell>Status</Cell>
-        <Cell>{condition.status}</Cell>
-      </tr>
-      <tr>
-        <Cell>Reason</Cell>
-        <Cell>{condition.reason}</Cell>
-      </tr>
-      <tr>
-        <Cell>Message</Cell>
-        <Cell>{condition.message}</Cell>
-      </tr>
-    {/each}
+    <tr>
+      <td colspan="2">
+        <Table>
+          <tr>
+            <th align="left">Type</th><th align="left">Status</th><th align="left">Updated</th><th align="left">Reason</th><th align="left">Message</th>
+          </tr>
+          {#each artifact.conditions as condition}
+            <tr>
+              <td>{condition.type}</td>
+              <td>{condition.status}</td>
+              <td>{humanizeDuration(moment().diff(condition.lastTransitionTime), { round: true, largest: 1 })}</td>
+              <td>{condition.reason}</td>
+              <td>{condition.message}</td>
+            </tr>
+          {/each}
+        </Table>
+      </td>
+    </tr>
   {/if}
   {#if artifact.addresses}
     <tr>

--- a/packages/renderer/src/lib/kube/details/KubeNodeStatusArtifact.svelte
+++ b/packages/renderer/src/lib/kube/details/KubeNodeStatusArtifact.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
 import type { V1NodeStatus } from '@kubernetes/client-node';
-import humanizeDuration from 'humanize-duration';
-import moment from 'moment';
 
 import Cell from '/@/lib/details/DetailsCell.svelte';
-import Table from '/@/lib/details/DetailsTable.svelte';
 import Title from '/@/lib/details/DetailsTitle.svelte';
+
+import ConditionsTable from './ConditionsTable.svelte';
 
 export let artifact: V1NodeStatus | undefined;
 </script>
@@ -63,24 +62,7 @@ export let artifact: V1NodeStatus | undefined;
     <tr>
       <Title>Conditions</Title>
     </tr>
-    <tr>
-      <td colspan="2">
-        <Table>
-          <tr>
-            <th align="left">Type</th><th align="left">Status</th><th align="left">Updated</th><th align="left">Reason</th><th align="left">Message</th>
-          </tr>
-          {#each artifact.conditions as condition}
-            <tr>
-              <td>{condition.type}</td>
-              <td>{condition.status}</td>
-              <td>{humanizeDuration(moment().diff(condition.lastTransitionTime), { round: true, largest: 1 })}</td>
-              <td>{condition.reason}</td>
-              <td>{condition.message}</td>
-            </tr>
-          {/each}
-        </Table>
-      </td>
-    </tr>
+    <ConditionsTable conditions={artifact.conditions} />
   {/if}
   {#if artifact.addresses}
     <tr>


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Display the Deployments and Nodes condition in a table.
 
### Screenshot / video of UI

Deployments before

![deploy-conditions-before](https://github.com/user-attachments/assets/9df1a09f-1701-4b98-b9f1-b5518adbfdab)

Deployments after

![deploy-conditions-after](https://github.com/user-attachments/assets/cf213f62-5985-44f7-8a69-f70d9b36f367)

Nodes before

![node-conditions-before](https://github.com/user-attachments/assets/78646eb2-62af-4016-b5b6-a65973008708)

Nodes after

![node-conditions-after](https://github.com/user-attachments/assets/1bb23fdf-6ab2-4a8e-b6d0-cbb380ee4240)

### What issues does this PR fix or reference?

Fixes #9121

### How to test this PR?

Check conditions in Deployments Details > Summary and Nodes Details > Summary

- [x] Tests are covering the bug fix or the new feature
