### PR TITLE
feat(ui): adding port forwarding to Kubernetes services

### DIFF
--- a/packages/renderer/src/lib/kube/details/KubeServiceArtifact.spec.ts
+++ b/packages/renderer/src/lib/kube/details/KubeServiceArtifact.spec.ts
@@ -19,9 +19,14 @@
 import '@testing-library/jest-dom/vitest';
 
 import { render, screen } from '@testing-library/svelte';
-import { expect, test } from 'vitest';
+import { readable } from 'svelte/store';
+import { beforeEach, expect, test, vi } from 'vitest';
 
-import KubeServiceSpecArtifact from './KubeServiceArtifact.svelte'; // Adjust the import path as necessary
+import * as kubeContextStore from '/@/stores/kubernetes-contexts-state'; // Adjust the import path as necessary
+
+import KubeServiceSpecArtifact from './KubeServiceArtifact.svelte';
+
+vi.mock('/@/stores/kubernetes-contexts-state', async () => ({}));
 
 const fakeServiceSpec = {
   type: 'ClusterIP',
@@ -38,6 +43,12 @@ const fakeServiceSpec = {
     department: 'engineering',
   },
 };
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  vi.mocked(kubeContextStore).kubernetesCurrentContextPortForwards = readable([]);
+});
 
 test('Renders service spec correctly', () => {
   render(KubeServiceSpecArtifact, { artifact: fakeServiceSpec });

--- a/packages/renderer/src/lib/kube/details/KubeServiceArtifact.svelte
+++ b/packages/renderer/src/lib/kube/details/KubeServiceArtifact.svelte
@@ -3,8 +3,15 @@ import type { V1ServiceSpec } from '@kubernetes/client-node';
 
 import Cell from '/@/lib/details/DetailsCell.svelte';
 import Title from '/@/lib/details/DetailsTitle.svelte';
+import KubePorts from '/@/lib/kube/details/KubePortsList.svelte';
+import { WorkloadKind } from '/@api/kubernetes-port-forward-model';
 
-export let artifact: V1ServiceSpec | undefined;
+interface Props {
+  artifact?: V1ServiceSpec;
+  serviceName?: string;
+  namespace?: string;
+}
+let { artifact, serviceName, namespace }: Props = $props();
 </script>
 
 {#if artifact}
@@ -29,18 +36,12 @@ export let artifact: V1ServiceSpec | undefined;
     <Cell>Session Affinity</Cell>
     <Cell>{artifact?.sessionAffinity}</Cell>
   </tr>
-  {#if artifact.ports}
-    <tr>
-      <Cell>Ports</Cell>
-      <Cell>
-        {#each artifact.ports as port}
-          <div>
-            {port.name ? port.name + ':' : ''}{port.port}{port.nodePort ? ':' + port.nodePort : ''}/{port.protocol}
-          </div>
-        {/each}
-      </Cell>
-    </tr>
-  {/if}
+  <KubePorts namespace={namespace} resourceName={serviceName} kind={WorkloadKind.SERVICE} ports={artifact.ports?.map((port) => ({
+    name: port.name,
+    value: port.port,
+    protocol: port.protocol,
+    displayValue: `${port.name ? port.name + ':' : ''}${port.port}${port.nodePort ? ':' + port.nodePort : ''}/${port.protocol}`,
+  }))}/>
   {#if artifact.selector}
     <tr>
       <Cell>Selectors</Cell>

--- a/packages/renderer/src/lib/service/ServiceDetailsSummary.spec.ts
+++ b/packages/renderer/src/lib/service/ServiceDetailsSummary.spec.ts
@@ -20,9 +20,14 @@ import '@testing-library/jest-dom/vitest';
 
 import type { V1Service } from '@kubernetes/client-node';
 import { render, screen } from '@testing-library/svelte';
-import { beforeAll, expect, test, vi } from 'vitest';
+import { readable } from 'svelte/store';
+import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
+
+import * as kubeContextStore from '/@/stores/kubernetes-contexts-state';
 
 import ServiceDetailsSummary from './ServiceDetailsSummary.svelte';
+
+vi.mock('/@/stores/kubernetes-contexts-state', async () => ({}));
 
 const service: V1Service = {
   metadata: {
@@ -48,6 +53,12 @@ const kubernetesReadNamespacedServiceMock = vi.fn();
 beforeAll(() => {
   (window as any).kubernetesGetCurrentNamespace = kubernetesGetCurrentNamespaceMock;
   (window as any).kubernetesReadNamespacedService = kubernetesReadNamespacedServiceMock;
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  vi.mocked(kubeContextStore).kubernetesCurrentContextPortForwards = readable([]);
 });
 
 test('Expect basic rendering', async () => {

--- a/packages/renderer/src/lib/service/ServiceDetailsSummary.svelte
+++ b/packages/renderer/src/lib/service/ServiceDetailsSummary.svelte
@@ -22,7 +22,7 @@ basic information -->
   {#if service}
     <KubeObjectMetaArtifact artifact={service.metadata} />
     <KubeServiceStatusArtifact artifact={service.status} />
-    <KubeServiceArtifact artifact={service.spec} />
+    <KubeServiceArtifact serviceName={service.metadata?.name} namespace={service.metadata?.namespace} artifact={service.spec} />
   {:else}
     <p class="text-purple-500 font-medium">Loading ...</p>
   {/if}


### PR DESCRIPTION
### What does this PR do?

Adding port forwarding option to Kubernetes services (Only UI).

### Screenshot / video of UI

https://github.com/user-attachments/assets/b8c58e20-49c2-4c16-b685-a96366b431b3

![image](https://github.com/user-attachments/assets/2fef8b6d-6cdb-4e70-b8ed-036aa46ddaeb)

### What issues does this PR fix or reference?

~~:warning: need rebase after https://github.com/containers/podman-desktop/pull/9680~~

Fixes https://github.com/containers/podman-desktop/issues/9665

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

1. Create a service pointing to a pod (E.g. nginx)

```
apiVersion: v1
kind: Pod
metadata:
  name: static-web
  labels:
    role: myrole
spec:
  containers:
    - image: nginx
      name: web
      ports:
        - containerPort: 80
          name: web
          protocol: TCP
---
apiVersion: v1
kind: Service
metadata:
  name: my-service
spec:
  ports:
    - port: 8080
      protocol: TCP
      targetPort: 80
  selector:
    role: myrole
```

2. Go to service list
3. assert `my-service` is visible
4. Go to summary
5. assert `Forward...` button visible
6. Click on forward
7. Assert Open and Remove button visible
8. Click on Open
9. assert nginx in the browser 