### PR TITLE
feat(k8s-port-forwaring): increasing management of ports mapping

### DIFF
--- a/packages/api/src/kubernetes-port-forward-model.ts
+++ b/packages/api/src/kubernetes-port-forward-model.ts
@@ -40,6 +40,32 @@ export interface PortMapping {
   remotePort: number;
 }
 
+export interface ForwardOptions {
+  /**
+   * The name of the resource.
+   */
+  name: string;
+
+  /**
+   * The namespace of the resource.
+   */
+  namespace: string;
+
+  /**
+   * The kind of the workload.
+   */
+  kind: WorkloadKind;
+
+  /**
+   * The forward to create
+   */
+  forward: PortMapping;
+  /**
+   * The display name for the forward configuration.
+   */
+  displayName: string;
+}
+
 /**
  * Interface representing the configuration for forwarding ports.
  * @see WorkloadKind

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -87,7 +87,7 @@ import type { ImageInspectInfo } from '/@api/image-inspect-info.js';
 import type { ImageSearchOptions, ImageSearchResult, ImageTagsListOptions } from '/@api/image-registry.js';
 import type { KubeContext } from '/@api/kubernetes-context.js';
 import type { ContextGeneralState, ResourceName } from '/@api/kubernetes-contexts-states.js';
-import type { UserForwardConfig } from '/@api/kubernetes-port-forward-model.js';
+import type { ForwardOptions, PortMapping, UserForwardConfig } from '/@api/kubernetes-port-forward-model.js';
 import type { ManifestCreateOptions, ManifestInspectInfo, ManifestPushOptions } from '/@api/manifest-info.js';
 import type { NetworkInspectInfo } from '/@api/network-info.js';
 import type { NotificationCard, NotificationCardOptions } from '/@api/notification.js';
@@ -2469,15 +2469,15 @@ export class PluginSystem {
 
     this.ipcHandle(
       'kubernetes-client:createPortForward',
-      async (_listener, config: UserForwardConfig): Promise<UserForwardConfig> => {
-        return kubernetesClient.createPortForward(config);
+      async (_listener, options: ForwardOptions): Promise<UserForwardConfig> => {
+        return kubernetesClient.createPortForward(options);
       },
     );
 
     this.ipcHandle(
       'kubernetes-client:deletePortForward',
-      async (_listener, config: UserForwardConfig): Promise<void> => {
-        return kubernetesClient.deletePortForward(config);
+      async (_listener, config: UserForwardConfig, mapping?: PortMapping): Promise<void> => {
+        return kubernetesClient.deletePortForward(config, mapping);
       },
     );
 

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.ts
@@ -71,7 +71,7 @@ import type { KubernetesPortForwardService } from '/@/plugin/kubernetes/kubernet
 import { KubernetesPortForwardServiceProvider } from '/@/plugin/kubernetes/kubernetes-port-forward-service.js';
 import type { KubeContext } from '/@api/kubernetes-context.js';
 import type { ContextGeneralState, ResourceName } from '/@api/kubernetes-contexts-states.js';
-import type { UserForwardConfig } from '/@api/kubernetes-port-forward-model.js';
+import type { ForwardOptions, PortMapping, UserForwardConfig } from '/@api/kubernetes-port-forward-model.js';
 import type { V1Route } from '/@api/openshift-types.js';
 
 import type { ApiSenderType } from '../api.js';
@@ -1765,14 +1765,14 @@ export class KubernetesClient {
     return this.ensurePortForwardService().listForwards();
   }
 
-  public async createPortForward(config: UserForwardConfig): Promise<UserForwardConfig> {
+  public async createPortForward(config: ForwardOptions): Promise<UserForwardConfig> {
     const service = this.ensurePortForwardService();
     const newConfig = await service.createForward(config);
     await service.startForward(newConfig);
-    return config;
+    return newConfig;
   }
 
-  public async deletePortForward(config: UserForwardConfig): Promise<void> {
-    return this.ensurePortForwardService().deleteForward(config);
+  public async deletePortForward(config: UserForwardConfig, mapping?: PortMapping): Promise<void> {
+    return this.ensurePortForwardService().deleteForward(config, mapping);
   }
 }

--- a/packages/main/src/plugin/kubernetes/kubernetes-port-forward-connection.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-port-forward-connection.spec.ts
@@ -725,6 +725,33 @@ describe('PortForwardConnectionService', () => {
       expect(disposable2.dispose).toHaveBeenCalled();
     });
 
+    test('should start port forwarding on specified mapping', async () => {
+      const mapping: PortMapping = { localPort: 3001, remotePort: 8080 };
+      const forwardConfig: ForwardConfig = {
+        kind: WorkloadKind.POD,
+        name: 'test-pod',
+        namespace: 'default',
+        forwards: [{ localPort: 3000, remotePort: 80 }, mapping],
+      };
+
+      const pod: V1Pod = {
+        apiVersion: 'v1',
+        kind: 'Pod',
+        metadata: { name: 'test-pod', namespace: 'default' },
+      };
+
+      mockCoreV1Api.readNamespacedPod.mockResolvedValueOnce(pod);
+
+      const disposable1 = new MockDisposable();
+
+      vi.spyOn(service, 'performForward').mockResolvedValueOnce(disposable1);
+
+      const disposable = await service.startForward(forwardConfig, mapping);
+
+      expect(service.performForward).toHaveBeenCalledTimes(1);
+      expect(disposable.dispose).toBeInstanceOf(Function);
+    });
+
     test('should throw an error if port forwarding fails', async () => {
       const forwardConfig: ForwardConfig = {
         kind: WorkloadKind.POD,

--- a/packages/main/src/plugin/kubernetes/kubernetes-port-forward-connection.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-port-forward-connection.ts
@@ -56,10 +56,11 @@ export class PortForwardConnectionService {
   /**
    * Starts the port forwarding based on the provided configuration.
    * @param config - The forwarding configuration.
+   * @param mapping - The mapping to start, if not specified all {@link ForwardConfig#forwards} will be started
    * @returns A promise that resolves to a disposable resource to stop the forwarding.
    * @throws If any of the port forwarding fail.
    */
