### PR TITLE
fix: watch /var/run/docker.sock on macOS

### DIFF
--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -2193,11 +2193,8 @@ function setupDisguisedPodmanSocketWatcher(
   });
 
   let socketWatcher: extensionApi.FileSystemWatcher | undefined = undefined;
-  if (isLinux()) {
+  if (isLinux() || isMac()) {
     socketWatcher = extensionApi.fs.createFileSystemWatcher(socketFile);
-  } else if (isMac()) {
-    // watch parent directory
-    socketWatcher = extensionApi.fs.createFileSystemWatcher(path.dirname(socketFile));
   }
 
   // only trigger if the watched file is the socket file


### PR DESCRIPTION
This works now, because FileSystemWatcherImpl is using fs.realpath to resolve /var/run to its original name and there is no loop issues anymore.

### What does this PR do?

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Fix #9406.

### How to test this PR?

Pull the branch and run `pnpm watch`, there should be no /private folder watch related issues anymore.

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
