### PR TITLE
feat: display 3rd party contribution to Docker Compatibility page

### DIFF
--- a/extensions/compose/package.json
+++ b/extensions/compose/package.json
@@ -130,6 +130,22 @@
           "scope": ["DEFAULT", "Onboarding"],
           "hidden": true,
           "description": "Install system-wide instead of just your user directory, so compose can be accessed on the command line. Note: You may be prompted for elevated system privileges when enabling this."
+        },
+        "podman.compose.cli.support.enabled": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Compose support installed. You can use `podman compose` using the podman CLI.",
+          "when": "(isMac || isWindows) && compose.isComposeInstalledSystemWide",
+          "group": "podman-desktop.podman",
+          "scope": "DockerCompatibility"
+        },
+        "podman.compose.cli.support.missing": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Without compose support in podman you won't be able to use compose projects using the podman CLI. :button[Setup...]{command=compose.openComposeOnboarding}",
+          "when": "(isMac || isWindows) && !compose.isComposeInstalledSystemWide",
+          "group": "podman-desktop.podman",
+          "scope": "DockerCompatibility"
         }
       }
     }

--- a/extensions/podman/packages/extension/package.json
+++ b/extensions/podman/packages/extension/package.json
@@ -203,6 +203,22 @@
           "default": true,
           "description": "Use macOS Rosetta to run x86_64 Linux binaries on Podman 5.1.0 and above, disabling will use qemu. NOTE: This setting is only applied when creating new machines.",
           "when": "isMac"
+        },
+        "third-party.docker.tool.compatibility.enabled": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Disabling this option will prevent third-party Docker-compatible tools to use Podman. :button[Disable]{command=podman.disableCompatibilityMode}",
+          "when": "isMac && podman.podmanDockerCompatibilityEnabled",
+          "group": "podman-desktop.podman",
+          "scope": "DockerCompatibility"
+        },
+        "third-party.docker.tool.compatibility.disabled": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Enabling this option will direct third-party Docker-compatible tools to use Podman. :button[Enable]{command=podman.enableCompatibilityMode}",
+          "when": "isMac && !podman.podmanDockerCompatibilityEnabled",
+          "group": "podman-desktop.podman",
+          "scope": "DockerCompatibility"
         }
       }
     },

--- a/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityContributions.spec.ts
+++ b/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityContributions.spec.ts
@@ -1,0 +1,146 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { ContextUI } from '/@/lib/context/context';
+import { configurationProperties } from '/@/stores/configurationProperties';
+import { context } from '/@/stores/context';
+import { extensionInfos } from '/@/stores/extensions';
+import type { ExtensionInfo } from '/@api/extension-info';
+
+import PreferencesDockerCompatibilityContributions from './PreferencesDockerCompatibilityContributions.svelte';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  Object.defineProperty(global, 'window', {
+    value: {
+      navigator: {
+        clipboard: {
+          writeText: vi.fn(),
+        },
+      },
+    },
+    writable: true,
+  });
+});
+
+test('display group', async () => {
+  // one extension
+  extensionInfos.set([
+    {
+      id: 'my.extensionId',
+      name: 'My Extension',
+      description: 'My Extension description',
+      version: '1.0.0',
+      publisher: 'My Publisher',
+      icon: 'my-icon',
+      state: 'started',
+    } as ExtensionInfo,
+  ]);
+
+  // two properties with the same group
+  // one property without a group
+  // one property with a different scope
+  configurationProperties.set([
+    {
+      id: 'my.first.property',
+      title: 'First Property',
+      markdownDescription: 'First Property Description',
+      parentId: '',
+      scope: 'DockerCompatibility',
+      group: 'my.extensionId',
+      extension: {
+        id: 'my.extensionId',
+      },
+    },
+    {
+      id: 'my.other.property',
+      title: 'Other Property',
+      markdownDescription: 'Other Property Description',
+      parentId: '',
+      scope: 'DockerCompatibility',
+      group: 'my.extensionId',
+      extension: {
+        id: 'my.extensionId',
+      },
+    },
+    {
+      id: 'my.property.without.group',
+      title: 'Property Without Group',
+      parentId: '',
+      scope: 'DockerCompatibility',
+      group: '',
+      extension: {
+        id: 'my.extensionId',
+      },
+    },
+    {
+      id: 'my.property.with.different.scope',
+      title: 'Property With Different Scope',
+      parentId: '',
+      scope: 'DEFAULT',
+      group: 'my.extensionId',
+    },
+  ]);
+
+  render(PreferencesDockerCompatibilityContributions);
+
+  // check that the group is being displayed
+  const groupName = screen.getByRole('list', { name: 'my.extensionId' });
+  expect(groupName).toBeInTheDocument();
+
+  // now, check that the two properties are there
+
+  // search for text "My First: Property"
+  const firstProperty = screen.getByRole('status', { name: 'My First: Property' });
+  expect(firstProperty).toBeInTheDocument();
+
+  // check markdown description
+  const firstPropertyDescription = screen.getByRole('document', { name: 'my.first.property' });
+  expect(firstPropertyDescription).toBeInTheDocument();
+
+  // search for text "My Other: Property"
+  const otherProperty = screen.getByRole('status', { name: 'My Other: Property' });
+  expect(otherProperty).toBeInTheDocument();
+
+  // other markdown description
+  const otherPropertyDescription = screen.getByRole('document', { name: 'my.other.property' });
+  expect(otherPropertyDescription).toBeInTheDocument();
+});
+
+test('no group if empty', async () => {
+  // no property
+  configurationProperties.set([]);
+
+  // no extensions
+  extensionInfos.set([]);
+
+  // no global context
+  context.set(new ContextUI());
+
+  render(PreferencesDockerCompatibilityContributions);
+
+  // no list item
+  const listItems = screen.queryAllByRole('list');
+  expect(listItems.length).toBe(0);
+});

