### PR TITLE
chore: change no update release notes button in status bar

### DIFF
--- a/packages/main/src/plugin/updater.ts
+++ b/packages/main/src/plugin/updater.ts
@@ -176,7 +176,7 @@ export class Updater {
         title: 'Version',
         message: `Using version ${this.#currentVersion}`,
         detail: detailMessage,
-        buttons: ['View release notes'],
+        buttons: ['View release notes banner'],
       });
       if (result.response === 0) {
         await this.configurationRegistry.updateConfigurationValue(`releaseNotesBanner.show`, 'show');


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
The current behavior of the `View release notes` button in the status bar when there is no update available is confusing. This PR updates the wording of the button to make it more clear what it is supposed to do.
(I can also add `router.goto('/')` when clicking on the button from any page on PD if we'd like to include it in this PR)

### Screenshot / video of UI

![Screenshot from 2024-10-25 13-07-00](https://github.com/user-attachments/assets/4d00ab12-872c-4b29-b14f-91133dfedc4d)

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
