### PR TITLE
chore: adding string value for workload kind

### DIFF
--- a/packages/api/src/kubernetes-port-forward-model.ts
+++ b/packages/api/src/kubernetes-port-forward-model.ts
@@ -20,9 +20,9 @@
  * Enumeration representing the kind of Kubernetes workload.
  */
 export enum WorkloadKind {
-  POD,
-  DEPLOYMENT,
-  SERVICE,
+  POD = 'pod',
+  DEPLOYMENT = 'deployment',
+  SERVICE = 'service',
 }
 
 /**

--- a/packages/main/src/plugin/kubernetes/kubernetes-port-forward-storage.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-port-forward-storage.spec.ts
@@ -137,7 +137,7 @@ describe('FileBasedConfigStorage', () => {
   const sampleConfig: UserForwardConfig = {
     name: 'test-name',
     namespace: 'test-namespace',
-    kind: 0,
+    kind: WorkloadKind.POD,
     forwards: [{ localPort: 8080, remotePort: 80 }],
     displayName: 'test-display-name',
   };
@@ -259,7 +259,7 @@ describe('MemoryBasedConfigStorage', () => {
   const sampleConfig: UserForwardConfig = {
     name: 'test-name',
     namespace: 'test-namespace',
-    kind: 0,
+    kind: WorkloadKind.POD,
     forwards: [{ localPort: 8080, remotePort: 80 }],
     displayName: 'test-display-name',
   };
@@ -338,7 +338,7 @@ describe('ConfigManagementService', () => {
   const sampleConfig: UserForwardConfig = {
     name: 'test-name',
     namespace: 'test-namespace',
-    kind: 0,
+    kind: WorkloadKind.POD,
     forwards: [{ localPort: 8080, remotePort: 80 }],
     displayName: 'test-display-name',
   };


### PR DESCRIPTION
### What does this PR do?

We need to have a matching string for the `WorkloadKind` to be able to nicely display in the table what kind of Kube resources it is.

### Screenshot / video of UI

![Screenshot from 2024-10-28 15-02-05](https://github.com/user-attachments/assets/18bee0ca-0c28-4859-9345-4dc2f1ef984a)

### What issues does this PR fix or reference?

Required for https://github.com/containers/podman-desktop/issues/9275

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Existing tests ensure no regression
