### PR TITLE
chore(test): remove an assertion that blocks the check for an existing kind cluster

### DIFF
--- a/tests/playwright/src/utility/operations.ts
+++ b/tests/playwright/src/utility/operations.ts
@@ -332,7 +332,6 @@ export async function createKindCluster(
     const resourcesPage = await settingsPage.openTabPage(ResourcesPage);
     await playExpect(resourcesPage.heading).toBeVisible({ timeout: 10_000 });
     await playExpect.poll(async () => resourcesPage.resourceCardIsVisible('kind')).toBeTruthy();
-    await playExpect(kindResourceCard.markdownContent).toBeVisible();
     await playExpect(kindResourceCard.createButton).toBeVisible();
 
     if (await kindResourceCard.doesResourceElementExist()) {


### PR DESCRIPTION
Signed-off-by: Anton Misskii <amisskii@redhat.com>

### What does this PR do?

Ensures that the Kind Cluster will always be deleted in the deploy-to-kubernetes test scenario. Move the assertion of cluster presence.

### What issues does this PR fix or reference?

https://github.com/containers/podman-desktop/issues/9677

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
