### PR TITLE
feat: adding port forwarding actions to kube container details

### DIFF
--- a/packages/renderer/src/lib/kube/KubePodDetailsSummary.svelte
+++ b/packages/renderer/src/lib/kube/KubePodDetailsSummary.svelte
@@ -14,7 +14,7 @@ export let pod: V1Pod | undefined;
   {#if pod}
     <KubeObjectMetaArtifact artifact={pod.metadata} />
     <KubePodStatusArtifact artifact={pod.status} />
-    <KubePodSpecArtifact artifact={pod.spec} />
+    <KubePodSpecArtifact podName={pod.metadata?.name} namespace={pod.metadata?.namespace} artifact={pod.spec} />
   {:else}
     <p class="text-[var(--pd-state-info)] font-medium">Loading ...</p>
   {/if}

--- a/packages/renderer/src/lib/kube/details/KubeContainerArtifact.spec.ts
+++ b/packages/renderer/src/lib/kube/details/KubeContainerArtifact.spec.ts
@@ -20,9 +20,14 @@ import '@testing-library/jest-dom/vitest';
 
 import type { V1Container } from '@kubernetes/client-node';
 import { render, screen } from '@testing-library/svelte';
-import { expect, test } from 'vitest';
+import { readable } from 'svelte/store';
+import { beforeEach, expect, test, vi } from 'vitest';
 
-import KubeContainerArtifact from './KubeContainerArtifact.svelte'; // Adjust the import path as necessary
+import * as kubeContextStore from '/@/stores/kubernetes-contexts-state'; // Adjust the import path as necessary
+
+import KubeContainerArtifact from './KubeContainerArtifact.svelte';
+
+vi.mock('/@/stores/kubernetes-contexts-state', async () => ({}));
 
 const fakeContainer: V1Container = {
   name: 'fakeContainerName',
@@ -41,6 +46,12 @@ const fakeContainer: V1Container = {
     { name: 'volumeMount2', mountPath: '/path/to/mount2' },
   ],
 };
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  vi.mocked(kubeContextStore).kubernetesCurrentContextPortForwards = readable([]);
+});
 
 test('Container artifact renders with correct values', async () => {
   render(KubeContainerArtifact, { artifact: fakeContainer });

--- a/packages/renderer/src/lib/kube/details/KubeContainerArtifact.svelte
+++ b/packages/renderer/src/lib/kube/details/KubeContainerArtifact.svelte
@@ -4,7 +4,12 @@ import type { V1Container } from '@kubernetes/client-node';
 import Cell from '/@/lib/details/DetailsCell.svelte';
 import KubeContainerPorts from '/@/lib/kube/details/KubeContainerPorts.svelte';
 
-export let artifact: V1Container | undefined;
+interface Props {
+  artifact?: V1Container;
+  podName?: string;
+  namespace?: string;
+}
+let { artifact, podName, namespace }: Props = $props();
 </script>
 
 {#if artifact}
@@ -20,7 +25,7 @@ export let artifact: V1Container | undefined;
     <Cell>Image Pull Policy</Cell>
     <Cell>{artifact.imagePullPolicy}</Cell>
   </tr>
-  <KubeContainerPorts ports={artifact.ports ?? []}/>
+  <KubeContainerPorts namespace={namespace} podName={podName}  ports={artifact.ports}/>
   {#if artifact.env}
     <tr>
       <Cell>Environment Variables</Cell>

--- a/packages/renderer/src/lib/kube/details/KubeContainerPort.spec.ts
+++ b/packages/renderer/src/lib/kube/details/KubeContainerPort.spec.ts
@@ -1,0 +1,152 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render } from '@testing-library/svelte';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import KubeContainerPort from '/@/lib/kube/details/KubeContainerPort.svelte';
+import { type UserForwardConfig, WorkloadKind } from '/@api/kubernetes-port-forward-model';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  (window.getFreePort as unknown) = vi.fn().mockResolvedValue(55_001);
+  (window.createKubernetesPortForward as unknown) = vi.fn();
+  (window.openExternal as unknown) = vi.fn();
+  (window.deleteKubernetesPortForward as unknown) = vi.fn();
+});
+
+const DUMMY_FORWARD_CONFIG: UserForwardConfig = {
+  name: 'dummy-pod-name',
+  namespace: 'dummy-ns',
+  kind: WorkloadKind.POD,
+  forwards: [
+    {
+      localPort: 55_076,
+      remotePort: 80,
+    },
+  ],
+  displayName: 'dummy name',
+};
+
+describe('port forwarding', () => {
+  test('forward button should be visible and unique for each container port', async () => {
+    const { getByTitle } = render(KubeContainerPort, {
+      namespace: 'dummy-ns',
+      port: {
+        containerPort: 80,
+        protocol: 'TCP',
+      },
+      forwardConfig: undefined,
+      podName: 'dummy-pod-name',
+    });
+
+    const port80 = getByTitle('Forward container port 80');
+    expect(port80).toBeDefined();
+  });
+
+  test('forward button should call ', async () => {
+    const { getByTitle } = render(KubeContainerPort, {
+      namespace: 'dummy-ns',
+      port: {
+        containerPort: 80,
+        protocol: 'TCP',
+      },
+      forwardConfig: undefined,
+      podName: 'dummy-pod-name',
+    });
+
+    const forwardBtn = getByTitle('Forward container port 80');
+    await fireEvent.click(forwardBtn);
+
+    await vi.waitFor(() => {
+      expect(window.getFreePort).toHaveBeenCalled();
+      expect(window.createKubernetesPortForward).toHaveBeenCalledWith({
+        displayName: 'dummy-pod-name/undefined',
+        forward: {
+          localPort: 55001,
+          remotePort: 80,
+        },
+        kind: 'pod',
+        name: 'dummy-pod-name',
+        namespace: 'dummy-ns',
+      });
+    });
+  });
+
+  test('existing forward should display actions', async () => {
+    const { getByTitle } = render(KubeContainerPort, {
+      namespace: 'dummy-ns',
+      port: {
+        containerPort: 80,
+        protocol: 'TCP',
+      },
+      forwardConfig: DUMMY_FORWARD_CONFIG,
+      podName: 'dummy-pod-name',
+    });
+
+    const openBtn = getByTitle('Open in browser');
+    expect(openBtn).toBeDefined();
+
+    const removeBtn = getByTitle('Remove port forward');
+    expect(removeBtn).toBeDefined();
+  });
+
+  test('open button should use window.openExternal with proper local port', async () => {
+    const { getByTitle } = render(KubeContainerPort, {
+      namespace: 'dummy-ns',
+      port: {
+        containerPort: 80,
+        protocol: 'TCP',
+      },
+      forwardConfig: DUMMY_FORWARD_CONFIG,
+      podName: 'dummy-pod-name',
+    });
+
+    const openBtn = getByTitle('Open in browser');
+    await fireEvent.click(openBtn);
+
+    await vi.waitFor(() => {
+      expect(window.openExternal).toHaveBeenCalledWith('http://localhost:55076');
+    });
+  });
+
+  test('remove button should use window.deleteKubernetesPortForward with proper local port', async () => {
+    const { getByTitle } = render(KubeContainerPort, {
+      namespace: 'dummy-ns',
+      port: {
+        containerPort: 80,
+        protocol: 'TCP',
+      },
+      forwardConfig: DUMMY_FORWARD_CONFIG,
+      podName: 'dummy-pod-name',
+    });
+
+    const removeBtn = getByTitle('Remove port forward');
+    await fireEvent.click(removeBtn);
+
+    await vi.waitFor(() => {
+      expect(window.deleteKubernetesPortForward).toHaveBeenCalledWith(
+        DUMMY_FORWARD_CONFIG,
+        DUMMY_FORWARD_CONFIG.forwards[0],
+      );
+    });
+  });
+});

--- a/packages/renderer/src/lib/kube/details/KubeContainerPort.spec.ts
+++ b/packages/renderer/src/lib/kube/details/KubeContainerPort.spec.ts
@@ -149,4 +149,26 @@ describe('port forwarding', () => {
       );
     });
   });
