### PR TITLE
fix: tty when container run with it options

### DIFF
--- a/packages/renderer/src/lib/container/ContainerDetailsTtyTerminal.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsTtyTerminal.svelte
@@ -65,7 +65,7 @@ onMount(async () => {
 </script>
 
 <div class="h-full" class:hidden={container.state !== 'RUNNING'}>
-  <TerminalWindow class="h-full" bind:terminal={attachContainerTerminal} screenReaderMode={screenReaderMode} disableStdIn={false} />
+  <TerminalWindow class="h-full" bind:terminal={attachContainerTerminal} screenReaderMode={screenReaderMode} disableStdIn={false} showCursor={true} />
 </div>
 
 <EmptyScreen

--- a/packages/renderer/src/lib/container/ContainerDetailsTtyTerminal.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsTtyTerminal.svelte
@@ -13,6 +13,26 @@ export let container: ContainerInfoUI;
 export let screenReaderMode = false;
 let attachContainerTerminal: Terminal;
 let closed = false;
+let callbackId: number;
+
+let listened = false;
+$: listenTerminalData(attachContainerTerminal, callbackId);
+
+// listenTerminalData only when attachContainerTerminal is bound from TerminalWindow component
+// and callbackId is defined
+function listenTerminalData(terminal: Terminal, cbId: number) {
+  if (!attachContainerTerminal || !cbId) {
+    return;
+  }
+  if (listened) {
+    return;
+  }
+  listened = true;
+  // pass data from xterm to container
+  terminal.onData(data => {
+    window.attachContainerSend(callbackId, data);
+  });
+}
 
 // update terminal when receiving data
 function receiveDataCallback(data: Buffer) {
@@ -30,18 +50,13 @@ async function attachToContainer() {
   }
 
   // attach to the container
-  const callbackId = await window.attachContainer(
+  callbackId = await window.attachContainer(
     container.engineId,
     container.id,
     receiveDataCallback,
     () => {},
     receiveEndCallback,
   );
-
-  // pass data from xterm to container
-  attachContainerTerminal?.onData(data => {
-    window.attachContainerSend(callbackId, data);
-  });
 }
 
 onMount(async () => {
@@ -50,7 +65,7 @@ onMount(async () => {
 </script>
 
 <div class="h-full" class:hidden={container.state !== 'RUNNING'}>
-  <TerminalWindow class="h-full" bind:terminal={attachContainerTerminal} screenReaderMode={screenReaderMode} />
+  <TerminalWindow class="h-full" bind:terminal={attachContainerTerminal} screenReaderMode={screenReaderMode} disableStdIn={false} />
 </div>
 
 <EmptyScreen

--- a/packages/renderer/src/lib/ui/TerminalWindow.svelte
+++ b/packages/renderer/src/lib/ui/TerminalWindow.svelte
@@ -12,6 +12,7 @@ export let terminal: Terminal;
 export let convertEol: boolean | undefined = undefined;
 export let disableStdIn: boolean = true;
 export let screenReaderMode: boolean | undefined = undefined;
+export let showCursor: boolean = false;
 
 let logsXtermDiv: HTMLDivElement;
 let resizeHandler: () => void;
@@ -43,8 +44,10 @@ async function refreshTerminal(): Promise<void> {
   terminal.loadAddon(fitAddon);
 
   terminal.open(logsXtermDiv);
-  // disable cursor
-  terminal.write('\x1b[?25l');
+  if (!showCursor) {
+    // disable cursor
+    terminal.write('\x1b[?25l');
+  }
 
   // call fit addon each time we resize the window
   resizeHandler = (): void => {


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

tty when container run with it options

### Screenshot / video of UI


### What issues does this PR fix or reference?

Fix #9718 

### How to test this PR?

Run a container with `-it` and access the TTY tab, you should be able to use the TTY tab as terminal


- [ ] Tests are covering the bug fix or the new feature
