### PR TITLE
refactor(kubernetes): simplify the forward config interface

### DIFF
--- a/packages/api/src/kubernetes-port-forward-model.ts
+++ b/packages/api/src/kubernetes-port-forward-model.ts
@@ -92,9 +92,9 @@ export interface ForwardConfig {
   kind: WorkloadKind;
 
   /**
-   * The list of port mappings.
+   * The port mapping.
    */
-  forwards: PortMapping[];
+  forward: PortMapping;
 }
 
 /**

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -87,7 +87,7 @@ import type { ImageInspectInfo } from '/@api/image-inspect-info.js';
 import type { ImageSearchOptions, ImageSearchResult, ImageTagsListOptions } from '/@api/image-registry.js';
 import type { KubeContext } from '/@api/kubernetes-context.js';
 import type { ContextGeneralState, ResourceName } from '/@api/kubernetes-contexts-states.js';
-import type { ForwardOptions, PortMapping, UserForwardConfig } from '/@api/kubernetes-port-forward-model.js';
+import type { ForwardOptions, UserForwardConfig } from '/@api/kubernetes-port-forward-model.js';
 import type { ManifestCreateOptions, ManifestInspectInfo, ManifestPushOptions } from '/@api/manifest-info.js';
 import type { NetworkInspectInfo } from '/@api/network-info.js';
 import type { NotificationCard, NotificationCardOptions } from '/@api/notification.js';
@@ -2477,8 +2477,8 @@ export class PluginSystem {
 
     this.ipcHandle(
       'kubernetes-client:deletePortForward',
-      async (_listener, config: UserForwardConfig, mapping?: PortMapping): Promise<void> => {
-        return kubernetesClient.deletePortForward(config, mapping);
+      async (_listener, config: UserForwardConfig): Promise<void> => {
+        return kubernetesClient.deletePortForward(config);
       },
     );
 

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.ts
@@ -71,7 +71,7 @@ import type { KubernetesPortForwardService } from '/@/plugin/kubernetes/kubernet
 import { KubernetesPortForwardServiceProvider } from '/@/plugin/kubernetes/kubernetes-port-forward-service.js';
 import type { KubeContext } from '/@api/kubernetes-context.js';
 import type { ContextGeneralState, ResourceName } from '/@api/kubernetes-contexts-states.js';
-import type { ForwardOptions, PortMapping, UserForwardConfig } from '/@api/kubernetes-port-forward-model.js';
+import type { ForwardOptions, UserForwardConfig } from '/@api/kubernetes-port-forward-model.js';
 import type { V1Route } from '/@api/openshift-types.js';
 
 import type { ApiSenderType } from '../api.js';
@@ -1772,7 +1772,7 @@ export class KubernetesClient {
     return newConfig;
   }
 
-  public async deletePortForward(config: UserForwardConfig, mapping?: PortMapping): Promise<void> {
-    return this.ensurePortForwardService().deleteForward(config, mapping);
+  public async deletePortForward(config: UserForwardConfig): Promise<void> {
+    return this.ensurePortForwardService().deleteForward(config);
   }
 }

--- a/packages/main/src/plugin/kubernetes/kubernetes-port-forward-connection.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-port-forward-connection.spec.ts
@@ -696,44 +696,7 @@ describe('PortForwardConnectionService', () => {
         kind: WorkloadKind.POD,
         name: 'test-pod',
         namespace: 'default',
-        forwards: [
-          { localPort: 3000, remotePort: 80 },
-          { localPort: 3001, remotePort: 8080 },
-        ],
-      };
-
-      const pod: V1Pod = {
-        apiVersion: 'v1',
-        kind: 'Pod',
-        metadata: { name: 'test-pod', namespace: 'default' },
-      };
-
-      mockCoreV1Api.readNamespacedPod.mockResolvedValueOnce(pod);
-
-      const disposable1 = new MockDisposable();
-      const disposable2 = new MockDisposable();
-
-      vi.spyOn(service, 'performForward').mockResolvedValueOnce(disposable1).mockResolvedValueOnce(disposable2);
-
-      const disposable = await service.startForward(forwardConfig);
-
-      expect(service.performForward).toHaveBeenCalledTimes(2);
-      expect(disposable.dispose).toBeInstanceOf(Function);
-
-      disposable.dispose();
-
-      expect(disposable1.dispose).toHaveBeenCalled();
-      expect(disposable2.dispose).toHaveBeenCalled();
-    });
-
-    test('should start port forwarding on specified mapping', async () => {
-      const mapping: PortMapping = { localPort: 3001, remotePort: 8080 };
-      const forwardConfig: ForwardConfig = {
-        id: 'fake-id',
-        kind: WorkloadKind.POD,
-        name: 'test-pod',
-        namespace: 'default',
-        forwards: [{ localPort: 3000, remotePort: 80 }, mapping],
+        forward: { localPort: 3000, remotePort: 80 },
       };
 
       const pod: V1Pod = {
@@ -748,7 +711,39 @@ describe('PortForwardConnectionService', () => {
 
       vi.spyOn(service, 'performForward').mockResolvedValueOnce(disposable1);
 
-      const disposable = await service.startForward(forwardConfig, mapping);
+      const disposable = await service.startForward(forwardConfig);
+
+      expect(service.performForward).toHaveBeenCalledOnce();
+      expect(disposable.dispose).toBeInstanceOf(Function);
+
+      disposable.dispose();
+
+      expect(disposable1.dispose).toHaveBeenCalled();
+    });
+
+    test('should start port forwarding on specified mapping', async () => {
+      const mapping: PortMapping = { localPort: 3001, remotePort: 8080 };
+      const forwardConfig: ForwardConfig = {
+        id: 'fake-id',
+        kind: WorkloadKind.POD,
+        name: 'test-pod',
+        namespace: 'default',
+        forward: mapping,
+      };
+
+      const pod: V1Pod = {
+        apiVersion: 'v1',
+        kind: 'Pod',
+        metadata: { name: 'test-pod', namespace: 'default' },
+      };
+
+      mockCoreV1Api.readNamespacedPod.mockResolvedValueOnce(pod);
+
+      const disposable1 = new MockDisposable();
+
+      vi.spyOn(service, 'performForward').mockResolvedValueOnce(disposable1);
+
+      const disposable = await service.startForward(forwardConfig);
 
       expect(service.performForward).toHaveBeenCalledTimes(1);
       expect(disposable.dispose).toBeInstanceOf(Function);
@@ -760,7 +755,7 @@ describe('PortForwardConnectionService', () => {
         kind: WorkloadKind.POD,
         name: 'test-pod',
         namespace: 'default',
-        forwards: [{ localPort: 3000, remotePort: 80 }],
+        forward: { localPort: 3000, remotePort: 80 },
       };
 
       const pod: V1Pod = {
@@ -776,38 +771,6 @@ describe('PortForwardConnectionService', () => {
       await expect(service.startForward(forwardConfig)).rejects.toThrow('Failed to forward port');
 
       expect(service.performForward).toHaveBeenCalledTimes(1);
-    });
-
-    test('should dispose all successful forwards if any fail', async () => {
-      const forwardConfig: ForwardConfig = {
-        id: 'fake-id',
-        kind: WorkloadKind.POD,
-        name: 'test-pod',
-        namespace: 'default',
-        forwards: [
-          { localPort: 3000, remotePort: 80 },
-          { localPort: 3001, remotePort: 8080 },
-        ],
-      };
-
-      const pod: V1Pod = {
-        apiVersion: 'v1',
-        kind: 'Pod',
-        metadata: { name: 'test-pod', namespace: 'default' },
-      };
-
-      mockCoreV1Api.readNamespacedPod.mockResolvedValueOnce(pod);
-
-      const disposable1 = new MockDisposable();
-
-      vi.spyOn(service, 'performForward')
-        .mockResolvedValueOnce(disposable1)
-        .mockRejectedValueOnce(new Error('Failed to forward port'));
-
-      await expect(service.startForward(forwardConfig)).rejects.toThrow('Failed to forward port');
-
-      expect(service.performForward).toHaveBeenCalledTimes(2);
-      expect(disposable1.dispose).toHaveBeenCalled();
     });
   });
 });

--- a/packages/main/src/plugin/kubernetes/kubernetes-port-forward-connection.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-port-forward-connection.ts
@@ -56,7 +56,6 @@ export class PortForwardConnectionService {
   /**
    * Starts the port forwarding based on the provided configuration.
    * @param config - The forwarding configuration.
-   * @param mapping - The mapping to start, if not specified all {@link ForwardConfig#forward} will be started
    * @returns A promise that resolves to a disposable resource to stop the forwarding.
    * @throws If any of the port forwarding fail.
    */

