### PR TITLE
chore: remember collapsed state of learning center

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -163,6 +163,7 @@ import { InputQuickPickRegistry } from './input-quickpick/input-quickpick-regist
 import { ExtensionInstaller } from './install/extension-installer.js';
 import { KubernetesClient } from './kubernetes/kubernetes-client.js';
 import { downloadGuideList } from './learning-center/learning-center.js';
+import { LearningCenterInit } from './learning-center-init.js';
 import { LibpodApiInit } from './libpod-api-enable/libpod-api-init.js';
 import type { MessageBoxOptions, MessageBoxReturnValue } from './message-box.js';
 import { MessageBox } from './message-box.js';
@@ -615,6 +616,9 @@ export class PluginSystem {
 
     const releaseNotesBannerConfiguration = new ReleaseNotesBannerInit(configurationRegistry);
     releaseNotesBannerConfiguration.init();
+
+    const learningCenterConfiguration = new LearningCenterInit(configurationRegistry);
+    learningCenterConfiguration.init();
 
     const terminalInit = new TerminalInit(configurationRegistry);
     terminalInit.init();

--- a/packages/main/src/plugin/learning-center-init.spec.ts
+++ b/packages/main/src/plugin/learning-center-init.spec.ts
@@ -1,0 +1,48 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test, vi } from 'vitest';
+
+import type { ConfigurationRegistry } from './configuration-registry.js';
+import { LearningCenterInit } from './learning-center-init.js';
+
+let learningCenterInit: LearningCenterInit;
+
+const registerConfigurationsMock = vi.fn();
+
+const configurationRegistryMock = {
+  registerConfigurations: registerConfigurationsMock,
+} as unknown as ConfigurationRegistry;
+
+test('should register configuration', async () => {
+  learningCenterInit = new LearningCenterInit(configurationRegistryMock);
+
+  learningCenterInit.init();
+
+  expect(configurationRegistryMock.registerConfigurations).toBeCalled();
+
+  const configurationNode = vi.mocked(configurationRegistryMock.registerConfigurations).mock.calls[0]?.[0][0];
+  expect(configurationNode?.id).toBe('learningCenter');
+  expect(configurationNode?.title).toBe('Show learning center content');
+  expect(configurationNode?.properties).toBeDefined();
+  expect(Object.keys(configurationNode?.properties ?? {}).length).toBe(1);
+  expect(configurationNode?.properties?.['learningCenter.expanded']).toBeDefined();
+  expect(configurationNode?.properties?.['learningCenter.expanded']?.type).toBe('boolean');
+  expect(configurationNode?.properties?.['learningCenter.expanded']?.default).toBe(true);
+  expect(configurationNode?.properties?.['learningCenter.expanded']?.hidden).toBe(true);
+});

--- a/packages/main/src/plugin/learning-center-init.ts
+++ b/packages/main/src/plugin/learning-center-init.ts
@@ -1,0 +1,40 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { IConfigurationNode, IConfigurationRegistry } from './configuration-registry.js';
+
+export class LearningCenterInit {
+  constructor(private configurationRegistry: IConfigurationRegistry) {}
+
+  init(): void {
+    const learningCenterConfiguration: IConfigurationNode = {
+      id: 'learningCenter',
+      title: 'Show learning center content',
+      type: 'object',
+      properties: {
+        ['learningCenter.expanded']: {
+          type: 'boolean',
+          default: true,
+          hidden: true,
+        },
+      },
+    };
+
+    this.configurationRegistry.registerConfigurations([learningCenterConfiguration]);
+  }
+}

--- a/packages/renderer/src/lib/learning-center/LearningCenter.spec.ts
+++ b/packages/renderer/src/lib/learning-center/LearningCenter.spec.ts
@@ -21,7 +21,8 @@
 import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
