### PR TITLE
fix: create new connection form dropdown FormData

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
@@ -350,6 +350,12 @@ async function handleOnSubmit(e: any) {
     if (key.id && !formData.has(key.id) && key.type === 'boolean') {
       data[key.id] = false;
     }
+    if (key.id && !formData.has(key.id)) {
+      const value = configurationValues.get(key.id)?.value;
+      if (value !== undefined) {
+        data[key.id] = value;
+      }
+    }
   });
 
   for (let field of formData) {

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
@@ -350,12 +350,6 @@ async function handleOnSubmit(e: any) {
     if (key.id && !formData.has(key.id) && key.type === 'boolean') {
       data[key.id] = false;
     }
-    if (key.id && !formData.has(key.id)) {
-      const value = configurationValues.get(key.id)?.value;
-      if (value !== undefined) {
-        data[key.id] = value;
-      }
-    }
   });
 
   for (let field of formData) {

--- a/packages/ui/src/lib/dropdown/Dropdown.svelte
+++ b/packages/ui/src/lib/dropdown/Dropdown.svelte
@@ -230,7 +230,7 @@ function onWindowClick(e: Event): void {
     </div>
   {/if}
 
-  <select use:buildOptions class="hidden" bind:value={value}>
+  <select use:buildOptions class="hidden" name={name} bind:value={value}>
     {@render children?.()}
   </select>
 </div>


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR fixes the `Create new ...` form with the dropdown values by adding a name to the hidden `select` component in `Dropdown` so that `FormData`  would get this field and its value

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Fixes https://github.com/containers/podman-desktop/issues/9706

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
Option 1
1. Install podman desktop on Mac OS
2. Install Podman (5.2.5)
3. Create Podman Machine with LibKRun provider
4. Assert: Machine exists on Resources page, there is Libkrun value shown

Option 2.
0. DO NOT HAVE DOCKER INSTALLED
1. Install podman Desktop, podman, minikube
2. Create and start podman machine (any)
3. Create Minikube cluster with default values (driver == podman)
4. Assert: Cluster is created

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
