### PR TITLE
fix: use `utf16le` ecoding in powershell call for Virtual Machine Platform detection

### DIFF
--- a/extensions/podman/packages/extension/src/podman-install.spec.ts
+++ b/extensions/podman/packages/extension/src/podman-install.spec.ts
@@ -298,6 +298,9 @@ test('expect winVirtualMachine preflight check return successful result if the v
 
   const winVirtualMachinePlatformCheck = new VirtualMachinePlatformCheck();
   const result = await winVirtualMachinePlatformCheck.execute();
+  expect(extensionApi.process.exec).toBeCalledWith(expect.anything(), expect.arrayContaining([expect.anything()]), {
+    encoding: 'utf16le',
+  });
   expect(result.successful).toBeTruthy();
 });
 

--- a/extensions/podman/packages/extension/src/podman-install.ts
+++ b/extensions/podman/packages/extension/src/podman-install.ts
@@ -647,9 +647,13 @@ export class VirtualMachinePlatformCheck extends BaseCheck {
   async execute(): Promise<extensionApi.CheckResult> {
     try {
       // set CurrentUICulture to force output in english
-      const { stdout: res } = await extensionApi.process.exec('powershell.exe', [
-        '(Get-WmiObject -Query "Select * from Win32_OptionalFeature where InstallState = \'1\'").Name | select-string VirtualMachinePlatform',
-      ]);
+      const { stdout: res } = await extensionApi.process.exec(
+        'powershell.exe',
+        [
+          '(Get-WmiObject -Query "Select * from Win32_OptionalFeature where InstallState = \'1\'").Name | select-string VirtualMachinePlatform',
+        ],
+        { encoding: 'utf16le' },
+      );
       if (res.indexOf('VirtualMachinePlatform') >= 0) {
         return this.createSuccessfulResult();
       }

--- a/extensions/podman/packages/extension/src/podman-install.ts
+++ b/extensions/podman/packages/extension/src/podman-install.ts
@@ -650,7 +650,7 @@ export class VirtualMachinePlatformCheck extends BaseCheck {
       const { stdout: res } = await extensionApi.process.exec(
         'powershell.exe',
         [
-          '(Get-WmiObject -Query "Select * from Win32_OptionalFeature where InstallState = \'1\'").Name | select-string VirtualMachinePlatform',
+          '[System.Console]::OutputEncoding = [System.Text.Encoding]::Unicode; (Get-WmiObject -Query "Select * from Win32_OptionalFeature where InstallState = \'1\'").Name | select-string VirtualMachinePlatform',
         ],
         { encoding: 'utf16le' },
       );


### PR DESCRIPTION
### What does this PR do?

Uses default encoding for powershell execution similar to https://github.com/containers/podman-desktop/pull/4918 to find string in powershell output.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Fix #7414.

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
