### PR TITLE
fix: terminal is not restarted if container if not running + state management

### DIFF
--- a/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
@@ -28,10 +28,9 @@ let sendCallbackId: number | undefined;
 let terminalContent: string = '';
 let serializeAddon: SerializeAddon;
 let lastState = $state('');
-let containerState = $state(container.state);
+let containerState = $derived(container.state);
 
 $effect(() => {
-  containerState = container.state;
   if (lastState === 'STARTING' && containerState === 'RUNNING') {
     restartTerminal();
   }


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

- the terminal is not restarted if the container is not running
- Svelte state is reduced to only the container state, not the entire container information, or  the $effect was respawned in an infinite loop when a container restarts.

### Screenshot / video of UI

https://github.com/user-attachments/assets/9fe9bb5d-709a-4ce4-a9b5-03607700e762

### What issues does this PR fix or reference?

Fixes #9771 

### How to test this PR?

- Start a container, go to the terminal page, check that the terminal works as expected
- Stop the container
- restart the container
- the terminal should be working again
- the app should work 
- no error should appear in the console

- [ ] Tests are covering the bug fix or the new feature
