### PR TITLE
fix: status bar progress bar percentage display

### DIFF
--- a/packages/renderer/src/lib/statusbar/TaskIndicator.spec.ts
+++ b/packages/renderer/src/lib/statusbar/TaskIndicator.spec.ts
@@ -98,3 +98,20 @@ test('multiple tasks running should display them', async () => {
   expect(status).toBeDefined();
   expect(status.textContent).toBe('2 tasks running');
 });
+
+test('task with defined progress value should display it', async () => {
+  tasksInfo.set([
+    {
+      name: 'Dummy Task',
+      state: 'running',
+      status: 'in-progress',
+      started: 0,
+      id: 'dummy-task',
+      progress: 50,
+    },
+  ]);
+
+  const { getByText } = render(TaskIndicator);
+  const span = getByText('50%');
+  expect(span).toBeDefined();
+});

--- a/packages/renderer/src/lib/statusbar/TaskIndicator.svelte
+++ b/packages/renderer/src/lib/statusbar/TaskIndicator.svelte
@@ -13,7 +13,7 @@ let title: string | undefined = $derived.by(() => {
 });
 
 let progress: number | undefined = $derived.by(() => {
-  if (runningTasks.length !== 0) return undefined;
+  if (runningTasks.length === 0) return undefined;
   return runningTasks[0].progress ?? 0;
 });
 
@@ -29,7 +29,7 @@ function toggleTaskManager(): void {
         <div class="flex items-center gap-x-2">
           <span role="status" class="max-w-32 text-ellipsis overflow-hidden whitespace-nowrap">{title}</span>
           {#if (progress ?? 0) >= 0}
-            <ProgressBar height="h-1" width="w-20" progress={progress} />
+            <ProgressBar class="items-center" height="h-1" width="w-20" progress={progress} />
           {/if}
         </div>
       </button>

--- a/packages/renderer/src/lib/task-manager/ProgressBar.spec.ts
+++ b/packages/renderer/src/lib/task-manager/ProgressBar.spec.ts
@@ -46,3 +46,10 @@ test('Expect class to be propagated', async () => {
 
   expect(container.children[0]).toHaveClass('dummy-class');
 });
+
+test('Expect aria-label to be propagated', async () => {
+  const { getByLabelText } = render(ProgressBar, { progress: 5, 'aria-label': 'hello-world' });
+
+  const container = getByLabelText('hello-world');
+  expect(container).toBeDefined();
+});

--- a/packages/renderer/src/lib/task-manager/ProgressBar.spec.ts
+++ b/packages/renderer/src/lib/task-manager/ProgressBar.spec.ts
@@ -40,3 +40,9 @@ test('Expect that the progress bar is incremental', async () => {
   expect(progressBar).toHaveClass('progress-bar-incremental');
   expect(progressBar.classList.contains('progress-bar-indeterminate')).toBe(false);
 });
+
+test('Expect class to be propagated', async () => {
+  const { container } = render(ProgressBar, { progress: 5, class: 'dummy-class' });
+
+  expect(container.children[0]).toHaveClass('dummy-class');
+});

--- a/packages/renderer/src/lib/task-manager/ProgressBar.svelte
+++ b/packages/renderer/src/lib/task-manager/ProgressBar.svelte
@@ -31,8 +31,8 @@
 <script lang="ts">
 interface Props {
   progress?: number;
-  width: string;
-  height: string;
+  width?: string;
+  height?: string;
   class?: string;
 }
 

--- a/packages/renderer/src/lib/task-manager/ProgressBar.svelte
+++ b/packages/renderer/src/lib/task-manager/ProgressBar.svelte
@@ -35,7 +35,6 @@ interface Props extends HTMLAttributes<HTMLElement> {
   progress?: number;
   width?: string;
   height?: string;
-  class?: string;
 }
 
 let { progress, width = 'w-36', height = 'h-4', class: className, ...restProps }: Props = $props();

--- a/packages/renderer/src/lib/task-manager/ProgressBar.svelte
+++ b/packages/renderer/src/lib/task-manager/ProgressBar.svelte
@@ -29,17 +29,19 @@
 </style>
 
 <script lang="ts">
-interface Props {
+import type { HTMLAttributes } from 'svelte/elements';
+
+interface Props extends HTMLAttributes<HTMLElement> {
   progress?: number;
   width?: string;
   height?: string;
   class?: string;
 }
 
-let { class: className, progress, width = 'w-36', height = 'h-4' }: Props = $props();
+let { progress, width = 'w-36', height = 'h-4', class: className, ...restProps }: Props = $props();
 </script>
 
-<div class="flex flex-row {className}">
+<div class="flex flex-row {className}" {...restProps} >
   <div class="{width} {height} rounded-full bg-[var(--pd-progressBar-bg)] progress-bar overflow-hidden">
     {#if progress !== undefined}
       <div

--- a/packages/renderer/src/lib/task-manager/ProgressBar.svelte
+++ b/packages/renderer/src/lib/task-manager/ProgressBar.svelte
@@ -29,12 +29,17 @@
 </style>
 
 <script lang="ts">
-export let progress: number | undefined;
-export let width: string = 'w-36';
-export let height: string = 'h-4';
+interface Props {
+  progress?: number;
+  width: string;
+  height: string;
+  class?: string;
+}
+
+let { class: className, progress, width = 'w-36', height = 'h-4' }: Props = $props();
 </script>
 
-<div class="flex flex-row">
+<div class="flex flex-row {className}">
   <div class="{width} {height} rounded-full bg-[var(--pd-progressBar-bg)] progress-bar overflow-hidden">
     {#if progress !== undefined}
       <div


### PR DESCRIPTION
### What does this PR do?

Fix the progress status bar not showing the progress value. There is also a missalignement when we show the percentage, that can be fixed by providing an align class to the `ProgressBar.svelte`

### Screenshot / video of UI

![image](https://github.com/user-attachments/assets/f254d717-ad94-420b-9e1b-0e20299948ff)

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/9418

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

#### Testing manually

You may add the following in an extension activate function

```ts
  extensionApi.window.withProgress(
    { location: extensionApi.ProgressLocation.TASK_WIDGET, title: `Fake loading` },
    async (progress) => {
      progress.report({ increment: 20 });

      return new Promise((resolve, reject) => {
        setTimeout(() => {
          resolve();
        }, 60_000);
      });
    },
  )
```
