### PR TITLE
chore: redirect to dashboard when clicking on release notes button in statusbar

### DIFF
--- a/packages/renderer/src/App.spec.ts
+++ b/packages/renderer/src/App.spec.ts
@@ -214,3 +214,11 @@ test('go to nodes page when last kubernetes page not available', async () => {
   await tick();
   expect(mocks.NodesList).toHaveBeenCalled();
 });
+
+test('receive show-release-notes event from main', async () => {
+  render(App);
+
+  messages.get('show-release-notes');
+
+  expect(mocks.DashboardPage).toBeCalled();
+});

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -93,6 +93,10 @@ window.events?.receive('context-menu:visible', visible => {
   }
 });
 
+window.events?.receive('show-release-notes', () => {
+  router.goto('/');
+});
+
 window.events?.receive('navigate', (navigationRequest: unknown) => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   handleNavigation(navigationRequest as NavigationRequest<any>);


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
When clicking on the view release notes button in the status bar, it will redirect the user to the Dashboard page where the release notes banner will be visible

### Screenshot / video of UI
[Screencast from 2024-10-25 13-33-27.webm](https://github.com/user-attachments/assets/8f01a6c6-35cf-442a-af7f-14a9a49ea6c1)


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/containers/podman-desktop/issues/9271

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
Go to any page in PD, click on the version button in the status bar, click view release notes and assert that you've been taken to the dashboard page

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
