### PR TITLE
chore: add option to view nav icon title

### DIFF
--- a/packages/main/src/plugin/appearance-init.spec.ts
+++ b/packages/main/src/plugin/appearance-init.spec.ts
@@ -139,7 +139,8 @@ test('should register a configuration', async () => {
 });
 
 test('Icon should be default if not in dev env', () => {
-  vi.unstubAllEnvs();
+  vi.resetAllMocks();
+  vi.stubEnv('DEV', false);
   const appearanceInit = new AppearanceInit(configurationRegistry);
   appearanceInit.init();
 

--- a/packages/main/src/plugin/appearance-init.spec.ts
+++ b/packages/main/src/plugin/appearance-init.spec.ts
@@ -116,6 +116,7 @@ test('Expect unknown theme to be set to system', async () => {
 });
 
 test('should register a configuration', async () => {
+  vi.stubEnv('DEV', true);
   const appearanceInit = new AppearanceInit(configurationRegistry);
   appearanceInit.init();
 
@@ -131,8 +132,19 @@ test('should register a configuration', async () => {
   expect(configurationNode?.properties?.['preferences.zoomLevel']?.default).toBe(0);
   expect(configurationNode?.properties?.['preferences.zoomLevel']?.step).toBe(0.1);
 
-  expect(configurationNode?.properties?.['preferences.navigationAppearance']).toBeDefined();
-  expect(configurationNode?.properties?.['preferences.navigationAppearance']?.description).toBeDefined();
-  expect(configurationNode?.properties?.['preferences.navigationAppearance']?.type).toBe('string');
-  expect(configurationNode?.properties?.['preferences.navigationAppearance']?.default).toBe('icon and title');
+  expect(configurationNode?.properties?.['preferences.navigationBarLayout']).toBeDefined();
+  expect(configurationNode?.properties?.['preferences.navigationBarLayout']?.description).toBeDefined();
+  expect(configurationNode?.properties?.['preferences.navigationBarLayout']?.type).toBe('string');
+  expect(configurationNode?.properties?.['preferences.navigationBarLayout']?.default).toBe('icon + title');
+});
+
+test('Icon should be default if not in dev env', () => {
+  vi.unstubAllEnvs();
+  const appearanceInit = new AppearanceInit(configurationRegistry);
+  appearanceInit.init();
+
+  expect(configurationRegistry.registerConfigurations).toBeCalled();
+  const configurationNode = vi.mocked(configurationRegistry.registerConfigurations).mock.calls[0]?.[0][0];
+
+  expect(configurationNode?.properties?.['preferences.navigationBarLayout']?.default).toBe('icon');
 });

--- a/packages/main/src/plugin/appearance-init.spec.ts
+++ b/packages/main/src/plugin/appearance-init.spec.ts
@@ -124,10 +124,15 @@ test('should register a configuration', async () => {
   expect(configurationNode?.id).toBe('preferences.appearance');
   expect(configurationNode?.title).toBe('Appearance');
   expect(configurationNode?.properties).toBeDefined();
-  expect(Object.keys(configurationNode?.properties ?? {}).length).toBe(2);
+  expect(Object.keys(configurationNode?.properties ?? {}).length).toBe(3);
   expect(configurationNode?.properties?.['preferences.zoomLevel']).toBeDefined();
   expect(configurationNode?.properties?.['preferences.zoomLevel']?.markdownDescription).toBeDefined();
   expect(configurationNode?.properties?.['preferences.zoomLevel']?.type).toBe('number');
   expect(configurationNode?.properties?.['preferences.zoomLevel']?.default).toBe(0);
   expect(configurationNode?.properties?.['preferences.zoomLevel']?.step).toBe(0.1);
+
+  expect(configurationNode?.properties?.['preferences.navigationAppearance']).toBeDefined();
+  expect(configurationNode?.properties?.['preferences.navigationAppearance']?.description).toBeDefined();
+  expect(configurationNode?.properties?.['preferences.navigationAppearance']?.type).toBe('string');
+  expect(configurationNode?.properties?.['preferences.navigationAppearance']?.default).toBe('icon and title');
 });

--- a/packages/main/src/plugin/appearance-init.ts
+++ b/packages/main/src/plugin/appearance-init.ts
@@ -50,8 +50,8 @@ export class AppearanceInit {
         [`${AppearanceSettings.SectionName}.${AppearanceSettings.NavigationAppearance}`]: {
           description: 'Select icon and title or just icon for navigation icons',
           type: 'string',
-          enum: ['icon + title', 'icon'],
-          default: import.meta.env.DEV ? 'icon + title' : 'icon',
+          enum: [AppearanceSettings.IconAndTitle, AppearanceSettings.Icon],
+          default: import.meta.env.DEV ? AppearanceSettings.IconAndTitle : AppearanceSettings.Icon,
         },
       },
     };

--- a/packages/main/src/plugin/appearance-init.ts
+++ b/packages/main/src/plugin/appearance-init.ts
@@ -47,6 +47,12 @@ export class AppearanceInit {
           default: 0,
           step: 0.1,
         },
+        [`${AppearanceSettings.SectionName}.${AppearanceSettings.NavigationAppearance}`]: {
+          description: 'Select icon and title or just icon for navigation icons',
+          type: 'string',
+          enum: ['icon and title', 'icon'],
+          default: 'icon and title',
+        },
       },
     };
 

--- a/packages/main/src/plugin/appearance-init.ts
+++ b/packages/main/src/plugin/appearance-init.ts
@@ -50,8 +50,8 @@ export class AppearanceInit {
         [`${AppearanceSettings.SectionName}.${AppearanceSettings.NavigationAppearance}`]: {
           description: 'Select icon and title or just icon for navigation icons',
           type: 'string',
-          enum: ['icon and title', 'icon'],
-          default: 'icon and title',
+          enum: ['icon + title', 'icon'],
+          default: import.meta.env.DEV ? 'icon + title' : 'icon',
         },
       },
     };

--- a/packages/main/src/plugin/appearance-settings.ts
+++ b/packages/main/src/plugin/appearance-settings.ts
@@ -23,4 +23,5 @@ export enum AppearanceSettings {
   DarkEnumValue = 'dark',
   SystemEnumValue = 'system',
   ZoomLevel = 'zoomLevel',
+  NavigationAppearance = 'navigationAppearance',
 }

--- a/packages/main/src/plugin/appearance-settings.ts
+++ b/packages/main/src/plugin/appearance-settings.ts
@@ -23,5 +23,5 @@ export enum AppearanceSettings {
   DarkEnumValue = 'dark',
   SystemEnumValue = 'system',
   ZoomLevel = 'zoomLevel',
-  NavigationAppearance = 'navigationAppearance',
+  NavigationAppearance = 'navigationBarLayout',
 }

--- a/packages/main/src/plugin/appearance-settings.ts
+++ b/packages/main/src/plugin/appearance-settings.ts
@@ -24,4 +24,6 @@ export enum AppearanceSettings {
   SystemEnumValue = 'system',
   ZoomLevel = 'zoomLevel',
   NavigationAppearance = 'navigationBarLayout',
+  Icon = 'icon',
+  IconAndTitle = 'icon + title',
 }

--- a/packages/renderer/src/AppNavigation.spec.ts
+++ b/packages/renderer/src/AppNavigation.spec.ts
@@ -20,6 +20,7 @@ import '@testing-library/jest-dom/vitest';
 
 import type { KubernetesObject } from '@kubernetes/client-node';
 import { render, screen } from '@testing-library/svelte';
