### PR TITLE
chore: convert k8s date format to ISO string before humanizing duration

### DIFF
--- a/packages/renderer/src/lib/pod/pod-utils.spec.ts
+++ b/packages/renderer/src/lib/pod/pod-utils.spec.ts
@@ -123,4 +123,43 @@ test('Expect to get node and namespace from pod info', () => {
 
   expect(pod.node).toBe('node1');
   expect(pod.namespace).toBe('default');
+
+  // Expect the date to be undefined because we did not pass any Created values in podInfo
+  expect(pod.created).toBe(undefined);
+});
+
+test('Expect k8s format to convert to humanizedDuration format correctly', () => {
+  // Expect age to show 2 years
+  const created = new Date();
+  created.setFullYear(created.getFullYear() - 2);
+  const podUtils = new PodUtils();
+  const podInfo = {
+    kind: 'kubernetes',
+    Namespace: 'default',
+    Id: 'pod-id',
+    Created: created.toISOString(),
+  } as unknown as PodInfo;
+  const pod = podUtils.getPodInfoUI(podInfo);
+  expect(pod.age).toBe('2 years');
+
+  // Do the same for 2 months
+  const created2 = new Date();
+  created2.setMonth(created.getMonth() - 2);
+  podInfo.Created = created2.toISOString();
+  const pod2 = podUtils.getPodInfoUI(podInfo);
+  expect(pod2.age).toBe('2 months');
+
+  // Expect age to show 2 days
+  const created3 = new Date();
+  created3.setDate(created.getDate() - 2);
+  podInfo.Created = created3.toISOString();
+  const pod3 = podUtils.getPodInfoUI(podInfo);
+  expect(pod3.age).toBe('2 days');
+
+  // Expect age to be 2 hours
+  const created4 = new Date();
+  created4.setHours(created.getHours() - 2);
+  podInfo.Created = created4.toISOString();
+  const pod4 = podUtils.getPodInfoUI(podInfo);
+  expect(pod4.age).toBe('2 hours');
 });

--- a/packages/renderer/src/lib/pod/pod-utils.ts
+++ b/packages/renderer/src/lib/pod/pod-utils.ts
@@ -28,19 +28,15 @@ export class PodUtils {
   }
 
   humanizeAge(started: string): string {
-    // Return nothing if 'started' is not even provided
+    // Return nothing if 'started' is not provided
     if (!started) {
       return '';
     }
 
-    // To avoid https://momentjs.com/guides/#/warnings/js-date/ warning
-    // and provide better compatibility with the library, we will convert to ISO format before
-    // passing to moment.
-    const startedDate = new Date(started).toISOString();
-
+    const startedDate = toISOStringSafe(started);
     const uptimeInMs = moment().diff(startedDate);
 
-    // make it human friendly
+    // Make it human-friendly
     return humanizeDuration(uptimeInMs, { round: true, largest: 1 });
   }
 
@@ -49,10 +45,8 @@ export class PodUtils {
       return undefined;
     }
 
-    // To avoid https://momentjs.com/guides/#/warnings/js-date/ warning
-    // and provide better compatibility with the library, we will convert to ISO format before
-    // passing to moment
-    return moment(new Date(podInfoUI.created).toISOString()).toDate();
+    const createdDate = toISOStringSafe(podInfoUI.created);
+    return moment(createdDate).toDate();
   }
 
   getEngineId(podinfo: PodInfo): string {
@@ -146,4 +140,12 @@ export function ensureRestrictedSecurityContext(body: any) {
       container.securityContext.capabilities.drop.push('ALL');
     }
   });
+}
+
+// Utility function to safely convert a date string to ISO format
+// To avoid https://momentjs.com/guides/#/warnings/js-date/ warning
+// and provide better compatibility with the library, we will convert to ISO format before
+// passing to moment
+export function toISOStringSafe(date: string): string {
+  return new Date(date).toISOString();
 }

--- a/packages/renderer/src/lib/pod/pod-utils.ts
+++ b/packages/renderer/src/lib/pod/pod-utils.ts
@@ -28,8 +28,18 @@ export class PodUtils {
   }
 
   humanizeAge(started: string): string {
-    // get start time in ms
-    const uptimeInMs = moment().diff(started);
+    // Return nothing if 'started' is not even provided
+    if (!started) {
+      return '';
+    }
+
+    // To avoid https://momentjs.com/guides/#/warnings/js-date/ warning
+    // and provide better compatibility with the library, we will convert to ISO format before
+    // passing to moment.
+    const startedDate = new Date(started).toISOString();
+
+    const uptimeInMs = moment().diff(startedDate);
+
     // make it human friendly
     return humanizeDuration(uptimeInMs, { round: true, largest: 1 });
   }
@@ -39,8 +49,10 @@ export class PodUtils {
       return undefined;
     }
 
-    // make it human friendly
-    return moment(podInfoUI.created).toDate();
+    // To avoid https://momentjs.com/guides/#/warnings/js-date/ warning
+    // and provide better compatibility with the library, we will convert to ISO format before
+    // passing to moment
+    return moment(new Date(podInfoUI.created).toISOString()).toDate();
   }
 
   getEngineId(podinfo: PodInfo): string {


### PR DESCRIPTION
chore: convert k8s date format to ISO string before humanizing duration

### What does this PR do?

Converts the date to ISO string due to deprecation warning from moment,
this provides more compatibility / no warnings.

Added tests for 2 years / 2 months / 2 days / 2 hours, as well as
another check in humanizeAge where we return blank if there is no actual
date passed into the function.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/9719

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

1. Load pods page with kubernetes objects
2. No warning shown anymore

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
