### PR TITLE
fix(CliToolRegistry): notify on register install or update

### DIFF
--- a/packages/main/src/plugin/cli-tool-registry.spec.ts
+++ b/packages/main/src/plugin/cli-tool-registry.spec.ts
@@ -121,8 +121,14 @@ suite('cli module', () => {
         doUninstall: vi.fn(),
       };
       const newCliTool = cliToolRegistry.createCliTool(extensionInfo, options);
+      // should notify create after creating a tool
+      expect(apiSender.send).toHaveBeenNthCalledWith(1, 'cli-tool-create');
       cliToolRegistry.registerUpdate(newCliTool as CliToolImpl, updater);
+      // should notify change after registering an update
+      expect(apiSender.send).toHaveBeenNthCalledWith(2, 'cli-tool-change', newCliTool.id);
       cliToolRegistry.registerInstaller(newCliTool as CliToolImpl, installer);
+      // should notify change after registering an installer
+      expect(apiSender.send).toHaveBeenNthCalledWith(3, 'cli-tool-change', newCliTool.id);
       const infoList = cliToolRegistry.getCliToolInfos();
       expect(infoList.length).equals(1);
       expect(infoList[0]).toMatchObject({

--- a/packages/main/src/plugin/cli-tool-registry.ts
+++ b/packages/main/src/plugin/cli-tool-registry.ts
@@ -56,6 +56,7 @@ export class CliToolRegistry {
 
   registerUpdate(cliTool: CliToolImpl, updater: CliToolUpdate | CliToolSelectUpdate): Disposable {
     this.cliToolsUpdater.set(cliTool.id, updater);
+    this.apiSender.send('cli-tool-change', cliTool.id);
 
     return Disposable.create(() => {
       this.cliToolsUpdater.delete(cliTool.id);
@@ -65,6 +66,7 @@ export class CliToolRegistry {
 
   registerInstaller(cliTool: CliToolImpl, installer: CliToolInstaller): Disposable {
     this.cliToolsInstaller.set(cliTool.id, installer);
+    this.apiSender.send('cli-tool-change', cliTool.id);
 
     return Disposable.create(() => {
       this.cliToolsInstaller.delete(cliTool.id);


### PR DESCRIPTION
### What does this PR do?

Make the CliToolRegistry notify the frontend when a new update or installer is registered.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/9811
Required for https://github.com/containers/podman-desktop-extension-minikube/pull/201 

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