-  async startForward(config: ForwardConfig): Promise<IDisposable> {
+  async startForward(config: ForwardConfig, mapping?: PortMapping): Promise<IDisposable> {
     if (this.configRequirementsChecker) {
       await this.configRequirementsChecker.checkRuntimeRequirements(config);
     }
@@ -67,7 +68,7 @@ export class PortForwardConnectionService {
     const resource = await this.getWorkloadResource(config.kind, config.name, config.namespace);
 
     const results = await Promise.allSettled(
-      config.forwards.map(async forward => {
+      (mapping ? [mapping] : config.forwards).map(async forward => {
         const forwardSetup = await this.getForwardingSetup(resource, forward);
         return this.performForward(forwardSetup);
       }),

--- a/packages/main/src/plugin/kubernetes/kubernetes-port-forward-service.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-port-forward-service.spec.ts
@@ -28,6 +28,7 @@ import {
 import type { ConfigManagementService } from '/@/plugin/kubernetes/kubernetes-port-forward-storage.js';
 import type { IDisposable } from '/@/plugin/types/disposable.js';
 import type { ForwardConfig, UserForwardConfig } from '/@api/kubernetes-port-forward-model.js';
+import { WorkloadKind } from '/@api/kubernetes-port-forward-model.js';
 
 vi.mock('/@/plugin/kubernetes/kubernetes-port-forward-connection.js');
 vi.mock('/@/plugin/kubernetes/kubernetes-port-forward-storage.js');
@@ -66,19 +67,31 @@ describe('KubernetesPortForwardService', () => {
     receive: vi.fn(),
   };
 
-  const sampleUserForwardConfig: UserForwardConfig = {
-    name: 'test-name',
-    namespace: 'test-namespace',
-    kind: 0,
-    forwards: [{ localPort: 8080, remotePort: 80 }],
-    displayName: 'test-display-name',
-  };
-
   const sampleForwardConfig: ForwardConfig = {
     name: 'test-name',
     namespace: 'test-namespace',
-    kind: 0,
+    kind: WorkloadKind.POD,
     forwards: [{ localPort: 8080, remotePort: 80 }],
+  };
+
+  const sampleUserForwardConfig: UserForwardConfig = {
+    ...sampleForwardConfig,
+    displayName: 'test-display-name',
+  };
+
+  const complexForwardConfig: ForwardConfig = {
+    name: 'test-name',
+    namespace: 'test-namespace',
+    kind: WorkloadKind.POD,
+    forwards: [
+      { localPort: 8080, remotePort: 80 },
+      { localPort: 9090, remotePort: 90 },
+    ],
+  };
+
+  const complexUserForwardConfig: UserForwardConfig = {
+    ...complexForwardConfig,
+    displayName: 'complex-display-name',
   };
 
   beforeEach(() => {
@@ -86,6 +99,7 @@ describe('KubernetesPortForwardService', () => {
     mockConfigManagementService = {
       createForward: vi.fn().mockResolvedValue(sampleUserForwardConfig),
       deleteForward: vi.fn().mockResolvedValue(undefined),
+      updateForward: vi.fn().mockResolvedValue(sampleUserForwardConfig),
       listForwards: vi.fn().mockResolvedValue([sampleUserForwardConfig]),
     } as unknown as ConfigManagementService;
 
@@ -101,7 +115,17 @@ describe('KubernetesPortForwardService', () => {
   });
 
   test('should create a forward configuration', async () => {
-    const result = await service.createForward(sampleUserForwardConfig);
+    vi.mocked(mockConfigManagementService.listForwards).mockResolvedValue([]);
+    const forward = sampleUserForwardConfig.forwards[0];
+    if (!forward) throw new Error('undefined forward');
+
+    const result = await service.createForward({
+      name: sampleUserForwardConfig.name,
+      kind: sampleUserForwardConfig.kind,
+      namespace: sampleUserForwardConfig.namespace,
+      forward: forward,
+      displayName: sampleUserForwardConfig.displayName,
+    });
     expect(result).toEqual(sampleUserForwardConfig);
     expect(mockConfigManagementService.createForward).toHaveBeenCalledWith(sampleUserForwardConfig);
     expect(apiSenderMock.send).toHaveBeenCalledWith('kubernetes-port-forwards-update', []);
@@ -122,16 +146,79 @@ describe('KubernetesPortForwardService', () => {
   test('should start port forwarding for a given configuration', async () => {
     const disposable = await service.startForward(sampleForwardConfig);
     expect(disposable).toHaveProperty('dispose');
-    expect(mockForwardingConnectionService.startForward).toHaveBeenCalledWith(sampleForwardConfig);
+    expect(mockForwardingConnectionService.startForward).toHaveBeenCalledWith(
+      sampleForwardConfig,
+      sampleForwardConfig.forwards[0],
+    );
   });
 
-  test('should dispose on delete', async () => {
-    const result = await service.createForward(sampleUserForwardConfig);
-    const disposable = await service.startForward(result);
+  test('should dispose for a given configuration', async () => {
+    const disposeMock = vi.fn();
+    vi.mocked(mockForwardingConnectionService.startForward).mockResolvedValue({
+      dispose: disposeMock,
+    });
+
+    const disposable = await service.startForward(sampleForwardConfig);
     expect(disposable).toHaveProperty('dispose');
-    const disposeMock = vi.spyOn(disposable, 'dispose');
-    expect(mockForwardingConnectionService.startForward).toHaveBeenCalledWith(result);
-    await service.deleteForward(sampleUserForwardConfig);
+
+    service.dispose();
     expect(disposeMock).toHaveBeenCalled();
+  });
+
+  test('delete a multiple mapping should dispose all disposables', async () => {
+    const disposeMock = vi.fn();
+    vi.mocked(mockForwardingConnectionService.startForward).mockResolvedValue({
+      dispose: disposeMock,
+    });
+    await service.startForward(complexForwardConfig);
+
+    await service.deleteForward(complexUserForwardConfig);
+
+    expect(disposeMock).toHaveBeenCalledTimes(2);
+    expect(mockConfigManagementService.deleteForward).toHaveBeenCalledWith(complexUserForwardConfig);
+    expect(mockConfigManagementService.updateForward).not.toHaveBeenCalled();
+  });
+
+  test('delete a mapping in a multiple mapping should update config without the one removed', async () => {
+    const disposeMock = vi.fn();
+    vi.mocked(mockForwardingConnectionService.startForward).mockResolvedValue({
+      dispose: disposeMock,
+    });
+    await service.startForward(complexForwardConfig);
+
+    await service.deleteForward(complexUserForwardConfig, complexUserForwardConfig.forwards[0]);
+
+    expect(disposeMock).toHaveBeenCalledTimes(1);
+    expect(mockConfigManagementService.deleteForward).not.toHaveBeenCalled();
+    expect(mockConfigManagementService.updateForward).toHaveBeenCalledWith(complexUserForwardConfig, {
+      ...complexUserForwardConfig,
+      forwards: [complexUserForwardConfig.forwards[1]],
+    });
+  });
+
+  test('calling start second time with an updated version should not start the same mapping twice', async () => {
+    const mappingA = complexForwardConfig.forwards[0];
+    const mappingB = complexForwardConfig.forwards[1];
+
+    if (!mappingA || !mappingB) throw new Error('undefined mapping');
+
+    await service.startForward({
+      ...complexForwardConfig,
+      forwards: [mappingA],
+    });
+
+    expect(mockForwardingConnectionService.startForward).toHaveBeenCalledWith(expect.anything(), mappingA);
+    expect(mockForwardingConnectionService.startForward).not.toHaveBeenCalledWith(expect.anything(), mappingB);
+
+    await service.startForward({
+      ...complexForwardConfig,
+      forwards: [mappingA, mappingB],
+    });
+
+    expect(mockForwardingConnectionService.startForward).toHaveBeenNthCalledWith(1, expect.anything(), mappingA);
+    expect(mockForwardingConnectionService.startForward).toHaveBeenNthCalledWith(2, expect.anything(), mappingB);
+
+    // ensure only called twice, once for mappingA one for mappingB
+    expect(mockForwardingConnectionService.startForward).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/main/src/plugin/kubernetes/kubernetes-port-forward-service.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-port-forward-service.ts
@@ -23,8 +23,14 @@ import { PortForwardConnectionService } from '/@/plugin/kubernetes/kubernetes-po
 import { ConfigManagementService, MemoryBasedStorage } from '/@/plugin/kubernetes/kubernetes-port-forward-storage.js';
 import { ForwardConfigRequirements } from '/@/plugin/kubernetes/kubernetes-port-forward-validation.js';
 import type { IDisposable } from '/@/plugin/types/disposable.js';
+import { Disposable } from '/@/plugin/types/disposable.js';
 import { isFreePort } from '/@/plugin/util/port.js';
-import type { ForwardConfig, UserForwardConfig } from '/@api/kubernetes-port-forward-model.js';
+import type {
+  ForwardConfig,
+  ForwardOptions,
+  PortMapping,
+  UserForwardConfig,
+} from '/@api/kubernetes-port-forward-model.js';
 
 /**
  * Service provider for Kubernetes port forwarding.
@@ -83,38 +89,88 @@ export class KubernetesPortForwardService implements IDisposable {
 
   dispose(): void {
     this.#disposables.forEach(disposable => disposable.dispose());
-  }
-
-  private getPortForwardKey(config: ForwardConfig): string {
-    return `${config.namespace}/${config.name}/${config.kind}`;
+    this.#disposables.clear();
   }
 
   /**
-   * Creates a new forward configuration.
-   * @param config - The forward configuration to create.
-   * @returns The created forward configuration.
-   * @see UserForwardConfig
+   * Each key is specific for a dedicated remotePort
+   * @param config
+   * @param mapping
+   * @private
    */
-  async createForward(config: UserForwardConfig): Promise<ForwardConfig> {
-    const forwardConfig = await this.configManagementService.createForward(config);
+  private getPortForwardKey(config: ForwardConfig, mapping: PortMapping): string {
+    return `${config.namespace}/${config.name}/${config.kind}/${mapping.remotePort}`;
+  }
+
+  /**
+   * Creates a new forward
+   * If we have an already existing ForwardConfig we will update it
+   * @returns The created forward configuration.
+   * @see
+   * @param options
+   */
+  async createForward(options: ForwardOptions): Promise<UserForwardConfig> {
+    const configs = await this.listForwards();
+    const userForwardConfig: UserForwardConfig | undefined = configs.find(
+      config => config.name === options.name && config.namespace === options.namespace && config.kind === options.kind,
+    );
+    let result: UserForwardConfig;
+    if (userForwardConfig) {
+      result = await this.configManagementService.updateForward(userForwardConfig, {
+        name: options.name,
+        forwards: [...userForwardConfig.forwards, options.forward],
+        namespace: options.namespace,
+        kind: options.kind,
+        displayName: options.displayName,
+      });
+    } else {
+      result = await this.configManagementService.createForward({
+        name: options.name,
+        forwards: [options.forward],
+        namespace: options.namespace,
+        kind: options.kind,
+        displayName: options.displayName,
+      });
+    }
+
     this.apiSender.send('kubernetes-port-forwards-update', await this.listForwards());
-    return forwardConfig;
+    return result;
   }
 
   /**
    * Deletes an existing forward configuration.
    * @param config - The forward configuration to delete.
+   * @param mapping - The mapping to delete, if mapping is undefined, delete all
    * @returns Void if the operation successful.
    * @see UserForwardConfig
    */
-  async deleteForward(config: UserForwardConfig): Promise<void> {
-    const key = this.getPortForwardKey(config);
-    const disposable = this.#disposables.get(key);
-    if (disposable) {
-      disposable.dispose();
-      this.#disposables.delete(key);
+  async deleteForward(config: UserForwardConfig, mapping?: PortMapping): Promise<void> {
+    const keys: string[] = [];
+    if (mapping) {
+      keys.push(this.getPortForwardKey(config, mapping));
+    } else {
+      keys.push(...config.forwards.map(forward => this.getPortForwardKey(config, forward)));
     }
-    await this.configManagementService.deleteForward(config);
+
+    for (const key of keys) {
+      const disposable = this.#disposables.get(key);
+      if (disposable) {
+        disposable.dispose();
+        this.#disposables.delete(key);
+      }
+    }
+
+    const newConfig: UserForwardConfig = {
+      ...config,
+      forwards: config.forwards.filter(forward => !keys.includes(this.getPortForwardKey(config, forward))),
+    };
+
+    if (newConfig.forwards.length === 0) {
+      await this.configManagementService.deleteForward(config);
+    } else {
+      await this.configManagementService.updateForward(config, newConfig);
+    }
+
     this.apiSender.send('kubernetes-port-forwards-update', await this.listForwards());
   }
 
@@ -134,8 +190,17 @@ export class KubernetesPortForwardService implements IDisposable {
    * @see ForwardConfig
    */
   async startForward(config: ForwardConfig): Promise<IDisposable> {
-    const disposable = await this.forwardingConnectionService.startForward(config);
-    this.#disposables.set(this.getPortForwardKey(config), disposable);
-    return disposable;
+    const disposables: IDisposable[] = [];
+    for (const forward of config.forwards) {
+      const key = this.getPortForwardKey(config, forward);
+
+      if (!this.#disposables.has(key)) {
+        const disposable = await this.forwardingConnectionService.startForward(config, forward);
+        disposables.push(disposable);
+        this.#disposables.set(key, disposable);
+      }
+    }
+
+    return Disposable.from(...disposables);
   }
 }

--- a/packages/main/src/plugin/kubernetes/kubernetes-port-forward-storage.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-port-forward-storage.spec.ts
@@ -31,6 +31,7 @@ import {
   PreferenceFolderBasedStorage,
 } from '/@/plugin/kubernetes/kubernetes-port-forward-storage.js';
 import type { UserForwardConfig } from '/@api/kubernetes-port-forward-model.js';
+import { WorkloadKind } from '/@api/kubernetes-port-forward-model.js';
 
 vi.mock('node:fs/promises', () => ({
   mkdir: vi.fn(),
@@ -368,5 +369,27 @@ describe('ConfigManagementService', () => {
 
     expect(result).toEqual([sampleConfig]);
     expect(mockConfigStorage.listForwards).toHaveBeenCalled();
+  });
+
+  test('should update configurations', async () => {
+    mockConfigStorage.listForwards = vi.fn().mockResolvedValue([sampleConfig]);
+    const service = new ConfigManagementService(mockConfigStorage);
+
+    const old = {
+      forwards: [],
+      displayName: 'dummy',
+      namespace: 'default',
+      kind: WorkloadKind.POD,
+      name: 'hihi',
+    };
+
+    const newConfig = {
+      ...old,
+      name: 'hoho',
+    };
+
+    await service.updateForward(old, newConfig);
+
+    expect(mockConfigStorage.updateForward).toHaveBeenCalledWith(old, newConfig);
   });
 });

--- a/packages/main/src/plugin/kubernetes/kubernetes-port-forward-storage.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-port-forward-storage.ts
@@ -379,6 +379,17 @@ export class ConfigManagementService {
   }
 
   /**
+   * Update an existing forward configuration.
+   * @param oldConfig - The forward configuration to update
+   * @param newConfig - The
+   * @returns The updated configuration
+   * @see UserForwardConfig
+   */
+  async updateForward(oldConfig: UserForwardConfig, newConfig: UserForwardConfig): Promise<UserForwardConfig> {
+    return this.configStorage.updateForward(oldConfig, newConfig);
+  }
+
+  /**
    * Lists all forward configurations.
    * @returns A list of forward configurations.
    * @see UserForwardConfig

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -67,7 +67,7 @@ import type { ImageInspectInfo } from '/@api/image-inspect-info';
 import type { ImageSearchOptions, ImageSearchResult, ImageTagsListOptions } from '/@api/image-registry';
 import type { KubeContext } from '/@api/kubernetes-context';
 import type { ContextGeneralState, ResourceName } from '/@api/kubernetes-contexts-states';
-import type { UserForwardConfig } from '/@api/kubernetes-port-forward-model';
+import type { ForwardOptions, PortMapping, UserForwardConfig } from '/@api/kubernetes-port-forward-model';
 import type { ManifestCreateOptions, ManifestInspectInfo, ManifestPushOptions } from '/@api/manifest-info';
 import type { NetworkInspectInfo } from '/@api/network-info';
 import type { NotificationCard, NotificationCardOptions } from '/@api/notification';
@@ -2125,14 +2125,17 @@ export function initExposure(): void {
 
   contextBridge.exposeInMainWorld(
     'createKubernetesPortForward',
-    async (config: UserForwardConfig): Promise<UserForwardConfig> => {
-      return ipcInvoke('kubernetes-client:createPortForward', config);
+    async (options: ForwardOptions): Promise<UserForwardConfig> => {
+      return ipcInvoke('kubernetes-client:createPortForward', options);
     },
   );
 
-  contextBridge.exposeInMainWorld('deleteKubernetesPortForward', async (config: UserForwardConfig): Promise<void> => {
-    return ipcInvoke('kubernetes-client:deletePortForward', config);
-  });
+  contextBridge.exposeInMainWorld(
+    'deleteKubernetesPortForward',
+    async (config: UserForwardConfig, mapping?: PortMapping): Promise<void> => {
+      return ipcInvoke('kubernetes-client:deletePortForward', config, mapping);
+    },
+  );
 
   contextBridge.exposeInMainWorld(
     'openshiftCreateRoute',


### PR DESCRIPTION
### What does this PR do?

Allowing the frontend to have a better control of the port forwarding: A `ForwardConfig` can contains multiple `forwards`, meaning we can forward multiple ports for a given object (container, service, node).

However, the only methods exposed would only allow to create and delete, meaning we could do add a new mapping to an existing config.

### Notable changes

- New `ForwardOptions` interface, which is designed to avoid the client (frontend) to provide a full UserForwardConfig.

- Changing the signature of `window.createKubernetesPortForward`

```diff
- window.createKubernetesPortForward(config: UserForwardConfig)
+ window.createKubernetesPortForward(options: ForwardOptions)
```

This allow the client to call `createKubernetesPortForward` each time its want to add a new port forward, without having to worry to update, delete, create the UserForwardConfig. The backend should be responsible of updating, doing stuff...

- Changing the signature of `window.deletePortForward`

```diff
- window.deletePortForward(config: UserForwardConfig)
+ window.deletePortForward(config: UserForwardConfig, mapping?: PortMapping)
```

A `UserForwardConfig` can contains multiple PortMapping, the user may want to only delete one.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/9591

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

Feature can be tested in https://github.com/containers/podman-desktop/pull/9590
