### PR TITLE
chore: kubernetes pods store

### DIFF
--- a/packages/renderer/src/stores/kubernetes-contexts-state.spec.ts
+++ b/packages/renderer/src/stores/kubernetes-contexts-state.spec.ts
@@ -36,7 +36,9 @@ import {
 const kubernetesRegisterGetCurrentContextResourcesMock: Mock<
   (resourceName: ResourceName) => Promise<KubernetesObject[]>
 > = vi.fn();
-const kubernetesUnregisterGetCurrentContextResourcesMock: Mock<(resourceName: ResourceName) => Promise<[]>> = vi.fn();
+const kubernetesUnregisterGetCurrentContextResourcesMock: Mock<
+  (resourceName: ResourceName) => Promise<KubernetesObject[]>
+> = vi.fn().mockResolvedValue([]);
 
 const callbacks = new Map<string, any>();
 const eventEmitter = {

--- a/packages/renderer/src/stores/kubernetes-contexts-state.spec.ts
+++ b/packages/renderer/src/stores/kubernetes-contexts-state.spec.ts
@@ -1,0 +1,130 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import type { KubernetesObject } from '@kubernetes/client-node';
+import type { Readable } from 'svelte/store';
+import type { Mock } from 'vitest';
+import { beforeAll, expect, test, vi } from 'vitest';
+
+import type { ResourceName } from '/@api/kubernetes-contexts-states';
+
+import {
+  kubernetesCurrentContextDeployments,
+  kubernetesCurrentContextNodes,
+  kubernetesCurrentContextPods,
+  kubernetesCurrentContextServices,
+} from './kubernetes-contexts-state';
+
+// define mocks and event callback
+const kubernetesRegisterGetCurrentContextResourcesMock: Mock<
+  (resourceName: ResourceName) => Promise<KubernetesObject[]>
+> = vi.fn();
+const kubernetesUnregisterGetCurrentContextResourcesMock: Mock<(resourceName: ResourceName) => Promise<[]>> = vi.fn();
+
+const callbacks = new Map<string, any>();
+const eventEmitter = {
+  receive: (message: string, callback: any) => {
+    callbacks.set(message, callback);
+  },
+};
+
+// patch window object
+Object.defineProperty(global, 'window', {
+  value: {
+    kubernetesRegisterGetCurrentContextResources: kubernetesRegisterGetCurrentContextResourcesMock,
+    kubernetesUnregisterGetCurrentContextResources: kubernetesUnregisterGetCurrentContextResourcesMock,
+    addEventListener: eventEmitter.receive,
+    events: {
+      receive: eventEmitter.receive,
+    },
+  },
+  writable: true,
+});
+
+beforeAll(() => {
+  vi.clearAllMocks();
+});
+
+test.each(['nodes', 'pods', 'deployments', 'services'])('confirm %s store is receiving events', async resourceName => {
+  switch (resourceName) {
+    case 'nodes': {
+      await testKubernetesStore(resourceName, kubernetesCurrentContextNodes);
+      break;
+    }
+    case 'pods': {
+      await testKubernetesStore(resourceName, kubernetesCurrentContextPods);
+      break;
+    }
+    case 'deployments': {
+      await testKubernetesStore(resourceName, kubernetesCurrentContextDeployments);
+      break;
+    }
+    case 'services': {
+      await testKubernetesStore(resourceName, kubernetesCurrentContextServices);
+      break;
+    }
+  }
+});
+
+async function testKubernetesStore(resourceName: string, store: Readable<KubernetesObject[]>): Promise<void> {
+  const event = `kubernetes-current-context-${resourceName}-update`;
+
+  const object1: KubernetesObject = {
+    Id: 'id123',
+  } as unknown as KubernetesObject;
+  const object2: KubernetesObject = {
+    Id: 'id246',
+  } as unknown as KubernetesObject;
+
+  // start with one object in resources and subscribe
+  kubernetesRegisterGetCurrentContextResourcesMock.mockImplementation(type =>
+    Promise.resolve(type === resourceName ? [object1] : []),
+  );
+
+  let resources: KubernetesObject[] = [];
+  const unsubscribe = store.subscribe(value => {
+    resources = value;
+  });
+
+  // confirm store has the correct initial data
+  await vi.waitFor(() => {
+    expect(resources).toHaveLength(1);
+  });
+  expect(resources[0]).toBe(object1);
+
+  // update object via an event
+  const callback = callbacks.get(event);
+  expect(callback).toBeDefined();
+  await callback();
+
+  callbacks.get(event)([object2, object1]);
+
+  // wait for data to be updated
+  await vi.waitFor(() => {
+    expect(resources).toHaveLength(2);
+  });
+
+  // confirm correct data
+  expect(resources[0]).toBe(object2);
+  expect(resources[1]).toBe(object1);
+
+  // unsubscribe
+  unsubscribe();
+}

--- a/packages/renderer/src/stores/kubernetes-contexts-state.ts
+++ b/packages/renderer/src/stores/kubernetes-contexts-state.ts
@@ -166,6 +166,26 @@ export const kubernetesCurrentContextNodesFiltered = derived(
   ([$searchPattern, $nodes]) => $nodes.filter(node => findMatchInLeaves(node, $searchPattern.toLowerCase())),
 );
 
+// Pods
+
+export const kubernetesCurrentContextPods = readable<KubernetesObject[]>([], set => {
+  window.kubernetesRegisterGetCurrentContextResources('pods').then(value => set(value));
+  window.events?.receive('kubernetes-current-context-pods-update', (value: unknown) => {
+    set(value as KubernetesObject[]);
+  });
+  return () => {
+    window.kubernetesUnregisterGetCurrentContextResources('pods');
+  };
+});
+
+export const podSearchPattern = writable('');
+
+// The pods in the current context, filtered with `podSearchPattern`
+export const kubernetesCurrentContextPodsFiltered = derived(
+  [podSearchPattern, kubernetesCurrentContextPods],
+  ([$searchPattern, $pods]) => $pods.filter(pod => findMatchInLeaves(pod, $searchPattern.toLowerCase())),
+);
+
 // PersistentVolumeClaims
 
 export const kubernetesCurrentContextPersistentVolumeClaims = readable<KubernetesObject[]>([], set => {

--- a/packages/renderer/src/stores/kubernetes-contexts-state.ts
+++ b/packages/renderer/src/stores/kubernetes-contexts-state.ts
@@ -169,12 +169,17 @@ export const kubernetesCurrentContextNodesFiltered = derived(
 // Pods
 
 export const kubernetesCurrentContextPods = readable<KubernetesObject[]>([], set => {
-  window.kubernetesRegisterGetCurrentContextResources('pods').then(value => set(value));
+  window
+    .kubernetesRegisterGetCurrentContextResources('pods')
+    .then(value => set(value))
+    .catch((err: unknown) => console.log('Error registering Kubernetes pods', err));
   window.events?.receive('kubernetes-current-context-pods-update', (value: unknown) => {
     set(value as KubernetesObject[]);
   });
   return () => {
-    window.kubernetesUnregisterGetCurrentContextResources('pods');
+    window
+      .kubernetesUnregisterGetCurrentContextResources('pods')
+      .catch((err: unknown) => console.log('Error unregistering Kubernetes pods', err));
   };
 });
 


### PR DESCRIPTION
### What does this PR do?

We have informers for all the Kube objects, except for pods where we have the informer in main but don't expose the store in renderer.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

For consistency/completeness, a very small part of #8818, and possibly needed for #9502.

### How to test this PR?

PR checks enough for now.