### PR TITLE
fix: next version check

### DIFF
--- a/packages/main/src/plugin/updater.spec.ts
+++ b/packages/main/src/plugin/updater.spec.ts
@@ -782,3 +782,26 @@ test('update is not available when next version is less than the current version
 
   expect(updater.updateAvailable()).toBeFalsy();
 });
+
+test('update is not available when next version empty', async () => {
+  vi.mocked(autoUpdater.checkForUpdates).mockResolvedValue({
+    updateInfo: {
+      version: '',
+    },
+  } as unknown as UpdateCheckResult);
+
+  vi.mocked(app.getVersion).mockReturnValue('1.5.1');
+  const updater = new Updater(
+    messageBoxMock,
+    configurationRegistryMock,
+    statusBarRegistryMock,
+    commandRegistryMock,
+    taskManagerMock,
+    apiSenderMock,
+  );
+  updater.init();
+
+  await vi.waitFor(() => expect(autoUpdater.checkForUpdates).toBeCalled());
+
+  expect(updater.updateAvailable()).toBeFalsy();
+});

--- a/packages/main/src/plugin/updater.spec.ts
+++ b/packages/main/src/plugin/updater.spec.ts
@@ -373,11 +373,9 @@ describe('expect update command to depends on context', async () => {
 
     vi.mocked(autoUpdater.checkForUpdates).mockResolvedValue({
       updateInfo: {
-        version: '1.2.0',
+        version: '@debug-next',
       },
     } as unknown as UpdateCheckResult);
-
-    vi.mocked(app.getVersion).mockReturnValue('1.1.0');
 
     let mListener: UpdateCommandListener | undefined;
     vi.mocked(commandRegistryMock.registerCommand).mockImplementation(
@@ -423,7 +421,7 @@ describe('expect update command to depends on context', async () => {
       cancelId: 2,
       buttons: ['Update now', `What's new`, 'Remind me later', `Don't show again`],
       message:
-        'A new version v1.2.0 of Podman Desktop is available. Do you want to update your current version v1.1.0?',
+        'A new version v@debug-next of Podman Desktop is available. Do you want to update your current version v@debug?',
       title: 'Update Available now',
       type: 'info',
     });
@@ -439,7 +437,7 @@ describe('expect update command to depends on context', async () => {
       cancelId: 2,
       buttons: ['Update now', `What's new`, 'Cancel'],
       message:
-        'A new version v1.2.0 of Podman Desktop is available. Do you want to update your current version v1.1.0?',
+        'A new version v@debug-next of Podman Desktop is available. Do you want to update your current version v@debug?',
       title: 'Update Available now',
       type: 'info',
     });
@@ -804,4 +802,27 @@ test('update is not available when next version empty', async () => {
   await vi.waitFor(() => expect(autoUpdater.checkForUpdates).toBeCalled());
 
   expect(updater.updateAvailable()).toBeFalsy();
+});
+
+test('update version is not full semver', async () => {
+  vi.mocked(autoUpdater.checkForUpdates).mockResolvedValue({
+    updateInfo: {
+      version: '1.5',
+    },
+  } as unknown as UpdateCheckResult);
+
+  vi.mocked(app.getVersion).mockReturnValue('1.4.1');
+  const updater = new Updater(
+    messageBoxMock,
+    configurationRegistryMock,
+    statusBarRegistryMock,
+    commandRegistryMock,
+    taskManagerMock,
+    apiSenderMock,
+  );
+  updater.init();
+
+  await vi.waitFor(() => expect(autoUpdater.checkForUpdates).toBeCalled());
+
+  expect(updater.updateAvailable()).toBeTruthy();
 });

--- a/packages/main/src/plugin/updater.spec.ts
+++ b/packages/main/src/plugin/updater.spec.ts
@@ -826,3 +826,26 @@ test('update version is not full semver', async () => {
 
   expect(updater.updateAvailable()).toBeTruthy();
 });
+
+test('versions are not numbered versions', async () => {
+  vi.mocked(autoUpdater.checkForUpdates).mockResolvedValue({
+    updateInfo: {
+      version: 'foo',
+    },
+  } as unknown as UpdateCheckResult);
+
+  vi.mocked(app.getVersion).mockReturnValue('bar');
+  const updater = new Updater(
+    messageBoxMock,
+    configurationRegistryMock,
+    statusBarRegistryMock,
+    commandRegistryMock,
+    taskManagerMock,
+    apiSenderMock,
+  );
+  updater.init();
+
+  await vi.waitFor(() => expect(autoUpdater.checkForUpdates).toBeCalled());
+
+  expect(updater.updateAvailable()).toBeTruthy();
+});

--- a/packages/main/src/plugin/updater.spec.ts
+++ b/packages/main/src/plugin/updater.spec.ts
@@ -373,9 +373,11 @@ describe('expect update command to depends on context', async () => {
 
     vi.mocked(autoUpdater.checkForUpdates).mockResolvedValue({
       updateInfo: {
-        version: '@debug-next',
+        version: '1.2.0',
       },
     } as unknown as UpdateCheckResult);
+
+    vi.mocked(app.getVersion).mockReturnValue('1.1.0');
 
     let mListener: UpdateCommandListener | undefined;
     vi.mocked(commandRegistryMock.registerCommand).mockImplementation(
@@ -421,7 +423,7 @@ describe('expect update command to depends on context', async () => {
       cancelId: 2,
       buttons: ['Update now', `What's new`, 'Remind me later', `Don't show again`],
       message:
-        'A new version v@debug-next of Podman Desktop is available. Do you want to update your current version v@debug?',
+        'A new version v1.2.0 of Podman Desktop is available. Do you want to update your current version v1.1.0?',
       title: 'Update Available now',
       type: 'info',
     });
@@ -437,7 +439,7 @@ describe('expect update command to depends on context', async () => {
       cancelId: 2,
       buttons: ['Update now', `What's new`, 'Cancel'],
       message:
-        'A new version v@debug-next of Podman Desktop is available. Do you want to update your current version v@debug?',
+        'A new version v1.2.0 of Podman Desktop is available. Do you want to update your current version v1.1.0?',
       title: 'Update Available now',
       type: 'info',
     });
@@ -711,4 +713,72 @@ test('get release notes in dev mode', async () => {
   } finally {
     vi.unstubAllEnvs();
   }
+});
+
+test('update is available when next version is greater then current version', async () => {
+  vi.mocked(autoUpdater.checkForUpdates).mockResolvedValue({
+    updateInfo: {
+      version: '1.5.1',
+    },
+  } as unknown as UpdateCheckResult);
+
+  vi.mocked(app.getVersion).mockReturnValue('1.5.0');
+
+  const updater = new Updater(
+    messageBoxMock,
+    configurationRegistryMock,
+    statusBarRegistryMock,
+    commandRegistryMock,
+    taskManagerMock,
+    apiSenderMock,
+  );
+  updater.init();
+
+  await vi.waitFor(() => expect(autoUpdater.checkForUpdates).toBeCalled());
+  expect(updater.updateAvailable()).toBeTruthy();
+});
+
+test('update is not available when next version is the same as the current version', async () => {
+  vi.mocked(autoUpdater.checkForUpdates).mockResolvedValue({
+    updateInfo: {
+      version: '1.5.0',
+    },
+  } as unknown as UpdateCheckResult);
+
+  vi.mocked(app.getVersion).mockReturnValue('1.5.0');
+  const updater = new Updater(
+    messageBoxMock,
+    configurationRegistryMock,
+    statusBarRegistryMock,
+    commandRegistryMock,
+    taskManagerMock,
+    apiSenderMock,
+  );
+  updater.init();
+
+  await vi.waitFor(() => expect(autoUpdater.checkForUpdates).toBeCalled());
+  expect(updater.updateAvailable()).toBeFalsy();
+});
+
+test('update is not available when next version is less than the current version', async () => {
+  vi.mocked(autoUpdater.checkForUpdates).mockResolvedValue({
+    updateInfo: {
+      version: '1.5.0',
+    },
+  } as unknown as UpdateCheckResult);
+
+  vi.mocked(app.getVersion).mockReturnValue('1.5.1');
+  const updater = new Updater(
+    messageBoxMock,
+    configurationRegistryMock,
+    statusBarRegistryMock,
+    commandRegistryMock,
+    taskManagerMock,
+    apiSenderMock,
+  );
+  updater.init();
+
+  await vi.waitFor(() => expect(autoUpdater.checkForUpdates).toBeCalled());
+
+  expect(updater.updateAvailable()).toBeFalsy();
 });

--- a/packages/main/src/plugin/updater.ts
+++ b/packages/main/src/plugin/updater.ts
@@ -26,7 +26,7 @@ import {
   type UpdateDownloadedEvent,
   type UpdateInfo,
 } from 'electron-updater';
-import { compare } from 'semver';
+import { compare, valid } from 'semver';
 
 import type { CommandRegistry } from '/@/plugin/command-registry.js';
 import type { ConfigurationRegistry } from '/@/plugin/configuration-registry.js';
@@ -404,10 +404,13 @@ export class Updater {
       .checkForUpdates()
       .then(result => {
         this.#updateCheckResult = result ?? undefined;
-        this.#nextVersion =
+        if (
+          !valid(app.getVersion()) ||
+          !valid(this.#updateCheckResult?.updateInfo.version ?? '') ||
           compare(app.getVersion(), this.#updateCheckResult?.updateInfo.version ?? '') === -1
-            ? this.getFormattedVersion(this.#updateCheckResult?.updateInfo)
-            : undefined;
+        ) {
+          this.#nextVersion = this.getFormattedVersion(this.#updateCheckResult?.updateInfo);
+        }
       })
       .catch((error: unknown) => {
         console.log('unable to check for updates', error);

--- a/packages/main/src/plugin/updater.ts
+++ b/packages/main/src/plugin/updater.ts
@@ -26,6 +26,7 @@ import {
   type UpdateDownloadedEvent,
   type UpdateInfo,
 } from 'electron-updater';
+import { compare } from 'semver';
 
 import type { CommandRegistry } from '/@/plugin/command-registry.js';
 import type { ConfigurationRegistry } from '/@/plugin/configuration-registry.js';
@@ -403,7 +404,10 @@ export class Updater {
       .checkForUpdates()
       .then(result => {
         this.#updateCheckResult = result ?? undefined;
-        this.#nextVersion = this.getFormattedVersion(this.#updateCheckResult?.updateInfo);
+        this.#nextVersion =
+          compare(app.getVersion(), this.#updateCheckResult?.updateInfo.version ?? '') === -1
+            ? this.getFormattedVersion(this.#updateCheckResult?.updateInfo)
+            : undefined;
       })
       .catch((error: unknown) => {
         console.log('unable to check for updates', error);
@@ -411,7 +415,8 @@ export class Updater {
   }
 
   public updateAvailable(): boolean {
-    return this.#updateCheckResult !== undefined && this.#currentVersion !== this.#nextVersion;
+    console.log(!!this.#nextVersion);
+    return !!this.#nextVersion;
   }
 
   public init(): Disposable {

--- a/packages/main/src/plugin/updater.ts
+++ b/packages/main/src/plugin/updater.ts
@@ -415,7 +415,6 @@ export class Updater {
   }
 
   public updateAvailable(): boolean {
-    console.log(!!this.#nextVersion);
     return !!this.#nextVersion;
   }
 


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR changes the nextVersion value in updater to be set only when its is greater than the current version. It also updates the function `updateAvailable()` to return boolean based on if nextVersion is set or undefined.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/containers/podman-desktop/issues/9521
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
