### PR TITLE
feat: add category field to feedback

### DIFF
--- a/packages/api/src/feedback.ts
+++ b/packages/api/src/feedback.ts
@@ -1,0 +1,26 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export type FeedbackCategory = 'developers' | 'feature' | 'bug';
+
+export interface FeedbackProperties {
+  category: FeedbackCategory;
+  rating: number;
+  comment?: string;
+  contact?: string;
+}

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -58,6 +58,7 @@ import type { ContainerStatsInfo } from '/@api/container-stats-info';
 import type { ContributionInfo } from '/@api/contribution-info';
 import type { DockerContextInfo, DockerSocketMappingStatusInfo } from '/@api/docker-compatibility-info';
 import type { ExtensionInfo } from '/@api/extension-info';
+import type { FeedbackProperties } from '/@api/feedback';
 import type { HistoryInfo } from '/@api/history-info';
 import type { IconInfo } from '/@api/icon-info';
 import type { ImageCheckerInfo } from '/@api/image-checker-info';
@@ -118,15 +119,6 @@ export type OpenSaveDialogResultCallback = (result: string | string[] | undefine
 export type LogType = 'log' | 'warn' | 'trace' | 'debug' | 'error';
 const originalConsole = console;
 const memoryLogs: { logType: LogType; date: Date; message: string }[] = [];
-
-export type FeedbackCategory = 'developers' | 'feature' | 'bug';
-
-export interface FeedbackProperties {
-  category: FeedbackCategory;
-  rating: number;
-  comment?: string;
-  contact?: string;
-}
 
 export interface KeyLogger {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -119,7 +119,10 @@ export type LogType = 'log' | 'warn' | 'trace' | 'debug' | 'error';
 const originalConsole = console;
 const memoryLogs: { logType: LogType; date: Date; message: string }[] = [];
 
+export type FeedbackCategory = 'developers' | 'feature' | 'bug';
+
 export interface FeedbackProperties {
+  category: FeedbackCategory;
   rating: number;
   comment?: string;
   contact?: string;

--- a/packages/renderer/src/lib/feedback/SendFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/SendFeedback.spec.ts
@@ -166,13 +166,13 @@ test('Expect category to be sent', async () => {
   render(SendFeedback, {});
 
   // click on a smiley
-  const categorySelect = screen.getByRole('button', { name: 'Address words to developers' });
+  const categorySelect = screen.getByRole('button', { name: /Direct your words to the developers/ });
   expect(categorySelect).toBeInTheDocument();
   categorySelect.focus();
 
   // select the Feature request category
   await userEvent.keyboard('[ArrowDown]');
-  const featureCategory = screen.getByRole('button', { name: 'Feature request' });
+  const featureCategory = screen.getByRole('button', { name: /Feature request/ });
   expect(featureCategory).toBeInTheDocument();
   await fireEvent.click(featureCategory);
 

--- a/packages/renderer/src/lib/feedback/SendFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/SendFeedback.spec.ts
@@ -36,6 +36,7 @@ beforeAll(() => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (window as any).openExternal = vi.fn();
   (window as any).telemetryTrack = vi.fn();
+  (window as any).sendFeedback = vi.fn();
 });
 
 test('Expect that the button is disabled when loading the page', async () => {
@@ -158,5 +159,35 @@ test('Expect GitHub dialog visible when very-happy-smiley selected', async () =>
   await vi.waitFor(() => {
     expect(window.telemetryTrack).toHaveBeenCalledWith('feedback.openGitHub');
     expect(window.openExternal).toHaveBeenCalledWith('https://github.com/containers/podman-desktop');
+  });
+});
+
+test('Expect category to be sent', async () => {
+  render(SendFeedback, {});
+
+  // click on a smiley
+  const categorySelect = screen.getByRole('button', { name: 'Address words to developers' });
+  expect(categorySelect).toBeInTheDocument();
+  categorySelect.focus();
+
+  // select the Feature request category
+  await userEvent.keyboard('[ArrowDown]');
+  const featureCategory = screen.getByRole('button', { name: 'Feature request' });
+  expect(featureCategory).toBeInTheDocument();
+  await fireEvent.click(featureCategory);
+
+  // click on a smiley
+  const smiley = screen.getByRole('button', { name: 'very-happy-smiley' });
+  await fireEvent.click(smiley);
+
+  // click on submit button
+  const button = screen.getByRole('button', { name: 'Send feedback' });
+  expect(button).toBeInTheDocument();
+  expect(button).toBeEnabled();
+  await fireEvent.click(button);
+
+  expect(window.sendFeedback).toHaveBeenCalledWith({
+    category: 'feature',
+    rating: 4,
   });
 });

--- a/packages/renderer/src/lib/feedback/SendFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/SendFeedback.svelte
@@ -8,19 +8,27 @@ import {
   faSmile,
   faStar,
 } from '@fortawesome/free-solid-svg-icons';
-import { Button, ErrorMessage, Link } from '@podman-desktop/ui-svelte';
+import { Button, Dropdown, ErrorMessage, Link } from '@podman-desktop/ui-svelte';
 import Fa from 'svelte-fa';
 
-import type { FeedbackProperties } from '../../../../preload/src/index';
+import type { FeedbackCategory, FeedbackProperties } from '../../../../preload/src/index';
 import Dialog from '../dialogs/Dialog.svelte';
 import WarningMessage from '../ui/WarningMessage.svelte';
 
 let displayModal = false;
 
+const FEEDBACK_CATEGORIES = new Map<FeedbackCategory, string>([
+  ['developers', 'Address words to developers'],
+  ['feature', 'Feature request'],
+  ['bug', 'Bug'],
+]);
+const DEFAULT_CATEGORY: FeedbackCategory = 'developers';
+
 // feedback of the user
 let smileyRating = 0;
 let tellUsWhyFeedback = '';
 let contactInformation = '';
+let category: FeedbackCategory = DEFAULT_CATEGORY;
 
 $: hasFeedback =
   (tellUsWhyFeedback && tellUsWhyFeedback.trim().length > 4) ||
@@ -37,6 +45,7 @@ function hideModal(): void {
   smileyRating = 0;
   tellUsWhyFeedback = '';
   contactInformation = '';
+  category = DEFAULT_CATEGORY;
 }
 
 function selectSmiley(item: number): void {
@@ -45,6 +54,7 @@ function selectSmiley(item: number): void {
 
 async function sendFeedback(): Promise<void> {
   const properties: FeedbackProperties = {
+    category: category,
     rating: smileyRating,
   };
 
@@ -72,7 +82,11 @@ async function openGitHub(): Promise<void> {
 {#if displayModal}
   <Dialog title="Share your feedback" on:close={() => hideModal()}>
     <svelte:fragment slot="content">
-      <label for="smiley" class="block mb-2 text-sm font-medium text-[var(--pd-modal-text)]"
+      <label for="category" class="block mb-2 text-sm font-medium text-[var(--pd-modal-text)]">Category</label>
+      <Dropdown name="category" bind:value={category}
+      options={Array.from(FEEDBACK_CATEGORIES).map(e => ({ value: e[0], label: e[1] }))}>
+      </Dropdown>
+      <label for="smiley" class="block mt-4 mb-2 text-sm font-medium text-[var(--pd-modal-text)]"
         >How was your experience with Podman Desktop?</label>
       <div class="flex space-x-4">
         <button aria-label="very-sad-smiley" on:click={() => selectSmiley(1)}>

--- a/packages/renderer/src/lib/feedback/SendFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/SendFeedback.svelte
@@ -11,7 +11,8 @@ import {
 import { Button, Dropdown, ErrorMessage, Link } from '@podman-desktop/ui-svelte';
 import Fa from 'svelte-fa';
 
-import type { FeedbackCategory, FeedbackProperties } from '../../../../preload/src/index';
+import type { FeedbackCategory, FeedbackProperties } from '/@api/feedback';
+
 import Dialog from '../dialogs/Dialog.svelte';
 import WarningMessage from '../ui/WarningMessage.svelte';
 

--- a/packages/renderer/src/lib/feedback/SendFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/SendFeedback.svelte
@@ -18,9 +18,9 @@ import WarningMessage from '../ui/WarningMessage.svelte';
 let displayModal = false;
 
 const FEEDBACK_CATEGORIES = new Map<FeedbackCategory, string>([
-  ['developers', 'Address words to developers'],
-  ['feature', 'Feature request'],
-  ['bug', 'Bug'],
+  ['developers', '💬 Direct your words to the developers'],
+  ['feature', '🚀 Feature request'],
+  ['bug', '🪲 Bug'],
 ]);
 const DEFAULT_CATEGORY: FeedbackCategory = 'developers';
 


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Add category field to feedback.

### Screenshot / video of UI
![feedback-category-close-2](https://github.com/user-attachments/assets/3ecf305f-b979-47a4-b42c-5a6a17fac834)
![categories-emojies](https://github.com/user-attachments/assets/4eec2ca5-fcc7-472c-8548-1c1ff960665c)

### What issues does this PR fix or reference?

Fixes #9582 

### How to test this PR?
Open the feedback page, select a category, a rating, and send the feedback.
Check in the telemetry that the category has been set in the event data.

- [x] Tests are covering the bug fix or the new feature
