### PR TITLE
fix(ui): prevent non-tcp port to be forwarded

### DIFF
--- a/packages/renderer/src/lib/kube/details/KubePort.spec.ts
+++ b/packages/renderer/src/lib/kube/details/KubePort.spec.ts
@@ -184,4 +184,42 @@ describe('port forwarding', () => {
       expect(error.textContent).toBe('Dummy error');
     });
   });
+
+  test('non-TCP port should not display the forward action', async () => {
+    const { queryByTitle, getByText } = render(KubePort, {
+      namespace: 'dummy-ns',
+      port: {
+        displayValue: '80/UDP',
+        value: 80,
+        protocol: 'UDP',
+      },
+      forwardConfig: undefined,
+      resourceName: 'dummy-pod-name',
+      kind: WorkloadKind.POD,
+    });
+
+    const port80 = queryByTitle('Forward port 80');
+    expect(port80).toBeNull();
+
+    const tooltip = getByText('UDP cannot be forwarded.');
+    expect(tooltip).toBeDefined();
+  });
+
+  // kubernetes default to TCP
+  test('undefined protocol should display the forward action', async () => {
+    const { getByTitle } = render(KubePort, {
+      namespace: 'dummy-ns',
+      port: {
+        displayValue: '80',
+        value: 80,
+        protocol: undefined,
+      },
+      forwardConfig: undefined,
+      resourceName: 'dummy-pod-name',
+      kind: WorkloadKind.POD,
+    });
+
+    const port80 = getByTitle('Forward port 80');
+    expect(port80).not.toBeNull();
+  });
 });