-import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { tick } from 'svelte';
+import { afterEach, beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
 import learningCenter from '../../../../main/src/plugin/learning-center/guides.json';
 import LearningCenter from './LearningCenter.svelte';
@@ -44,12 +45,23 @@ class ResizeObserver {
 
 const updateConfigurationValueMock = vi.fn();
 const getConfigurationValueMock = vi.fn();
+const listGuidesMock = vi.fn().mockReturnValue(learningCenter.guides);
+
+beforeAll(() => {
+  Object.defineProperty(window, 'getConfigurationValue', {
+    value: getConfigurationValueMock,
+  });
+  Object.defineProperty(window, 'listGuides', {
+    value: listGuidesMock,
+  });
+  Object.defineProperty(window, 'updateConfigurationValue', {
+    value: updateConfigurationValueMock,
+  });
+  global.ResizeObserver = ResizeObserver;
+});
 
 beforeEach(() => {
-  (window as any).ResizeObserver = ResizeObserver;
-  (window as any).listGuides = vi.fn().mockReturnValue(learningCenter.guides);
-  (window as any).updateConfigurationValue = updateConfigurationValueMock;
-  (window as any).getConfigurationValue = getConfigurationValueMock;
+  listGuidesMock.mockReturnValue(learningCenter.guides);
 });
 
 afterEach(() => {
@@ -84,23 +96,26 @@ test('Clicking on LearningCenter title hides carousel with guides', async () => 
 test('Toggling expansion sets configuration', async () => {
   render(LearningCenter);
 
+  // wait for onMount
+  await tick();
+
   expect(updateConfigurationValueMock).not.toHaveBeenCalled();
 
-  const toggle = screen.getByText('Learning Center');
-  expect(toggle).toBeInTheDocument();
-  expect(toggle.parentElement?.parentElement).toHaveAttribute('aria-expanded', 'true');
+  const button = screen.getByRole('button', { name: 'Learning Center' });
+  expect(button).toBeInTheDocument();
+  expect(button).toHaveAttribute('aria-expanded', 'true');
 
-  await fireEvent.click(toggle);
+  await fireEvent.click(button);
   expect(updateConfigurationValueMock).toHaveBeenCalledWith('learningCenter.expanded', false);
-  expect(toggle.parentElement?.parentElement).toHaveAttribute('aria-expanded', 'false');
+  expect(button).toHaveAttribute('aria-expanded', 'false');
 
-  await fireEvent.click(toggle);
+  await fireEvent.click(button);
   expect(updateConfigurationValueMock).toHaveBeenCalledWith('learningCenter.expanded', true);
-  expect(toggle.parentElement?.parentElement).toHaveAttribute('aria-expanded', 'true');
+  expect(button).toHaveAttribute('aria-expanded', 'true');
 
-  await fireEvent.click(toggle);
+  await fireEvent.click(button);
   expect(updateConfigurationValueMock).toHaveBeenCalledWith('learningCenter.expanded', false);
-  expect(toggle.parentElement?.parentElement).toHaveAttribute('aria-expanded', 'false');
+  expect(button).toHaveAttribute('aria-expanded', 'false');
 });
 
 test('Expanded when the config value not set', async () => {

--- a/packages/renderer/src/lib/learning-center/LearningCenter.spec.ts
+++ b/packages/renderer/src/lib/learning-center/LearningCenter.spec.ts
@@ -20,7 +20,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { fireEvent, render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
 import learningCenter from '../../../../main/src/plugin/learning-center/guides.json';
@@ -42,9 +42,14 @@ class ResizeObserver {
   unobserve = vi.fn();
 }
 
+const updateConfigurationValueMock = vi.fn();
+const getConfigurationValueMock = vi.fn();
+
 beforeEach(() => {
   (window as any).ResizeObserver = ResizeObserver;
   (window as any).listGuides = vi.fn().mockReturnValue(learningCenter.guides);
+  (window as any).updateConfigurationValue = updateConfigurationValueMock;
+  (window as any).getConfigurationValue = getConfigurationValueMock;
 });
 
 afterEach(() => {
@@ -74,4 +79,53 @@ test('Clicking on LearningCenter title hides carousel with guides', async () => 
   await vi.waitFor(async () => {
     expect(screen.queryByText(learningCenter.guides[0].title)).not.toBeInTheDocument();
   });
+});
+
+test('Toggling expansion sets configuration', async () => {
+  render(LearningCenter);
+
+  expect(updateConfigurationValueMock).not.toHaveBeenCalled();
+
+  const toggle = screen.getByText('Learning Center');
+  expect(toggle).toBeInTheDocument();
+  expect(toggle.parentElement?.parentElement).toHaveAttribute('aria-expanded', 'true');
+
+  await fireEvent.click(toggle);
+  expect(updateConfigurationValueMock).toHaveBeenCalledWith('learningCenter.expanded', false);
+  expect(toggle.parentElement?.parentElement).toHaveAttribute('aria-expanded', 'false');
+
+  await fireEvent.click(toggle);
+  expect(updateConfigurationValueMock).toHaveBeenCalledWith('learningCenter.expanded', true);
+  expect(toggle.parentElement?.parentElement).toHaveAttribute('aria-expanded', 'true');
+
+  await fireEvent.click(toggle);
+  expect(updateConfigurationValueMock).toHaveBeenCalledWith('learningCenter.expanded', false);
+  expect(toggle.parentElement?.parentElement).toHaveAttribute('aria-expanded', 'false');
+});
+
+test('Expanded when the config value not set', async () => {
+  render(LearningCenter);
+
+  const button = screen.getByRole('button', { name: 'Learning Center' });
+  expect(button).toHaveAttribute('aria-expanded', 'true');
+});
+
+test('Collapsed when the config value is set to not expanded', async () => {
+  getConfigurationValueMock.mockResolvedValue(false);
+  render(LearningCenter);
+
+  await waitFor(() => expect(getConfigurationValueMock).toBeCalled());
+
+  const button = screen.getByRole('button', { name: 'Learning Center' });
+  expect(button).toHaveAttribute('aria-expanded', 'false');
+});
+
+test('Expanded when the config value is set to expanded', async () => {
+  getConfigurationValueMock.mockResolvedValue(true);
+  render(LearningCenter);
+
+  await waitFor(() => expect(getConfigurationValueMock).toBeCalled());
+
+  const button = screen.getByRole('button', { name: 'Learning Center' });
+  expect(button).toHaveAttribute('aria-expanded', 'true');
 });

--- a/packages/renderer/src/lib/learning-center/LearningCenter.svelte
+++ b/packages/renderer/src/lib/learning-center/LearningCenter.svelte
@@ -1,22 +1,33 @@
 <script lang="ts">
-import { Carousel } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 
 import type { Guide } from '../../../../main/src/plugin/learning-center/learning-center-api';
+import Carousel from '../carousel/Carousel.svelte';
 import { fadeSlide } from '../ui/animations';
 import GuideCard from './GuideCard.svelte';
 
 let guides: Guide[] = [];
 let expanded: boolean = true;
 
+const configProperty = 'learningCenter.expanded';
+
 onMount(async () => {
   guides = await window.listGuides();
+  const configValue = await window.getConfigurationValue<boolean>(configProperty);
+  if (typeof configValue !== 'undefined') {
+    expanded = configValue;
+  }
 });
+
+async function toggle() {
+  expanded = !expanded;
+  await window.updateConfigurationValue(configProperty, expanded);
+}
 </script>
 
 <div class="flex flex-1 flex-col bg-[var(--pd-content-card-bg)] p-5 rounded-lg">
   <div>
-    <button on:click={(): boolean => (expanded = !expanded)} class="">
+    <button on:click={toggle} aria-expanded="{expanded}">
       <div class="flex flex-row space-x-2 items-center text-[var(--pd-content-card-header-text)]">
         {#if expanded}
           <i class="fas fa-chevron-down"></i>
@@ -31,7 +42,7 @@ onMount(async () => {
     <div role="region" class="mt-5">
       <div transition:fadeSlide={{ duration: 500 }}>
         <Carousel cards={guides} let:card>
-          <GuideCard guide={card as Guide} />
+          <GuideCard guide={card} />
         </Carousel>
       </div>
     </div>

--- a/packages/renderer/src/lib/learning-center/LearningCenter.svelte
+++ b/packages/renderer/src/lib/learning-center/LearningCenter.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
+import { Carousel } from '@podman-desktop/ui-svelte';
 import { onDestroy, onMount } from 'svelte';
 
 import { onDidChangeConfiguration } from '/@/stores/configurationProperties';
 
 import type { Guide } from '../../../../main/src/plugin/learning-center/learning-center-api';
-import Carousel from '../carousel/Carousel.svelte';
 import { fadeSlide } from '../ui/animations';
 import GuideCard from './GuideCard.svelte';
 
@@ -12,7 +12,7 @@ let guides: Guide[] = $state([]);
 let expanded: boolean = $state(true);
 let initialized: boolean = $state(false);
 
-const listener: EventListener = (obj: any) => {
+const listener: EventListener = (obj: object) => {
   if ('detail' in obj) {
     const detail = obj.detail as { key: string; value: boolean };
     if (CONFIGURATION_KEY === detail?.key) {
@@ -60,7 +60,7 @@ async function toggle(): Promise<void> {
     <div role="region" class="mt-5">
       <div transition:fadeSlide={{ duration: 250 }}>
         <Carousel cards={guides} let:card>
-          <GuideCard guide={card} />
+          <GuideCard guide={card as Guide} />
         </Carousel>
       </div>
     </div>

--- a/packages/renderer/src/lib/learning-center/LearningCenter.svelte
+++ b/packages/renderer/src/lib/learning-center/LearningCenter.svelte
@@ -1,33 +1,49 @@
 <script lang="ts">
-import { onMount } from 'svelte';
+import { onDestroy, onMount } from 'svelte';
+
+import { onDidChangeConfiguration } from '/@/stores/configurationProperties';
 
 import type { Guide } from '../../../../main/src/plugin/learning-center/learning-center-api';
 import Carousel from '../carousel/Carousel.svelte';
 import { fadeSlide } from '../ui/animations';
 import GuideCard from './GuideCard.svelte';
 
-let guides: Guide[] = [];
-let expanded: boolean = true;
+let guides: Guide[] = $state([]);
+let expanded: boolean = $state(true);
+let initialized: boolean = $state(false);
 
-const configProperty = 'learningCenter.expanded';
+const listener: EventListener = (obj: any) => {
+  if ('detail' in obj) {
+    const detail = obj.detail as { key: string; value: boolean };
+    if (CONFIGURATION_KEY === detail?.key) {
+      expanded = detail.value;
+    }
+  }
+};
+
+const CONFIGURATION_KEY = 'learningCenter.expanded';
 
 onMount(async () => {
   guides = await window.listGuides();
-  const configValue = await window.getConfigurationValue<boolean>(configProperty);
-  if (typeof configValue !== 'undefined') {
-    expanded = configValue;
-  }
+
+  onDidChangeConfiguration.addEventListener(CONFIGURATION_KEY, listener);
+  expanded = (await window.getConfigurationValue<boolean>(CONFIGURATION_KEY)) ?? true;
+  initialized = true;
 });
 
-async function toggle() {
+onDestroy(() => {
+  onDidChangeConfiguration.removeEventListener(CONFIGURATION_KEY, listener);
+});
+
+async function toggle(): Promise<void> {
   expanded = !expanded;
-  await window.updateConfigurationValue(configProperty, expanded);
+  await window.updateConfigurationValue(CONFIGURATION_KEY, expanded);
 }
 </script>
 
 <div class="flex flex-1 flex-col bg-[var(--pd-content-card-bg)] p-5 rounded-lg">
   <div>
-    <button on:click={toggle} aria-expanded="{expanded}">
+    <button onclick={toggle} aria-expanded="{expanded}">
       <div class="flex flex-row space-x-2 items-center text-[var(--pd-content-card-header-text)]">
         {#if expanded}
           <i class="fas fa-chevron-down"></i>
@@ -38,13 +54,16 @@ async function toggle() {
       </div>
     </button>
   </div>
+
+  {#if initialized}
   {#if expanded}
     <div role="region" class="mt-5">
-      <div transition:fadeSlide={{ duration: 500 }}>
+      <div transition:fadeSlide={{ duration: 250 }}>
         <Carousel cards={guides} let:card>
           <GuideCard guide={card} />
         </Carousel>
       </div>
     </div>
+  {/if}
   {/if}
 </div>


### PR DESCRIPTION
### What does this PR do?

Stores the collapsed/expanded state of the learning center to settings so that it reopens the same way after a restart, using the same method as the release notes. Adds an aria role to make it easy to test.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #9416.

### How to test this PR?

Open Podman Desktop: learning center should be initially open.
Close it and restart: still closed.
Open it and restart: still open.

- [x] Tests are covering the bug fix or the new feature