### PR TITLE
feat: allow for extensions to navigate to an onboarding screen

### DIFF
--- a/packages/api/src/navigation-page.ts
+++ b/packages/api/src/navigation-page.ts
@@ -28,6 +28,7 @@ export enum NavigationPage {
   IMAGES = 'images',
   IMAGE_BUILD = 'image-build',
   IMAGE = 'image',
+  ONBOARDING = 'preferences-onboarding',
   PODS = 'pods',
   POD = 'pod',
   VOLUMES = 'volumes',

--- a/packages/api/src/navigation-request.ts
+++ b/packages/api/src/navigation-request.ts
@@ -32,6 +32,7 @@ export interface NavigationParameters {
   [NavigationPage.IMAGES]: never;
   [NavigationPage.IMAGE_BUILD]: never;
   [NavigationPage.IMAGE]: { id: string; engineId: string; tag: string };
+  [NavigationPage.ONBOARDING]: { extensionId: string };
   [NavigationPage.PODS]: never;
   [NavigationPage.POD]: { kind: string; name: string; engineId: string };
   [NavigationPage.VOLUMES]: never;

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -4798,6 +4798,12 @@ declare module '@podman-desktop/api' {
     export function navigateToEditProviderContainerConnection(connection: ProviderContainerConnection): Promise<void>;
 
     /**
+     *  Navigate to a specific onboarding page referenced by its extensionId
+     * @param extensionId The id of the extension to navigate to or if missing, default to the extension calling the method
+     */
+    export function navigateToOnboarding(extensionId?: string): Promise<void>;
+
+    /**
      * Allow to define custom route for an extension.
      *
      * @remarks

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -1435,6 +1435,13 @@ export class ExtensionLoader {
       ): Promise<void> => {
         await this.navigationManager.navigateToEditProviderContainerConnection(connection);
       },
+      navigateToOnboarding: async (extensionId?: string): Promise<void> => {
+        let onboardingExtensionId = extensionId;
+        if (!onboardingExtensionId) {
+          onboardingExtensionId = extensionInfo.id;
+        }
+        await this.navigationManager.navigateToOnboarding(onboardingExtensionId);
+      },
       navigate: async (routeId: string, ...args: unknown[]): Promise<void> => {
         return this.navigationManager.navigateToRoute(`${extensionInfo.id}.${routeId}`, args);
       },

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -654,6 +654,7 @@ export class PluginSystem {
       providerRegistry,
       webviewRegistry,
       commandRegistry,
+      onboardingRegistry,
     );
 
     this.extensionLoader = new ExtensionLoader(

--- a/packages/main/src/plugin/navigation/navigation-manager.spec.ts
+++ b/packages/main/src/plugin/navigation/navigation-manager.spec.ts
@@ -20,7 +20,9 @@ import type { ProviderContainerConnection } from '@podman-desktop/api';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { CommandRegistry } from '/@/plugin/command-registry.js';
+import type { OnboardingRegistry } from '/@/plugin/onboarding-registry.js';
 import { NavigationPage } from '/@api/navigation-page.js';
+import type { OnboardingInfo } from '/@api/onboarding.js';
 import type { WebviewInfo } from '/@api/webview-info.js';
 
 import type { ApiSenderType } from '../api.js';
@@ -65,6 +67,10 @@ const commandRegistry: CommandRegistry = {
   executeCommand: vi.fn(),
 } as unknown as CommandRegistry;
 
+const onboardingRegistry: OnboardingRegistry = {
+  getOnboarding: vi.fn(),
+} as unknown as OnboardingRegistry;
+
 beforeEach(() => {
   vi.resetAllMocks();
   navigationManager = new TestNavigationManager(
@@ -74,6 +80,7 @@ beforeEach(() => {
     providerRegistry,
     webviewRegistry,
     commandRegistry,
+    onboardingRegistry,
   );
 });
 
@@ -174,6 +181,19 @@ test('check navigateToEditProviderContainerConnection', async () => {
     parameters: {
       provider: 'id',
       name: Buffer.from(connection.connection.name).toString('base64'),
+    },
+  });
+});
+
+test('check navigateToOnboarding', async () => {
+  vi.mocked(onboardingRegistry.getOnboarding).mockReturnValue({ extension: 'foo' } as OnboardingInfo);
+
+  await navigationManager.navigateToOnboarding('my.extension');
+
+  expect(apiSender.send).toHaveBeenCalledWith('navigate', {
+    page: NavigationPage.ONBOARDING,
+    parameters: {
+      extensionId: 'my.extension',
     },
   });
 });

--- a/packages/main/src/plugin/navigation/navigation-manager.ts
+++ b/packages/main/src/plugin/navigation/navigation-manager.ts
@@ -22,6 +22,7 @@ import type { ApiSenderType } from '/@/plugin/api.js';
 import type { CommandRegistry } from '/@/plugin/command-registry.js';
 import type { ContainerProviderRegistry } from '/@/plugin/container-registry.js';
 import type { ContributionManager } from '/@/plugin/contribution-manager.js';
+import type { OnboardingRegistry } from '/@/plugin/onboarding-registry.js';
 import { NavigationPage } from '/@api/navigation-page.js';
 import type { NavigationRequest } from '/@api/navigation-request.js';
 
@@ -44,6 +45,7 @@ export class NavigationManager {
     private providerRegistry: ProviderRegistry,
     private webviewRegistry: WebviewRegistry,
     private commandRegistry: CommandRegistry,
+    private onboardingRegistry: OnboardingRegistry,
   ) {
     this.#registry = new Map();
   }
@@ -122,6 +124,12 @@ export class NavigationManager {
 
   private async assertContainerExist(id: string): Promise<void> {
     if (!(await this.containerRegistry.containerExist(id))) throw new Error(`Container with id ${id} cannot be found.`);
+  }
+
+  private assertOnboardingExist(extensionId: string): void {
+    if (!this.onboardingRegistry.getOnboarding(extensionId)) {
+      throw new Error(`Onboarding with extension id ${extensionId} cannot be found.`);
+    }
   }
 
   async navigateToContainerLogs(id: string): Promise<void> {
@@ -298,6 +306,17 @@ export class NavigationManager {
       parameters: {
         provider: internalId,
         name: Buffer.from(connection.connection.name).toString('base64'),
+      },
+    });
+  }
+
+  async navigateToOnboarding(extensionId: string): Promise<void> {
+    this.assertOnboardingExist(extensionId);
+
+    this.navigateTo({
+      page: NavigationPage.ONBOARDING,
+      parameters: {
+        extensionId: extensionId,
       },
     });
   }

--- a/packages/renderer/src/navigation.spec.ts
+++ b/packages/renderer/src/navigation.spec.ts
@@ -111,6 +111,17 @@ test(`Test navigationHandle for ${NavigationPage.IMAGE}`, () => {
   expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/images/123/dummyEngineId/ZHVtbXlUYWc=');
 });
 
+test(`Test navigationHandle for ${NavigationPage.ONBOARDING}`, () => {
+  handleNavigation({
+    page: NavigationPage.ONBOARDING,
+    parameters: {
+      extensionId: 'my.extension',
+    },
+  });
+
+  expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/preferences/onboarding/my.extension');
+});
+
 test(`Test navigationHandle for ${NavigationPage.PODS}`, () => {
   handleNavigation({ page: NavigationPage.PODS });
 

--- a/packages/renderer/src/navigation.ts
+++ b/packages/renderer/src/navigation.ts
@@ -75,6 +75,9 @@ export const handleNavigation = (request: InferredNavigationRequest<NavigationPa
         `/images/${request.parameters.id}/${request.parameters.engineId}/${Buffer.from(request.parameters.tag).toString('base64')}`,
       );
       break;
+    case NavigationPage.ONBOARDING:
+      router.goto(`/preferences/onboarding/${request.parameters.extensionId}`);
+      break;
     case NavigationPage.PODS:
       router.goto(`/pods`);
       break;


### PR DESCRIPTION
### What does this PR do?
allow extensions to navigate to the onboarding screen of an extension

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/9744

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