--- a/packages/renderer/src/lib/kube/details/KubePort.svelte
+++ b/packages/renderer/src/lib/kube/details/KubePort.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-import { faSquareUpRight, faTrash } from '@fortawesome/free-solid-svg-icons';
-import { Button, ErrorMessage } from '@podman-desktop/ui-svelte';
+import { faQuestionCircle, faSquareUpRight, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { Button, ErrorMessage, Tooltip } from '@podman-desktop/ui-svelte';
+import Fa from 'svelte-fa';
 
 import type { PortMapping, UserForwardConfig, WorkloadKind } from '/@api/kubernetes-port-forward-model';
 
@@ -73,20 +74,25 @@ async function removePortForward(): Promise<void> {
 </script>
 
 <span aria-label="port {port.value}" class="flex gap-x-2 items-center">
-  {port.displayValue}
+    {port.displayValue}
   {#if mapping}
-    <Button title="Open in browser" disabled={loading} icon={faSquareUpRight} on:click={openExternal.bind(undefined)} class="px-1 py-0.5" padding="0">
-      Open
-    </Button>
-    <Button title="Remove port forward" disabled={loading} icon={faTrash} on:click={removePortForward.bind(undefined)} class="px-1 py-0.5" padding="0">
-      Remove
-    </Button>
-  {:else}
-    <Button title="Forward port {port.value}" disabled={loading} on:click={onForwardRequest.bind(undefined, port)} class="px-1 py-0.5" padding="0">
-      Forward...
-    </Button>
-  {/if}
+      <Button title="Open in browser" disabled={loading} icon={faSquareUpRight} on:click={openExternal.bind(undefined)} class="px-1 py-0.5" padding="0">
+        Open
+      </Button>
+      <Button title="Remove port forward" disabled={loading} icon={faTrash} on:click={removePortForward.bind(undefined)} class="px-1 py-0.5" padding="0">
+        Remove
+      </Button>
+    {:else if (port.protocol ?? 'TCP') === 'TCP'}
+      <Button title="Forward port {port.value}" disabled={loading || (!!port.protocol && port.protocol !== 'TCP')} on:click={onForwardRequest.bind(undefined, port)} class="px-1 py-0.5" padding="0">
+        Forward...
+      </Button>
+      {:else}
+  <Tooltip class="w-min" tip={`${port.protocol} cannot be forwarded.`}>
+    <Fa size="1.1x" class="cursor-pointer" icon={faQuestionCircle} />
+  </Tooltip>
+    {/if}
   {#if error}
-     <ErrorMessage error={error} />
-  {/if}
+       <ErrorMessage error={error} />
+    {/if}
 </span>
+

--- a/packages/renderer/src/lib/kube/details/KubePort.svelte
+++ b/packages/renderer/src/lib/kube/details/KubePort.svelte
@@ -74,25 +74,41 @@ async function removePortForward(): Promise<void> {
 </script>
 
 <span aria-label="port {port.value}" class="flex gap-x-2 items-center">
-    {port.displayValue}
+  {port.displayValue}
   {#if mapping}
-      <Button title="Open in browser" disabled={loading} icon={faSquareUpRight} on:click={openExternal.bind(undefined)} class="px-1 py-0.5" padding="0">
-        Open
-      </Button>
-      <Button title="Remove port forward" disabled={loading} icon={faTrash} on:click={removePortForward.bind(undefined)} class="px-1 py-0.5" padding="0">
-        Remove
-      </Button>
-    {:else if (port.protocol ?? 'TCP') === 'TCP'}
-      <Button title="Forward port {port.value}" disabled={loading || (!!port.protocol && port.protocol !== 'TCP')} on:click={onForwardRequest.bind(undefined, port)} class="px-1 py-0.5" padding="0">
-        Forward...
-      </Button>
-      {:else}
-  <Tooltip class="w-min" tip={`${port.protocol} cannot be forwarded.`}>
-    <Fa size="1.1x" class="cursor-pointer" icon={faQuestionCircle} />
-  </Tooltip>
-    {/if}
+    <Button
+      title="Open in browser"
+      disabled={loading}
+      icon={faSquareUpRight}
+      on:click={openExternal.bind(undefined)}
+      class="px-1 py-0.5"
+      padding="0">
+      Open
+    </Button>
+    <Button
+      title="Remove port forward"
+      disabled={loading}
+      icon={faTrash}
+      on:click={removePortForward.bind(undefined)}
+      class="px-1 py-0.5"
+      padding="0">
+      Remove
+    </Button>
+  {:else if (port.protocol ?? 'TCP') === 'TCP'}
+    <Button
+      title="Forward port {port.value}"
+      disabled={loading || (!!port.protocol && port.protocol !== 'TCP')}
+      on:click={onForwardRequest.bind(undefined, port)}
+      class="px-1 py-0.5"
+      padding="0">
+      Forward...
+    </Button>
+  {:else}
+    <Tooltip class="w-min" tip={`${port.protocol} cannot be forwarded.`}>
+      <Fa size="1.1x" class="cursor-pointer" icon={faQuestionCircle} />
+    </Tooltip>
+  {/if}
   {#if error}
-       <ErrorMessage error={error} />
-    {/if}
+    <ErrorMessage error={error} />
+  {/if}
 </span>
-

--- a/packages/renderer/src/lib/kube/details/KubePort.svelte
+++ b/packages/renderer/src/lib/kube/details/KubePort.svelte
@@ -97,7 +97,7 @@ async function removePortForward(): Promise<void> {
   {:else if (port.protocol ?? 'TCP') === 'TCP'}
     <Button
       title="Forward port {port.value}"
-      disabled={loading || (!!port.protocol && port.protocol !== 'TCP')}
+      disabled={loading}
       on:click={onForwardRequest.bind(undefined, port)}
       class="px-1 py-0.5"
       padding="0">


### PR DESCRIPTION
### What does this PR do?

Preventing (frontend) to forward a port non-TCP.

### Screenshot / video of UI

![image](https://github.com/user-attachments/assets/4d71bc4b-f930-443e-a83e-19d28a0c955d)

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/9676

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

1. apply a Kubernetes pod with a non-TCP port
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: static-web
  labels:
    role: myrole
spec:
  containers:
    - image: nginx
      name: web
      ports:
        - containerPort: 80
          name: web
          protocol: TCP
        - containerPort: 8080
          name: complex
          protocol: UDP
```
2. Go to pod details
3. assert TCP port have forward button
4. assert UDP port do not have forward button