### PR TITLE
chore: properties can be part of a group

### DIFF
--- a/packages/main/src/plugin/configuration-registry.spec.ts
+++ b/packages/main/src/plugin/configuration-registry.spec.ts
@@ -274,6 +274,28 @@ test('addConfigurationEnum with a previous default value', async () => {
   expect(val).toEqual('myValue1');
 });
 
+test('check to be able to register a property with a group', async () => {
+  const node: IConfigurationNode = {
+    id: 'custom',
+    title: 'Fake Property',
+    properties: {
+      'my.fake.property': {
+        description: 'property being part of a group',
+        type: 'string',
+        group: 'myGroup',
+        default: 'myDefault',
+      },
+    },
+  };
+
+  configurationRegistry.registerConfigurations([node]);
+
+  const records = configurationRegistry.getConfigurationProperties();
+  const record = records['my.fake.property'];
+  expect(record).toBeDefined();
+  expect(record?.group).toEqual('myGroup');
+});
+
 describe('should be notified when a configuration is updated', async () => {
   test('expect correct properties', async () => {
     const listener = vi.fn();

--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -59,6 +59,7 @@ export interface IConfigurationPropertySchema {
   type?: IConfigurationPropertySchemaType | IConfigurationPropertySchemaType[];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   default?: any;
+  group?: string;
   description?: string;
   placeholder?: string;
   markdownDescription?: string;


### PR DESCRIPTION
### What does this PR do?
for some case, we need to be able to say two properties are part of a given group. Add the optional property so it's possible to group properties

usecase: group compose & podman socket helper property to a common block in the UI

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

part of https://github.com/containers/podman-desktop/issues/9242

### How to test this PR?

unit test provided

- [x] Tests are covering the bug fix or the new feature
