### PR TITLE
chore: move 2 pixel back to the left the cards to align with the mockup

### DIFF
--- a/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityDockerContext.svelte
+++ b/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityDockerContext.svelte
@@ -36,7 +36,7 @@ $effect(() => {
 </script>
 
 <div
-  class="bg-[var(--pd-invert-content-card-bg)] rounded-md mt-2 ml-2 divide-x divide-[var(--pd-content-divider)] flex flex-col lg:flex-row">
+  class="bg-[var(--pd-invert-content-card-bg)] rounded-md mt-2 divide-x divide-[var(--pd-content-divider)] flex flex-col lg:flex-row">
   <div class="flex flex-row grow px-2 py-2 justify-between text-[color:var(--pd-invert-content-card-text)]">
     <div class="flex flex-col w-full">
       <div class="flex flex-row items-center text-[color:var(--pd-invert-content-card-text)]">

--- a/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityRendering.svelte
+++ b/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityRendering.svelte
@@ -9,7 +9,7 @@ import PreferencesDockerCompatibilitySocketMappingStatus from './PreferencesDock
     Podman Desktop provides compatibility with Docker, allowing you to use your existing Docker commands, images and
     workflows.
   </svelte:fragment>
-  <div class="flex flex-col space-y-4">
+  <div class="flex flex-col space-y-2">
     <div class="container" role="list">
       <div class="text-lg font-medium first-letter:uppercase">Docker Preferences</div>
       <PreferencesDockerCompatibilitySocketMappingStatus />

--- a/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilitySocketMappingStatus.svelte
+++ b/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilitySocketMappingStatus.svelte
@@ -43,7 +43,7 @@ onMount(async () => {
 </script>
 
 <div
-  class="bg-[var(--pd-invert-content-card-bg)] rounded-md m-2 divide-x divide-[var(--pd-content-divider)] flex flex-col lg:flex-row">
+  class="bg-[var(--pd-invert-content-card-bg)] rounded-md my-2 divide-x divide-[var(--pd-content-divider)] flex flex-col lg:flex-row">
   <div class="flex flex-row grow px-2 py-2 justify-between text-[color:var(--pd-invert-content-card-text)]">
     <div class="flex flex-col">
       <div class="flex flex-row items-center text-[color:var(--pd-invert-content-card-text)]">


### PR DESCRIPTION
### What does this PR do?
move 2 pixel back to the left the cards to align with the mockup

### Screenshot / video of UI
before:
![image](https://github.com/user-attachments/assets/0e665df1-4af6-41c7-8fda-5352f889e651)


after:
![image](https://github.com/user-attachments/assets/ad0e5453-5b08-4c9d-8857-653dca222a2d)




<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

part of https://github.com/containers/podman-desktop/issues/9242


### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
