### PR TITLE
fix: dispose existing port forwards on delete

### DIFF
--- a/packages/main/src/plugin/kubernetes/kubernetes-port-forward-service.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-port-forward-service.spec.ts
@@ -125,12 +125,13 @@ describe('KubernetesPortForwardService', () => {
     expect(mockForwardingConnectionService.startForward).toHaveBeenCalledWith(sampleForwardConfig);
   });
 
-  test('should dispose for a given configuration', async () => {
-    const disposable = await service.startForward(sampleForwardConfig);
+  test('should dispose on delete', async () => {
+    const result = await service.createForward(sampleUserForwardConfig);
+    const disposable = await service.startForward(result);
     expect(disposable).toHaveProperty('dispose');
     const disposeMock = vi.spyOn(disposable, 'dispose');
-    expect(mockForwardingConnectionService.startForward).toHaveBeenCalledWith(sampleForwardConfig);
-    service.dispose();
+    expect(mockForwardingConnectionService.startForward).toHaveBeenCalledWith(result);
+    await service.deleteForward(sampleUserForwardConfig);
     expect(disposeMock).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Fixes #9561

### What does this PR do?

Dispose an existing port forwarding on delete

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

#9561 

### How to test this PR?

Run `pnpm test:main`

- [x] Tests are covering the bug fix or the new feature
