### PR TITLE
fix: skip output folder during format actions

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -10,6 +10,7 @@
       "**/builtin/*.cdix/**",
       "**/coverage/**",
       "**/dist/**",
+      "**/output/**",
       "**/packages/ui/.svelte-kit/**",
       "**/exposedIn*.d.ts",
       "website/.docusaurus/**",


### PR DESCRIPTION
Fixes #9549

### What does this PR do?

Add new rule to skip output folders during format

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

#9549

### How to test this PR?

Run E2E tests then `pnpm format:check`

- [ ] Tests are covering the bug fix or the new feature
