### PR TITLE
refactor(kubernetes): removed unused `displayName` property from port forward config

### DIFF
--- a/packages/api/src/kubernetes-port-forward-model.ts
+++ b/packages/api/src/kubernetes-port-forward-model.ts
@@ -60,10 +60,6 @@ export interface ForwardOptions {
    * The forward to create
    */
   forward: PortMapping;
-  /**
-   * The display name for the forward configuration.
-   */
-  displayName: string;
 }
 
 /**
@@ -95,16 +91,4 @@ export interface ForwardConfig {
    * The port mapping.
    */
   forward: PortMapping;
-}
-
-/**
- * Interface representing a user-specific forward configuration.
- * Extends the base {@link ForwardConfig} interface.
- * @see ForwardConfig
- */
-export interface UserForwardConfig extends ForwardConfig {
-  /**
-   * The display name for the forward configuration.
-   */
-  displayName: string;
 }

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -87,7 +87,7 @@ import type { ImageInspectInfo } from '/@api/image-inspect-info.js';
 import type { ImageSearchOptions, ImageSearchResult, ImageTagsListOptions } from '/@api/image-registry.js';
 import type { KubeContext } from '/@api/kubernetes-context.js';
 import type { ContextGeneralState, ResourceName } from '/@api/kubernetes-contexts-states.js';
-import type { ForwardOptions, UserForwardConfig } from '/@api/kubernetes-port-forward-model.js';
+import type { ForwardConfig, ForwardOptions } from '/@api/kubernetes-port-forward-model.js';
 import type { ManifestCreateOptions, ManifestInspectInfo, ManifestPushOptions } from '/@api/manifest-info.js';
 import type { NetworkInspectInfo } from '/@api/network-info.js';
 import type { NotificationCard, NotificationCardOptions } from '/@api/notification.js';
@@ -2464,23 +2464,20 @@ export class PluginSystem {
       },
     );
 
