### PR TITLE
fix: creating hyperv machine in airgap now does not try to use wsl image

### DIFF
--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -2090,7 +2090,7 @@ export async function createMachine(
       parameters.push(`docker://${imageUri}`);
       telemetryRecords.imagePath = 'custom-registry';
     }
-  } else if (isMac() || extensionApi.env.isWindows) {
+  } else if (isMac() || (extensionApi.env.isWindows && provider === 'wsl')) {
     // check if we have an embedded asset for the image path for macOS or Windows
     let suffix = '';
     if (extensionApi.env.isWindows) {


### PR DESCRIPTION
### What does this PR do?
Adds support for airgapped hyperv
Relevant PR: https://github.com/containers/podman-desktop/pull/9303 (will be rebased based on this changes)

- [x] rebase after https://github.com/containers/podman-desktop/pull/9708 will be merged 

### What issues does this PR fix or reference?
Closes #9314 

### How to test this PR?
Try to create a HyperV machine in airgap mode:
1. pnpm install
2. AIRGAP_DOWNLOAD=true pnpm compile:current --win nsis
3. run created airgap instalator with admin
4. create HyperV machine - should end with error dial TCP... 125 error code (~ does not have an access to internet)
- [x] Tests are covering the bug fix or the new feature
