### PR TITLE
feat: initial Kubernetes dashboard

### DIFF
--- a/packages/renderer/src/App.spec.ts
+++ b/packages/renderer/src/App.spec.ts
@@ -35,9 +35,8 @@ const mocks = vi.hoisted(() => ({
   RunImage: vi.fn(),
   ImagesList: vi.fn(),
   SubmenuNavigation: vi.fn(),
-  KubernetesEmptyPage: vi.fn(),
   DeploymentsList: vi.fn(),
-  NodesList: vi.fn(),
+  KubernetesDashboard: vi.fn(),
 }));
 
 vi.mock('./lib/dashboard/DashboardPage.svelte', () => ({
@@ -69,16 +68,12 @@ vi.mock('./SubmenuNavigation.svelte', () => ({
   default: mocks.SubmenuNavigation,
 }));
 
-vi.mock('./lib/kube/KubernetesEmptyPage.svelte', () => ({
-  default: mocks.KubernetesEmptyPage,
+vi.mock('./lib/kube/KubernetesDashboard.svelte', () => ({
+  default: mocks.KubernetesDashboard,
 }));
 
 vi.mock('./lib/deployments/DeploymentsList.svelte', () => ({
   default: mocks.DeploymentsList,
-}));
-
-vi.mock('./lib/node/NodesList.svelte', () => ({
-  default: mocks.NodesList,
 }));
 
 vi.mock('/@/stores/kubernetes-contexts-state', async () => {
@@ -172,7 +167,7 @@ test('do not display kubernetes empty screen if current context', async () => {
   render(App);
   router.goto('/kubernetes/deployments');
   await tick();
-  expect(mocks.KubernetesEmptyPage).not.toHaveBeenCalled();
+  expect(mocks.KubernetesDashboard).not.toHaveBeenCalled();
   expect(mocks.DeploymentsList).toHaveBeenCalled();
 });
 
@@ -186,7 +181,7 @@ test('displays kubernetes empty screen if no current context, without Kubernetes
   render(App);
   router.goto('/kubernetes/deployments');
   await tick();
-  expect(mocks.KubernetesEmptyPage).toHaveBeenCalled();
+  expect(mocks.KubernetesDashboard).toHaveBeenCalled();
   expect(mocks.DeploymentsList).not.toHaveBeenCalled();
   expect(mocks.SubmenuNavigation).not.toHaveBeenCalled();
 });
@@ -199,18 +194,19 @@ test('go to last kubernetes page when available', async () => {
   expect(mocks.DeploymentsList).toHaveBeenCalled();
 });
 
-test('go to nodes page when last kubernetes page is /kubernetes', async () => {
+test('go to dashboard page when last kubernetes page is /kubernetes', async () => {
   lastSubmenuPages.set({ Kubernetes: '/kubernetes' });
   render(App);
   router.goto('/kubernetes');
   await tick();
-  expect(mocks.NodesList).toHaveBeenCalled();
+
+  expect(mocks.KubernetesDashboard).toHaveBeenCalled();
 });
 
-test('go to nodes page when last kubernetes page not available', async () => {
+test('go to dashboard page when last kubernetes page not available', async () => {
   lastSubmenuPages.set({});
   render(App);
   router.goto('/kubernetes');
   await tick();
-  expect(mocks.NodesList).toHaveBeenCalled();
+  expect(mocks.KubernetesDashboard).toHaveBeenCalled();
 });

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -42,7 +42,7 @@ import IngressDetails from './lib/ingresses-routes/IngressDetails.svelte';
 import IngressesRoutesList from './lib/ingresses-routes/IngressesRoutesList.svelte';
 import RouteDetails from './lib/ingresses-routes/RouteDetails.svelte';
 import KubePlayYAML from './lib/kube/KubePlayYAML.svelte';
-import KubernetesEmptyPage from './lib/kube/KubernetesEmptyPage.svelte';
+import KubernetesDashboard from './lib/kube/KubernetesDashboard.svelte';
 import ManifestDetails from './lib/manifest/ManifestDetails.svelte';
 import NodeDetails from './lib/node/NodeDetails.svelte';
 import NodesList from './lib/node/NodesList.svelte';
@@ -232,14 +232,17 @@ window.events?.receive('navigate', (navigationRequest: unknown) => {
         </Route>
         {#if $kubernetesCurrentContextState.error === NO_CURRENT_CONTEXT_ERROR}
           <Route path="/kubernetes/*" breadcrumb="Kubernetes" navigationHint="root">
-            <KubernetesEmptyPage />
+            <KubernetesDashboard />
           </Route>
         {:else}
-          <!-- Redirect /kubernetes to nodes if we end up on /kubernetes without a context error
-           we use router.goto to preserve the navbar remembering the navigation location.
+          <!-- Redirect /kubernetes to dashboard if we end up on /kubernetes without a context error 
+           we use router.goto to preserve the navbar remembering the navigation location. 
            TODO: Remove after https://github.com/containers/podman-desktop/issues/8825 is implemented -->
           <Route path="/kubernetes" breadcrumb="Kubernetes" navigationHint="root">
-            {router.goto($lastSubmenuPages['Kubernetes'] === '/kubernetes' ? '/kubernetes/nodes' : ($lastSubmenuPages['Kubernetes'] ?? '/kubernetes/nodes'))}
+            {router.goto($lastSubmenuPages['Kubernetes'] === '/kubernetes' ? '/kubernetes/dashboard' : ($lastSubmenuPages['Kubernetes'] ?? '/kubernetes/dashboard'))}
+          </Route>
+          <Route path="/kubernetes/dashboard" breadcrumb="Dashboard" navigationHint="root">
+            <KubernetesDashboard />
           </Route>
           <Route path="/kubernetes/nodes" breadcrumb="Nodes" navigationHint="root">
             <NodesList />

--- a/packages/renderer/src/lib/kube/KubernetesDashboard.spec.ts
+++ b/packages/renderer/src/lib/kube/KubernetesDashboard.spec.ts
@@ -39,10 +39,9 @@ const openExternalMock = vi.fn();
 
 // fake the window object
 beforeAll(() => {
-  //(window as any).events = eventsMock;
-  //(window as any).getConfigurationValue = vi.fn();
-  //(window as any).sendNavigationItems = vi.fn();
-  (window as any).openExternal = openExternalMock;
+  Object.defineProperty(window, 'openExternal', {
+    value: openExternalMock,
+  });
 });
 
 beforeEach(() => {

--- a/packages/renderer/src/lib/kube/KubernetesDashboard.spec.ts
+++ b/packages/renderer/src/lib/kube/KubernetesDashboard.spec.ts
@@ -1,0 +1,117 @@
+/**********************************************************************
+ * Copyright (C) 2023-2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import type { KubernetesObject } from '@kubernetes/client-node';
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { readable } from 'svelte/store';
+import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
+
+import { kubernetesContexts } from '/@/stores/kubernetes-contexts';
+import * as kubeContextStore from '/@/stores/kubernetes-contexts-state';
+import type { KubeContext } from '/@api/kubernetes-context';
+import type { ContextGeneralState } from '/@api/kubernetes-contexts-states';
+
+import KubernetesDashboard from './KubernetesDashboard.svelte';
+
+vi.mock('/@/stores/kubernetes-contexts-state', async () => {
+  return {};
+});
+
+const openExternalMock = vi.fn();
+
+// fake the window object
+beforeAll(() => {
+  //(window as any).events = eventsMock;
+  //(window as any).getConfigurationValue = vi.fn();
+  //(window as any).sendNavigationItems = vi.fn();
+  (window as any).openExternal = openExternalMock;
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('Verify basic page', async () => {
+  // mock no kubernetes resources
+  vi.mocked(kubeContextStore).kubernetesCurrentContextDeployments = readable<KubernetesObject[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextServices = readable<KubernetesObject[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextIngresses = readable<KubernetesObject[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextRoutes = readable<KubernetesObject[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextNodes = readable<KubernetesObject[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextConfigMaps = readable<KubernetesObject[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextSecrets = readable<KubernetesObject[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextPersistentVolumeClaims = readable<KubernetesObject[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextState = readable<ContextGeneralState>({} as ContextGeneralState);
+
+  render(KubernetesDashboard);
+
+  const title = screen.getByText('Dashboard');
+  expect(title).toBeInTheDocument();
+});
+
+test('Verify documentation link works', async () => {
+  render(KubernetesDashboard);
+
+  const docs = screen.getByText('Kubernetes documentation');
+  expect(docs).toBeInTheDocument();
+
+  expect(openExternalMock).not.toHaveBeenCalled();
+  await userEvent.click(docs);
+  expect(openExternalMock).toHaveBeenCalledWith('https://podman-desktop.io/docs/kubernetes');
+});
+
+test('Verify basic page with cluster', async () => {
+  // mock no kubernetes resources
+  vi.mocked(kubeContextStore).kubernetesCurrentContextDeployments = readable<KubernetesObject[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextServices = readable<KubernetesObject[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextIngresses = readable<KubernetesObject[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextRoutes = readable<KubernetesObject[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextNodes = readable<KubernetesObject[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextConfigMaps = readable<KubernetesObject[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextSecrets = readable<KubernetesObject[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextPersistentVolumeClaims = readable<KubernetesObject[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextState = readable<ContextGeneralState>({} as ContextGeneralState);
+
+  const mockContext: KubeContext = {
+    name: 'context-name',
+    cluster: 'cluster-name',
+    user: 'user-name',
+    currentContext: true,
+    clusterInfo: {
+      name: 'cluster-name',
+      server: 'https://server-name',
+    },
+  };
+  kubernetesContexts.set([mockContext]);
+
+  render(KubernetesDashboard);
+
+  const title = screen.getByText('Dashboard');
+  expect(title).toBeInTheDocument();
+
+  const metrics = screen.getByText('Metrics');
+  expect(metrics).toBeInTheDocument();
+  expect(metrics.nextElementSibling?.childElementCount).toBe(6);
+
+  const guides = screen.getByText('Explore articles and blog posts');
+  expect(guides).toBeInTheDocument();
+  expect(guides.nextElementSibling?.childElementCount).toBe(3);
+});

--- a/packages/renderer/src/lib/kube/KubernetesDashboard.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesDashboard.svelte
@@ -38,8 +38,8 @@ let configMapSecretCount = $derived(
   $kubernetesCurrentContextConfigMaps.length + $kubernetesCurrentContextSecrets.length,
 );
 
-function openKubernetesDocumentation() {
-  window.openExternal('https://podman-desktop.io/docs/kubernetes');
+async function openKubernetesDocumentation(): Promise<void> {
+  await window.openExternal('https://podman-desktop.io/docs/kubernetes');
 }
 </script>
 

--- a/packages/renderer/src/lib/kube/KubernetesDashboard.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesDashboard.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+import { Link, NavPage } from '@podman-desktop/ui-svelte';
+
+import KubernetesCurrentContextConnectionBadge from '/@/lib/ui/KubernetesCurrentContextConnectionBadge.svelte';
+import {
+  kubernetesCurrentContextConfigMaps,
+  kubernetesCurrentContextDeployments,
+  kubernetesCurrentContextIngresses,
+  kubernetesCurrentContextNodes,
+  kubernetesCurrentContextPersistentVolumeClaims,
+  kubernetesCurrentContextRoutes,
+  kubernetesCurrentContextSecrets,
+  kubernetesCurrentContextServices,
+  kubernetesCurrentContextState,
+} from '/@/stores/kubernetes-contexts-state';
+import { NO_CURRENT_CONTEXT_ERROR } from '/@api/kubernetes-contexts-states';
+
+import { kubernetesContexts } from '../../stores/kubernetes-contexts';
+import ConfigMapSecretIcon from '../images/ConfigMapSecretIcon.svelte';
+import DeploymentIcon from '../images/DeploymentIcon.svelte';
+import IngressRouteIcon from '../images/IngressRouteIcon.svelte';
+import NodeIcon from '../images/NodeIcon.svelte';
+import PvcIcon from '../images/PVCIcon.svelte';
+import ServiceIcon from '../images/ServiceIcon.svelte';
+import KubernetesDashboardGuideCard from './KubernetesDashboardGuideCard.svelte';
+import KubernetesDashboardResourceCard from './KubernetesDashboardResourceCard.svelte';
+import KubernetesEmptyPage from './KubernetesEmptyPage.svelte';
+
+let noContexts = $derived($kubernetesCurrentContextState.error === NO_CURRENT_CONTEXT_ERROR);
+let currentContextName = $derived($kubernetesContexts.find(context => context.currentContext)?.name);
+
+let nodeCount = $derived($kubernetesCurrentContextNodes.length);
+let deploymentCount = $derived($kubernetesCurrentContextDeployments.length);
+let serviceCount = $derived($kubernetesCurrentContextServices.length);
+let ingressRouteCount = $derived($kubernetesCurrentContextIngresses.length + $kubernetesCurrentContextRoutes.length);
+let pvcCount = $derived($kubernetesCurrentContextPersistentVolumeClaims.length);
+let configMapSecretCount = $derived(
+  $kubernetesCurrentContextConfigMaps.length + $kubernetesCurrentContextSecrets.length,
+);
+
+function openKubernetesDocumentation() {
+  window.openExternal('https://podman-desktop.io/docs/kubernetes');
+}
+</script>
+
+<NavPage searchEnabled={false}  title="Dashboard">
+  <svelte:fragment slot="bottom-additional-actions">
+    <div class="flex grow justify-end">
+      <KubernetesCurrentContextConnectionBadge />
+    </div>
+  </svelte:fragment>
+
+  <div class="flex min-w-full h-full" slot="content">
+    {#if noContexts}
+        <KubernetesEmptyPage />
+    {:else}
+        <div class="flex flex-col space-y-4 min-w-full overflow-y-auto">
+            <div class="flex flex-col gap-4 p-5 pb-2">
+                <span>Here you can manage and interact with Kubernetes clusters with features like connecting to clusters, and
+                viewing workloads like deployments and services.</span>
+
+                <span>Get up and running by clicking one of the menu items!</span>
+
+                <Link class="place-self-start" on:click={openKubernetesDocumentation}>Kubernetes documentation</Link>
+            </div>
+
+            <div class="flex flex-col gap-4 bg-[var(--pd-content-card-bg)] grow p-5">
+                {#if currentContextName}
+                    <div class="text-xl pt-2">Metrics</div>
+                    <div class="grid grid-cols-4 gap-4">
+                        <KubernetesDashboardResourceCard type='Nodes' Icon={NodeIcon} count={nodeCount} link='/kubernetes/nodes'/>
+                        <KubernetesDashboardResourceCard type='Deployments' Icon={DeploymentIcon} count={deploymentCount} link='/kubernetes/deployments'/>
+                        <KubernetesDashboardResourceCard type='Services' Icon={ServiceIcon} count={serviceCount} link='/kubernetes/services'/>
+                        <KubernetesDashboardResourceCard type='Ingresses & Routes' Icon={IngressRouteIcon} count={ingressRouteCount} link='/kubernetes/ingressesRoutes'/>
+                        <KubernetesDashboardResourceCard type='Persistent Volume Claims' Icon={PvcIcon} count={pvcCount} link='/kubernetes/persistentvolumeclaims'/>
+                        <KubernetesDashboardResourceCard type='ConfigMaps & Secrets' Icon={ConfigMapSecretIcon} count={configMapSecretCount} link='/kubernetes/configmapsSecrets'/>
+                    </div>
+                {/if}
+
+                <div class="text-xl pt-2">Explore articles and blog posts</div>
+                <div class="grid grid-cols-3 gap-4">
+                    <KubernetesDashboardGuideCard title='Deploy and test Kubernetes containers using Podman Desktop' link='https://developers.redhat.com/articles/2023/06/09/deploy-and-test-kubernetes-containers-using-podman-desktop'/>
+                    <KubernetesDashboardGuideCard title='Working with Kubernetes in Podman Desktop' link='https://developers.redhat.com/articles/2023/11/06/working-kubernetes-podman-desktop'/>
+                    <KubernetesDashboardGuideCard title='Share your local podman images with the Kubernetes cluster' link='https://podman-desktop.io/blog/sharing-podman-images-with-kubernetes-cluster'/>
+                </div>
+            </div>
+        </div>
+    {/if}
+  </div>
+</NavPage>

--- a/packages/renderer/src/lib/kube/KubernetesDashboardGuideCard.spec.ts
+++ b/packages/renderer/src/lib/kube/KubernetesDashboardGuideCard.spec.ts
@@ -28,7 +28,9 @@ const openExternalMock = vi.fn();
 
 // fake the window object
 beforeAll(() => {
-  (window as any).openExternal = openExternalMock;
+  Object.defineProperty(window, 'openExternal', {
+    value: openExternalMock,
+  });
 });
 
 test('Verify basic card format', async () => {
@@ -50,7 +52,7 @@ test('Verify basic card format', async () => {
   expect(button).toBeInTheDocument();
 });
 
-test('Expect clicking words', async () => {
+test('Expect clicking works', async () => {
   const link = 'http://test-link';
   render(KubernetesDashboardGuideCard, { title: 'a title', link: link });
 

--- a/packages/renderer/src/lib/kube/KubernetesDashboardGuideCard.spec.ts
+++ b/packages/renderer/src/lib/kube/KubernetesDashboardGuideCard.spec.ts
@@ -1,0 +1,63 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { beforeAll, expect, test, vi } from 'vitest';
+
+import KubernetesDashboardGuideCard from './KubernetesDashboardGuideCard.svelte';
+
+const openExternalMock = vi.fn();
+
+// fake the window object
+beforeAll(() => {
+  (window as any).openExternal = openExternalMock;
+});
+
+test('Verify basic card format', async () => {
+  const title = 'a title';
+  render(KubernetesDashboardGuideCard, { title: title, link: 'test' });
+
+  const titleComp = screen.getByText(title);
+  expect(titleComp).toBeInTheDocument();
+  expect(titleComp).toHaveClass('text-[var(--pd-content-card-carousel-card-header-text)]');
+  expect(titleComp).toHaveClass('text-center');
+  expect(titleComp).toHaveClass('font-semibold');
+
+  expect(titleComp.parentElement).toHaveClass('bg-[var(--pd-content-card-carousel-card-bg)]');
+  expect(titleComp.parentElement).toHaveClass('hover:bg-[var(--pd-content-card-carousel-card-hover-bg)]');
+  expect(titleComp.parentElement).toHaveClass('rounded-md');
+  expect(titleComp.parentElement).toHaveClass('items-center');
+
+  const button = screen.getByRole('button', { name: 'Read more' });
+  expect(button).toBeInTheDocument();
+});
+
+test('Expect clicking words', async () => {
+  const link = 'http://test-link';
+  render(KubernetesDashboardGuideCard, { title: 'a title', link: link });
+
+  const button = screen.getByRole('button', { name: 'Read more' });
+  expect(button).toBeInTheDocument();
+
+  expect(openExternalMock).not.toHaveBeenCalled();
+  await userEvent.click(button);
+  expect(openExternalMock).toHaveBeenCalledWith(link);
+});

--- a/packages/renderer/src/lib/kube/KubernetesDashboardGuideCard.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesDashboardGuideCard.svelte
@@ -8,8 +8,8 @@ interface Props {
 
 let { title, link }: Props = $props();
 
-function openLink() {
-  window.openExternal(link);
+async function openLink(): Promise<void> {
+  await window.openExternal(link);
 }
 </script>
 

--- a/packages/renderer/src/lib/kube/KubernetesDashboardGuideCard.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesDashboardGuideCard.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+import { Button } from '@podman-desktop/ui-svelte';
+
+interface Props {
+  title: string;
+  link: string;
+}
+
+let { title, link }: Props = $props();
+
+function openLink() {
+  window.openExternal(link);
+}
+</script>
+
+<div class="flex flex-col gap-4 p-4 bg-[var(--pd-content-card-carousel-card-bg)] hover:bg-[var(--pd-content-card-carousel-card-hover-bg)] rounded-md items-center">
+  <div class="text-[var(--pd-content-card-carousel-card-header-text)] text-center font-semibold">{title}</div>
+  <Button on:click={openLink}>Read more</Button>
+</div>

--- a/packages/renderer/src/lib/kube/KubernetesDashboardResourceCard.spec.ts
+++ b/packages/renderer/src/lib/kube/KubernetesDashboardResourceCard.spec.ts
@@ -1,0 +1,56 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { router } from 'tinro';
+import { expect, test, vi } from 'vitest';
+
+import NodeIcon from '../images/NodeIcon.svelte';
+import KubernetesDashboardResourceCard from './KubernetesDashboardResourceCard.svelte';
+
+test('Verify basic card format', async () => {
+  const params = { type: 'a type', Icon: NodeIcon, count: 4, link: 'test' };
+  render(KubernetesDashboardResourceCard, params);
+
+  const type = screen.getByText(params.type);
+  expect(type).toBeInTheDocument();
+  expect(type).toHaveClass('text-[var(--pd-invert-content-card-text)]');
+  expect(type).toHaveClass('font-semibold');
+
+  const count = screen.getByText(params.count);
+  expect(count).toBeInTheDocument();
+  expect(count).toHaveClass('text-2xl');
+  expect(count).toHaveClass('text-[var(--pd-invert-content-card-text)]');
+});
+
+test('Expect clicking words', async () => {
+  const gotoSpy = vi.spyOn(router, 'goto');
+
+  const params = { type: 'a type', Icon: NodeIcon, count: 4, link: 'test-link' };
+  render(KubernetesDashboardResourceCard, params);
+
+  const type = screen.getByText(params.type);
+  expect(type).toBeInTheDocument();
+
+  expect(gotoSpy).not.toHaveBeenCalled();
+  await userEvent.click(type);
+  expect(gotoSpy).toHaveBeenCalledWith(params.link);
+});

--- a/packages/renderer/src/lib/kube/KubernetesDashboardResourceCard.spec.ts
+++ b/packages/renderer/src/lib/kube/KubernetesDashboardResourceCard.spec.ts
@@ -41,7 +41,7 @@ test('Verify basic card format', async () => {
   expect(count).toHaveClass('text-[var(--pd-invert-content-card-text)]');
 });
 
-test('Expect clicking words', async () => {
+test('Expect clicking works', async () => {
   const gotoSpy = vi.spyOn(router, 'goto');
 
   const params = { type: 'a type', Icon: NodeIcon, count: 4, link: 'test-link' };

--- a/packages/renderer/src/lib/kube/KubernetesDashboardResourceCard.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesDashboardResourceCard.svelte
@@ -11,7 +11,7 @@ interface Props {
 
 let { type, Icon, count, link }: Props = $props();
 
-function openLink() {
+function openLink(): void {
   router.goto(link);
 }
 </script>

--- a/packages/renderer/src/lib/kube/KubernetesDashboardResourceCard.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesDashboardResourceCard.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+import type { Component } from 'svelte';
+import { router } from 'tinro';
+
+interface Props {
+  type: string;
+  Icon: Component;
+  count: number;
+  link: string;
+}
+
+let { type, Icon, count, link }: Props = $props();
+
+function openLink() {
+  router.goto(link);
+}
+</script>
+
+<button class="flex flex-col gap-4 p-4 bg-[var(--pd-content-card-carousel-card-bg)] hover:bg-[var(--pd-content-card-carousel-card-hover-bg)] rounded-md" onclick={openLink}>
+  <div class="text-[var(--pd-invert-content-card-text)] font-semibold text-start">{type}</div>
+  <div class="grid grid-cols-2 gap-4 w-full grow items-end">
+    <div class="justify-self-center text-[var(--pd-button-primary-bg)]"><Icon size={40}/></div>
+    <div class="flex flex-col">
+      <span class="text-[var(--pd-invert-content-card-text)]">Total</span>
+      <div class="text-2xl text-[var(--pd-invert-content-card-text)]" aria-label="{type} count">{count}</div>
+    </div>
+  </div>
+</button>

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-dashboard.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-dashboard.svelte.spec.ts
@@ -1,0 +1,30 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test } from 'vitest';
+
+import { createNavigationKubernetesDashboardEntry } from './navigation-registry-k8s-dashboard.svelte';
+
+test('createNavigationKubernetesNodesEntry', async () => {
+  const entry = createNavigationKubernetesDashboardEntry();
+
+  expect(entry).toBeDefined();
+  expect(entry.name).toBe('Dashboard');
+  expect(entry.link).toBe('/kubernetes/dashboard');
+  expect(entry.tooltip).toBe('Dashboard');
+});

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-dashboard.svelte.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-dashboard.svelte.ts
@@ -1,0 +1,35 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import KubeIcon from '/@/lib/images/KubeIcon.svelte';
+
+import type { NavigationRegistryEntry } from '../navigation-registry';
+
+export function createNavigationKubernetesDashboardEntry(): NavigationRegistryEntry {
+  const registry: NavigationRegistryEntry = {
+    name: 'Dashboard',
+    icon: { iconComponent: KubeIcon },
+    link: '/kubernetes/dashboard',
+    tooltip: 'Dashboard',
+    type: 'entry',
+    get counter() {
+      return 0;
+    },
+  };
+  return registry;
+}

--- a/packages/renderer/src/stores/navigation/navigation-registry-kubernetes.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-kubernetes.svelte.spec.ts
@@ -67,9 +67,9 @@ test('createNavigationImageEntry with current context', async () => {
   expect(entry.name).toBe('Kubernetes');
   expect(entry.icon.iconComponent).toBe(KubeIcon);
 
-  // should have 6 items
+  // should have 7 items
   await vi.waitFor(() => {
-    expect(entry.items?.length).toBe(6);
+    expect(entry.items?.length).toBe(7);
   });
 });
 

--- a/packages/renderer/src/stores/navigation/navigation-registry-kubernetes.svelte.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-kubernetes.svelte.ts
@@ -21,6 +21,7 @@ import { NO_CURRENT_CONTEXT_ERROR } from '/@api/kubernetes-contexts-states';
 
 import { kubernetesCurrentContextState } from '../kubernetes-contexts-state';
 import { createNavigationKubernetesConfigMapSecretsEntry } from './kubernetes/navigation-registry-k8s-configmap-secrets.svelte';
+import { createNavigationKubernetesDashboardEntry } from './kubernetes/navigation-registry-k8s-dashboard.svelte';
 import { createNavigationKubernetesDeploymentsEntry } from './kubernetes/navigation-registry-k8s-deployments.svelte';
 import { createNavigationKubernetesIngressesRoutesEntry } from './kubernetes/navigation-registry-k8s-ingresses-routes.svelte';
 import { createNavigationKubernetesNodesEntry } from './kubernetes/navigation-registry-k8s-nodes.svelte';
@@ -37,6 +38,7 @@ const displayedItems = $derived(context ? kubernetesNavigationGroupItems : []);
 
 export function createNavigationKubernetesGroup(): NavigationRegistryEntry {
   const newItems: NavigationRegistryEntry[] = [];
+  newItems.push(createNavigationKubernetesDashboardEntry());
   newItems.push(createNavigationKubernetesNodesEntry());
   newItems.push(createNavigationKubernetesDeploymentsEntry());
   newItems.push(createNavigationKubernetesServicesEntry());


### PR DESCRIPTION
### What does this PR do?

Adds a dashboard to the Kubernetes section, as the first/default page. Follows the basic design from #9263 using current content/capability and without changing the nav structure.

The Kubernetes empty page is embedded in the dashboard, so now you'd see the top + empty page (but still no nav).

### Screenshot / video of UI

<img width="1022" alt="Screenshot 2024-10-24 at 1 27 53 PM" src="https://github.com/user-attachments/assets/878b1bd9-760f-4a16-be60-413f5d9c3b33">

### What issues does this PR fix or reference?

Fixes #9264.

### How to test this PR?

Go to Kubernetes section.

- [x] Tests are covering the bug fix or the new feature