### PR TITLE
fix: start secondary informers for current context only

### DIFF
--- a/packages/main/src/plugin/kubernetes/contexts-manager.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager.ts
@@ -347,9 +347,12 @@ export class ContextsManager {
             state.reachable = reachable;
             state.error = reachable ? undefined : state.error; // if reachable we remove error
             if (reachable) {
-              for (const resourceName of secondaryResources) {
-                if (this.secondaryWatchers.hasSubscribers(resourceName)) {
-                  this.startResourceInformer(context.name, resourceName);
+              // start secondary informers, for current context only
+              if (this.kubeConfig.currentContext === context.name) {
+                for (const resourceName of secondaryResources) {
+                  if (this.secondaryWatchers.hasSubscribers(resourceName)) {
+                    this.startResourceInformer(context.name, resourceName);
+                  }
                 }
               }
             } else {


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Start secondary informers for current context only

### What issues does this PR fix or reference?

Fixes #9702 

### How to test this PR?

Edit the kubeconfig file to remove the line `current-context: ...`. No error should happen.

- [x] Tests are covering the bug fix or the new feature
