### PR TITLE
fix: restart container on terminal page

### DIFF
--- a/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
@@ -31,7 +31,8 @@ let lastState = $state('');
 let containerState = $derived(container.state);
 
 $effect(() => {
-  if (lastState === 'STARTING' && containerState === 'RUNNING') {
+  if ((lastState === 'STARTING' || lastState === 'RESTARTING') && containerState === 'RUNNING') {
+    console.log('==> restart');
     restartTerminal();
   }
   lastState = container.state;
@@ -55,6 +56,7 @@ function receiveDataCallback(data: Buffer) {
 function receiveEndCallback() {
   // need to reopen a new terminal if container is running
   if (containerState === 'RUNNING') {
+    console.log('==> shellInContainer 2');
     window
       .shellInContainer(container.engineId, container.id, receiveDataCallback, () => {}, receiveEndCallback)
       .then(id => {
@@ -76,6 +78,7 @@ async function executeShellIntoContainer() {
   }
 
   // grab logs of the container
+  console.log('==> shellInContainer 1');
   const callbackId = await window.shellInContainer(
     container.engineId,
     container.id,

--- a/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
@@ -32,7 +32,6 @@ let containerState = $derived(container.state);
 
 $effect(() => {
   if ((lastState === 'STARTING' || lastState === 'RESTARTING') && containerState === 'RUNNING') {
-    console.log('==> restart');
     restartTerminal();
   }
   lastState = container.state;
@@ -56,7 +55,6 @@ function receiveDataCallback(data: Buffer) {
 function receiveEndCallback() {
   // need to reopen a new terminal if container is running
   if (containerState === 'RUNNING') {
-    console.log('==> shellInContainer 2');
     window
       .shellInContainer(container.engineId, container.id, receiveDataCallback, () => {}, receiveEndCallback)
       .then(id => {
@@ -78,7 +76,6 @@ async function executeShellIntoContainer() {
   }
 
   // grab logs of the container
-  console.log('==> shellInContainer 1');
   const callbackId = await window.shellInContainer(
     container.engineId,
     container.id,


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Restart the terminal when the container is in RUNNING state with a previous RESTARTING state (before, only the STARTING state was taken into consideration).


### What issues does this PR fix or reference?

Fixes #9794 

### How to test this PR?

- Start a container and go to its terminal page
- Restart the container (with the "Restart container" button, not stop+start)
- check that the terminal is visible again and that you can type character and get response.

- [x] Tests are covering the bug fix or the new feature
