### PR TITLE
feat: blank kubeconfig path will be set to default one

### DIFF
--- a/packages/main/src/plugin/kubernetes/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.ts
@@ -225,7 +225,10 @@ export class KubernetesClient {
     // Update the property on change
     this.configurationRegistry.onDidChangeConfiguration(async e => {
       if (e.key === 'kubernetes.Kubeconfig') {
-        const val = e.value as string;
+        let val = e.value as string;
+        if (!val?.trim()) {
+          val = defaultKubeconfigPath;
+        }
         this.setupWatcher(val);
         await this.setKubeconfig(Uri.file(val));
       }


### PR DESCRIPTION
### What does this PR do?
Checks if the kubeconfig path is empty string/ just whitespace, if yes sets the kubeconfig path to default one

### Screenshot / video of UI



https://github.com/user-attachments/assets/350fbb30-52c1-4400-a4fa-d3a0effcea1f



### What issues does this PR fix or reference?
Closes #9101 

### How to test this PR?
Try to set kubeconfig path to empty string 
- [x] Tests are covering the bug fix or the new feature