--- a/packages/main/src/plugin/kubernetes/kubernetes-port-forward-service.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-port-forward-service.spec.ts
@@ -76,28 +76,12 @@ describe('KubernetesPortForwardService', () => {
     name: 'test-name',
     namespace: 'test-namespace',
     kind: WorkloadKind.POD,
-    forwards: [{ localPort: 8080, remotePort: 80 }],
+    forward: { localPort: 8080, remotePort: 80 },
   };
 
   const sampleUserForwardConfig: UserForwardConfig = {
     ...sampleForwardConfig,
     displayName: 'test-display-name',
-  };
-
-  const complexForwardConfig: ForwardConfig = {
-    id: 'fake-id',
-    name: 'test-name',
-    namespace: 'test-namespace',
-    kind: WorkloadKind.POD,
-    forwards: [
-      { localPort: 8080, remotePort: 80 },
-      { localPort: 9090, remotePort: 90 },
-    ],
-  };
-
-  const complexUserForwardConfig: UserForwardConfig = {
-    ...complexForwardConfig,
-    displayName: 'complex-display-name',
   };
 
   beforeEach(() => {
@@ -123,7 +107,7 @@ describe('KubernetesPortForwardService', () => {
 
   test('should create a forward configuration', async () => {
     vi.mocked(mockConfigManagementService.listForwards).mockResolvedValue([]);
-    const forward = sampleUserForwardConfig.forwards[0];
+    const forward = sampleUserForwardConfig.forward;
     if (!forward) throw new Error('undefined forward');
 
     const result = await service.createForward({
@@ -135,28 +119,19 @@ describe('KubernetesPortForwardService', () => {
     });
     expect(result).toEqual(sampleUserForwardConfig);
     expect(mockConfigManagementService.createForward).toHaveBeenCalledWith(sampleUserForwardConfig);
-    expect(apiSenderMock.send).toHaveBeenCalledWith('kubernetes-port-forwards-update', []);
+    expect(apiSenderMock.send).toHaveBeenCalledWith('kubernetes-port-forward-update', []);
   });
 
   test('should delete a forward configuration', async () => {
     await service.deleteForward(sampleUserForwardConfig);
     expect(mockConfigManagementService.deleteForward).toHaveBeenCalledWith(sampleUserForwardConfig);
-    expect(apiSenderMock.send).toHaveBeenCalledWith('kubernetes-port-forwards-update', []);
+    expect(apiSenderMock.send).toHaveBeenCalledWith('kubernetes-port-forward-update', []);
   });
 
   test('should list all forward configurations', async () => {
     const result = await service.listForwards();
     expect(result).toEqual([sampleUserForwardConfig]);
     expect(mockConfigManagementService.listForwards).toHaveBeenCalled();
-  });
-
-  test('should start port forwarding for a given configuration', async () => {
-    const disposable = await service.startForward(sampleForwardConfig);
-    expect(disposable).toHaveProperty('dispose');
-    expect(mockForwardingConnectionService.startForward).toHaveBeenCalledWith(
-      sampleForwardConfig,
-      sampleForwardConfig.forwards[0],
-    );
   });
 
   test('should dispose for a given configuration', async () => {
@@ -170,62 +145,5 @@ describe('KubernetesPortForwardService', () => {
 
     service.dispose();
     expect(disposeMock).toHaveBeenCalled();
-  });
-
-  test('delete a multiple mapping should dispose all disposables', async () => {
-    const disposeMock = vi.fn();
-    vi.mocked(mockForwardingConnectionService.startForward).mockResolvedValue({
-      dispose: disposeMock,
-    });
-    await service.startForward(complexForwardConfig);
-
-    await service.deleteForward(complexUserForwardConfig);
-
-    expect(disposeMock).toHaveBeenCalledTimes(2);
-    expect(mockConfigManagementService.deleteForward).toHaveBeenCalledWith(complexUserForwardConfig);
-    expect(mockConfigManagementService.updateForward).not.toHaveBeenCalled();
-  });
-
-  test('delete a mapping in a multiple mapping should update config without the one removed', async () => {
-    const disposeMock = vi.fn();
-    vi.mocked(mockForwardingConnectionService.startForward).mockResolvedValue({
-      dispose: disposeMock,
-    });
-    await service.startForward(complexForwardConfig);
-
-    await service.deleteForward(complexUserForwardConfig, complexUserForwardConfig.forwards[0]);
-
-    expect(disposeMock).toHaveBeenCalledTimes(1);
-    expect(mockConfigManagementService.deleteForward).not.toHaveBeenCalled();
-    expect(mockConfigManagementService.updateForward).toHaveBeenCalledWith(complexUserForwardConfig, {
-      ...complexUserForwardConfig,
-      forwards: [complexUserForwardConfig.forwards[1]],
-    });
-  });
-
-  test('calling start second time with an updated version should not start the same mapping twice', async () => {
-    const mappingA = complexForwardConfig.forwards[0];
-    const mappingB = complexForwardConfig.forwards[1];
-
-    if (!mappingA || !mappingB) throw new Error('undefined mapping');
-
-    await service.startForward({
-      ...complexForwardConfig,
-      forwards: [mappingA],
-    });
-
-    expect(mockForwardingConnectionService.startForward).toHaveBeenCalledWith(expect.anything(), mappingA);
-    expect(mockForwardingConnectionService.startForward).not.toHaveBeenCalledWith(expect.anything(), mappingB);
-
-    await service.startForward({
-      ...complexForwardConfig,
-      forwards: [mappingA, mappingB],
-    });
-
-    expect(mockForwardingConnectionService.startForward).toHaveBeenNthCalledWith(1, expect.anything(), mappingA);
-    expect(mockForwardingConnectionService.startForward).toHaveBeenNthCalledWith(2, expect.anything(), mappingB);
-
-    // ensure only called twice, once for mappingA one for mappingB
-    expect(mockForwardingConnectionService.startForward).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/main/src/plugin/kubernetes/kubernetes-port-forward-service.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-port-forward-service.spec.ts
@@ -119,13 +119,13 @@ describe('KubernetesPortForwardService', () => {
     });
     expect(result).toEqual(sampleUserForwardConfig);
     expect(mockConfigManagementService.createForward).toHaveBeenCalledWith(sampleUserForwardConfig);
-    expect(apiSenderMock.send).toHaveBeenCalledWith('kubernetes-port-forward-update', []);
+    expect(apiSenderMock.send).toHaveBeenCalledWith('kubernetes-port-forwards-update', []);
   });
 
   test('should delete a forward configuration', async () => {
     await service.deleteForward(sampleUserForwardConfig);
     expect(mockConfigManagementService.deleteForward).toHaveBeenCalledWith(sampleUserForwardConfig);
-    expect(apiSenderMock.send).toHaveBeenCalledWith('kubernetes-port-forward-update', []);
+    expect(apiSenderMock.send).toHaveBeenCalledWith('kubernetes-port-forwards-update', []);
   });
 
   test('should list all forward configurations', async () => {

--- a/packages/main/src/plugin/kubernetes/kubernetes-port-forward-service.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-port-forward-service.ts
@@ -27,12 +27,7 @@ import { ForwardConfigRequirements } from '/@/plugin/kubernetes/kubernetes-port-
 import type { IDisposable } from '/@/plugin/types/disposable.js';
 import { Disposable } from '/@/plugin/types/disposable.js';
 import { isFreePort } from '/@/plugin/util/port.js';
-import type {
-  ForwardConfig,
-  ForwardOptions,
-  PortMapping,
-  UserForwardConfig,
-} from '/@api/kubernetes-port-forward-model.js';
+import type { ForwardConfig, ForwardOptions, UserForwardConfig } from '/@api/kubernetes-port-forward-model.js';
 
 /**
  * Service provider for Kubernetes port forwarding.
@@ -58,7 +53,7 @@ export class KubernetesPortForwardServiceProvider {
 
   /**
    * Gets the configuration key for the given Kubernetes configuration.
-   * The key is used for caching services and also for storing information about created forwards linked to each service.
+   * The key is used for caching services and also for storing information about created forward linked to each service.
    *
    * @param kubeConfig - The Kubernetes configuration.
    * @returns The configuration key.
@@ -86,7 +81,7 @@ export class KubernetesPortForwardService implements IDisposable {
     private forwardingConnectionService: PortForwardConnectionService,
     private apiSender: ApiSenderType,
   ) {
-    this.apiSender.send('kubernetes-port-forwards-update', []);
+    this.apiSender.send('kubernetes-port-forward-update', []);
   }
 
   dispose(): void {
@@ -95,47 +90,28 @@ export class KubernetesPortForwardService implements IDisposable {
   }
 
   /**
-   * Each key is specific for a dedicated remotePort
+   * Return the identifier of the ForwardConfig
    * @param config
-   * @param mapping
    * @private
    */
-  private getPortForwardKey(config: ForwardConfig, mapping: PortMapping): string {
-    return `${config.namespace}/${config.name}/${config.kind}/${mapping.remotePort}`;
+  private getPortForwardKey(config: ForwardConfig): string {
+    return config.id;
   }
 
   /**
-   * Creates a new forward
-   * If we have an already existing ForwardConfig we will update it
+   * Creates a new forward configuration
    * @returns The created forward configuration.
-   * @see
    * @param options
    */
   async createForward(options: ForwardOptions): Promise<UserForwardConfig> {
-    const configs = await this.listForwards();
-    const userForwardConfig: UserForwardConfig | undefined = configs.find(
-      config => config.name === options.name && config.namespace === options.namespace && config.kind === options.kind,
-    );
-    let result: UserForwardConfig;
-    if (userForwardConfig) {
-      result = await this.configManagementService.updateForward(userForwardConfig, {
-        id: userForwardConfig.id,
-        name: options.name,
-        forwards: [...userForwardConfig.forwards, options.forward],
-        namespace: options.namespace,
-        kind: options.kind,
-        displayName: options.displayName,
-      });
-    } else {
-      result = await this.configManagementService.createForward({
-        id: randomUUID(),
-        name: options.name,
-        forwards: [options.forward],
-        namespace: options.namespace,
-        kind: options.kind,
-        displayName: options.displayName,
-      });
-    }
+    const result: UserForwardConfig = await this.configManagementService.createForward({
+      id: randomUUID(),
+      name: options.name,
+      forward: options.forward,
+      namespace: options.namespace,
+      kind: options.kind,
+      displayName: options.displayName,
+    });
 
     this.apiSender.send('kubernetes-port-forwards-update', await this.listForwards());
     return result;
@@ -144,36 +120,20 @@ export class KubernetesPortForwardService implements IDisposable {
   /**
    * Deletes an existing forward configuration.
    * @param config - The forward configuration to delete.
-   * @param mapping - The mapping to delete, if mapping is undefined, delete all
    * @returns Void if the operation successful.
    * @see UserForwardConfig
    */
-  async deleteForward(config: UserForwardConfig, mapping?: PortMapping): Promise<void> {
-    const keys: string[] = [];
-    if (mapping) {
-      keys.push(this.getPortForwardKey(config, mapping));
-    } else {
-      keys.push(...config.forwards.map(forward => this.getPortForwardKey(config, forward)));
+  async deleteForward(config: UserForwardConfig): Promise<void> {
+    const key = this.getPortForwardKey(config);
+    if (!this.#disposables.has(key)) {
+      throw new Error(`cannot delete forward with key ${key}.`);
     }
 
-    for (const key of keys) {
-      const disposable = this.#disposables.get(key);
-      if (disposable) {
-        disposable.dispose();
-        this.#disposables.delete(key);
-      }
-    }
+    const disposable = this.#disposables.get(key);
+    disposable?.dispose();
+    this.#disposables.delete(key);
 
-    const newConfig: UserForwardConfig = {
-      ...config,
-      forwards: config.forwards.filter(forward => !keys.includes(this.getPortForwardKey(config, forward))),
-    };
-
-    if (newConfig.forwards.length === 0) {
-      await this.configManagementService.deleteForward(config);
-    } else {
-      await this.configManagementService.updateForward(config, newConfig);
-    }
+    await this.configManagementService.deleteForward(config);
 
     this.apiSender.send('kubernetes-port-forwards-update', await this.listForwards());
   }
@@ -194,17 +154,15 @@ export class KubernetesPortForwardService implements IDisposable {
    * @see ForwardConfig
    */
   async startForward(config: ForwardConfig): Promise<IDisposable> {
-    const disposables: IDisposable[] = [];
-    for (const forward of config.forwards) {
-      const key = this.getPortForwardKey(config, forward);
+    const key = this.getPortForwardKey(config);
+    if (this.#disposables.has(key)) throw new Error('forward already started');
 
-      if (!this.#disposables.has(key)) {
-        const disposable = await this.forwardingConnectionService.startForward(config, forward);
-        disposables.push(disposable);
-        this.#disposables.set(key, disposable);
-      }
-    }
+    const disposable = await this.forwardingConnectionService.startForward(config);
+    this.#disposables.set(key, disposable);
 
-    return Disposable.from(...disposables);
+    return Disposable.create(() => {
+      this.#disposables.delete(key);
+      disposable.dispose();
+    });
   }
 }

--- a/packages/main/src/plugin/kubernetes/kubernetes-port-forward-service.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-port-forward-service.ts
@@ -90,15 +90,6 @@ export class KubernetesPortForwardService implements IDisposable {
   }
 
   /**
-   * Return the identifier of the ForwardConfig
-   * @param config
-   * @private
-   */
-  private getPortForwardKey(config: ForwardConfig): string {
-    return config.id;
-  }
-
-  /**
    * Creates a new forward configuration
    * @returns The created forward configuration.
    * @param options
@@ -124,11 +115,9 @@ export class KubernetesPortForwardService implements IDisposable {
    * @see UserForwardConfig
    */
   async deleteForward(config: UserForwardConfig): Promise<void> {
-    const key = this.getPortForwardKey(config);
-
-    const disposable = this.#disposables.get(key);
+    const disposable = this.#disposables.get(config.id);
     disposable?.dispose();
-    this.#disposables.delete(key);
+    this.#disposables.delete(config.id);
 
     await this.configManagementService.deleteForward(config);
 
@@ -151,14 +140,13 @@ export class KubernetesPortForwardService implements IDisposable {
    * @see ForwardConfig
    */
   async startForward(config: ForwardConfig): Promise<IDisposable> {
-    const key = this.getPortForwardKey(config);
-    if (this.#disposables.has(key)) throw new Error('forward already started');
+    if (this.#disposables.has(config.id)) throw new Error('forward already started');
 
     const disposable = await this.forwardingConnectionService.startForward(config);
-    this.#disposables.set(key, disposable);
+    this.#disposables.set(config.id, disposable);
 
     return Disposable.create(() => {
-      this.#disposables.delete(key);
+      this.#disposables.delete(config.id);
       disposable.dispose();
     });
   }

--- a/packages/main/src/plugin/kubernetes/kubernetes-port-forward-service.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-port-forward-service.ts
@@ -81,7 +81,7 @@ export class KubernetesPortForwardService implements IDisposable {
     private forwardingConnectionService: PortForwardConnectionService,
     private apiSender: ApiSenderType,
   ) {
-    this.apiSender.send('kubernetes-port-forward-update', []);
+    this.apiSender.send('kubernetes-port-forwards-update', []);
   }
 
   dispose(): void {

--- a/packages/main/src/plugin/kubernetes/kubernetes-port-forward-service.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-port-forward-service.ts
@@ -125,9 +125,6 @@ export class KubernetesPortForwardService implements IDisposable {
    */
   async deleteForward(config: UserForwardConfig): Promise<void> {
     const key = this.getPortForwardKey(config);
-    if (!this.#disposables.has(key)) {
-      throw new Error(`cannot delete forward with key ${key}.`);
-    }
 
     const disposable = this.#disposables.get(key);
     disposable?.dispose();

--- a/packages/main/src/plugin/kubernetes/kubernetes-port-forward-storage.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-port-forward-storage.spec.ts
@@ -139,7 +139,7 @@ describe('FileBasedConfigStorage', () => {
     name: 'test-name',
     namespace: 'test-namespace',
     kind: WorkloadKind.POD,
-    forwards: [{ localPort: 8080, remotePort: 80 }],
+    forward: { localPort: 8080, remotePort: 80 },
     displayName: 'test-display-name',
   };
 
@@ -262,7 +262,7 @@ describe('MemoryBasedConfigStorage', () => {
     name: 'test-name',
     namespace: 'test-namespace',
     kind: WorkloadKind.POD,
-    forwards: [{ localPort: 8080, remotePort: 80 }],
+    forward: { localPort: 8080, remotePort: 80 },
     displayName: 'test-display-name',
   };
 
@@ -342,7 +342,7 @@ describe('ConfigManagementService', () => {
     name: 'test-name',
     namespace: 'test-namespace',
     kind: WorkloadKind.POD,
-    forwards: [{ localPort: 8080, remotePort: 80 }],
+    forward: { localPort: 8080, remotePort: 80 },
     displayName: 'test-display-name',
   };
 
@@ -378,8 +378,8 @@ describe('ConfigManagementService', () => {
     mockConfigStorage.listForwards = vi.fn().mockResolvedValue([sampleConfig]);
     const service = new ConfigManagementService(mockConfigStorage);
 
-    const old = {
-      forwards: [],
+    const old: UserForwardConfig = {
+      forward: { localPort: 8080, remotePort: 80 },
       displayName: 'dummy',
       namespace: 'default',
       kind: WorkloadKind.POD,

--- a/packages/main/src/plugin/kubernetes/kubernetes-port-forward-validation.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-port-forward-validation.spec.ts
@@ -27,7 +27,7 @@ describe('ForwardConfigRequirements', () => {
     name: 'validName',
     namespace: 'validNamespace',
     kind: WorkloadKind.POD,
-    forwards: [{ localPort: 8080, remotePort: 80 }],
+    forward: { localPort: 8080, remotePort: 80 },
   };
 
   test('should pass all requirements', async () => {
@@ -56,14 +56,6 @@ describe('ForwardConfigRequirements', () => {
     await expect(requirements.checkRuntimeRequirements(invalidConfig)).rejects.toThrow('Found empty namespace.');
   });
 
-  test('should fail with empty port mappings', async () => {
-    const portChecker = vi.fn().mockResolvedValue(true);
-    const requirements = new ForwardConfigRequirements(portChecker);
-    const invalidConfig = { ...validConfig, forwards: [] };
-
-    await expect(requirements.checkRuntimeRequirements(invalidConfig)).rejects.toThrow('Found empty port mappings.');
-  });
-
   test('should fail if port is not available', async () => {
     const portChecker = vi.fn().mockRejectedValue(new Error('Port is already in use.'));
     const requirements = new ForwardConfigRequirements(portChecker);
@@ -71,19 +63,12 @@ describe('ForwardConfigRequirements', () => {
     await expect(requirements.checkRuntimeRequirements(validConfig)).rejects.toThrow();
   });
 
-  test('should aggregate multiple port check failures', async () => {
-    const portChecker = vi.fn().mockImplementation(port => {
-      if (port === 8080) return Promise.resolve(true);
-      if (port === 8081) return Promise.reject(new Error(`Port ${port} is not available`));
-      return Promise.resolve(true);
-    });
+  test('should propagate port check failures', async () => {
+    const portChecker = vi.fn().mockRejectedValue(new Error(`Port 8081 is not available`));
     const requirements = new ForwardConfigRequirements(portChecker);
     const multiPortConfig = {
       ...validConfig,
-      forwards: [
-        { localPort: 8080, remotePort: 80 },
-        { localPort: 8081, remotePort: 81 },
-      ],
+      forward: { localPort: 8080, remotePort: 80 },
     };
 
     await expect(requirements.checkRuntimeRequirements(multiPortConfig)).rejects.toThrow('Port 8081 is not available');

--- a/packages/main/src/plugin/kubernetes/kubernetes-port-forward-validation.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-port-forward-validation.ts
@@ -50,17 +50,8 @@ export class ForwardConfigRequirements {
     if (config.namespace.length === 0) {
       throw new Error('Found empty namespace.');
     }
-    if (config.forwards.length === 0) {
-      throw new Error('Found empty port mappings.');
-    }
 
-    const localPortList = config.forwards.map(forward => forward.localPort);
-    const results = await Promise.allSettled(localPortList.map(async port => this.portChecker(port)));
-
-    const failedForwards = results.filter(result => result.status === 'rejected') as PromiseRejectedResult[];
-    if (failedForwards.length > 0) {
-      const reasons = failedForwards.map(attempt => attempt.reason).join('\n');
-      throw new Error(reasons);
-    }
+    const available = await this.portChecker(config.forward.localPort);
+    if (!available) throw new Error('port not available');
   }
 }

--- a/packages/preload/src/index.spec.ts
+++ b/packages/preload/src/index.spec.ts
@@ -229,7 +229,10 @@ test('createKubernetesPortForward', async () => {
     namespace: 'kubernetes',
     name: 'service',
     kind: WorkloadKind.SERVICE,
-    forwards: [],
+    forward: {
+      localPort: 50_050,
+      remotePort: 88,
+    },
   };
 
   vi.mocked(ipcRenderer.invoke).mockResolvedValue({ result: userPortForward });
@@ -265,7 +268,10 @@ test('deleteKubernetesPortForward', async () => {
     namespace: 'kubernetes',
     name: 'service',
     kind: WorkloadKind.SERVICE,
-    forwards: [],
+    forward: {
+      localPort: 50_050,
+      remotePort: 88,
+    },
   };
 
   vi.mocked(ipcRenderer.invoke).mockResolvedValue({ result: undefined });

--- a/packages/renderer/src/lib/kube/details/KubePort.spec.ts
+++ b/packages/renderer/src/lib/kube/details/KubePort.spec.ts
@@ -39,12 +39,10 @@ const DUMMY_FORWARD_CONFIG: UserForwardConfig = {
   name: 'dummy-pod-name',
   namespace: 'dummy-ns',
   kind: WorkloadKind.POD,
-  forwards: [
-    {
-      localPort: 55_076,
-      remotePort: 80,
-    },
-  ],
+  forward: {
+    localPort: 55_076,
+    remotePort: 80,
+  },
   displayName: 'dummy name',
 };
 
@@ -155,10 +153,7 @@ describe('port forwarding', () => {
     await fireEvent.click(removeBtn);
 
     await vi.waitFor(() => {
-      expect(window.deleteKubernetesPortForward).toHaveBeenCalledWith(
-        DUMMY_FORWARD_CONFIG,
-        DUMMY_FORWARD_CONFIG.forwards[0],
-      );
+      expect(window.deleteKubernetesPortForward).toHaveBeenCalledWith(DUMMY_FORWARD_CONFIG);
     });
   });
 

--- a/packages/renderer/src/lib/kube/details/KubePort.svelte
+++ b/packages/renderer/src/lib/kube/details/KubePort.svelte
@@ -17,9 +17,7 @@ interface Props {
 
 let { port, forwardConfig, resourceName, namespace, kind }: Props = $props();
 
-let mapping: PortMapping | undefined = $derived(
-  forwardConfig?.forwards.find(mapping => mapping.remotePort === port.value),
-);
+let mapping: PortMapping | undefined = $derived(forwardConfig?.forward);
 let loading: boolean = $state(false);
 let error: string | undefined = $state(undefined);
 
@@ -64,7 +62,7 @@ async function removePortForward(): Promise<void> {
   loading = true;
 
   try {
-    await window.deleteKubernetesPortForward(forwardConfig, mapping);
+    await window.deleteKubernetesPortForward(forwardConfig);
   } catch (err: unknown) {
     console.error(err);
   } finally {

--- a/packages/renderer/src/lib/kube/details/KubePortsList.svelte
+++ b/packages/renderer/src/lib/kube/details/KubePortsList.svelte
@@ -15,9 +15,11 @@ interface Props {
 
 let { ports, resourceName, namespace, kind }: Props = $props();
 
-let userForwardConfig: UserForwardConfig | undefined = $derived(
-  $kubernetesCurrentContextPortForwards.find(
-    forward => forward.kind === kind && forward.name === resourceName && forward.namespace === namespace,
+let forwardConfigs: Map<number, UserForwardConfig> = $derived(
+  new Map(
+    $kubernetesCurrentContextPortForwards
+      .filter(forward => forward.kind === kind && forward.name === resourceName && forward.namespace === namespace)
+      .map(config => [config.forward.remotePort, config]),
   ),
 );
 </script>
@@ -28,7 +30,7 @@ let userForwardConfig: UserForwardConfig | undefined = $derived(
     <Cell>
       <div class="flex gap-y-1 flex-col">
         {#each ports as port}
-          <KubePort namespace={namespace} kind={kind} resourceName={resourceName} port={port} forwardConfig={userForwardConfig}/>
+          <KubePort namespace={namespace} kind={kind} resourceName={resourceName} port={port} forwardConfig={forwardConfigs.get(port.value)}/>
         {/each}
       </div>
     </Cell>

--- a/packages/renderer/src/lib/kubernetes-port-forward/PortForwardActions.spec.ts
+++ b/packages/renderer/src/lib/kubernetes-port-forward/PortForwardActions.spec.ts
@@ -35,17 +35,15 @@ const MOCKED_USER_FORWARD_CONFIG: UserForwardConfig = {
   namespace: 'dummy-ns',
   kind: WorkloadKind.POD,
   displayName: 'dummy-display-name',
-  forwards: [
-    {
-      localPort: 55_087,
-      remotePort: 80,
-    },
-  ],
+  forward: {
+    localPort: 55_087,
+    remotePort: 80,
+  },
 };
 
 const MOCKED_PORT_FORWARD_ROW: PortForwardRow = {
   ...MOCKED_USER_FORWARD_CONFIG,
-  mapping: MOCKED_USER_FORWARD_CONFIG.forwards[0],
+  mapping: MOCKED_USER_FORWARD_CONFIG.forward,
 };
 
 beforeEach(() => {

--- a/packages/renderer/src/lib/kubernetes-port-forward/PortForwardActions.spec.ts
+++ b/packages/renderer/src/lib/kubernetes-port-forward/PortForwardActions.spec.ts
@@ -91,8 +91,5 @@ test('remove should call deleteKubernetesPortForward', async () => {
   const deleteBtn = getByTitle('Delete forwarded port');
   await fireEvent.click(deleteBtn);
 
-  expect(window.deleteKubernetesPortForward).toHaveBeenCalledWith(
-    MOCKED_USER_FORWARD_CONFIG,
-    MOCKED_PORT_FORWARD_ROW.mapping,
-  );
+  expect(window.deleteKubernetesPortForward).toHaveBeenCalledWith(MOCKED_USER_FORWARD_CONFIG);
 });

--- a/packages/renderer/src/lib/kubernetes-port-forward/PortForwardActions.svelte
+++ b/packages/renderer/src/lib/kubernetes-port-forward/PortForwardActions.svelte
@@ -15,14 +15,18 @@ let { object }: Props = $props();
 
 let userConfigForward: UserForwardConfig | undefined = $derived(
   $kubernetesCurrentContextPortForwards.find(
-    forward => forward.kind === object.kind && forward.name === object.name && forward.namespace === object.namespace,
+    config =>
+      config.kind === object.kind &&
+      config.name === object.name &&
+      config.namespace === object.namespace &&
+      config.forward.remotePort === object.mapping.remotePort,
   ),
 );
 
 async function deletePortForward(): Promise<void> {
   if (!userConfigForward) return;
 
-  await window.deleteKubernetesPortForward(userConfigForward, object.mapping);
+  await window.deleteKubernetesPortForward(userConfigForward);
 }
 
 async function openExternal(): Promise<void> {

--- a/packages/renderer/src/lib/kubernetes-port-forward/PortForwardActions.svelte
+++ b/packages/renderer/src/lib/kubernetes-port-forward/PortForwardActions.svelte
@@ -19,7 +19,8 @@ let userConfigForward: UserForwardConfig | undefined = $derived(
       config.kind === object.kind &&
       config.name === object.name &&
       config.namespace === object.namespace &&
-      config.forward.remotePort === object.mapping.remotePort,
+      config.forward.remotePort === object.mapping.remotePort &&
+      config.forward.localPort === object.mapping.localPort,
   ),
 );
 

--- a/packages/renderer/src/lib/kubernetes-port-forward/PortForwardingList.svelte
+++ b/packages/renderer/src/lib/kubernetes-port-forward/PortForwardingList.svelte
@@ -43,15 +43,10 @@ const columns = [
 const row = new TableRow<PortForwardRow>({});
 
 let portForwardRows: PortForwardRow[] = $derived.by(() => {
-  return $kubernetesCurrentContextPortForwards.reduce((accumulator, value) => {
-    accumulator.push(
-      ...value.forwards.map(forward => ({
-        ...value,
-        mapping: forward,
-      })),
-    );
-    return accumulator;
-  }, [] as PortForwardRow[]);
+  return $kubernetesCurrentContextPortForwards.map(config => ({
+    ...config,
+    mapping: config.forward,
+  }));
 });
 </script>
 


### PR DESCRIPTION
### What does this PR do?

This PR simplify the `ForwardConfig` interface. The change update the `forwards` property as followed

```diff
- forwards: PortMapping[],
+ forward: PortMapping,
```

The idea is that a ForwardConfig should only manage a single port mapping, as it is very difficult to manipulate (create, delete) multiple port forwarding with a single object.

Direct consequence is simplifying the `kubernetes-client:deletePortForward` IPC and the subsequence code implementation that was introduced in https://github.com/containers/podman-desktop/pull/9592

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

- Following https://github.com/containers/podman-desktop/pull/9783
- Part of https://github.com/containers/podman-desktop/issues/9637

All steps can be found in https://github.com/containers/podman-desktop/issues/9637#issuecomment-2459684176

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

You can check that there is no regression by creating a pod and a service, starting multiple port forward **for a single k8s resource**

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: static-web
  namespace: default
  labels:
    role: myrole
spec:
  containers:
    - name: web
      image: nginx
      ports:
        - name: web
          containerPort: 80
          protocol: TCP
---
apiVersion: v1
kind: Service
metadata:
  name: my-service
  namespace: default
spec:
  ports:
    - name: demo
      protocol: TCP
      port: 8080
      targetPort: 80
    - name: dummy
      protocol: TCP
      port: 8081
      targetPort: 80
  selector:
    role: myrole
```
