### PR TITLE
feat: display Deployments events

### DIFF
--- a/packages/renderer/src/lib/deployments/DeploymentColumnActions.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnActions.spec.ts
@@ -26,6 +26,7 @@ import type { DeploymentUI } from './DeploymentUI';
 
 test('Expect action buttons', async () => {
   const deployment: DeploymentUI = {
+    uid: '123',
     name: 'my-deployment',
     status: 'RUNNING',
     namespace: '',

--- a/packages/renderer/src/lib/deployments/DeploymentColumnConditions.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnConditions.spec.ts
@@ -26,6 +26,7 @@ import type { DeploymentCondition } from './DeploymentUI';
 
 function createDeploymentUI(conditions: DeploymentCondition[]) {
   return {
+    uid: '123',
     name: 'my-deployment',
     status: '',
     namespace: '',

--- a/packages/renderer/src/lib/deployments/DeploymentColumnName.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnName.spec.ts
@@ -26,6 +26,7 @@ import DeploymentColumnName from './DeploymentColumnName.svelte';
 import type { DeploymentUI } from './DeploymentUI';
 
 const deployment: DeploymentUI = {
+  uid: '123',
   name: 'my-deployment',
   status: '',
   namespace: 'default',

--- a/packages/renderer/src/lib/deployments/DeploymentColumnPods.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnPods.spec.ts
@@ -26,6 +26,7 @@ import type { DeploymentUI } from './DeploymentUI';
 
 test('Expect simple column styling', async () => {
   const deployment: DeploymentUI = {
+    uid: '123',
     name: 'my-deployment',
     status: '',
     namespace: '',

--- a/packages/renderer/src/lib/deployments/DeploymentColumnStatus.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnStatus.spec.ts
@@ -26,6 +26,7 @@ import type { DeploymentUI } from './DeploymentUI';
 
 test('Expect simple column styling', async () => {
   const deployment: DeploymentUI = {
+    uid: '123',
     name: 'my-deployment',
     status: 'RUNNING',
     namespace: '',

--- a/packages/renderer/src/lib/deployments/DeploymentDetailsSummary.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentDetailsSummary.svelte
@@ -2,14 +2,19 @@
 import type { V1Deployment } from '@kubernetes/client-node';
 import { ErrorMessage } from '@podman-desktop/ui-svelte';
 
+import Cell from '/@/lib/details/DetailsCell.svelte';
 import Table from '/@/lib/details/DetailsTable.svelte';
+import Title from '/@/lib/details/DetailsTitle.svelte';
 
+import type { EventUI } from '../events/EventUI';
+import EventsTable from '../kube/details/EventsTable.svelte';
 import KubeDeploymentArtifact from '../kube/details/KubeDeploymentArtifact.svelte';
 import KubeDeploymentStatusArtifact from '../kube/details/KubeDeploymentStatusArtifact.svelte';
 import KubeObjectMetaArtifact from '../kube/details/KubeObjectMetaArtifact.svelte';
 
 export let deployment: V1Deployment | undefined;
 export let kubeError: string | undefined = undefined;
+export let events: EventUI[];
 </script>
 
 <!-- Show the kube error if we're unable to retrieve the data correctly, but we still want to show the
@@ -25,5 +30,13 @@ basic information -->
     <KubeDeploymentArtifact artifact={deployment.spec} />
   {:else}
     <p class="text-[var(--pd-state-info)] font-medium">Loading ...</p>
+  {/if}
+  <tr>
+    <Title>Events</Title>
+  </tr>
+  {#if events.length}
+    <EventsTable events={events} />
+  {:else}
+    <tr><Cell>No events</Cell></tr>
   {/if}
 </Table>

--- a/packages/renderer/src/lib/deployments/deployment-utils.ts
+++ b/packages/renderer/src/lib/deployments/deployment-utils.ts
@@ -41,6 +41,7 @@ export class DeploymentUtils {
     }
 
     return {
+      uid: deployment.metadata?.uid ?? '',
       name: deployment.metadata?.name ?? '',
       status: status,
       namespace: deployment.metadata?.namespace ?? '',

--- a/packages/renderer/src/lib/events/EventUI.ts
+++ b/packages/renderer/src/lib/events/EventUI.ts
@@ -16,13 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { V1ObjectMeta } from '@kubernetes/client-node';
-
 export interface EventUI {
   count?: number;
-  apiVersion?: string;
-  kind?: string;
-  metadata?: V1ObjectMeta;
   type?: string;
   reason?: string;
   firstTimestamp?: Date;

--- a/packages/renderer/src/lib/events/EventUI.ts
+++ b/packages/renderer/src/lib/events/EventUI.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,20 +16,17 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-export interface DeploymentUI {
-  uid: string;
-  name: string;
-  status: string;
-  namespace: string;
-  replicas: number;
-  ready: number;
-  created?: Date;
-  selected: boolean;
-  conditions: DeploymentCondition[];
-}
+import type { V1ObjectMeta } from '@kubernetes/client-node';
 
-export interface DeploymentCondition {
-  type: string;
+export interface EventUI {
+  count?: number;
+  apiVersion?: string;
+  kind?: string;
+  metadata?: V1ObjectMeta;
+  type?: string;
   reason?: string;
+  firstTimestamp?: Date;
+  lastTimestamp?: Date;
+  reportingComponent?: string;
   message?: string;
 }

--- a/packages/renderer/src/lib/kube/details/EventsTable.spec.ts
+++ b/packages/renderer/src/lib/kube/details/EventsTable.spec.ts
@@ -1,0 +1,83 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen, within } from '@testing-library/svelte';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+
+import type { EventUI } from '../../events/EventUI';
+import EventsTable from './EventsTable.svelte';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+test('expect the events are displayed', async () => {
+  const events: EventUI[] = [
+    {
+      count: 1,
+      type: 'Normal',
+      reason: 'FirstReason',
+      reportingComponent: 'a-controller',
+      message: 'a first message',
+      firstTimestamp: new Date(),
+      lastTimestamp: new Date(),
+    },
+    {
+      count: 2,
+      type: 'Warning',
+      reason: 'SecondReason',
+      reportingComponent: 'another-controller',
+      message: 'a second message',
+      firstTimestamp: new Date(),
+    },
+  ];
+
+  vi.advanceTimersByTime(5_000);
+  events[1].lastTimestamp = new Date();
+
+  vi.advanceTimersByTime(20_000);
+
+  render(EventsTable, {
+    props: {
+      events: events,
+    },
+  });
+  const table = await screen.findByRole('table');
+  expect(table).toBeDefined();
+  const rows = await within(table).findAllByRole('row');
+  expect(rows).toBeDefined();
+  expect(rows.length).toBe(3);
+
+  expect(within(rows[1]).getByText('25 seconds')).toBeInTheDocument();
+  expect(within(rows[1]).getByText('Normal')).toBeInTheDocument();
+  expect(within(rows[1]).getByText('FirstReason')).toBeInTheDocument();
+  expect(within(rows[1]).getByText('a-controller')).toBeInTheDocument();
+  expect(within(rows[1]).getByText('a first message')).toBeInTheDocument();
+
+  expect(within(rows[2]).getByText('20 seconds (2x over 25 seconds)')).toBeInTheDocument();
+  expect(within(rows[2]).getByText('Warning')).toBeInTheDocument();
+  expect(within(rows[2]).getByText('SecondReason')).toBeInTheDocument();
+  expect(within(rows[2]).getByText('another-controller')).toBeInTheDocument();
+  expect(within(rows[2]).getByText('a second message')).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/kube/details/EventsTable.svelte
+++ b/packages/renderer/src/lib/kube/details/EventsTable.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+import humanizeDuration from 'humanize-duration';
+import moment from 'moment';
+
+import type { EventUI } from '../../events/EventUI';
+
+export let events: EventUI[];
+
+$: events.sort((ev1, ev2) => ((ev1.lastTimestamp ?? Date.now()) < (ev2.lastTimestamp ?? Date.now()) ? -1 : 1));
+function getAgeAndCount(event: EventUI): string {
+  let result = `${humanizeDuration(moment().diff(event.lastTimestamp), { round: true, largest: 1 })}`;
+  if ((event.count ?? 0) > 1) {
+    result += ` (${event.count}x over ${humanizeDuration(moment().diff(event.firstTimestamp), { round: true, largest: 1 })})`;
+  }
+  return result;
+}
+</script>
+    
+<tr>
+  <td colspan="2">
+    <table class="w-full ml-2.5">
+      <tbody>
+        <tr>
+          <th align="left">Type</th><th align="left">Reason</th><th align="left">Age</th><th align="left">From</th><th align="left">Message</th>
+        </tr>
+        {#each events as event}
+          <tr>
+            <td>{event.type}</td>
+            <td>{event.reason}</td>
+            <td>{getAgeAndCount(event)}</td>
+            <td>{event.reportingComponent}</td>
+            <td>{event.message}</td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  </td>
+</tr>
+  

--- a/packages/renderer/src/lib/kube/details/EventsTable.svelte
+++ b/packages/renderer/src/lib/kube/details/EventsTable.svelte
@@ -10,9 +10,9 @@ interface Props {
 
 let { events }: Props = $props();
 
-$effect(() => {
-  events.sort((ev1, ev2) => ((ev1.lastTimestamp ?? Date.now()) < (ev2.lastTimestamp ?? Date.now()) ? -1 : 1));
-});
+let sortedEvents: EventUI[] = $derived(
+  events.toSorted((ev1, ev2) => ((ev1.lastTimestamp ?? Date.now()) < (ev2.lastTimestamp ?? Date.now()) ? -1 : 1)),
+);
 
 function getAgeAndCount(event: EventUI): string {
   let result = `${humanizeDuration(moment().diff(event.lastTimestamp), { round: true, largest: 1 })}`;
@@ -30,7 +30,7 @@ function getAgeAndCount(event: EventUI): string {
         <tr>
           <th align="left">Type</th><th align="left">Reason</th><th align="left">Age</th><th align="left">From</th><th align="left">Message</th>
         </tr>
-        {#each events as event}
+        {#each sortedEvents as event}
           <tr>
             <td>{event.type}</td>
             <td>{event.reason}</td>

--- a/packages/renderer/src/lib/kube/details/EventsTable.svelte
+++ b/packages/renderer/src/lib/kube/details/EventsTable.svelte
@@ -4,9 +4,16 @@ import moment from 'moment';
 
 import type { EventUI } from '../../events/EventUI';
 
-export let events: EventUI[];
+interface Props {
+  events: EventUI[];
+}
 
-$: events.sort((ev1, ev2) => ((ev1.lastTimestamp ?? Date.now()) < (ev2.lastTimestamp ?? Date.now()) ? -1 : 1));
+let { events }: Props = $props();
+
+$effect(() => {
+  events.sort((ev1, ev2) => ((ev1.lastTimestamp ?? Date.now()) < (ev2.lastTimestamp ?? Date.now()) ? -1 : 1));
+});
+
 function getAgeAndCount(event: EventUI): string {
   let result = `${humanizeDuration(moment().diff(event.lastTimestamp), { round: true, largest: 1 })}`;
   if ((event.count ?? 0) > 1) {

--- a/packages/renderer/src/stores/kubernetes-contexts-state.ts
+++ b/packages/renderer/src/stores/kubernetes-contexts-state.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { KubernetesObject } from '@kubernetes/client-node';
+import type { CoreV1Event, KubernetesObject } from '@kubernetes/client-node';
 import { derived, type Readable, readable, writable } from 'svelte/store';
 
 import type { CheckingState, ContextGeneralState } from '/@api/kubernetes-contexts-states';
@@ -247,6 +247,17 @@ export const kubernetesCurrentContextRoutesFiltered = derived(
   [routeSearchPattern, kubernetesCurrentContextRoutes],
   ([$searchPattern, $routes]) => $routes.filter(route => findMatchInLeaves(route, $searchPattern.toLowerCase())),
 );
+
+// Events
+export const kubernetesCurrentContextEvents = readable<CoreV1Event[]>([], set => {
+  window.kubernetesRegisterGetCurrentContextResources('events').then(value => set(value as CoreV1Event[]));
+  window.events?.receive('kubernetes-current-context-events-update', (value: unknown) => {
+    set(value as CoreV1Event[]);
+  });
+  return () => {
+    window.kubernetesUnregisterGetCurrentContextResources('events');
+  };
+});
 
 // Port Forwarding
 


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Display the Events related to a Deployment in the Summary page of the Deployment

### Screenshot / video of UI

![deploy-events](https://github.com/user-attachments/assets/9773b0f1-05f7-453e-8185-e99293891548)


### What issues does this PR fix or reference?

Part of #6210 

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