+import { tick } from 'svelte';
 import { readable } from 'svelte/store';
 import type { TinroRouteMeta } from 'tinro';
 import { beforeAll, expect, test, vi } from 'vitest';
@@ -123,6 +124,7 @@ test('Test contributions', () => {
 });
 
 test('NAV_BAR_LAYOUT updates on configuration change', async () => {
+  const NAV_BAR_LAYOUT = `${AppearanceSettings.SectionName}.${AppearanceSettings.NavigationAppearance}`;
   const meta = {
     url: '/',
   } as unknown as TinroRouteMeta;
@@ -134,6 +136,15 @@ test('NAV_BAR_LAYOUT updates on configuration change', async () => {
     meta,
     exitSettingsCallback: () => {},
   });
+  await tick();
 
-  callbacks.get(`${AppearanceSettings.SectionName}.${AppearanceSettings.NavigationAppearance}`)?.();
+  callbacks.get(NAV_BAR_LAYOUT)?.({ detail: { key: NAV_BAR_LAYOUT, value: AppearanceSettings.IconAndTitle } });
+  await tick();
+  expect(screen.getByTitle('Dashboard')).toBeInTheDocument();
+  expect(screen.getByRole('navigation')).toHaveClass('min-w-fit');
+
+  callbacks.get(NAV_BAR_LAYOUT)?.({ detail: { key: NAV_BAR_LAYOUT, value: AppearanceSettings.Icon } });
+  await tick();
+  expect(screen.queryByTitle('Dashboard')).not.toBeInTheDocument();
+  expect(screen.getByRole('navigation')).toHaveClass('min-w-leftnavbar');
 });

--- a/packages/renderer/src/AppNavigation.spec.ts
+++ b/packages/renderer/src/AppNavigation.spec.ts
@@ -140,11 +140,11 @@ test('NAV_BAR_LAYOUT updates on configuration change', async () => {
 
   callbacks.get(NAV_BAR_LAYOUT)?.({ detail: { key: NAV_BAR_LAYOUT, value: AppearanceSettings.IconAndTitle } });
   await tick();
-  expect(screen.getByTitle('Dashboard')).toBeInTheDocument();
+  expect(screen.getByLabelText('Dashboard title')).toBeInTheDocument();
   expect(screen.getByRole('navigation')).toHaveClass('min-w-fit');
 
   callbacks.get(NAV_BAR_LAYOUT)?.({ detail: { key: NAV_BAR_LAYOUT, value: AppearanceSettings.Icon } });
   await tick();
-  expect(screen.queryByTitle('Dashboard')).not.toBeInTheDocument();
+  expect(screen.queryByLabelText('Dashboard title')).not.toBeInTheDocument();
   expect(screen.getByRole('navigation')).toHaveClass('min-w-leftnavbar');
 });

