### PR TITLE
chore: adding id property to forward config

### DIFF
--- a/packages/api/src/kubernetes-port-forward-model.ts
+++ b/packages/api/src/kubernetes-port-forward-model.ts
@@ -75,7 +75,7 @@ export interface ForwardConfig {
   /**
    * Identifier of the forward config
    */
-  uuid: string;
+  id: string;
   /**
    * The name of the resource.
    */

--- a/packages/api/src/kubernetes-port-forward-model.ts
+++ b/packages/api/src/kubernetes-port-forward-model.ts
@@ -73,6 +73,10 @@ export interface ForwardOptions {
  */
 export interface ForwardConfig {
   /**
+   * Identifier of the forward config
+   */
+  uuid: string;
+  /**
    * The name of the resource.
    */
   name: string;

--- a/packages/main/src/plugin/kubernetes/kubernetes-port-forward-connection.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-port-forward-connection.spec.ts
@@ -692,7 +692,7 @@ describe('PortForwardConnectionService', () => {
 
     test('should start port forwarding successfully', async () => {
       const forwardConfig: ForwardConfig = {
-        uuid: 'fake-uuid',
+        id: 'fake-id',
         kind: WorkloadKind.POD,
         name: 'test-pod',
         namespace: 'default',
@@ -729,7 +729,7 @@ describe('PortForwardConnectionService', () => {
     test('should start port forwarding on specified mapping', async () => {
       const mapping: PortMapping = { localPort: 3001, remotePort: 8080 };
       const forwardConfig: ForwardConfig = {
-        uuid: 'fake-uuid',
+        id: 'fake-id',
         kind: WorkloadKind.POD,
         name: 'test-pod',
         namespace: 'default',
@@ -756,7 +756,7 @@ describe('PortForwardConnectionService', () => {
 
     test('should throw an error if port forwarding fails', async () => {
       const forwardConfig: ForwardConfig = {
-        uuid: 'fake-uuid',
+        id: 'fake-id',
         kind: WorkloadKind.POD,
         name: 'test-pod',
         namespace: 'default',
@@ -780,7 +780,7 @@ describe('PortForwardConnectionService', () => {
 
     test('should dispose all successful forwards if any fail', async () => {
       const forwardConfig: ForwardConfig = {
-        uuid: 'fake-uuid',
+        id: 'fake-id',
         kind: WorkloadKind.POD,
         name: 'test-pod',
         namespace: 'default',

--- a/packages/main/src/plugin/kubernetes/kubernetes-port-forward-connection.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-port-forward-connection.spec.ts
@@ -692,6 +692,7 @@ describe('PortForwardConnectionService', () => {
 
     test('should start port forwarding successfully', async () => {
       const forwardConfig: ForwardConfig = {
+        uuid: 'fake-uuid',
         kind: WorkloadKind.POD,
         name: 'test-pod',
         namespace: 'default',
@@ -728,6 +729,7 @@ describe('PortForwardConnectionService', () => {
     test('should start port forwarding on specified mapping', async () => {
       const mapping: PortMapping = { localPort: 3001, remotePort: 8080 };
       const forwardConfig: ForwardConfig = {
+        uuid: 'fake-uuid',
         kind: WorkloadKind.POD,
         name: 'test-pod',
         namespace: 'default',
@@ -754,6 +756,7 @@ describe('PortForwardConnectionService', () => {
 
     test('should throw an error if port forwarding fails', async () => {
       const forwardConfig: ForwardConfig = {
+        uuid: 'fake-uuid',
         kind: WorkloadKind.POD,
         name: 'test-pod',
         namespace: 'default',
@@ -777,6 +780,7 @@ describe('PortForwardConnectionService', () => {
 
     test('should dispose all successful forwards if any fail', async () => {
       const forwardConfig: ForwardConfig = {
+        uuid: 'fake-uuid',
         kind: WorkloadKind.POD,
         name: 'test-pod',
         namespace: 'default',

--- a/packages/main/src/plugin/kubernetes/kubernetes-port-forward-service.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-port-forward-service.spec.ts
@@ -72,7 +72,7 @@ describe('KubernetesPortForwardService', () => {
   };
 
   const sampleForwardConfig: ForwardConfig = {
-    uuid: 'fake-uuid',
+    id: 'fake-id',
     name: 'test-name',
     namespace: 'test-namespace',
     kind: WorkloadKind.POD,
@@ -85,7 +85,7 @@ describe('KubernetesPortForwardService', () => {
   };
 
   const complexForwardConfig: ForwardConfig = {
-    uuid: 'fake-uuid',
+    id: 'fake-id',
     name: 'test-name',
     namespace: 'test-namespace',
     kind: WorkloadKind.POD,
@@ -118,7 +118,7 @@ describe('KubernetesPortForwardService', () => {
       mockForwardingConnectionService,
       apiSenderMock,
     );
-    vi.mocked(randomUUID).mockReturnValue('fake-uuid' as UUID);
+    vi.mocked(randomUUID).mockReturnValue('fake-id' as UUID);
   });
 
   test('should create a forward configuration', async () => {

--- a/packages/main/src/plugin/kubernetes/kubernetes-port-forward-service.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-port-forward-service.spec.ts
@@ -16,6 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { UUID } from 'node:crypto';
+import { randomUUID } from 'node:crypto';
+
 import type { KubeConfig } from '@kubernetes/client-node';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -35,6 +38,7 @@ vi.mock('/@/plugin/kubernetes/kubernetes-port-forward-storage.js');
 vi.mock('/@/plugin/kubernetes/kubernetes-port-forward-validation.js');
 vi.mock('/@/plugin/util/port.js');
 vi.mock('/@/plugin/directories.js');
+vi.mock('node:crypto');
 
 class TestKubernetesPortForwardServiceProvider extends KubernetesPortForwardServiceProvider {
   public override getKubeConfigKey(kubeConfig: KubeConfig): string {
@@ -68,6 +72,7 @@ describe('KubernetesPortForwardService', () => {
   };
 
   const sampleForwardConfig: ForwardConfig = {
+    uuid: 'fake-uuid',
     name: 'test-name',
     namespace: 'test-namespace',
     kind: WorkloadKind.POD,
@@ -80,6 +85,7 @@ describe('KubernetesPortForwardService', () => {
   };
 
   const complexForwardConfig: ForwardConfig = {
+    uuid: 'fake-uuid',
     name: 'test-name',
     namespace: 'test-namespace',
     kind: WorkloadKind.POD,
@@ -112,6 +118,7 @@ describe('KubernetesPortForwardService', () => {
       mockForwardingConnectionService,
       apiSenderMock,
     );
+    vi.mocked(randomUUID).mockReturnValue('fake-uuid' as UUID);
   });
 
   test('should create a forward configuration', async () => {

--- a/packages/main/src/plugin/kubernetes/kubernetes-port-forward-service.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-port-forward-service.ts
@@ -119,7 +119,7 @@ export class KubernetesPortForwardService implements IDisposable {
     let result: UserForwardConfig;
     if (userForwardConfig) {
       result = await this.configManagementService.updateForward(userForwardConfig, {
-        uuid: userForwardConfig.uuid,
+        id: userForwardConfig.id,
         name: options.name,
         forwards: [...userForwardConfig.forwards, options.forward],
         namespace: options.namespace,
@@ -128,7 +128,7 @@ export class KubernetesPortForwardService implements IDisposable {
       });
     } else {
       result = await this.configManagementService.createForward({
-        uuid: randomUUID(),
+        id: randomUUID(),
         name: options.name,
         forwards: [options.forward],
         namespace: options.namespace,

--- a/packages/main/src/plugin/kubernetes/kubernetes-port-forward-service.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-port-forward-service.ts
@@ -15,6 +15,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
+import { randomUUID } from 'node:crypto';
+
 import type { KubeConfig } from '@kubernetes/client-node';
 
 import type { ApiSenderType } from '/@/plugin/api.js';
@@ -117,6 +119,7 @@ export class KubernetesPortForwardService implements IDisposable {
     let result: UserForwardConfig;
     if (userForwardConfig) {
       result = await this.configManagementService.updateForward(userForwardConfig, {
+        uuid: userForwardConfig.uuid,
         name: options.name,
         forwards: [...userForwardConfig.forwards, options.forward],
         namespace: options.namespace,
@@ -125,6 +128,7 @@ export class KubernetesPortForwardService implements IDisposable {
       });
     } else {
       result = await this.configManagementService.createForward({
+        uuid: randomUUID(),
         name: options.name,
         forwards: [options.forward],
         namespace: options.namespace,

--- a/packages/main/src/plugin/kubernetes/kubernetes-port-forward-storage.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-port-forward-storage.spec.ts
@@ -135,7 +135,7 @@ describe('FileBasedConfigStorage', () => {
   };
 
   const sampleConfig: UserForwardConfig = {
-    uuid: 'fake-uuid',
+    id: 'fake-id',
     name: 'test-name',
     namespace: 'test-namespace',
     kind: WorkloadKind.POD,
@@ -258,7 +258,7 @@ describe('FileBasedConfigStorage', () => {
 
 describe('MemoryBasedConfigStorage', () => {
   const sampleConfig: UserForwardConfig = {
-    uuid: 'fake-uuid',
+    id: 'fake-id',
     name: 'test-name',
     namespace: 'test-namespace',
     kind: WorkloadKind.POD,
@@ -338,7 +338,7 @@ describe('ConfigManagementService', () => {
   } as unknown as ForwardConfigStorage;
 
   const sampleConfig: UserForwardConfig = {
-    uuid: 'fake-uuid',
+    id: 'fake-id',
     name: 'test-name',
     namespace: 'test-namespace',
     kind: WorkloadKind.POD,
@@ -384,7 +384,7 @@ describe('ConfigManagementService', () => {
       namespace: 'default',
       kind: WorkloadKind.POD,
       name: 'hihi',
-      uuid: 'fake-uuid',
+      id: 'fake-id',
     };
 
     const newConfig = {

--- a/packages/main/src/plugin/kubernetes/kubernetes-port-forward-storage.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-port-forward-storage.spec.ts
@@ -135,6 +135,7 @@ describe('FileBasedConfigStorage', () => {
   };
 
   const sampleConfig: UserForwardConfig = {
+    uuid: 'fake-uuid',
     name: 'test-name',
     namespace: 'test-namespace',
     kind: WorkloadKind.POD,
@@ -257,6 +258,7 @@ describe('FileBasedConfigStorage', () => {
 
 describe('MemoryBasedConfigStorage', () => {
   const sampleConfig: UserForwardConfig = {
+    uuid: 'fake-uuid',
     name: 'test-name',
     namespace: 'test-namespace',
     kind: WorkloadKind.POD,
@@ -336,6 +338,7 @@ describe('ConfigManagementService', () => {
   } as unknown as ForwardConfigStorage;
 
   const sampleConfig: UserForwardConfig = {
+    uuid: 'fake-uuid',
     name: 'test-name',
     namespace: 'test-namespace',
     kind: WorkloadKind.POD,
@@ -381,6 +384,7 @@ describe('ConfigManagementService', () => {
       namespace: 'default',
       kind: WorkloadKind.POD,
       name: 'hihi',
+      uuid: 'fake-uuid',
     };
 
     const newConfig = {

--- a/packages/main/src/plugin/kubernetes/kubernetes-port-forward-validation.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-port-forward-validation.spec.ts
@@ -23,6 +23,7 @@ import { type ForwardConfig, WorkloadKind } from '/@api/kubernetes-port-forward-
 
 describe('ForwardConfigRequirements', () => {
   const validConfig: ForwardConfig = {
+    uuid: 'fake-uuid',
     name: 'validName',
     namespace: 'validNamespace',
     kind: WorkloadKind.POD,

--- a/packages/main/src/plugin/kubernetes/kubernetes-port-forward-validation.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-port-forward-validation.spec.ts
@@ -23,7 +23,7 @@ import { type ForwardConfig, WorkloadKind } from '/@api/kubernetes-port-forward-
 
 describe('ForwardConfigRequirements', () => {
   const validConfig: ForwardConfig = {
-    uuid: 'fake-uuid',
+    id: 'fake-id',
     name: 'validName',
     namespace: 'validNamespace',
     kind: WorkloadKind.POD,

--- a/packages/preload/src/index.spec.ts
+++ b/packages/preload/src/index.spec.ts
@@ -224,7 +224,7 @@ test('createKubernetesPortForward', async () => {
   );
 
   const userPortForward: UserForwardConfig = {
-    uuid: 'fake-uuid',
+    id: 'fake-id',
     displayName: 'My port forward',
     namespace: 'kubernetes',
     name: 'service',
@@ -260,7 +260,7 @@ test('deleteKubernetesPortForward', async () => {
   );
 
   const userPortForward: UserForwardConfig = {
-    uuid: 'fake-uuid',
+    id: 'fake-id',
     displayName: 'My port forward',
     namespace: 'kubernetes',
     name: 'service',

--- a/packages/preload/src/index.spec.ts
+++ b/packages/preload/src/index.spec.ts
@@ -224,6 +224,7 @@ test('createKubernetesPortForward', async () => {
   );
 
   const userPortForward: UserForwardConfig = {
+    uuid: 'fake-uuid',
     displayName: 'My port forward',
     namespace: 'kubernetes',
     name: 'service',
@@ -259,6 +260,7 @@ test('deleteKubernetesPortForward', async () => {
   );
 
   const userPortForward: UserForwardConfig = {
+    uuid: 'fake-uuid',
     displayName: 'My port forward',
     namespace: 'kubernetes',
     name: 'service',

--- a/packages/renderer/src/lib/kube/details/KubePort.spec.ts
+++ b/packages/renderer/src/lib/kube/details/KubePort.spec.ts
@@ -35,7 +35,7 @@ beforeEach(() => {
 });
 
 const DUMMY_FORWARD_CONFIG: UserForwardConfig = {
-  uuid: 'fake-uuid',
+  id: 'fake-id',
   name: 'dummy-pod-name',
   namespace: 'dummy-ns',
   kind: WorkloadKind.POD,

--- a/packages/renderer/src/lib/kube/details/KubePort.spec.ts
+++ b/packages/renderer/src/lib/kube/details/KubePort.spec.ts
@@ -35,6 +35,7 @@ beforeEach(() => {
 });
 
 const DUMMY_FORWARD_CONFIG: UserForwardConfig = {
+  uuid: 'fake-uuid',
   name: 'dummy-pod-name',
   namespace: 'dummy-ns',
   kind: WorkloadKind.POD,

--- a/packages/renderer/src/lib/kubernetes-port-forward/PortForwardActions.spec.ts
+++ b/packages/renderer/src/lib/kubernetes-port-forward/PortForwardActions.spec.ts
@@ -30,6 +30,7 @@ import { type UserForwardConfig, WorkloadKind } from '/@api/kubernetes-port-forw
 vi.mock('/@/stores/kubernetes-contexts-state', async () => ({}));
 
 const MOCKED_USER_FORWARD_CONFIG: UserForwardConfig = {
+  uuid: 'fake-uuid',
   name: 'dummy-pod-name',
   namespace: 'dummy-ns',
   kind: WorkloadKind.POD,

--- a/packages/renderer/src/lib/kubernetes-port-forward/PortForwardActions.spec.ts
+++ b/packages/renderer/src/lib/kubernetes-port-forward/PortForwardActions.spec.ts
@@ -30,7 +30,7 @@ import { type UserForwardConfig, WorkloadKind } from '/@api/kubernetes-port-forw
 vi.mock('/@/stores/kubernetes-contexts-state', async () => ({}));
 
 const MOCKED_USER_FORWARD_CONFIG: UserForwardConfig = {
-  uuid: 'fake-uuid',
+  id: 'fake-id',
   name: 'dummy-pod-name',
   namespace: 'dummy-ns',
   kind: WorkloadKind.POD,


### PR DESCRIPTION
### What does this PR do?

First step of https://github.com/containers/podman-desktop/issues/9637, the end goal is to avoid passing the full object between the frontend and the backend to trigger action on it.

Currently it is complex to manipulate individual port forwarding, https://github.com/containers/podman-desktop/pull/9592 was made as a temporary solution. 

This PR adds a unique identifier (unused) to the `ForwardConfig` interface. This will allow in a follow-up PR to simplify the IPC  `kubernetes-client:deletePortForward` and the `KubernetesPortForwardService#deleteForward` implementation.

> ℹ️ I choose `uuid` because I find it easy to work with, but I know we have some places in podman desktop where we use a counter that we increment (we also use uuid for webview management). I am open to change if there is concern about uuids

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of https://github.com/containers/podman-desktop/issues/9637

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
