### PR TITLE
fix: start secondary informers for current context only (#9735)

### DIFF
--- a/packages/main/src/plugin/kubernetes/contexts-manager.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager.ts
@@ -347,9 +347,12 @@ export class ContextsManager {
             state.reachable = reachable;
             state.error = reachable ? undefined : state.error; // if reachable we remove error
             if (reachable) {
-              for (const resourceName of secondaryResources) {
-                if (this.secondaryWatchers.hasSubscribers(resourceName)) {
-                  this.startResourceInformer(context.name, resourceName);
+              // start secondary informers, for current context only
+              if (this.kubeConfig.currentContext === context.name) {
+                for (const resourceName of secondaryResources) {
+                  if (this.secondaryWatchers.hasSubscribers(resourceName)) {
+                    this.startResourceInformer(context.name, resourceName);
+                  }
                 }
               }
             } else {


### PR DESCRIPTION
### What does this PR do?

Backport of #9735 to v1.14.x
