### PR TITLE
feat: publish the catalog to the website in /extensions directory

### DIFF
--- a/website/src/pages/extensions/index.tsx
+++ b/website/src/pages/extensions/index.tsx
@@ -1,0 +1,24 @@
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import TailWindThemeSelector from '@site/src/components/TailWindThemeSelector';
+import Layout from '@theme/Layout';
+
+function ExtensionListFromIframe(): JSX.Element {
+  return (
+    <iframe
+      title="Extensions Catalog"
+      src="https://registry.podman-desktop.io/"
+      className="w-full min-h-[2000px] h-full"
+    />
+  );
+}
+
+export default function Extensions(): JSX.Element {
+  const { siteConfig } = useDocusaurusContext();
+
+  return (
+    <Layout title={siteConfig.title} description="Extensions" wrapperClassName="h-full">
+      <TailWindThemeSelector />
+      <ExtensionListFromIframe />
+    </Layout>
+  );
+}


### PR DESCRIPTION
### What does this PR do?
add a way to browse the catalog from the website

### Screenshot / video of UI


https://github.com/user-attachments/assets/a47cc0fc-ae57-4481-8302-ec734812b61d



### What issues does this PR fix or reference?

fixes #8972 

### How to test this PR?

Go to /extensions on the website

- [ ] Tests are covering the bug fix or the new feature
