### PR TITLE
feat(api): enhance the doUpdate signature

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -4600,7 +4600,7 @@ declare module '@podman-desktop/api' {
 
   export interface CliToolSelectUpdate {
     selectVersion: () => Promise<string>;
-    doUpdate: (logger: Logger) => Promise<void>;
+    doUpdate: (logger: Logger, version: string) => Promise<void>;
   }
 
   export interface CliToolInstaller {

--- a/packages/main/src/plugin/cli-tool-registry.spec.ts
+++ b/packages/main/src/plugin/cli-tool-registry.spec.ts
@@ -228,17 +228,42 @@ suite('cli module', () => {
       const newCliTool = cliToolRegistry.createCliTool(extensionInfo, options);
       // register the updater and call it
       const disposeUpdater = cliToolRegistry.registerUpdate(newCliTool as CliToolImpl, updater);
-      await cliToolRegistry.updateCliTool(newCliTool.id, {} as unknown as Logger);
 
-      expect(updateMock).toBeCalled();
+      const loggerMock: Logger = {} as unknown as Logger;
+      await cliToolRegistry.updateCliTool(newCliTool.id, '1.1.2', loggerMock);
+
+      expect(updateMock).toHaveBeenCalledWith(loggerMock);
       updateMock.mockReset();
 
       // dispose the updater and check it is not called again
       disposeUpdater.dispose();
       expect(apiSender.send).toBeCalledWith('cli-tool-change', 'ext-publisher.ext-name.tool-name');
-      await cliToolRegistry.updateCliTool(newCliTool.id, {} as unknown as Logger);
+      await cliToolRegistry.updateCliTool(newCliTool.id, '1.1.2', {} as unknown as Logger);
 
       expect(updateMock).not.toBeCalled();
+    });
+
+    test('expect CliToolSelectUpdate updater to receive version selected', async () => {
+      const updater: CliToolSelectUpdate = {
+        doUpdate: vi.fn(),
+        selectVersion: vi.fn(),
+      };
+      const options: CliToolOptions = {
+        name: 'tool-name',
+        displayName: 'tool-display-name',
+        markdownDescription: 'markdown description',
+        images: {},
+        version: '1.0.1',
+        path: 'path/to/tool-name',
+      };
+      const newCliTool = cliToolRegistry.createCliTool(extensionInfo, options);
+      // register the updater and call it
+      cliToolRegistry.registerUpdate(newCliTool as CliToolImpl, updater);
+
+      const loggerMock: Logger = {} as unknown as Logger;
+      await cliToolRegistry.updateCliTool(newCliTool.id, '1.1.2', loggerMock);
+
+      expect(updater.doUpdate).toHaveBeenCalledWith(loggerMock, '1.1.2');
     });
   });
 

--- a/packages/main/src/plugin/cli-tool-registry.ts
+++ b/packages/main/src/plugin/cli-tool-registry.ts
@@ -72,10 +72,15 @@ export class CliToolRegistry {
     });
   }
 
-  async updateCliTool(id: string, logger: Logger): Promise<void> {
-    const cliToolUpdater = this.cliToolsUpdater.get(id);
-    if (cliToolUpdater) {
-      await cliToolUpdater.doUpdate(logger);
+  async updateCliTool(id: string, version: string, logger: Logger): Promise<void> {
+    const cliToolUpdater: CliToolUpdate | CliToolSelectUpdate | undefined = this.cliToolsUpdater.get(id);
+    if (!cliToolUpdater) return;
+
+    // if is CliToolUpdate we do not need to provide the version
+    if ('version' in cliToolUpdater) {
+      return cliToolUpdater.doUpdate(logger);
+    } else {
+      return cliToolUpdater.doUpdate(logger, version);
     }
   }
 

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1503,7 +1503,7 @@ export class PluginSystem {
         });
 
         return cliToolRegistry
-          .updateCliTool(id, logger)
+          .updateCliTool(id, version, logger)
           .then(result => {
             task.status = 'success';
             return result;


### PR DESCRIPTION
### What does this PR do?

This PR change the signature of the `doUpdate` method registered through `registerUpdate`. This change is backward compatible, as it add an additional argument (the version).

When the user select a version the extension has to keep stored which result the user selected, which might not be ideal, and would be easier to have the version provided by the api once selected.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/9339

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