--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -73,7 +73,7 @@ function onDidChangeConfigurationCallback(e: Event): void {
           <NewContentOnDashboardBadge />
         </div>
         {#if iconWithTitle}
-          <div class="text-xs text-center ml-[2px]" title="Dashboard">
+          <div class="text-xs text-center ml-[2px]" aria-label="Dashboard title">
             Dashboard
           </div>
         {/if}
@@ -99,7 +99,7 @@ function onDidChangeConfigurationCallback(e: Event): void {
         <div class="flex flex-col items-center w-full h-full">
           <AccountIcon size={iconSize} />
           {#if iconWithTitle}
-            <div class="text-xs text-center ml-[2px]" title="Accounts">
+            <div class="text-xs text-center ml-[2px]" aria-label="Accounts title">
               Accounts
             </div>
           {/if}
@@ -112,7 +112,7 @@ function onDidChangeConfigurationCallback(e: Event): void {
   <NavItem href="/preferences" tooltip="Settings" bind:meta={meta} onClick={handleClick}>
     <SettingsIcon size={iconSize} />
     {#if iconWithTitle}
-      <div class="text-xs text-center ml-[2px]" title="Settings">
+      <div class="text-xs text-center ml-[2px]" aria-label="Settings title">
         Settings
       </div>
     {/if}

--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -31,16 +31,12 @@ const NAV_BAR_LAYOUT = `${AppearanceSettings.SectionName}.${AppearanceSettings.N
 
 onDidChangeConfiguration.addEventListener(NAV_BAR_LAYOUT, onDidChangeConfigurationCallback);
 
-let minNavbarWidth = $state('min-w-leftnavbar');
-
-$effect(() => {
-  minNavbarWidth = iconWithTitle ? 'min-w-fit' : 'min-w-leftnavbar';
-});
+let minNavbarWidth = $derived(iconWithTitle ? 'min-w-fit' : 'min-w-leftnavbar');
 
 onMount(async () => {
   const commandRegistry = new CommandRegistry();
   commandRegistry.init();
-  iconWithTitle = (await window.getConfigurationValue(NAV_BAR_LAYOUT)) === 'icon + title';
+  iconWithTitle = (await window.getConfigurationValue(NAV_BAR_LAYOUT)) === AppearanceSettings.IconAndTitle;
 });
 
 onDestroy(() => {
@@ -59,7 +55,7 @@ function onDidChangeConfigurationCallback(e: Event): void {
   if ('detail' in e) {
     const detail = e.detail as { key: string; value: string };
     if (NAV_BAR_LAYOUT === detail?.key) {
-      iconWithTitle = detail.value === 'icon + title';
+      iconWithTitle = detail.value === AppearanceSettings.IconAndTitle;
     }
   }
 }

--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -67,14 +67,16 @@ function onDidChangeConfigurationCallback(e: Event): void {
   <NavItem href="/" tooltip="Dashboard" bind:meta={meta} bind:iconWithTitle={iconWithTitle}>
     <div class="relative w-full">
       <div class="flex flex-col items-center w-full h-full">
-        <DashboardIcon size={iconSize} />
+        <div class="flex items-center w-fit h-full relative">
+          <DashboardIcon size={iconSize} />
+          <NewContentOnDashboardBadge />
+        </div>
         {#if iconWithTitle}
           <div class="text-xs text-center">
             Dashboard
           </div>
         {/if}
       </div>
-      <NewContentOnDashboardBadge />
     </div>
   </NavItem>
   {#each $navigationRegistry as navigationRegistryItem}

--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -63,7 +63,7 @@ function onDidChangeConfigurationCallback(e: Event): void {
 <nav
   class="group w-fit min-w-leftnavbar max-w-[65px] flex flex-col hover:overflow-y-none bg-[var(--pd-global-nav-bg)] border-[var(--pd-global-nav-bg-border)] border-r-[1px]"
   aria-label="AppNavigation">
-  <NavItem href="/" tooltip="Dashboard" bind:meta={meta} bind:iconWithTitle={iconWithTitle}>
+  <NavItem href="/" tooltip="Dashboard" bind:meta={meta} iconWithTitle={iconWithTitle}>
     <div class="relative w-full">
       <div class="flex flex-col items-center w-full h-full">
         <div class="flex items-center w-fit h-full relative">
@@ -82,10 +82,10 @@ function onDidChangeConfigurationCallback(e: Event): void {
     {#if navigationRegistryItem.items && navigationRegistryItem.type === 'group'}
       <!-- This is a group, list all items from the entry -->
       {#each navigationRegistryItem.items as item}
-        <NavRegistryEntry entry={item} bind:meta={meta} bind:iconWithTitle={iconWithTitle} />
+        <NavRegistryEntry entry={item} bind:meta={meta} iconWithTitle={iconWithTitle} />
       {/each}
     {:else if navigationRegistryItem.type === 'entry' || navigationRegistryItem.type === 'submenu'}
-      <NavRegistryEntry entry={navigationRegistryItem} bind:meta={meta} bind:iconWithTitle={iconWithTitle} />
+      <NavRegistryEntry entry={navigationRegistryItem} bind:meta={meta} iconWithTitle={iconWithTitle} />
     {/if}
   {/each}
 
@@ -94,7 +94,14 @@ function onDidChangeConfigurationCallback(e: Event): void {
   <div bind:this={outsideWindow}>
     <NavItem href="/accounts" tooltip="" bind:meta={meta} onClick={event => authActions?.onButtonClick(event)}>
       <Tooltip bottomRight tip="Accounts">
-        <AccountIcon size={iconSize} />
+        <div class="flex flex-col items-center w-full h-full">
+          <AccountIcon size={iconSize} />
+          {#if iconWithTitle}
+            <div class="text-xs text-center">
+              Accounts
+            </div>
+          {/if}
+        </div>
       </Tooltip>
       <AuthActions bind:this={authActions} outsideWindow={outsideWindow} />
     </NavItem>
@@ -102,10 +109,10 @@ function onDidChangeConfigurationCallback(e: Event): void {
 
   <NavItem href="/preferences" tooltip="Settings" bind:meta={meta} onClick={handleClick}>
     <SettingsIcon size={iconSize} />
-      {#if iconWithTitle}
-        <div class="text-xs text-center">
-          Settings
-        </div>
-      {/if}
+    {#if iconWithTitle}
+      <div class="text-xs text-center">
+        Settings
+      </div>
+    {/if}
   </NavItem>
 </nav>

--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -24,7 +24,7 @@ let { exitSettingsCallback, meta = $bindable() }: { exitSettingsCallback: () => 
 
 let authActions = $state<AuthActions>();
 let outsideWindow = $state<HTMLDivElement>();
-let iconWithTitle = $state(true);
+let iconWithTitle = $state(false);
 
 const iconSize = '22';
 const NAV_BAR_LAYOUT = `${AppearanceSettings.SectionName}.${AppearanceSettings.NavigationAppearance}`;

--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -71,7 +71,7 @@ function onDidChangeConfigurationCallback(e: Event): void {
           <NewContentOnDashboardBadge />
         </div>
         {#if iconWithTitle}
-          <div class="text-xs text-center">
+          <div class="text-xs text-center ml-1">
             Dashboard
           </div>
         {/if}
@@ -110,7 +110,7 @@ function onDidChangeConfigurationCallback(e: Event): void {
   <NavItem href="/preferences" tooltip="Settings" bind:meta={meta} onClick={handleClick}>
     <SettingsIcon size={iconSize} />
     {#if iconWithTitle}
-      <div class="text-xs text-center">
+      <div class="text-xs text-center ml-1">
         Settings
       </div>
     {/if}

--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -31,6 +31,12 @@ const NAV_BAR_LAYOUT = `${AppearanceSettings.SectionName}.${AppearanceSettings.N
 
 onDidChangeConfiguration.addEventListener(NAV_BAR_LAYOUT, onDidChangeConfigurationCallback);
 
+let minNavbarWidth = $state('min-w-leftnavbar');
+
+$effect(() => {
+  minNavbarWidth = iconWithTitle ? 'min-w-fit' : 'min-w-leftnavbar';
+});
+
 onMount(async () => {
   const commandRegistry = new CommandRegistry();
   commandRegistry.init();
@@ -61,7 +67,7 @@ function onDidChangeConfigurationCallback(e: Event): void {
 
 <svelte:window />
 <nav
-  class="group w-fit min-w-leftnavbar max-w-[65px] flex flex-col hover:overflow-y-none bg-[var(--pd-global-nav-bg)] border-[var(--pd-global-nav-bg-border)] border-r-[1px]"
+  class="group w-leftnavbar {minNavbarWidth} flex flex-col hover:overflow-y-none bg-[var(--pd-global-nav-bg)] border-[var(--pd-global-nav-bg-border)] border-r-[1px]"
   aria-label="AppNavigation">
   <NavItem href="/" tooltip="Dashboard" bind:meta={meta} iconWithTitle={iconWithTitle}>
     <div class="relative w-full">
@@ -71,7 +77,7 @@ function onDidChangeConfigurationCallback(e: Event): void {
           <NewContentOnDashboardBadge />
         </div>
         {#if iconWithTitle}
-          <div class="text-xs text-center ml-1">
+          <div class="text-xs text-center ml-[2px]">
             Dashboard
           </div>
         {/if}
@@ -97,7 +103,7 @@ function onDidChangeConfigurationCallback(e: Event): void {
         <div class="flex flex-col items-center w-full h-full">
           <AccountIcon size={iconSize} />
           {#if iconWithTitle}
-            <div class="text-xs text-center">
+            <div class="text-xs text-center ml-[2px]">
               Accounts
             </div>
           {/if}
@@ -110,7 +116,7 @@ function onDidChangeConfigurationCallback(e: Event): void {
   <NavItem href="/preferences" tooltip="Settings" bind:meta={meta} onClick={handleClick}>
     <SettingsIcon size={iconSize} />
     {#if iconWithTitle}
-      <div class="text-xs text-center ml-1">
+      <div class="text-xs text-center ml-[2px]">
         Settings
       </div>
     {/if}

--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -7,6 +7,7 @@ import type { TinroRouteMeta } from 'tinro';
 
 import { NavigationPage } from '/@api/navigation-page';
 
+import { AppearanceSettings } from '../../main/src/plugin/appearance-settings';
 import AuthActions from './lib/authentication/AuthActions.svelte';
 import { CommandRegistry } from './lib/CommandRegistry';
 import NewContentOnDashboardBadge from './lib/dashboard/NewContentOnDashboardBadge.svelte';
@@ -26,17 +27,18 @@ let outsideWindow = $state<HTMLDivElement>();
 let iconWithTitle = $state(true);
 
 const iconSize = '22';
+const NAV_BAR_LAYOUT = `${AppearanceSettings.SectionName}.${AppearanceSettings.NavigationAppearance}`;
 
-onDidChangeConfiguration.addEventListener('preferences.navigationAppearance', onDidChangeConfigurationCallback);
+onDidChangeConfiguration.addEventListener(NAV_BAR_LAYOUT, onDidChangeConfigurationCallback);
 
 onMount(async () => {
   const commandRegistry = new CommandRegistry();
   commandRegistry.init();
-  iconWithTitle = (await window.getConfigurationValue('preferences.navigationAppearance')) === 'icon and title';
+  iconWithTitle = (await window.getConfigurationValue(NAV_BAR_LAYOUT)) === 'icon + title';
 });
 
 onDestroy(() => {
-  onDidChangeConfiguration.removeEventListener('preferences.navigationAppearance', onDidChangeConfigurationCallback);
+  onDidChangeConfiguration.removeEventListener(NAV_BAR_LAYOUT, onDidChangeConfigurationCallback);
 });
 
 function handleClick(): void {
@@ -50,9 +52,10 @@ function handleClick(): void {
 function onDidChangeConfigurationCallback(e: Event): void {
   if ('detail' in e) {
     const detail = e.detail as { key: string; value: string };
-    if ('preferences.navigationAppearance' === detail?.key) {
-      iconWithTitle = detail.value === 'icon and title';
+    if (NAV_BAR_LAYOUT === detail?.key) {
+      iconWithTitle = detail.value === 'icon + title';
     }
+    console.log(detail.value);
   }
 }
 </script>

--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -65,7 +65,7 @@ function onDidChangeConfigurationCallback(e: Event): void {
 <nav
   class="group w-leftnavbar {minNavbarWidth} flex flex-col hover:overflow-y-none bg-[var(--pd-global-nav-bg)] border-[var(--pd-global-nav-bg-border)] border-r-[1px]"
   aria-label="AppNavigation">
-  <NavItem href="/" tooltip="Dashboard" bind:meta={meta} iconWithTitle={iconWithTitle}>
+  <NavItem href="/" tooltip="Dashboard" bind:meta={meta}>
     <div class="relative w-full">
       <div class="flex flex-col items-center w-full h-full">
         <div class="flex items-center w-fit h-full relative">
@@ -73,7 +73,7 @@ function onDidChangeConfigurationCallback(e: Event): void {
           <NewContentOnDashboardBadge />
         </div>
         {#if iconWithTitle}
-          <div class="text-xs text-center ml-[2px]">
+          <div class="text-xs text-center ml-[2px]" title="Dashboard">
             Dashboard
           </div>
         {/if}
@@ -99,7 +99,7 @@ function onDidChangeConfigurationCallback(e: Event): void {
         <div class="flex flex-col items-center w-full h-full">
           <AccountIcon size={iconSize} />
           {#if iconWithTitle}
-            <div class="text-xs text-center ml-[2px]">
+            <div class="text-xs text-center ml-[2px]" title="Accounts">
               Accounts
             </div>
           {/if}
@@ -112,7 +112,7 @@ function onDidChangeConfigurationCallback(e: Event): void {
   <NavItem href="/preferences" tooltip="Settings" bind:meta={meta} onClick={handleClick}>
     <SettingsIcon size={iconSize} />
     {#if iconWithTitle}
-      <div class="text-xs text-center ml-[2px]">
+      <div class="text-xs text-center ml-[2px]" title="Settings">
         Settings
       </div>
     {/if}

--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -61,7 +61,7 @@ function onDidChangeConfigurationCallback(e: Event): void {
 
 <svelte:window />
 <nav
-  class="group w-leftnavbar min-w-leftnavbar flex flex-col hover:overflow-y-none bg-[var(--pd-global-nav-bg)] border-[var(--pd-global-nav-bg-border)] border-r-[1px]"
+  class="group w-fit min-w-leftnavbar max-w-[65px] flex flex-col hover:overflow-y-none bg-[var(--pd-global-nav-bg)] border-[var(--pd-global-nav-bg-border)] border-r-[1px]"
   aria-label="AppNavigation">
   <NavItem href="/" tooltip="Dashboard" bind:meta={meta} bind:iconWithTitle={iconWithTitle}>
     <div class="relative w-full">

--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -55,7 +55,6 @@ function onDidChangeConfigurationCallback(e: Event): void {
     if (NAV_BAR_LAYOUT === detail?.key) {
       iconWithTitle = detail.value === 'icon + title';
     }
-    console.log(detail.value);
   }
 }
 </script>

--- a/packages/renderer/src/lib/ui/NavItem.spec.ts
+++ b/packages/renderer/src/lib/ui/NavItem.spec.ts
@@ -144,7 +144,35 @@ test('Expect that counter is rendered', async () => {
   const href = '/href';
   let counter = 0;
 
-  const result = render(NavItem, { counter, tooltip, href, meta: { url: '/test' } });
+  const result = render(NavItem, { counter, tooltip, href, meta: { url: '/test' }, iconWithTitle: false });
+
+  const element = screen.getByLabelText(tooltip);
+  expect(element).toBeInTheDocument();
+  expect(element).toHaveAttribute('href', '/href');
+
+  // unmount
+  result.unmount();
+
+  // ok now update the counter
+  counter = 4;
+
+  // check tooltip is working if counter is updated
+  render(NavItem, { counter, tooltip, href, meta: { url: '/test' }, iconWithTitle: false });
+
+  // get div with label tooltip
+  const element2 = screen.getByLabelText('Foo');
+  expect(element2).toBeInTheDocument();
+
+  // get text of the element
+  expect(element2.textContent).toContain('Foo (4)');
+});
+
+test('Expect default icon behavior with title and only counter tooltip', () => {
+  const tooltip = 'Foo';
+  const href = '/href';
+  let counter = 0;
+
+  const result = render(NavItem, { counter, tooltip, href, meta: { url: '/test' }, iconWithTitle: false });
 
   const element = screen.getByLabelText(tooltip);
   expect(element).toBeInTheDocument();
@@ -160,9 +188,10 @@ test('Expect that counter is rendered', async () => {
   render(NavItem, { counter, tooltip, href, meta: { url: '/test' } });
 
   // get div with label tooltip
-  const element2 = screen.getByLabelText('Foo');
+  const element2 = screen.getByText('4');
   expect(element2).toBeInTheDocument();
 
   // get text of the element
-  expect(element2.textContent).toContain('Foo (4)');
+  expect(element2.textContent).toContain('4');
+  expect(element2.textContent).not.toContain('Foo');
 });

--- a/packages/renderer/src/lib/ui/NavItem.spec.ts
+++ b/packages/renderer/src/lib/ui/NavItem.spec.ts
@@ -167,28 +167,18 @@ test('Expect that counter is rendered', async () => {
   expect(element2.textContent).toContain('Foo (4)');
 });
 
-test('Expect default icon behavior with title and only counter tooltip', () => {
+test('Expect icon behavior with title to have only counter in tooltip', () => {
   const tooltip = 'Foo';
   const href = '/href';
-  let counter = 0;
+  const counter = 4;
 
-  const result = render(NavItem, { counter, tooltip, href, meta: { url: '/test' }, iconWithTitle: false });
+  render(NavItem, { counter, tooltip, href, meta: { url: '/test' }, iconWithTitle: true });
 
   const element = screen.getByLabelText(tooltip);
   expect(element).toBeInTheDocument();
   expect(element).toHaveAttribute('href', '/href');
 
-  // unmount
-  result.unmount();
-
-  // ok now update the counter
-  counter = 4;
-
-  // check tooltip is working if counter is updated
-  render(NavItem, { counter, tooltip, href, meta: { url: '/test' } });
-
-  // get div with label tooltip
-  const element2 = screen.getByText('4');
+  const element2 = screen.getByLabelText('tooltip');
   expect(element2).toBeInTheDocument();
 
   // get text of the element

--- a/packages/renderer/src/lib/ui/NavItem.spec.ts
+++ b/packages/renderer/src/lib/ui/NavItem.spec.ts
@@ -144,7 +144,7 @@ test('Expect that counter is rendered', async () => {
   const href = '/href';
   let counter = 0;
 
-  const result = render(NavItem, { counter, tooltip, href, meta: { url: '/test' }, iconWithTitle: false });
+  const result = render(NavItem, { counter, tooltip, href, meta: { url: '/test' } });
 
   const element = screen.getByLabelText(tooltip);
   expect(element).toBeInTheDocument();
@@ -157,7 +157,7 @@ test('Expect that counter is rendered', async () => {
   counter = 4;
 
   // check tooltip is working if counter is updated
-  render(NavItem, { counter, tooltip, href, meta: { url: '/test' }, iconWithTitle: false });
+  render(NavItem, { counter, tooltip, href, meta: { url: '/test' } });
 
   // get div with label tooltip
   const element2 = screen.getByLabelText('Foo');
@@ -165,23 +165,4 @@ test('Expect that counter is rendered', async () => {
 
   // get text of the element
   expect(element2.textContent).toContain('Foo (4)');
-});
-
-test('Expect icon behavior with title to have only counter in tooltip', () => {
-  const tooltip = 'Foo';
-  const href = '/href';
-  const counter = 4;
-
-  render(NavItem, { counter, tooltip, href, meta: { url: '/test' }, iconWithTitle: true });
-
-  const element = screen.getByLabelText(tooltip);
-  expect(element).toBeInTheDocument();
-  expect(element).toHaveAttribute('href', '/href');
-
-  const element2 = screen.getByLabelText('tooltip');
-  expect(element2).toBeInTheDocument();
-
-  // get text of the element
-  expect(element2.textContent).toContain('4');
-  expect(element2.textContent).not.toContain('Foo');
 });

--- a/packages/renderer/src/lib/ui/NavItem.svelte
+++ b/packages/renderer/src/lib/ui/NavItem.svelte
@@ -14,7 +14,6 @@ export let ariaLabel: string | undefined = undefined;
 export let meta: TinroRouteMeta;
 export let onClick: MouseEventHandler<HTMLAnchorElement> | undefined = undefined;
 export let counter: number | undefined = undefined;
-export let iconWithTitle = false;
 
 let inSection: boolean = false;
 let uri: string;
@@ -25,11 +24,7 @@ $: selected = meta.url === uri || (uri !== '/' && meta.url.startsWith(uri));
 const navItems: Writable<number> = getContext('nav-items');
 
 let tooltipText = '';
-$: if (iconWithTitle) {
-  tooltipText = counter ? `${counter}` : '';
-} else {
-  tooltipText = counter ? `${tooltip} (${counter})` : tooltip;
-}
+$: tooltipText = counter ? `${tooltip} (${counter})` : tooltip;
 
 onMount(() => {
   inSection = navItems !== undefined;

--- a/packages/renderer/src/lib/ui/NavItem.svelte
+++ b/packages/renderer/src/lib/ui/NavItem.svelte
@@ -14,7 +14,7 @@ export let ariaLabel: string | undefined = undefined;
 export let meta: TinroRouteMeta;
 export let onClick: MouseEventHandler<HTMLAnchorElement> | undefined = undefined;
 export let counter: number | undefined = undefined;
-export let iconWithTitle = true;
+export let iconWithTitle = false;
 
 let inSection: boolean = false;
 let uri: string;
@@ -26,8 +26,10 @@ const navItems: Writable<number> = getContext('nav-items');
 
 let tooltipText = '';
 $: if (iconWithTitle) {
+  console.log('only number');
   tooltipText = counter ? `${counter}` : '';
 } else {
+  console.log('full tooltip');
   tooltipText = counter ? `${tooltip} (${counter})` : tooltip;
 }
 

--- a/packages/renderer/src/lib/ui/NavItem.svelte
+++ b/packages/renderer/src/lib/ui/NavItem.svelte
@@ -26,10 +26,8 @@ const navItems: Writable<number> = getContext('nav-items');
 
 let tooltipText = '';
 $: if (iconWithTitle) {
-  console.log('only number');
   tooltipText = counter ? `${counter}` : '';
 } else {
-  console.log('full tooltip');
   tooltipText = counter ? `${tooltip} (${counter})` : tooltip;
 }
 

--- a/packages/renderer/src/lib/ui/NavItem.svelte
+++ b/packages/renderer/src/lib/ui/NavItem.svelte
@@ -24,7 +24,12 @@ $: selected = meta.url === uri || (uri !== '/' && meta.url.startsWith(uri));
 
 const navItems: Writable<number> = getContext('nav-items');
 
-$: tooltipText = counter ? (iconWithTitle ? `${counter}` : `${tooltip} (${counter})`) : tooltip;
+let tooltipText = '';
+$: if (iconWithTitle) {
+  tooltipText = counter ? `${counter}` : '';
+} else {
+  tooltipText = counter ? `${tooltip} (${counter})` : tooltip;
+}
 
 onMount(() => {
   inSection = navItems !== undefined;

--- a/packages/renderer/src/lib/ui/NavItem.svelte
+++ b/packages/renderer/src/lib/ui/NavItem.svelte
@@ -14,6 +14,7 @@ export let ariaLabel: string | undefined = undefined;
 export let meta: TinroRouteMeta;
 export let onClick: MouseEventHandler<HTMLAnchorElement> | undefined = undefined;
 export let counter: number | undefined = undefined;
+export let iconWithTitle = true;
 
 let inSection: boolean = false;
 let uri: string;
@@ -23,7 +24,7 @@ $: selected = meta.url === uri || (uri !== '/' && meta.url.startsWith(uri));
 
 const navItems: Writable<number> = getContext('nav-items');
 
-$: tooltipText = counter ? `${tooltip} (${counter})` : tooltip;
+$: tooltipText = counter ? (iconWithTitle ? `${counter}` : `${tooltip} (${counter})`) : tooltip;
 
 onMount(() => {
   inSection = navItems !== undefined;
@@ -53,7 +54,7 @@ onDestroy(() => {
     class:hover:text-[color:var(--pd-global-nav-icon-hover)]={!selected || inSection}
     class:hover:bg-[var(--pd-global-nav-icon-hover-bg)]={!selected || inSection}
     class:hover:border-[var(--pd-global-nav-icon-hover-bg)]={!selected && !inSection}>
-    <Tooltip right tip={tooltipText}>
+    <Tooltip right tip={tooltipText} class="flex flex-col items-center">
       <slot />
     </Tooltip>
   </div>

--- a/packages/renderer/src/lib/ui/NavItem.svelte
+++ b/packages/renderer/src/lib/ui/NavItem.svelte
@@ -23,7 +23,6 @@ $: selected = meta.url === uri || (uri !== '/' && meta.url.startsWith(uri));
 
 const navItems: Writable<number> = getContext('nav-items');
 
-let tooltipText = '';
 $: tooltipText = counter ? `${tooltip} (${counter})` : tooltip;
 
 onMount(() => {

--- a/packages/renderer/src/lib/ui/NavRegistryEntry.spec.ts
+++ b/packages/renderer/src/lib/ui/NavRegistryEntry.spec.ts
@@ -90,7 +90,7 @@ test('Expect entry to have title if iconWithTitle is true', async () => {
   const meta = { url: '/test' } as TinroRouteMeta;
   render(NavRegistryEntry, { entry, meta, iconWithTitle: true });
 
-  const content = screen.getByTitle('Icon title');
+  const content = screen.getByTitle('Item1');
   expect(content).toBeInTheDocument();
   expect(content).toHaveTextContent('Item1');
 });
@@ -110,6 +110,6 @@ test('Expect entry to not have title by default', async () => {
   const meta = { url: '/test' } as TinroRouteMeta;
   render(NavRegistryEntry, { entry, meta });
 
-  const content = screen.queryByTitle('Icon title');
+  const content = screen.queryByTitle('Item1');
   expect(content).not.toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/ui/NavRegistryEntry.spec.ts
+++ b/packages/renderer/src/lib/ui/NavRegistryEntry.spec.ts
@@ -75,7 +75,27 @@ test('Expect hidden entry is not rendered', async () => {
   expect(content).not.toBeInTheDocument();
 });
 
-test('Expect entry to have title by default', async () => {
+test('Expect entry to have title if iconWithTitle is true', async () => {
+  const entry: NavigationRegistryEntry = {
+    name: 'Item1',
+    hidden: false,
+    icon: {
+      faIcon: { definition: faPuzzlePiece, size: 'lg' },
+    },
+    tooltip: 'Item tooltip',
+    link: '/mylink',
+    counter: 0,
+    type: 'entry',
+  };
+  const meta = { url: '/test' } as TinroRouteMeta;
+  render(NavRegistryEntry, { entry, meta, iconWithTitle: true });
+
+  const content = screen.getByTitle('Icon title');
+  expect(content).toBeInTheDocument();
+  expect(content).toHaveTextContent('Item1');
+});
+
+test('Expect entry to not have title by default', async () => {
   const entry: NavigationRegistryEntry = {
     name: 'Item1',
     hidden: false,
@@ -89,26 +109,6 @@ test('Expect entry to have title by default', async () => {
   };
   const meta = { url: '/test' } as TinroRouteMeta;
   render(NavRegistryEntry, { entry, meta });
-
-  const content = screen.getByTitle('Icon title');
-  expect(content).toBeInTheDocument();
-  expect(content).toHaveTextContent('Item1');
-});
-
-test('Expect entry to not have title if iconWithTitle is false', async () => {
-  const entry: NavigationRegistryEntry = {
-    name: 'Item1',
-    hidden: false,
-    icon: {
-      faIcon: { definition: faPuzzlePiece, size: 'lg' },
-    },
-    tooltip: 'Item tooltip',
-    link: '/mylink',
-    counter: 0,
-    type: 'entry',
-  };
-  const meta = { url: '/test' } as TinroRouteMeta;
-  render(NavRegistryEntry, { entry, meta, iconWithTitle: false });
 
   const content = screen.queryByTitle('Icon title');
   expect(content).not.toBeInTheDocument();

--- a/packages/renderer/src/lib/ui/NavRegistryEntry.spec.ts
+++ b/packages/renderer/src/lib/ui/NavRegistryEntry.spec.ts
@@ -90,7 +90,7 @@ test('Expect entry to have title if iconWithTitle is true', async () => {
   const meta = { url: '/test' } as TinroRouteMeta;
   render(NavRegistryEntry, { entry, meta, iconWithTitle: true });
 
-  const content = screen.getByTitle('Item1');
+  const content = screen.queryByLabelText('Item1 title');
   expect(content).toBeInTheDocument();
   expect(content).toHaveTextContent('Item1');
 });
@@ -110,6 +110,6 @@ test('Expect entry to not have title by default', async () => {
   const meta = { url: '/test' } as TinroRouteMeta;
   render(NavRegistryEntry, { entry, meta });
 
-  const content = screen.queryByTitle('Item1');
+  const content = screen.queryByLabelText('Item1 title');
   expect(content).not.toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/ui/NavRegistryEntry.spec.ts
+++ b/packages/renderer/src/lib/ui/NavRegistryEntry.spec.ts
@@ -74,3 +74,42 @@ test('Expect hidden entry is not rendered', async () => {
   const content = screen.queryByLabelText('Item1');
   expect(content).not.toBeInTheDocument();
 });
+
+test('Expect entry to have title by default', async () => {
+  const entry: NavigationRegistryEntry = {
+    name: 'Item1',
+    hidden: false,
+    icon: {
+      faIcon: { definition: faPuzzlePiece, size: 'lg' },
+    },
+    tooltip: 'Item tooltip',
+    link: '/mylink',
+    counter: 0,
+    type: 'entry',
+  };
+  const meta = { url: '/test' } as TinroRouteMeta;
+  render(NavRegistryEntry, { entry, meta });
+
+  const content = screen.getByTitle('Icon title');
+  expect(content).toBeInTheDocument();
+  expect(content).toHaveTextContent('Item1');
+});
+
+test('Expect entry to not have title if iconWithTitle is false', async () => {
+  const entry: NavigationRegistryEntry = {
+    name: 'Item1',
+    hidden: false,
+    icon: {
+      faIcon: { definition: faPuzzlePiece, size: 'lg' },
+    },
+    tooltip: 'Item tooltip',
+    link: '/mylink',
+    counter: 0,
+    type: 'entry',
+  };
+  const meta = { url: '/test' } as TinroRouteMeta;
+  render(NavRegistryEntry, { entry, meta, iconWithTitle: false });
+
+  const content = screen.queryByTitle('Icon title');
+  expect(content).not.toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/ui/NavRegistryEntry.svelte
+++ b/packages/renderer/src/lib/ui/NavRegistryEntry.svelte
@@ -30,7 +30,7 @@ let { entry, meta = $bindable(), iconWithTitle = false }: NavRegistryEntryProps 
       <img src={entry.icon.iconImage} width="22" height="22" alt={entry.name} />
     {/if}
     {#if iconWithTitle && entry.icon}
-      <div class="flex text-xs text-center max-w-[60px] ml-[2px]" title="Icon title">
+      <div class="text-xs text-center max-w-[60px] ml-[2px]" title="Icon title">
         {entry.name}
       </div>
     {/if}

--- a/packages/renderer/src/lib/ui/NavRegistryEntry.svelte
+++ b/packages/renderer/src/lib/ui/NavRegistryEntry.svelte
@@ -30,7 +30,7 @@ let { entry, meta = $bindable(), iconWithTitle = false }: NavRegistryEntryProps 
       <img src={entry.icon.iconImage} width="22" height="22" alt={entry.name} />
     {/if}
     {#if iconWithTitle && entry.icon}
-      <div class="text-xs text-center" title="Icon title">
+      <div class="text-xs text-center ml-1" title="Icon title">
         {entry.name}
       </div>
     {/if}

--- a/packages/renderer/src/lib/ui/NavRegistryEntry.svelte
+++ b/packages/renderer/src/lib/ui/NavRegistryEntry.svelte
@@ -8,11 +8,15 @@ import type { NavigationRegistryEntry } from '/@/stores/navigation/navigation-re
 
 import NavItem from './NavItem.svelte';
 
-let { entry, meta = $bindable() }: { entry: NavigationRegistryEntry; meta: TinroRouteMeta } = $props();
+let {
+  entry,
+  meta = $bindable(),
+  iconWithTitle = $bindable(),
+}: { entry: NavigationRegistryEntry; meta: TinroRouteMeta; iconWithTitle: boolean } = $props();
 </script>
 
 {#if !entry.hidden}
-  <NavItem href={entry.link} counter={entry.counter} tooltip={entry.tooltip} ariaLabel={entry.name} bind:meta={meta}>
+  <NavItem href={entry.link} counter={entry.counter} tooltip={entry.tooltip} ariaLabel={entry.name} bind:meta={meta} bind:iconWithTitle={iconWithTitle}>
     {#if entry.icon === undefined}
       {entry.name}
     {:else if entry.icon.faIcon}
@@ -22,6 +26,11 @@ let { entry, meta = $bindable() }: { entry: NavigationRegistryEntry; meta: Tinro
       <svelte:component this={entry.icon.iconComponent} size="24" />
     {:else if entry.icon.iconImage && typeof entry.icon.iconImage === 'string'}
       <img src={entry.icon.iconImage} width="22" height="22" alt={entry.name} />
+    {/if}
+    {#if iconWithTitle && entry.icon}
+      <div class="text-xs text-center">
+        {entry.name}
+      </div>
     {/if}
   </NavItem>
 {/if}

--- a/packages/renderer/src/lib/ui/NavRegistryEntry.svelte
+++ b/packages/renderer/src/lib/ui/NavRegistryEntry.svelte
@@ -8,11 +8,13 @@ import type { NavigationRegistryEntry } from '/@/stores/navigation/navigation-re
 
 import NavItem from './NavItem.svelte';
 
-let {
-  entry,
-  meta = $bindable(),
-  iconWithTitle = $bindable(),
-}: { entry: NavigationRegistryEntry; meta: TinroRouteMeta; iconWithTitle: boolean } = $props();
+interface NavRegistryEntryProps {
+  entry: NavigationRegistryEntry;
+  meta: TinroRouteMeta;
+  iconWithTitle: boolean;
+}
+
+let { entry, meta = $bindable(), iconWithTitle = $bindable() }: NavRegistryEntryProps = $props();
 </script>
 
 {#if !entry.hidden}

--- a/packages/renderer/src/lib/ui/NavRegistryEntry.svelte
+++ b/packages/renderer/src/lib/ui/NavRegistryEntry.svelte
@@ -14,7 +14,7 @@ interface NavRegistryEntryProps {
   iconWithTitle: boolean;
 }
 
-let { entry, meta = $bindable(), iconWithTitle }: NavRegistryEntryProps = $props();
+let { entry, meta = $bindable(), iconWithTitle = false }: NavRegistryEntryProps = $props();
 </script>
 
 {#if !entry.hidden}

--- a/packages/renderer/src/lib/ui/NavRegistryEntry.svelte
+++ b/packages/renderer/src/lib/ui/NavRegistryEntry.svelte
@@ -30,7 +30,7 @@ let { entry, meta = $bindable(), iconWithTitle = false }: NavRegistryEntryProps 
       <img src={entry.icon.iconImage} width="22" height="22" alt={entry.name} />
     {/if}
     {#if iconWithTitle && entry.icon}
-      <div class="text-xs text-center max-w-[60px] ml-[2px]" title={entry.name}>
+      <div class="text-xs text-center max-w-[60px] ml-[2px]" aria-label={`${entry.name} title`}>
         {entry.name}
       </div>
     {/if}

--- a/packages/renderer/src/lib/ui/NavRegistryEntry.svelte
+++ b/packages/renderer/src/lib/ui/NavRegistryEntry.svelte
@@ -18,7 +18,7 @@ let { entry, meta = $bindable(), iconWithTitle = false }: NavRegistryEntryProps 
 </script>
 
 {#if !entry.hidden}
-  <NavItem href={entry.link} counter={entry.counter} tooltip={entry.tooltip} ariaLabel={entry.name} bind:meta={meta} iconWithTitle={iconWithTitle}>
+  <NavItem href={entry.link} counter={entry.counter} tooltip={entry.tooltip} ariaLabel={entry.name} bind:meta={meta} >
     {#if entry.icon === undefined}
       {entry.name}
     {:else if entry.icon.faIcon}
@@ -30,7 +30,7 @@ let { entry, meta = $bindable(), iconWithTitle = false }: NavRegistryEntryProps 
       <img src={entry.icon.iconImage} width="22" height="22" alt={entry.name} />
     {/if}
     {#if iconWithTitle && entry.icon}
-      <div class="text-xs text-center max-w-[60px] ml-[2px]" title="Icon title">
+      <div class="text-xs text-center max-w-[60px] ml-[2px]" title={entry.name}>
         {entry.name}
       </div>
     {/if}

--- a/packages/renderer/src/lib/ui/NavRegistryEntry.svelte
+++ b/packages/renderer/src/lib/ui/NavRegistryEntry.svelte
@@ -28,7 +28,7 @@ let {
       <img src={entry.icon.iconImage} width="22" height="22" alt={entry.name} />
     {/if}
     {#if iconWithTitle && entry.icon}
-      <div class="text-xs text-center">
+      <div class="text-xs text-center" title="Icon title">
         {entry.name}
       </div>
     {/if}

--- a/packages/renderer/src/lib/ui/NavRegistryEntry.svelte
+++ b/packages/renderer/src/lib/ui/NavRegistryEntry.svelte
@@ -30,7 +30,7 @@ let { entry, meta = $bindable(), iconWithTitle = false }: NavRegistryEntryProps 
       <img src={entry.icon.iconImage} width="22" height="22" alt={entry.name} />
     {/if}
     {#if iconWithTitle && entry.icon}
-      <div class="text-xs text-center ml-1" title="Icon title">
+      <div class="flex text-xs text-center max-w-[60px] ml-[2px]" title="Icon title">
         {entry.name}
       </div>
     {/if}

--- a/packages/renderer/src/lib/ui/NavRegistryEntry.svelte
+++ b/packages/renderer/src/lib/ui/NavRegistryEntry.svelte
@@ -14,11 +14,11 @@ interface NavRegistryEntryProps {
   iconWithTitle: boolean;
 }
 
-let { entry, meta = $bindable(), iconWithTitle = $bindable() }: NavRegistryEntryProps = $props();
+let { entry, meta = $bindable(), iconWithTitle }: NavRegistryEntryProps = $props();
 </script>
 
 {#if !entry.hidden}
-  <NavItem href={entry.link} counter={entry.counter} tooltip={entry.tooltip} ariaLabel={entry.name} bind:meta={meta} bind:iconWithTitle={iconWithTitle}>
+  <NavItem href={entry.link} counter={entry.counter} tooltip={entry.tooltip} ariaLabel={entry.name} bind:meta={meta} iconWithTitle={iconWithTitle}>
     {#if entry.icon === undefined}
       {entry.name}
     {:else if entry.icon.faIcon}

--- a/packages/renderer/src/lib/webview/Webviews.spec.ts
+++ b/packages/renderer/src/lib/webview/Webviews.spec.ts
@@ -74,4 +74,53 @@ test('check we have list of webviews in navigation bar', async () => {
   // check link href
   expect(links[0]).toHaveAttribute('href', '/webviews/webviewId1');
   expect(links[1]).toHaveAttribute('href', '/webviews/webviewId2');
+
+  expect(screen.queryByTitle('Podman Desktop1')).not.toBeInTheDocument();
+  expect(screen.queryByTitle('Podman Desktop2')).not.toBeInTheDocument();
+});
+
+test('check that title shows up if iconWithTitle is true', async () => {
+  // register webviews to the store
+  const webviewTestList: WebviewInfo[] = [
+    {
+      id: 'webviewId1',
+      uuid: 'uuid1',
+      viewType: 'podman-desktop',
+      sourcePath: '/path/to/source',
+      icon: 'icon1',
+      name: 'Podman Desktop1',
+      html: '<html>newCode1</html>',
+      state: { stateData1: 'stateData1' },
+    },
+    {
+      id: 'webviewId2',
+      uuid: 'uuid2',
+      viewType: 'podman-desktop',
+      sourcePath: '/path/to/source',
+      icon: 'icon2',
+      name: 'Podman Desktop2',
+      html: '<html>newCode2</html>',
+      state: { stateData1: 'stateData2' },
+    },
+  ];
+
+  webviews.set(webviewTestList);
+  const fakeMeta = { url: '/webviews' } as unknown as TinroRouteMeta;
+  render(Webviews, { meta: fakeMeta, iconWithTitle: true });
+
+  const links = screen.getAllByRole('link');
+
+  // check we have 2 links
+  expect(links).toHaveLength(2);
+
+  // now check detail of each link
+  expect(links[0]).toHaveTextContent('Podman Desktop1');
+  expect(links[1]).toHaveTextContent('Podman Desktop2');
+
+  // check link href
+  expect(links[0]).toHaveAttribute('href', '/webviews/webviewId1');
+  expect(links[1]).toHaveAttribute('href', '/webviews/webviewId2');
+
+  expect(screen.getByTitle('Podman Desktop1')).toBeInTheDocument();
+  expect(screen.getByTitle('Podman Desktop2')).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/webview/Webviews.spec.ts
+++ b/packages/renderer/src/lib/webview/Webviews.spec.ts
@@ -60,7 +60,7 @@ test('check we have list of webviews in navigation bar', async () => {
 
   webviews.set(webviewTestList);
   const fakeMeta = { url: '/webviews' } as unknown as TinroRouteMeta;
-  render(Webviews, { meta: fakeMeta });
+  render(Webviews, { meta: fakeMeta, iconWithTitle: false });
 
   const links = screen.getAllByRole('link');
 

--- a/packages/renderer/src/lib/webview/Webviews.spec.ts
+++ b/packages/renderer/src/lib/webview/Webviews.spec.ts
@@ -75,8 +75,8 @@ test('check we have list of webviews in navigation bar', async () => {
   expect(links[0]).toHaveAttribute('href', '/webviews/webviewId1');
   expect(links[1]).toHaveAttribute('href', '/webviews/webviewId2');
 
-  expect(screen.queryByTitle('Podman Desktop1')).not.toBeInTheDocument();
-  expect(screen.queryByTitle('Podman Desktop2')).not.toBeInTheDocument();
+  expect(screen.queryByLabelText('Podman Desktop1 title')).not.toBeInTheDocument();
+  expect(screen.queryByLabelText('Podman Desktop2 title')).not.toBeInTheDocument();
 });
 
 test('check that title shows up if iconWithTitle is true', async () => {
@@ -121,6 +121,6 @@ test('check that title shows up if iconWithTitle is true', async () => {
   expect(links[0]).toHaveAttribute('href', '/webviews/webviewId1');
   expect(links[1]).toHaveAttribute('href', '/webviews/webviewId2');
 
-  expect(screen.getByTitle('Podman Desktop1')).toBeInTheDocument();
-  expect(screen.getByTitle('Podman Desktop2')).toBeInTheDocument();
+  expect(screen.queryByLabelText('Podman Desktop1 title')).toBeInTheDocument();
+  expect(screen.queryByLabelText('Podman Desktop2 title')).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/webview/Webviews.svelte
+++ b/packages/renderer/src/lib/webview/Webviews.svelte
@@ -12,7 +12,6 @@ export let iconWithTitle = true;
 </script>
 
 {#each $webviews as webview (webview.id)}
-{console.log(webview.name)}
   <NavItem href="/webviews/{webview.id}" bind:meta={meta} tooltip={webview.name} bind:iconWithTitle={iconWithTitle}>
     {#if !webview.icon}
       <Fa icon={faPuzzlePiece} size="1.5x" />

--- a/packages/renderer/src/lib/webview/Webviews.svelte
+++ b/packages/renderer/src/lib/webview/Webviews.svelte
@@ -12,14 +12,14 @@ export let iconWithTitle = true;
 </script>
 
 {#each $webviews as webview (webview.id)}
-  <NavItem href="/webviews/{webview.id}" bind:meta={meta} tooltip={webview.name} iconWithTitle={iconWithTitle}>
+  <NavItem href="/webviews/{webview.id}" bind:meta={meta} tooltip={webview.name}>
     {#if !webview.icon}
       <Fa icon={faPuzzlePiece} size="1.5x" />
     {:else}
       <IconImage image={webview?.icon} alt={webview.name} class="max-h-6 max-w-[24px]" />
     {/if}
     {#if iconWithTitle}
-      <div class="text-xs text-center" id="iconTitle">
+      <div class="text-xs text-center" title={webview.name}>
         {webview.name}
       </div>
     {/if}

--- a/packages/renderer/src/lib/webview/Webviews.svelte
+++ b/packages/renderer/src/lib/webview/Webviews.svelte
@@ -19,7 +19,7 @@ export let iconWithTitle = true;
       <IconImage image={webview?.icon} alt={webview.name} class="max-h-6 max-w-[24px]" />
     {/if}
     {#if iconWithTitle}
-      <div class="text-xs text-center" title={webview.name}>
+      <div class="text-xs text-center" aria-label={`${webview.name} title`}>
         {webview.name}
       </div>
     {/if}

--- a/packages/renderer/src/lib/webview/Webviews.svelte
+++ b/packages/renderer/src/lib/webview/Webviews.svelte
@@ -8,14 +8,21 @@ import NavItem from '/@/lib/ui/NavItem.svelte';
 import { webviews } from '/@/stores/webviews';
 
 export let meta: TinroRouteMeta;
+export let iconWithTitle = true;
 </script>
 
 {#each $webviews as webview (webview.id)}
-  <NavItem href="/webviews/{webview.id}" bind:meta={meta} tooltip={webview.name}>
+{console.log(webview.name)}
+  <NavItem href="/webviews/{webview.id}" bind:meta={meta} tooltip={webview.name} bind:iconWithTitle={iconWithTitle}>
     {#if !webview.icon}
       <Fa icon={faPuzzlePiece} size="1.5x" />
     {:else}
       <IconImage image={webview?.icon} alt={webview.name} class="max-h-6 max-w-[24px]" />
+    {/if}
+    {#if iconWithTitle}
+      <div class="text-xs text-center" id="iconTitle">
+        {webview.name}
+      </div>
     {/if}
   </NavItem>
 {/each}

--- a/packages/renderer/src/lib/webview/Webviews.svelte
+++ b/packages/renderer/src/lib/webview/Webviews.svelte
@@ -12,7 +12,7 @@ export let iconWithTitle = true;
 </script>
 
 {#each $webviews as webview (webview.id)}
-  <NavItem href="/webviews/{webview.id}" bind:meta={meta} tooltip={webview.name} bind:iconWithTitle={iconWithTitle}>
+  <NavItem href="/webviews/{webview.id}" bind:meta={meta} tooltip={webview.name} iconWithTitle={iconWithTitle}>
     {#if !webview.icon}
       <Fa icon={faPuzzlePiece} size="1.5x" />
     {:else}


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR adds a preferences option to show titles along with the icons in the navigation menu. This option by default is on, and the user can change it in the settings.
Possible follow ups - increase the width of the nav menu and add this option to the navigation popup (if needed)

### Screenshot / video of UI
![Screenshot from 2024-11-05 13-33-11](https://github.com/user-attachments/assets/3f8953e8-4767-4a7c-8d11-8636cbee76d2)


![Screenshot from 2024-11-04 23-20-14](https://github.com/user-attachments/assets/063e1519-e045-41c4-a828-5577e75ccde9)


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/containers/podman-desktop/issues/9662
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
