### PR TITLE
chore: add command in compose to display the onboarding

### DIFF
--- a/extensions/compose/src/extension.spec.ts
+++ b/extensions/compose/src/extension.spec.ts
@@ -122,6 +122,7 @@ test('commands registered', async () => {
   await activate(extensionContextMock);
 
   [
+    'compose.openComposeOnboarding',
     'compose.onboarding.checkDownloadedCommand',
     'compose.onboarding.downloadCommand',
     'compose.onboarding.promptUserForVersion',

--- a/extensions/compose/src/extension.ts
+++ b/extensions/compose/src/extension.ts
@@ -65,6 +65,11 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   const composeGitHubReleases = new ComposeGitHubReleases(octokit);
   const composeDownload = new ComposeDownload(extensionContext, composeGitHubReleases, os);
 
+  // add a command to display the onboarding page
+  const openOnboardingCommand = extensionApi.commands.registerCommand('compose.openComposeOnboarding', async () => {
+    await extensionApi.navigation.navigateToOnboarding();
+  });
+
   // ONBOARDING: Command to check compose is downloaded
   const onboardingCheckDownloadCommand = extensionApi.commands.registerCommand(
     'compose.onboarding.checkDownloadedCommand',
@@ -198,6 +203,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
 
   // Push the commands that will be used within the onboarding sequence
   extensionContext.subscriptions.push(
+    openOnboardingCommand,
     onboardingCheckDownloadCommand,
     onboardingPromptUserForVersionCommand,
     onboardingDownloadComposeCommand,


### PR DESCRIPTION
### What does this PR do?

add a command to display the compose onboarding

depends on:
- [ ] https://github.com/containers/podman-desktop/pull/9759


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

for docker compatibility mode
https://github.com/containers/podman-desktop/issues/9242

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
