### PR TITLE
fix: centered kubernetes empty page

### DIFF
--- a/packages/renderer/src/lib/kube/KubernetesDashboard.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesDashboard.svelte
@@ -50,7 +50,7 @@ async function openKubernetesDocumentation(): Promise<void> {
     </div>
   </svelte:fragment>
 
-  <div class="flex min-w-full h-full" slot="content">
+  <div class="flex min-w-full h-full justify-center" slot="content">
     {#if noContexts}
         <KubernetesEmptyPage />
     {:else}


### PR DESCRIPTION
### What does this PR do?
Fixes not aligned Kubernetes empty screen

### Screenshot / video of UI
Prev: 
![Image](https://github.com/user-attachments/assets/8b13a777-6521-4248-a06c-86eb7bc14721)

Now: 
![Image](https://github.com/user-attachments/assets/9169074a-023d-43bd-bbbc-a21be8a20628)


### What issues does this PR fix or reference?
Closes #9671 

### How to test this PR?
Delete all kubernetes clusters and check if the page is horizontally aligned

- [x] Tests are covering the bug fix or the new feature
