### PR TITLE
fix: add name to hidden select in Dropdown for FormData (#9708)

### DIFF
--- a/packages/ui/src/lib/dropdown/Dropdown.svelte
+++ b/packages/ui/src/lib/dropdown/Dropdown.svelte
@@ -230,7 +230,7 @@ function onWindowClick(e: Event): void {
     </div>
   {/if}
 
-  <select use:buildOptions class="hidden" bind:value={value}>
+  <select use:buildOptions class="hidden" name={name} bind:value={value}>
     {@render children?.()}
   </select>
 </div>


### PR DESCRIPTION
fix: add name to hidden select in Dropdown

Signed-off-by: Sonia Sandler <ssandler@redhat.com>
Cherry-picking Sonia Sandler fix for https://github.com/containers/podman-desktop/issues/9706 

Closes #9706 

Closes #9707 

