### PR TITLE
fix: cannot create machine with WSL provider without administrator ri…

### DIFF
--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -2002,6 +2002,14 @@ export async function createMachine(
   } else if (params['podman.factory.machine.win.provider']) {
     provider = params['podman.factory.machine.win.provider'];
     telemetryRecords.provider = provider;
+  } else {
+    if (isWindows()) {
+      provider = wslEnabled ? 'wsl' : 'hyperv';
+      telemetryRecords.provider = provider;
+    } else if (isMac()) {
+      provider = 'applehv';
+      telemetryRecords.provider = provider;
+    }
   }
 
   // cpus


### PR DESCRIPTION
…ghts when HyperV is enabled

Fixes #9328

### What does this PR do?

Allow Podman machine to be created according to the supported provider

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

#9328 

### How to test this PR?

1. export CONTAINERS_MACHINE_PROVIDER=hyperv
2. run podman desktop as non elevated
3. create a podman machine
 
- [x] Tests are covering the bug fix or the new feature