-    this.ipcHandle('kubernetes-client:getPortForwards', async (_listener): Promise<UserForwardConfig[]> => {
+    this.ipcHandle('kubernetes-client:getPortForwards', async (_listener): Promise<ForwardConfig[]> => {
       return kubernetesClient.getPortForwards();
     });
 
     this.ipcHandle(
       'kubernetes-client:createPortForward',
-      async (_listener, options: ForwardOptions): Promise<UserForwardConfig> => {
+      async (_listener, options: ForwardOptions): Promise<ForwardConfig> => {
         return kubernetesClient.createPortForward(options);
       },
     );
 
-    this.ipcHandle(
-      'kubernetes-client:deletePortForward',
-      async (_listener, config: UserForwardConfig): Promise<void> => {
-        return kubernetesClient.deletePortForward(config);
-      },
-    );
+    this.ipcHandle('kubernetes-client:deletePortForward', async (_listener, config: ForwardConfig): Promise<void> => {
+      return kubernetesClient.deletePortForward(config);
+    });
 
     this.ipcHandle(
       'openshift-client:createRoute',

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.ts
@@ -71,7 +71,7 @@ import type { KubernetesPortForwardService } from '/@/plugin/kubernetes/kubernet
 import { KubernetesPortForwardServiceProvider } from '/@/plugin/kubernetes/kubernetes-port-forward-service.js';
 import type { KubeContext } from '/@api/kubernetes-context.js';
 import type { ContextGeneralState, ResourceName } from '/@api/kubernetes-contexts-states.js';
-import type { ForwardOptions, UserForwardConfig } from '/@api/kubernetes-port-forward-model.js';
+import type { ForwardConfig, ForwardOptions } from '/@api/kubernetes-port-forward-model.js';
 import type { V1Route } from '/@api/openshift-types.js';
 
 import type { ApiSenderType } from '../api.js';
@@ -1761,18 +1761,18 @@ export class KubernetesClient {
     return this.#portForwardService;
   }
 
-  public async getPortForwards(): Promise<UserForwardConfig[]> {
+  public async getPortForwards(): Promise<ForwardConfig[]> {
     return this.ensurePortForwardService().listForwards();
   }
 
-  public async createPortForward(config: ForwardOptions): Promise<UserForwardConfig> {
+  public async createPortForward(config: ForwardOptions): Promise<ForwardConfig> {
     const service = this.ensurePortForwardService();
     const newConfig = await service.createForward(config);
     await service.startForward(newConfig);
     return newConfig;
   }
 
-  public async deletePortForward(config: UserForwardConfig): Promise<void> {
+  public async deletePortForward(config: ForwardConfig): Promise<void> {
     return this.ensurePortForwardService().deleteForward(config);
   }
 }

--- a/packages/main/src/plugin/kubernetes/kubernetes-port-forward-service.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-port-forward-service.spec.ts
@@ -30,7 +30,7 @@ import {
 } from '/@/plugin/kubernetes/kubernetes-port-forward-service.js';
 import type { ConfigManagementService } from '/@/plugin/kubernetes/kubernetes-port-forward-storage.js';
 import type { IDisposable } from '/@/plugin/types/disposable.js';
-import type { ForwardConfig, UserForwardConfig } from '/@api/kubernetes-port-forward-model.js';
+import type { ForwardConfig } from '/@api/kubernetes-port-forward-model.js';
 import { WorkloadKind } from '/@api/kubernetes-port-forward-model.js';
 
 vi.mock('/@/plugin/kubernetes/kubernetes-port-forward-connection.js');
@@ -79,18 +79,13 @@ describe('KubernetesPortForwardService', () => {
     forward: { localPort: 8080, remotePort: 80 },
   };
 
-  const sampleUserForwardConfig: UserForwardConfig = {
-    ...sampleForwardConfig,
-    displayName: 'test-display-name',
-  };
-
   beforeEach(() => {
     vi.clearAllMocks();
     mockConfigManagementService = {
-      createForward: vi.fn().mockResolvedValue(sampleUserForwardConfig),
+      createForward: vi.fn().mockResolvedValue(sampleForwardConfig),
       deleteForward: vi.fn().mockResolvedValue(undefined),
-      updateForward: vi.fn().mockResolvedValue(sampleUserForwardConfig),
-      listForwards: vi.fn().mockResolvedValue([sampleUserForwardConfig]),
+      updateForward: vi.fn().mockResolvedValue(sampleForwardConfig),
+      listForwards: vi.fn().mockResolvedValue([sampleForwardConfig]),
     } as unknown as ConfigManagementService;
 
     mockForwardingConnectionService = {
@@ -107,30 +102,29 @@ describe('KubernetesPortForwardService', () => {
 
   test('should create a forward configuration', async () => {
     vi.mocked(mockConfigManagementService.listForwards).mockResolvedValue([]);
-    const forward = sampleUserForwardConfig.forward;
+    const forward = sampleForwardConfig.forward;
     if (!forward) throw new Error('undefined forward');
 
     const result = await service.createForward({
-      name: sampleUserForwardConfig.name,
-      kind: sampleUserForwardConfig.kind,
-      namespace: sampleUserForwardConfig.namespace,
+      name: sampleForwardConfig.name,
+      kind: sampleForwardConfig.kind,
+      namespace: sampleForwardConfig.namespace,
       forward: forward,
-      displayName: sampleUserForwardConfig.displayName,
     });
-    expect(result).toEqual(sampleUserForwardConfig);
-    expect(mockConfigManagementService.createForward).toHaveBeenCalledWith(sampleUserForwardConfig);
+    expect(result).toEqual(sampleForwardConfig);
+    expect(mockConfigManagementService.createForward).toHaveBeenCalledWith(sampleForwardConfig);
     expect(apiSenderMock.send).toHaveBeenCalledWith('kubernetes-port-forwards-update', []);
   });
 
   test('should delete a forward configuration', async () => {
-    await service.deleteForward(sampleUserForwardConfig);
-    expect(mockConfigManagementService.deleteForward).toHaveBeenCalledWith(sampleUserForwardConfig);
+    await service.deleteForward(sampleForwardConfig);
+    expect(mockConfigManagementService.deleteForward).toHaveBeenCalledWith(sampleForwardConfig);
     expect(apiSenderMock.send).toHaveBeenCalledWith('kubernetes-port-forwards-update', []);
   });
 
   test('should list all forward configurations', async () => {
     const result = await service.listForwards();
-    expect(result).toEqual([sampleUserForwardConfig]);
+    expect(result).toEqual([sampleForwardConfig]);
     expect(mockConfigManagementService.listForwards).toHaveBeenCalled();
   });
 

--- a/packages/main/src/plugin/kubernetes/kubernetes-port-forward-service.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-port-forward-service.ts
@@ -27,7 +27,7 @@ import { ForwardConfigRequirements } from '/@/plugin/kubernetes/kubernetes-port-
 import type { IDisposable } from '/@/plugin/types/disposable.js';
 import { Disposable } from '/@/plugin/types/disposable.js';
 import { isFreePort } from '/@/plugin/util/port.js';
-import type { ForwardConfig, ForwardOptions, UserForwardConfig } from '/@api/kubernetes-port-forward-model.js';
+import type { ForwardConfig, ForwardOptions } from '/@api/kubernetes-port-forward-model.js';
 
 /**
  * Service provider for Kubernetes port forwarding.
@@ -94,14 +94,13 @@ export class KubernetesPortForwardService implements IDisposable {
    * @returns The created forward configuration.
    * @param options
    */
-  async createForward(options: ForwardOptions): Promise<UserForwardConfig> {
-    const result: UserForwardConfig = await this.configManagementService.createForward({
+  async createForward(options: ForwardOptions): Promise<ForwardConfig> {
+    const result: ForwardConfig = await this.configManagementService.createForward({
       id: randomUUID(),
       name: options.name,
       forward: options.forward,
       namespace: options.namespace,
       kind: options.kind,
-      displayName: options.displayName,
     });
 
     this.apiSender.send('kubernetes-port-forwards-update', await this.listForwards());
@@ -112,9 +111,9 @@ export class KubernetesPortForwardService implements IDisposable {
    * Deletes an existing forward configuration.
    * @param config - The forward configuration to delete.
    * @returns Void if the operation successful.
-   * @see UserForwardConfig
+   * @see ForwardConfig
    */
-  async deleteForward(config: UserForwardConfig): Promise<void> {
+  async deleteForward(config: ForwardConfig): Promise<void> {
     const disposable = this.#disposables.get(config.id);
     disposable?.dispose();
     this.#disposables.delete(config.id);
@@ -127,9 +126,9 @@ export class KubernetesPortForwardService implements IDisposable {
   /**
    * Lists all forward configurations.
    * @returns A list of forward configurations.
-   * @see UserForwardConfig
+   * @see ForwardConfig
    */
-  async listForwards(): Promise<UserForwardConfig[]> {
+  async listForwards(): Promise<ForwardConfig[]> {
     return this.configManagementService.listForwards();
   }
 

--- a/packages/preload/src/index.spec.ts
+++ b/packages/preload/src/index.spec.ts
@@ -23,7 +23,7 @@ import type { IpcRenderer, IpcRendererEvent } from 'electron';
 import { contextBridge, ipcRenderer } from 'electron';
 import { beforeEach, expect, test, vi } from 'vitest';
 
-import type { UserForwardConfig } from '/@api/kubernetes-port-forward-model';
+import type { ForwardConfig } from '/@api/kubernetes-port-forward-model';
 import { WorkloadKind } from '/@api/kubernetes-port-forward-model';
 
 import { buildApiSender, initExposure } from '.';
@@ -223,9 +223,8 @@ test('createKubernetesPortForward', async () => {
     },
   );
 
-  const userPortForward: UserForwardConfig = {
+  const userPortForward: ForwardConfig = {
     id: 'fake-id',
-    displayName: 'My port forward',
     namespace: 'kubernetes',
     name: 'service',
     kind: WorkloadKind.SERVICE,
@@ -262,9 +261,8 @@ test('deleteKubernetesPortForward', async () => {
     },
   );
 
-  const userPortForward: UserForwardConfig = {
+  const userPortForward: ForwardConfig = {
     id: 'fake-id',
-    displayName: 'My port forward',
     namespace: 'kubernetes',
     name: 'service',
     kind: WorkloadKind.SERVICE,

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -68,7 +68,7 @@ import type { ImageInspectInfo } from '/@api/image-inspect-info';
 import type { ImageSearchOptions, ImageSearchResult, ImageTagsListOptions } from '/@api/image-registry';
 import type { KubeContext } from '/@api/kubernetes-context';
 import type { ContextGeneralState, ResourceName } from '/@api/kubernetes-contexts-states';
-import type { ForwardOptions, PortMapping, UserForwardConfig } from '/@api/kubernetes-port-forward-model';
+import type { ForwardConfig, ForwardOptions } from '/@api/kubernetes-port-forward-model';
 import type { ManifestCreateOptions, ManifestInspectInfo, ManifestPushOptions } from '/@api/manifest-info';
 import type { NetworkInspectInfo } from '/@api/network-info';
 import type { NotificationCard, NotificationCardOptions } from '/@api/notification';
@@ -2114,23 +2114,20 @@ export function initExposure(): void {
     return ipcInvoke('kubernetes-client:refreshContextState', context);
   });
 
-  contextBridge.exposeInMainWorld('getKubernetesPortForwards', async (): Promise<UserForwardConfig[]> => {
+  contextBridge.exposeInMainWorld('getKubernetesPortForwards', async (): Promise<ForwardConfig[]> => {
     return ipcInvoke('kubernetes-client:getPortForwards');
   });
 
   contextBridge.exposeInMainWorld(
     'createKubernetesPortForward',
-    async (options: ForwardOptions): Promise<UserForwardConfig> => {
+    async (options: ForwardOptions): Promise<ForwardConfig> => {
       return ipcInvoke('kubernetes-client:createPortForward', options);
     },
   );
 
-  contextBridge.exposeInMainWorld(
-    'deleteKubernetesPortForward',
-    async (config: UserForwardConfig, mapping?: PortMapping): Promise<void> => {
-      return ipcInvoke('kubernetes-client:deletePortForward', config, mapping);
-    },
-  );
+  contextBridge.exposeInMainWorld('deleteKubernetesPortForward', async (config: ForwardConfig): Promise<void> => {
+    return ipcInvoke('kubernetes-client:deletePortForward', config);
+  });
 
   contextBridge.exposeInMainWorld(
     'openshiftCreateRoute',

--- a/packages/renderer/src/AppNavigation.spec.ts
+++ b/packages/renderer/src/AppNavigation.spec.ts
@@ -27,7 +27,7 @@ import { beforeAll, expect, test, vi } from 'vitest';
 import * as kubeContextStore from '/@/stores/kubernetes-contexts-state';
 import type { ContributionInfo } from '/@api/contribution-info';
 import type { ContextGeneralState } from '/@api/kubernetes-contexts-states';
-import type { UserForwardConfig } from '/@api/kubernetes-port-forward-model';
+import type { ForwardConfig } from '/@api/kubernetes-port-forward-model';
 
 import AppNavigation from './AppNavigation.svelte';
 import { contributions } from './stores/contribs';
@@ -60,7 +60,7 @@ test('Test rendering of the navigation bar with empty items', async () => {
   vi.mocked(kubeContextStore).kubernetesCurrentContextConfigMaps = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextSecrets = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextPersistentVolumeClaims = readable<KubernetesObject[]>([]);
-  vi.mocked(kubeContextStore).kubernetesCurrentContextPortForwards = readable<UserForwardConfig[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextPortForwards = readable<ForwardConfig[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextState = readable<ContextGeneralState>({} as ContextGeneralState);
 
   // init navigation registry

--- a/packages/renderer/src/lib/kube/details/KubePort.spec.ts
+++ b/packages/renderer/src/lib/kube/details/KubePort.spec.ts
@@ -21,7 +21,7 @@ import '@testing-library/jest-dom/vitest';
 import { fireEvent, render } from '@testing-library/svelte';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { type UserForwardConfig, WorkloadKind } from '/@api/kubernetes-port-forward-model';
+import { type ForwardConfig, WorkloadKind } from '/@api/kubernetes-port-forward-model';
 
 import KubePort from './KubePort.svelte';
 
@@ -34,7 +34,7 @@ beforeEach(() => {
   (window.deleteKubernetesPortForward as unknown) = vi.fn();
 });
 
-const DUMMY_FORWARD_CONFIG: UserForwardConfig = {
+const DUMMY_FORWARD_CONFIG: ForwardConfig = {
   id: 'fake-id',
   name: 'dummy-pod-name',
   namespace: 'dummy-ns',
@@ -43,7 +43,6 @@ const DUMMY_FORWARD_CONFIG: UserForwardConfig = {
     localPort: 55_076,
     remotePort: 80,
   },
-  displayName: 'dummy name',
 };
 
 describe('port forwarding', () => {

--- a/packages/renderer/src/lib/kube/details/KubePort.spec.ts
+++ b/packages/renderer/src/lib/kube/details/KubePort.spec.ts
@@ -82,7 +82,6 @@ describe('port forwarding', () => {
     await vi.waitFor(() => {
       expect(window.getFreePort).toHaveBeenCalled();
       expect(window.createKubernetesPortForward).toHaveBeenCalledWith({
-        displayName: 'dummy-pod-name/undefined',
         forward: {
           localPort: 55001,
           remotePort: 80,

--- a/packages/renderer/src/lib/kube/details/KubePort.svelte
+++ b/packages/renderer/src/lib/kube/details/KubePort.svelte
@@ -33,7 +33,6 @@ async function onForwardRequest(port: KubePortInfo): Promise<void> {
   const snapshot: KubePortInfo = $state.snapshot(port);
   try {
     await window.createKubernetesPortForward({
-      displayName: `${resourceName}/${snapshot.name}`,
       name: resourceName,
       kind: kind,
       namespace: namespace ?? 'default',

--- a/packages/renderer/src/lib/kube/details/KubePort.svelte
+++ b/packages/renderer/src/lib/kube/details/KubePort.svelte
@@ -3,13 +3,13 @@ import { faQuestionCircle, faSquareUpRight, faTrash } from '@fortawesome/free-so
 import { Button, ErrorMessage, Tooltip } from '@podman-desktop/ui-svelte';
 import Fa from 'svelte-fa';
 
-import type { PortMapping, UserForwardConfig, WorkloadKind } from '/@api/kubernetes-port-forward-model';
+import type { ForwardConfig, PortMapping, WorkloadKind } from '/@api/kubernetes-port-forward-model';
 
 import type { KubePortInfo } from './kube-port';
 
 interface Props {
   port: KubePortInfo;
-  forwardConfig?: UserForwardConfig;
+  forwardConfig?: ForwardConfig;
   resourceName?: string;
   namespace?: string;
   kind: WorkloadKind;

--- a/packages/renderer/src/lib/kube/details/KubePortsList.svelte
+++ b/packages/renderer/src/lib/kube/details/KubePortsList.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import Cell from '/@/lib/details/DetailsCell.svelte';
 import { kubernetesCurrentContextPortForwards } from '/@/stores/kubernetes-contexts-state';
-import type { UserForwardConfig, WorkloadKind } from '/@api/kubernetes-port-forward-model';
+import type { ForwardConfig, WorkloadKind } from '/@api/kubernetes-port-forward-model';
 
 import type { KubePortInfo } from './kube-port';
 import KubePort from './KubePort.svelte';
@@ -15,7 +15,7 @@ interface Props {
 
 let { ports, resourceName, namespace, kind }: Props = $props();
 
-let forwardConfigs: Map<number, UserForwardConfig> = $derived(
+let forwardConfigs: Map<number, ForwardConfig> = $derived(
   new Map(
     $kubernetesCurrentContextPortForwards
       .filter(forward => forward.kind === kind && forward.name === resourceName && forward.namespace === namespace)

--- a/packages/renderer/src/lib/kubernetes-port-forward/PortForwardActions.spec.ts
+++ b/packages/renderer/src/lib/kubernetes-port-forward/PortForwardActions.spec.ts
@@ -25,16 +25,15 @@ import { beforeEach, expect, test, vi } from 'vitest';
 import type { PortForwardRow } from '/@/lib/kubernetes-port-forward/port-forward-row';
 import PortForwardActions from '/@/lib/kubernetes-port-forward/PortForwardActions.svelte';
 import * as kubeContextStore from '/@/stores/kubernetes-contexts-state';
-import { type UserForwardConfig, WorkloadKind } from '/@api/kubernetes-port-forward-model';
+import { type ForwardConfig, WorkloadKind } from '/@api/kubernetes-port-forward-model';
 
 vi.mock('/@/stores/kubernetes-contexts-state', async () => ({}));
 
-const MOCKED_USER_FORWARD_CONFIG: UserForwardConfig = {
+const MOCKED_USER_FORWARD_CONFIG: ForwardConfig = {
   id: 'fake-id',
   name: 'dummy-pod-name',
   namespace: 'dummy-ns',
   kind: WorkloadKind.POD,
-  displayName: 'dummy-display-name',
   forward: {
     localPort: 55_087,
     remotePort: 80,

--- a/packages/renderer/src/lib/kubernetes-port-forward/PortForwardActions.svelte
+++ b/packages/renderer/src/lib/kubernetes-port-forward/PortForwardActions.svelte
@@ -4,7 +4,7 @@ import { faSquareUpRight, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
 import type { PortForwardRow } from '/@/lib/kubernetes-port-forward/port-forward-row';
 import { kubernetesCurrentContextPortForwards } from '/@/stores/kubernetes-contexts-state';
-import { type UserForwardConfig } from '/@api/kubernetes-port-forward-model';
+import { type ForwardConfig } from '/@api/kubernetes-port-forward-model';
 
 import ListItemButtonIcon from '../ui/ListItemButtonIcon.svelte';
 
@@ -13,7 +13,7 @@ interface Props {
 }
 let { object }: Props = $props();
 
-let userConfigForward: UserForwardConfig | undefined = $derived(
+let userConfigForward: ForwardConfig | undefined = $derived(
   $kubernetesCurrentContextPortForwards.find(
     config =>
       config.kind === object.kind &&

--- a/packages/renderer/src/lib/kubernetes-port-forward/PortForwardNameColumn.spec.ts
+++ b/packages/renderer/src/lib/kubernetes-port-forward/PortForwardNameColumn.spec.ts
@@ -48,7 +48,6 @@ test('name should be visible', () => {
       name: 'dummy-pod-name',
       namespace: 'dummy-ns',
       kind: WorkloadKind.POD,
-      displayName: '',
       mapping: DUMMY_MAPPING,
     },
   });
@@ -74,7 +73,6 @@ test('click on name should redirect to pod page', async () => {
       name: 'dummy-pod-name',
       namespace: 'dummy-ns',
       kind: WorkloadKind.POD,
-      displayName: '',
       mapping: DUMMY_MAPPING,
     },
   });

--- a/packages/renderer/src/lib/kubernetes-port-forward/port-forward-row.ts
+++ b/packages/renderer/src/lib/kubernetes-port-forward/port-forward-row.ts
@@ -21,6 +21,5 @@ export interface PortForwardRow {
   name: string;
   namespace: string;
   kind: WorkloadKind;
-  displayName: string;
   mapping: PortMapping;
 }

--- a/packages/renderer/src/stores/kubernetes-contexts-state.ts
+++ b/packages/renderer/src/stores/kubernetes-contexts-state.ts
@@ -20,7 +20,7 @@ import type { CoreV1Event, KubernetesObject } from '@kubernetes/client-node';
 import { derived, type Readable, readable, writable } from 'svelte/store';
 
 import type { CheckingState, ContextGeneralState } from '/@api/kubernetes-contexts-states';
-import type { UserForwardConfig } from '/@api/kubernetes-port-forward-model';
+import type { ForwardConfig } from '/@api/kubernetes-port-forward-model';
 
 import { findMatchInLeaves } from './search-util';
 
@@ -312,7 +312,7 @@ export const kubernetesCurrentContextEvents = readable<CoreV1Event[]>([], set =>
 
 // Port Forwarding
 
-export const kubernetesCurrentContextPortForwards = readable<UserForwardConfig[]>([], set => {
+export const kubernetesCurrentContextPortForwards = readable<ForwardConfig[]>([], set => {
   window
     .getKubernetesPortForwards()
     .then(value => {
@@ -320,6 +320,6 @@ export const kubernetesCurrentContextPortForwards = readable<UserForwardConfig[]
     })
     .catch((err: unknown) => console.log('Error getting port forwarding initial value', err));
   window.events?.receive('kubernetes-port-forwards-update', (value: unknown) => {
-    set(value as UserForwardConfig[]);
+    set(value as ForwardConfig[]);
   });
 });

--- a/packages/renderer/src/stores/navigation/navigation-registry-kubernetes.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-kubernetes.svelte.spec.ts
@@ -22,7 +22,7 @@ import { beforeEach, expect, test, vi } from 'vitest';
 
 import KubeIcon from '/@/lib/images/KubeIcon.svelte';
 import { type ContextGeneralState, NO_CURRENT_CONTEXT_ERROR } from '/@api/kubernetes-contexts-states';
-import type { UserForwardConfig } from '/@api/kubernetes-port-forward-model';
+import type { ForwardConfig } from '/@api/kubernetes-port-forward-model';
 
 import * as kubeContextStore from '../kubernetes-contexts-state';
 import { createNavigationKubernetesGroup } from './navigation-registry-kubernetes.svelte';
@@ -61,7 +61,7 @@ test('createNavigationImageEntry with current context', async () => {
   vi.mocked(kubeContextStore).kubernetesCurrentContextConfigMaps = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextSecrets = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextPersistentVolumeClaims = readable<KubernetesObject[]>([]);
-  vi.mocked(kubeContextStore).kubernetesCurrentContextPortForwards = readable<UserForwardConfig[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextPortForwards = readable<ForwardConfig[]>([]);
 
   const entry = createNavigationKubernetesGroup();
 
@@ -87,7 +87,7 @@ test('createNavigationImageEntry without current context', async () => {
   vi.mocked(kubeContextStore).kubernetesCurrentContextConfigMaps = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextSecrets = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextPersistentVolumeClaims = readable<KubernetesObject[]>([]);
-  vi.mocked(kubeContextStore).kubernetesCurrentContextPortForwards = readable<UserForwardConfig[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextPortForwards = readable<ForwardConfig[]>([]);
 
   const entry = createNavigationKubernetesGroup();
 


### PR DESCRIPTION
### What does this PR do?

This PR remove the `UserForwardConfig` interface, which were used to add a `displayName` property. During the implementation of https://github.com/containers/podman-desktop/pull/9645 I discussed with @jeffmaury, and we decided to keep it without using it (time constraint with release). Then later we should remove it (https://github.com/containers/podman-desktop/issues/9637).

As the `UserForwardConfig` only contains the `displayName` property: removing it completely in favour of `ForwardConfig`.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Part of https://github.com/containers/podman-desktop/issues/9637

All steps available in https://github.com/containers/podman-desktop/issues/9637#issuecomment-2459684176

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
