### PR TITLE
feat: create tasks for long running operations when using Podman Desktop API

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -2107,6 +2107,31 @@ declare module '@podman-desktop/api' {
     readonly webviewPanel: WebviewPanel;
   }
 
+  export type TaskState = 'running' | 'completed';
+  export type TaskStatus = 'in-progress' | 'success' | 'failure';
+
+  export interface TaskAction {
+    name: string;
+    execute: (task: Task) => void;
+  }
+
+  export interface TaskUpdateEvent {
+    action: 'update' | 'delete';
+    task: Task;
+  }
+
+  export interface Task extends Disposable {
+    readonly id: string;
+    name: string;
+    readonly started: number;
+    state: TaskState;
+    status: TaskStatus;
+    error?: string;
+    progress?: number;
+    action?: TaskAction;
+    readonly onUpdate: Event<TaskUpdateEvent>;
+  }
+
   export namespace window {
     /**
      * Show an information message. Optionally provide an array of items which will be presented as
@@ -2340,6 +2365,8 @@ declare module '@podman-desktop/api' {
     export function createWebviewPanel(viewType: string, title: string, options?: WebviewOptions): WebviewPanel;
 
     export function listWebviews(): Promise<WebviewInfo[]>;
+
+    export function createTask(options?: { title?: string; action?: TaskAction }): Task;
   }
 
   export namespace kubernetes {

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -1159,7 +1159,7 @@ export class ExtensionLoader {
       },
       saveImage(engineId: string, id: string, filename: string, token?: containerDesktopAPI.CancellationToken) {
         const task = taskManager.createTask({
-          title: `${extensionInfo.name}: Save images`,
+          title: `${extensionInfo.name}: Save image`,
         });
         return containerProviderRegistry
           .saveImage(engineId, id, filename, token)

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -692,6 +692,7 @@ export class PluginSystem {
       dialogRegistry,
       safeStorageRegistry,
       certificates,
+      taskManager,
     );
     await this.extensionLoader.init();
 


### PR DESCRIPTION
### What does this PR do?
This PR creates `Task`s for long running operations called by extensions and adds a new API function that allows extensions create their own `Task`s.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/containers/podman-desktop/issues/7398

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