+
+  test('error from createKubernetesPortForward should be displayed', async () => {
+    vi.mocked(window.createKubernetesPortForward).mockRejectedValue('Dummy error');
+
+    const { getByTitle, getByRole } = render(KubeContainerPort, {
+      namespace: 'dummy-ns',
+      port: {
+        containerPort: 80,
+        protocol: 'TCP',
+      },
+      forwardConfig: undefined,
+      podName: 'dummy-pod-name',
+    });
+
+    const port80 = getByTitle('Forward container port 80');
+    await fireEvent.click(port80);
+
+    await vi.waitFor(() => {
+      const error = getByRole('alert', { name: 'Error Message Content' });
+      expect(error.textContent).toBe('Dummy error');
+    });
+  });
 });

--- a/packages/renderer/src/lib/kube/details/KubeContainerPort.svelte
+++ b/packages/renderer/src/lib/kube/details/KubeContainerPort.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+import { faSquareUpRight, faTrash } from '@fortawesome/free-solid-svg-icons';
+import type { V1ContainerPort } from '@kubernetes/client-node';
+import { Button } from '@podman-desktop/ui-svelte';
+
+import { type PortMapping, type UserForwardConfig, WorkloadKind } from '/@api/kubernetes-port-forward-model';
+
+interface Props {
+  port: V1ContainerPort;
+  forwardConfig?: UserForwardConfig;
+  podName?: string;
+  namespace?: string;
+}
+
+let { port, forwardConfig, podName, namespace }: Props = $props();
+
+let mapping: PortMapping | undefined = $derived(
+  forwardConfig?.forwards.find(mapping => mapping.remotePort === port.containerPort),
+);
+let loading: boolean = $state(false);
+
+async function onForwardRequest(port: V1ContainerPort): Promise<void> {
+  if (!podName) throw new Error('pod name is undefined');
+  loading = true;
+
+  // get a free port starting from 50k
+  const freePort = await window.getFreePort(50_000);
+
+  // snapshot the object as Proxy cannot be serialized
+  const snapshot = $state.snapshot(port);
+  try {
+    await window.createKubernetesPortForward({
+      displayName: `${podName}/${snapshot.name}`,
+      name: podName,
+      kind: WorkloadKind.POD,
+      namespace: namespace ?? 'default',
+      forward: {
+        localPort: freePort,
+        remotePort: snapshot.containerPort,
+      },
+    });
+  } catch (err: unknown) {
+    console.error(err);
+  } finally {
+    loading = false;
+  }
+}
+
+async function openExternal(): Promise<void> {
+  if (!mapping) return;
+  return window.openExternal(`http://localhost:${mapping.localPort}`);
+}
+
+async function removePortForward(): Promise<void> {
+  if (!mapping) return;
+  if (!forwardConfig) return;
+  loading = true;
+
+  try {
+    await window.deleteKubernetesPortForward(forwardConfig, mapping);
+  } catch (err: unknown) {
+    console.error(err);
+  } finally {
+    loading = false;
+  }
+}
+</script>
+
+<span aria-label="container port {port.containerPort}" class="flex gap-x-2 items-center">
+  {port.containerPort}/{port.protocol}
+  {#if mapping}
+    <Button title="Open in browser" disabled={loading} icon={faSquareUpRight} on:click={openExternal.bind(undefined)} class="px-1 py-0.5" padding="0">
+      Open
+    </Button>
+    <Button title="Remove port forward" disabled={loading} icon={faTrash} on:click={removePortForward.bind(undefined)} class="px-1 py-0.5" padding="0">
+      Remove
+    </Button>
+  {:else}
+    <Button title="Forward container port {port.containerPort}" disabled={loading} on:click={onForwardRequest.bind(undefined, port)} class="px-1 py-0.5" padding="0">
+      Forward...
+    </Button>
+  {/if}
+</span>

--- a/packages/renderer/src/lib/kube/details/KubeContainerPorts.spec.ts
+++ b/packages/renderer/src/lib/kube/details/KubeContainerPorts.spec.ts
@@ -18,10 +18,27 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { render } from '@testing-library/svelte';
-import { expect, test } from 'vitest';
+import { fireEvent, render, within } from '@testing-library/svelte';
+import { readable } from 'svelte/store';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import KubeContainerPorts from '/@/lib/kube/details/KubeContainerPorts.svelte';
+import * as kubeContextStore from '/@/stores/kubernetes-contexts-state';
+import { type UserForwardConfig, WorkloadKind } from '/@api/kubernetes-port-forward-model';
+
+vi.mock('/@/stores/kubernetes-contexts-state', async () => ({}));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  vi.mocked(kubeContextStore).kubernetesCurrentContextPortForwards = readable([]);
+
+  (window.getKubernetesPortForwards as unknown) = vi.fn();
+  (window.getFreePort as unknown) = vi.fn().mockResolvedValue(55_001);
+  (window.createKubernetesPortForward as unknown) = vi.fn();
+  (window.openExternal as unknown) = vi.fn();
+  (window.deleteKubernetesPortForward as unknown) = vi.fn();
+});
 
 test('expect port title not to be visible when no ports provided', async () => {
   const { queryByText } = render(KubeContainerPorts);
@@ -62,4 +79,203 @@ test('expect multiple ports to be visible', async () => {
 
   const port100 = getByText('100/TCP');
   expect(port100).toBeDefined();
+});
+
+describe('port forwarding', () => {
+  test('forward button should be visible and unique for each container port', async () => {
+    const { getByTitle } = render(KubeContainerPorts, {
+      ports: [
+        {
+          containerPort: 80,
+          protocol: 'TCP',
+        },
+        {
+          containerPort: 100,
+          protocol: 'TCP',
+        },
+      ],
+    });
+
+    const port80 = getByTitle('Forward container port 80');
+    expect(port80).toBeDefined();
+
+    const port100 = getByTitle('Forward container port 100');
+    expect(port100).toBeDefined();
+  });
+
+  test('forward button should call ', async () => {
+    const { getByTitle } = render(KubeContainerPorts, {
+      ports: [
+        {
+          containerPort: 80,
+          protocol: 'TCP',
+        },
+      ],
+      namespace: 'dummy-ns',
+      podName: 'dummy-pod-name',
+    });
+
+    const forwardBtn = getByTitle('Forward container port 80');
+    await fireEvent.click(forwardBtn);
+
+    await vi.waitFor(() => {
+      expect(window.getFreePort).toHaveBeenCalled();
+      expect(window.createKubernetesPortForward).toHaveBeenCalledWith({
+        displayName: 'dummy-pod-name/undefined',
+        forward: {
+          localPort: 55001,
+          remotePort: 80,
+        },
+        kind: 'pod',
+        name: 'dummy-pod-name',
+        namespace: 'dummy-ns',
+      });
+    });
+  });
+
+  test('existing forward should display actions', async () => {
+    vi.mocked(kubeContextStore).kubernetesCurrentContextPortForwards = readable([
+      {
+        name: 'dummy-pod-name',
+        namespace: 'dummy-ns',
+        kind: WorkloadKind.POD,
+        forwards: [
+          {
+            localPort: 55_076,
+            remotePort: 80,
+          },
+        ],
+        displayName: 'dummy name',
+      },
+    ]);
+
+    const { getByTitle } = render(KubeContainerPorts, {
+      ports: [
+        {
+          containerPort: 80,
+          protocol: 'TCP',
+        },
+      ],
+      namespace: 'dummy-ns',
+      podName: 'dummy-pod-name',
+    });
+
+    const openBtn = getByTitle('Open in browser');
+    expect(openBtn).toBeDefined();
+
+    const removeBtn = getByTitle('Remove port forward');
+    expect(removeBtn).toBeDefined();
+  });
+
+  test('open button should use window.openExternal with proper local port', async () => {
+    vi.mocked(kubeContextStore).kubernetesCurrentContextPortForwards = readable([
+      {
+        name: 'dummy-pod-name',
+        namespace: 'dummy-ns',
+        kind: WorkloadKind.POD,
+        forwards: [
+          {
+            localPort: 55_076,
+            remotePort: 80,
+          },
+        ],
+        displayName: 'dummy name',
+      },
+    ]);
+
+    const { getByTitle } = render(KubeContainerPorts, {
+      ports: [
+        {
+          containerPort: 80,
+          protocol: 'TCP',
+        },
+      ],
+      namespace: 'dummy-ns',
+      podName: 'dummy-pod-name',
+    });
+
+    const openBtn = getByTitle('Open in browser');
+    await fireEvent.click(openBtn);
+
+    await vi.waitFor(() => {
+      expect(window.openExternal).toHaveBeenCalledWith('http://localhost:55076');
+    });
+  });
+
+  test('remove button should use window.deleteKubernetesPortForward with proper local port', async () => {
+    const config: UserForwardConfig = {
+      name: 'dummy-pod-name',
+      namespace: 'dummy-ns',
+      kind: WorkloadKind.POD,
+      forwards: [
+        {
+          localPort: 55_076,
+          remotePort: 80,
+        },
+      ],
+      displayName: 'dummy name',
+    };
+    vi.mocked(kubeContextStore).kubernetesCurrentContextPortForwards = readable([config]);
+
+    const { getByTitle } = render(KubeContainerPorts, {
+      ports: [
+        {
+          containerPort: 80,
+          protocol: 'TCP',
+        },
+      ],
+      namespace: 'dummy-ns',
+      podName: 'dummy-pod-name',
+    });
+
+    const removeBtn = getByTitle('Remove port forward');
+    await fireEvent.click(removeBtn);
+
+    await vi.waitFor(() => {
+      expect(window.deleteKubernetesPortForward).toHaveBeenCalledWith(config, config.forwards[0]);
+    });
+  });
+
+  test('remove button should only delete the targeted mapping', async () => {
+    const config: UserForwardConfig = {
+      name: 'dummy-pod-name',
+      namespace: 'dummy-ns',
+      kind: WorkloadKind.POD,
+      forwards: [
+        {
+          localPort: 55_076,
+          remotePort: 80,
+        },
+        {
+          localPort: 55_077,
+          remotePort: 90,
+        },
+      ],
+      displayName: 'dummy name',
+    };
+    vi.mocked(kubeContextStore).kubernetesCurrentContextPortForwards = readable([config]);
+
+    const { getByLabelText } = render(KubeContainerPorts, {
+      ports: [
+        {
+          containerPort: 80,
+          protocol: 'TCP',
+        },
+        {
+          containerPort: 90,
+          protocol: 'TCP',
+        },
+      ],
+      namespace: 'dummy-ns',
+      podName: 'dummy-pod-name',
+    });
+
+    const span = getByLabelText('container port 90');
+    const removeBtn = within(span).getByTitle('Remove port forward');
+    await fireEvent.click(removeBtn);
+
+    await vi.waitFor(() => {
+      expect(window.deleteKubernetesPortForward).toHaveBeenCalledWith(config, config.forwards[1]);
+    });
+  });
 });

--- a/packages/renderer/src/lib/kube/details/KubeContainerPorts.spec.ts
+++ b/packages/renderer/src/lib/kube/details/KubeContainerPorts.spec.ts
@@ -18,13 +18,12 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { fireEvent, render, within } from '@testing-library/svelte';
+import { render } from '@testing-library/svelte';
 import { readable } from 'svelte/store';
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
 
 import KubeContainerPorts from '/@/lib/kube/details/KubeContainerPorts.svelte';
 import * as kubeContextStore from '/@/stores/kubernetes-contexts-state';
-import { type UserForwardConfig, WorkloadKind } from '/@api/kubernetes-port-forward-model';
 
 vi.mock('/@/stores/kubernetes-contexts-state', async () => ({}));
 
@@ -32,12 +31,6 @@ beforeEach(() => {
   vi.resetAllMocks();
 
   vi.mocked(kubeContextStore).kubernetesCurrentContextPortForwards = readable([]);
-
-  (window.getKubernetesPortForwards as unknown) = vi.fn();
-  (window.getFreePort as unknown) = vi.fn().mockResolvedValue(55_001);
-  (window.createKubernetesPortForward as unknown) = vi.fn();
-  (window.openExternal as unknown) = vi.fn();
-  (window.deleteKubernetesPortForward as unknown) = vi.fn();
 });
 
 test('expect port title not to be visible when no ports provided', async () => {
@@ -79,203 +72,4 @@ test('expect multiple ports to be visible', async () => {
 
   const port100 = getByText('100/TCP');
   expect(port100).toBeDefined();
-});
-
-describe('port forwarding', () => {
-  test('forward button should be visible and unique for each container port', async () => {
-    const { getByTitle } = render(KubeContainerPorts, {
-      ports: [
-        {
-          containerPort: 80,
-          protocol: 'TCP',
-        },
-        {
-          containerPort: 100,
-          protocol: 'TCP',
-        },
-      ],
-    });
-
-    const port80 = getByTitle('Forward container port 80');
-    expect(port80).toBeDefined();
-
-    const port100 = getByTitle('Forward container port 100');
-    expect(port100).toBeDefined();
-  });
-
-  test('forward button should call ', async () => {
-    const { getByTitle } = render(KubeContainerPorts, {
-      ports: [
-        {
-          containerPort: 80,
-          protocol: 'TCP',
-        },
-      ],
-      namespace: 'dummy-ns',
-      podName: 'dummy-pod-name',
-    });
-
-    const forwardBtn = getByTitle('Forward container port 80');
-    await fireEvent.click(forwardBtn);
-
-    await vi.waitFor(() => {
-      expect(window.getFreePort).toHaveBeenCalled();
-      expect(window.createKubernetesPortForward).toHaveBeenCalledWith({
-        displayName: 'dummy-pod-name/undefined',
-        forward: {
-          localPort: 55001,
-          remotePort: 80,
-        },
-        kind: 'pod',
-        name: 'dummy-pod-name',
-        namespace: 'dummy-ns',
-      });
-    });
-  });
-
-  test('existing forward should display actions', async () => {
-    vi.mocked(kubeContextStore).kubernetesCurrentContextPortForwards = readable([
-      {
-        name: 'dummy-pod-name',
-        namespace: 'dummy-ns',
-        kind: WorkloadKind.POD,
-        forwards: [
-          {
-            localPort: 55_076,
-            remotePort: 80,
-          },
-        ],
-        displayName: 'dummy name',
-      },
-    ]);
-
-    const { getByTitle } = render(KubeContainerPorts, {
-      ports: [
-        {
-          containerPort: 80,
-          protocol: 'TCP',
-        },
-      ],
-      namespace: 'dummy-ns',
-      podName: 'dummy-pod-name',
-    });
-
-    const openBtn = getByTitle('Open in browser');
-    expect(openBtn).toBeDefined();
-
-    const removeBtn = getByTitle('Remove port forward');
-    expect(removeBtn).toBeDefined();
-  });
-
-  test('open button should use window.openExternal with proper local port', async () => {
-    vi.mocked(kubeContextStore).kubernetesCurrentContextPortForwards = readable([
-      {
-        name: 'dummy-pod-name',
-        namespace: 'dummy-ns',
-        kind: WorkloadKind.POD,
-        forwards: [
-          {
-            localPort: 55_076,
-            remotePort: 80,
-          },
-        ],
-        displayName: 'dummy name',
-      },
-    ]);
-
-    const { getByTitle } = render(KubeContainerPorts, {
-      ports: [
-        {
-          containerPort: 80,
-          protocol: 'TCP',
-        },
-      ],
-      namespace: 'dummy-ns',
-      podName: 'dummy-pod-name',
-    });
-
-    const openBtn = getByTitle('Open in browser');
-    await fireEvent.click(openBtn);
-
-    await vi.waitFor(() => {
-      expect(window.openExternal).toHaveBeenCalledWith('http://localhost:55076');
-    });
-  });
-
-  test('remove button should use window.deleteKubernetesPortForward with proper local port', async () => {
-    const config: UserForwardConfig = {
-      name: 'dummy-pod-name',
-      namespace: 'dummy-ns',
-      kind: WorkloadKind.POD,
-      forwards: [
-        {
-          localPort: 55_076,
-          remotePort: 80,
-        },
-      ],
-      displayName: 'dummy name',
-    };
-    vi.mocked(kubeContextStore).kubernetesCurrentContextPortForwards = readable([config]);
-
-    const { getByTitle } = render(KubeContainerPorts, {
-      ports: [
-        {
-          containerPort: 80,
-          protocol: 'TCP',
-        },
-      ],
-      namespace: 'dummy-ns',
-      podName: 'dummy-pod-name',
-    });
-
-    const removeBtn = getByTitle('Remove port forward');
-    await fireEvent.click(removeBtn);
-
-    await vi.waitFor(() => {
-      expect(window.deleteKubernetesPortForward).toHaveBeenCalledWith(config, config.forwards[0]);
-    });
-  });
-
-  test('remove button should only delete the targeted mapping', async () => {
-    const config: UserForwardConfig = {
-      name: 'dummy-pod-name',
-      namespace: 'dummy-ns',
-      kind: WorkloadKind.POD,
-      forwards: [
-        {
-          localPort: 55_076,
-          remotePort: 80,
-        },
-        {
-          localPort: 55_077,
-          remotePort: 90,
-        },
-      ],
-      displayName: 'dummy name',
-    };
-    vi.mocked(kubeContextStore).kubernetesCurrentContextPortForwards = readable([config]);
-
-    const { getByLabelText } = render(KubeContainerPorts, {
-      ports: [
-        {
-          containerPort: 80,
-          protocol: 'TCP',
-        },
-        {
-          containerPort: 90,
-          protocol: 'TCP',
-        },
-      ],
-      namespace: 'dummy-ns',
-      podName: 'dummy-pod-name',
-    });
-
-    const span = getByLabelText('container port 90');
-    const removeBtn = within(span).getByTitle('Remove port forward');
-    await fireEvent.click(removeBtn);
-
-    await vi.waitFor(() => {
-      expect(window.deleteKubernetesPortForward).toHaveBeenCalledWith(config, config.forwards[1]);
-    });
-  });
 });

--- a/packages/renderer/src/lib/kube/details/KubeContainerPorts.svelte
+++ b/packages/renderer/src/lib/kube/details/KubeContainerPorts.svelte
@@ -1,13 +1,76 @@
 <script lang="ts">
+import { faSquareUpRight, faTrash } from '@fortawesome/free-solid-svg-icons';
 import type { V1ContainerPort } from '@kubernetes/client-node';
+import { Button } from '@podman-desktop/ui-svelte';
 
 import Cell from '/@/lib/details/DetailsCell.svelte';
+import { kubernetesCurrentContextPortForwards } from '/@/stores/kubernetes-contexts-state';
+import { type PortMapping, type UserForwardConfig, WorkloadKind } from '/@api/kubernetes-port-forward-model';
 
 interface Props {
   ports?: V1ContainerPort[];
+  podName?: string;
+  namespace?: string;
 }
 
-let { ports }: Props = $props();
+let loading: boolean = $state(false);
+let { ports, podName, namespace }: Props = $props();
+
+let userForwardConfig: UserForwardConfig | undefined = $derived(
+  $kubernetesCurrentContextPortForwards.find(
+    forward => forward.kind === WorkloadKind.POD && forward.name === podName && forward.namespace === namespace,
+  ),
+);
+
+let portsMapping: Map<number, PortMapping> = $derived.by(() => {
+  return new Map<number, PortMapping>((userForwardConfig?.forwards ?? []).map(value => [value.remotePort, value]));
+});
+
+async function onForwardRequest(port: V1ContainerPort): Promise<void> {
+  if (!podName) throw new Error('pod name is undefined');
+  loading = true;
+
+  // get a free port starting from 50k
+  const freePort = await window.getFreePort(50_000);
+
+  // snapshot the object as Proxy cannot be serialized
+  const snapshot = $state.snapshot(port);
+  try {
+    await window.createKubernetesPortForward({
+      displayName: `${podName}/${snapshot.name}`,
+      name: podName,
+      kind: WorkloadKind.POD,
+      namespace: namespace ?? 'default',
+      forward: {
+        localPort: freePort,
+        remotePort: snapshot.containerPort,
+      },
+    });
+  } catch (err: unknown) {
+    console.error(err);
+  } finally {
+    loading = false;
+  }
+}
+
+async function openExternal(mapping?: PortMapping): Promise<void> {
+  if (!mapping) return;
+  return window.openExternal(`http://localhost:${mapping.localPort}`);
+}
+
+async function removePortForward(mapping?: PortMapping): Promise<void> {
+  if (!mapping) return;
+  if (!userForwardConfig) return;
+  loading = true;
+
+  try {
+    await window.deleteKubernetesPortForward(userForwardConfig, mapping);
+  } catch (err: unknown) {
+    console.error(err);
+  } finally {
+    loading = false;
+  }
+}
 </script>
 
 {#if ports && ports.length > 0}
@@ -15,13 +78,24 @@ let { ports }: Props = $props();
     <Cell class="flex">Ports</Cell>
     <Cell>
       <div class="flex gap-y-1 flex-col">
-        {#each ports as port (port.containerPort)}
-        <span>
-          {port.containerPort}/{port.protocol}
-        </span>
+        {#each ports as port}
+          <span aria-label="container port {port.containerPort}" class="flex gap-x-2 items-center">
+            {port.containerPort}/{port.protocol}
+            {#if portsMapping.has(port.containerPort)}
+              <Button title="Open in browser" disabled={loading} icon={faSquareUpRight} on:click={openExternal.bind(undefined, portsMapping.get(port.containerPort))} class="px-1 py-0.5" padding="0">
+                Open
+              </Button>
+              <Button title="Remove port forward" disabled={loading} icon={faTrash} on:click={removePortForward.bind(undefined, portsMapping.get(port.containerPort))} class="px-1 py-0.5" padding="0">
+                Remove
+              </Button>
+            {:else}
+              <Button title="Forward container port {port.containerPort}" disabled={loading} on:click={onForwardRequest.bind(undefined, port)} class="px-1 py-0.5" padding="0">
+                Forward...
+              </Button>
+            {/if}
+          </span>
         {/each}
       </div>
     </Cell>
   </tr>
 {/if}
-

--- a/packages/renderer/src/lib/kube/details/KubeContainerPorts.svelte
+++ b/packages/renderer/src/lib/kube/details/KubeContainerPorts.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
-import { faSquareUpRight, faTrash } from '@fortawesome/free-solid-svg-icons';
 import type { V1ContainerPort } from '@kubernetes/client-node';
-import { Button } from '@podman-desktop/ui-svelte';
 
 import Cell from '/@/lib/details/DetailsCell.svelte';
+import KubeContainerPort from '/@/lib/kube/details/KubeContainerPort.svelte';
 import { kubernetesCurrentContextPortForwards } from '/@/stores/kubernetes-contexts-state';
-import { type PortMapping, type UserForwardConfig, WorkloadKind } from '/@api/kubernetes-port-forward-model';
+import { type UserForwardConfig, WorkloadKind } from '/@api/kubernetes-port-forward-model';
 
 interface Props {
   ports?: V1ContainerPort[];
@@ -13,7 +12,6 @@ interface Props {
   namespace?: string;
 }
 
-let loading: boolean = $state(false);
 let { ports, podName, namespace }: Props = $props();
 
 let userForwardConfig: UserForwardConfig | undefined = $derived(
@@ -21,56 +19,6 @@ let userForwardConfig: UserForwardConfig | undefined = $derived(
     forward => forward.kind === WorkloadKind.POD && forward.name === podName && forward.namespace === namespace,
   ),
 );
-
-let portsMapping: Map<number, PortMapping> = $derived.by(() => {
-  return new Map<number, PortMapping>((userForwardConfig?.forwards ?? []).map(value => [value.remotePort, value]));
-});
-
-async function onForwardRequest(port: V1ContainerPort): Promise<void> {
-  if (!podName) throw new Error('pod name is undefined');
-  loading = true;
-
-  // get a free port starting from 50k
-  const freePort = await window.getFreePort(50_000);
-
-  // snapshot the object as Proxy cannot be serialized
-  const snapshot = $state.snapshot(port);
-  try {
-    await window.createKubernetesPortForward({
-      displayName: `${podName}/${snapshot.name}`,
-      name: podName,
-      kind: WorkloadKind.POD,
-      namespace: namespace ?? 'default',
-      forward: {
-        localPort: freePort,
-        remotePort: snapshot.containerPort,
-      },
-    });
-  } catch (err: unknown) {
-    console.error(err);
-  } finally {
-    loading = false;
-  }
-}
-
-async function openExternal(mapping?: PortMapping): Promise<void> {
-  if (!mapping) return;
-  return window.openExternal(`http://localhost:${mapping.localPort}`);
-}
-
-async function removePortForward(mapping?: PortMapping): Promise<void> {
-  if (!mapping) return;
-  if (!userForwardConfig) return;
-  loading = true;
-
-  try {
-    await window.deleteKubernetesPortForward(userForwardConfig, mapping);
-  } catch (err: unknown) {
-    console.error(err);
-  } finally {
-    loading = false;
-  }
-}
 </script>
 
 {#if ports && ports.length > 0}
@@ -79,21 +27,7 @@ async function removePortForward(mapping?: PortMapping): Promise<void> {
     <Cell>
       <div class="flex gap-y-1 flex-col">
         {#each ports as port}
-          <span aria-label="container port {port.containerPort}" class="flex gap-x-2 items-center">
-            {port.containerPort}/{port.protocol}
-            {#if portsMapping.has(port.containerPort)}
-              <Button title="Open in browser" disabled={loading} icon={faSquareUpRight} on:click={openExternal.bind(undefined, portsMapping.get(port.containerPort))} class="px-1 py-0.5" padding="0">
-                Open
-              </Button>
-              <Button title="Remove port forward" disabled={loading} icon={faTrash} on:click={removePortForward.bind(undefined, portsMapping.get(port.containerPort))} class="px-1 py-0.5" padding="0">
-                Remove
-              </Button>
-            {:else}
-              <Button title="Forward container port {port.containerPort}" disabled={loading} on:click={onForwardRequest.bind(undefined, port)} class="px-1 py-0.5" padding="0">
-                Forward...
-              </Button>
-            {/if}
-          </span>
+          <KubeContainerPort namespace={namespace} podName={podName} port={port} forwardConfig={userForwardConfig}/>
         {/each}
       </div>
     </Cell>

--- a/packages/renderer/src/lib/kube/details/KubePodSpecArtifact.svelte
+++ b/packages/renderer/src/lib/kube/details/KubePodSpecArtifact.svelte
@@ -8,7 +8,12 @@ import Title from '/@/lib/details/DetailsTitle.svelte';
 import Container from './KubeContainerArtifact.svelte';
 import Volume from './KubeVolumeArtifact.svelte';
 
-export let artifact: V1PodSpec | undefined;
+interface Props {
+  artifact?: V1PodSpec;
+  podName?: string;
+  namespace?: string;
+}
+let { artifact, podName, namespace }: Props = $props();
 </script>
 
 {#if artifact}
@@ -40,7 +45,7 @@ export let artifact: V1PodSpec | undefined;
       <tr>
         <Subtitle>{container.name}</Subtitle>
       </tr>
-      <Container artifact={container} />
+      <Container namespace={namespace} podName={podName} artifact={container} />
     {/each}
   {/if}
 


### PR DESCRIPTION
### What does this PR do?

Add the `Forward` action for Kubernetes **pods**, in the Summary page.

:warning: known issues https://github.com/containers/podman-desktop/issues/9640

### Screenshot / video of UI

![image](https://github.com/user-attachments/assets/94eea2bc-ce78-40fd-b924-9781a5ae45e4)

![image](https://github.com/user-attachments/assets/01db6ae6-6fe2-4655-aca1-f7fda299eee5)

**Error handling**

![image](https://github.com/user-attachments/assets/a1ef4ff4-dad6-4b56-8e55-0d83471d5cef)

### What issues does this PR fix or reference?

Need rebase after https://github.com/containers/podman-desktop/pull/9642
Part of https://github.com/containers/podman-desktop/issues/9273

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

**Testing manually**

1. assert __be connected to a k8s cluster__
2. deploy a K8S pod with exposed port(s)

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: static-web
spec:
  containers:
    - image: nginx
      name: web
      ports:
        - containerPort: 80
          name: web
          protocol: TCP
```

3. Go to `pod` summary
4. Assert `Forward...` next to container ports

![image](https://github.com/user-attachments/assets/a43eddcd-39d0-4ad5-a435-254f799fc2f7)

5. Forward valid port (E.g. 80)

![image](https://github.com/user-attachments/assets/094a1e7f-2dae-4fd7-b914-efc3c71430e3)

6. assert new actions available (open, remove)
7. click on `open`

![image](https://github.com/user-attachments/assets/50257812-65f9-45a7-a12a-4bbbaecf116c)

8. assert browser open with nginx page visible
9. return to podman desktop
10. remove forward

![image](https://github.com/user-attachments/assets/7144521e-ba90-48fa-9201-83209567251a)

11. assert `Forward...` button is back
12. refresh browser 
13. assert connection should lost/timeout
