### PR TITLE
feat(ui): adding kubernetesCurrentContextPortForwards store

### DIFF
--- a/packages/renderer/src/stores/kubernetes-contexts-state.ts
+++ b/packages/renderer/src/stores/kubernetes-contexts-state.ts
@@ -20,6 +20,7 @@ import type { KubernetesObject } from '@kubernetes/client-node';
 import { derived, type Readable, readable, writable } from 'svelte/store';
 
 import type { CheckingState, ContextGeneralState } from '/@api/kubernetes-contexts-states';
+import type { UserForwardConfig } from '/@api/kubernetes-port-forward-model';
 
 import { findMatchInLeaves } from './search-util';
 
@@ -246,3 +247,15 @@ export const kubernetesCurrentContextRoutesFiltered = derived(
   [routeSearchPattern, kubernetesCurrentContextRoutes],
   ([$searchPattern, $routes]) => $routes.filter(route => findMatchInLeaves(route, $searchPattern.toLowerCase())),
 );
+
+// Port Forwarding
+
+export const kubernetesCurrentContextPortForwards = readable<UserForwardConfig[]>([], set => {
+  window.getKubernetesPortForwards().then(value => {
+    set(value);
+  });
+  window.events?.receive('kubernetes-port-forwards-update', (value: unknown) => {
+    set((value ?? []) as UserForwardConfig[]);
+  });
+  return () => {};
+});

--- a/packages/renderer/src/stores/kubernetes-contexts-state.ts
+++ b/packages/renderer/src/stores/kubernetes-contexts-state.ts
@@ -255,7 +255,6 @@ export const kubernetesCurrentContextPortForwards = readable<UserForwardConfig[]
     set(value);
   });
   window.events?.receive('kubernetes-port-forwards-update', (value: unknown) => {
-    set((value ?? []) as UserForwardConfig[]);
+    set(value as UserForwardConfig[]);
   });
-  return () => {};
 });


### PR DESCRIPTION
### What does this PR do?

We need a store for the port forward config, to be able to list them (https://github.com/containers/podman-desktop/issues/9275) and properly show the actions such as delete, open in browser (https://github.com/containers/podman-desktop/issues/9273)

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