--- a/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityContributions.svelte
+++ b/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityContributions.svelte
@@ -1,0 +1,165 @@
+<script lang="ts">
+/* eslint-disable import/no-duplicates */
+import { onDestroy, onMount } from 'svelte';
+import { get, type Unsubscriber, type Writable } from 'svelte/store';
+
+/* eslint-enable import/no-duplicates */
+import { configurationProperties } from '/@/stores/configurationProperties';
+import { context } from '/@/stores/context';
+import { extensionInfos } from '/@/stores/extensions';
+import type { ExtensionInfo } from '/@api/extension-info';
+
+import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
+import IconImage from '../../appearance/IconImage.svelte';
+import type { ContextUI } from '../../context/context';
+import Markdown from '../../markdown/Markdown.svelte';
+import { isPropertyValidInContext } from '../Util';
+
+const DOCKER_COMPAT_SCOPE = 'DockerCompatibility';
+
+// svelte is not handling the store properly
+// should be fixed in 5.1.2+ but there is still an issue
+// https://github.com/sveltejs/svelte/pull/13887
+//
+let refreshValues = false;
+const subscribers: Unsubscriber[] = [];
+function wrapStore<T>(store: Writable<T>): T {
+  let wrapped = get(store);
+  subscribers.push(
+    store.subscribe(v => {
+      wrapped = v;
+      if (refreshValues) {
+        extractGroupItems();
+      }
+    }),
+  );
+  return wrapped;
+}
+
+const properties: IConfigurationPropertyRecordedSchema[] = $state($configurationProperties);
+const extensions: ExtensionInfo[] = $state($extensionInfos);
+const globalContext: ContextUI = $state(wrapStore(context));
+
+onMount(() => {
+  refreshValues = true;
+});
+
+onDestroy(() => {
+  for (const subscriber of subscribers) {
+    subscriber();
+  }
+});
+
+interface PropertyWithDisplayName extends IConfigurationPropertyRecordedSchema {
+  displayName: string;
+}
+
+interface GroupItem {
+  name: string;
+  icon?: string | { light: string; dark: string };
+  properties: PropertyWithDisplayName[];
+}
+
+// a list of group items
+const groupItems: { items: GroupItem[] } = $state({ items: [] });
+
+$effect(() => {
+  extractGroupItems();
+});
+function extractGroupItems(): void {
+  const updatedGroupItems: GroupItem[] = [];
+
+  // properties that are in the docker compatibility scope
+  const dockerCompatProperties = properties
+    .filter(property =>
+      Array.isArray(property.scope)
+        ? property.scope.find(s => s === DOCKER_COMPAT_SCOPE)
+        : property.scope === DOCKER_COMPAT_SCOPE,
+    )
+    .filter(property => isPropertyValidInContext(property.when, globalContext));
+
+  // filter out properties that are not in running extensions
+  const propertiesFromRunningExtensions = dockerCompatProperties.filter(property => {
+    return extensions.find(ext => ext.id === property.extension?.id && ext.state === 'started');
+  });
+
+  for (const property of propertiesFromRunningExtensions) {
+    // keep the value having a group
+    if (property.markdownDescription && property.group) {
+      const name = property.group;
+      let icon: string | { light: string; dark: string } | undefined;
+      // do we have a group item for this property ?
+      let groupItem = updatedGroupItems.find(item => item.name === name);
+      if (!groupItem) {
+        // get icon
+        const foundExtension = extensions.find(ext => ext.id === property.group);
+        if (foundExtension) {
+          icon = foundExtension.icon;
+        }
+        groupItem = {
+          name,
+          icon,
+          properties: [],
+        };
+        updatedGroupItems.push(groupItem);
+      }
+
+      // get last part of the id (after the last dot)
+      const beforeLastDot = property.id?.split('.').slice(0, -1).join('.');
+      const afterLastDot = property.id?.split('.').pop();
+
+      // replace all the dot with a space
+      // first letter of words to uppercase
+      const leftPart = (beforeLastDot ?? property.title).replace(/\./g, ' ').replace(/\b\w/g, l => l.toUpperCase());
+      const rightPart = afterLastDot?.replace(/\./g, ' ').replace(/\b\w/g, l => l.toUpperCase());
+
+      const displayName = `${leftPart}: ${rightPart}`;
+
+      // add the property to the group
+      groupItem.properties.push({ ...property, displayName });
+    }
+  }
+  groupItems.items = updatedGroupItems;
+}
+</script>
+
+{#each groupItems.items as groupItem}
+  <div class="container flex flex-row w-full pt-2" role="list" aria-label="{groupItem.name}">
+    <!-- column with the group-->
+    <div class="h-full bg-[var(--pd-button-primary-bg)] rounded p-1">
+      <IconImage
+        image={groupItem.icon}
+        alt={groupItem.name}
+        class="max-w-6 max-h-6"
+      />
+    </div>
+
+    <!-- column with the cards-->
+    <div class="px-2 w-full space-y-4">
+      {#each groupItem.properties as property (property.id)}
+        <div
+          class="bg-[var(--pd-invert-content-card-bg)] rounded-md ml-2 divide-x divide-[var(--pd-content-divider)] flex flex-col lg:flex-row w-full"
+        >
+          <div
+            class="flex flex-row grow p-2 justify-between text-[color:var(--pd-invert-content-card-text)] w-full"
+          >
+            <div class="flex flex-col w-full">
+              <div
+                class="flex flex-row items-center text-[color:var(--pd-invert-content-card-text)]"
+                role="status"
+                aria-label="{property.displayName}"
+              >
+                {property.displayName}
+              </div>
+              <div class="mt-2 flex flex-row items-center">
+                <div class="flex flex-col w-full" role="document" aria-label="{property.id}">
+                  <Markdown markdown={property.markdownDescription} />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      {/each}
+    </div>
+  </div>
+{/each}

--- a/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityRendering.svelte
+++ b/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityRendering.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import SettingsPage from '../SettingsPage.svelte';
+import PreferencesDockerCompatibilityContributions from './PreferencesDockerCompatibilityContributions.svelte';
 import PreferencesDockerCompatibilityDockerContext from './PreferencesDockerCompatibilityDockerContext.svelte';
 import PreferencesDockerCompatibilitySocketMappingStatus from './PreferencesDockerCompatibilitySocketMappingStatus.svelte';
 </script>
@@ -18,5 +19,9 @@ import PreferencesDockerCompatibilitySocketMappingStatus from './PreferencesDock
       <div class="text-lg font-medium first-letter:uppercase">Docker CLI Context</div>
       <PreferencesDockerCompatibilityDockerContext />
     </div>
+
+    <PreferencesDockerCompatibilityContributions />
+
   </div>
+
 </SettingsPage>


### PR DESCRIPTION
### What does this PR do?
Allow extensions to contribute to the docker compatibility page

### Screenshot / video of UI

https://github.com/user-attachments/assets/844f385e-5489-4768-acbe-d6a4d53fed7b



### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/9242


### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
