### PR TITLE
docs: update release image static link and product announcement

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -210,7 +210,7 @@ An example of a previous post: https://www.reddit.com/r/podman/comments/10moat6/
 #### Email announcement
 
 1. Send email to devtools-team at redhat.com, Podman-Desktop at redhat.com
-1. Send email to product-announce at redhat.com (high level)
+1. Check in with the Product Manager (PM) about the product-announce announcement (high level)
 1. Send email to podman-desktop at lists.podman.io (no links to Red Hat internal slack, etc.)
 
 ## Release notes template
@@ -224,7 +224,7 @@ authors: [YOURUSERNAME]
 tags: [podman-desktop, release, kubernetes, openshift]
 hide_table_of_contents: false
 <!-- This image link is used for social media previews / thumbnails. Release images are available: https://github.com/containers/podman-desktop-internal/tree/main/release-images -->
-image: /blog/img/podman-desktop-release-1.X/X.png
+image: /img/blog/podman-desktop-release-1.X/X.png
 ---
 
 <!-- ADD IMPORT REACTPLAYER IF USING VIDEO -->


### PR DESCRIPTION
### What does this PR do?
Updates the release process document to have the correct static link for the release image in the release notes template and include the new product-announce at redhat.com announcement process.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
