### PR TITLE
fix: sort array of image names, move matches on top

### DIFF
--- a/packages/renderer/src/lib/ui/Typeahead.spec.ts
+++ b/packages/renderer/src/lib/ui/Typeahead.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 import '@testing-library/jest-dom/vitest';
 
-import { render, screen, within } from '@testing-library/svelte';
+import { render, screen, waitFor, within } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { tick } from 'svelte';
 import { expect, test } from 'vitest';
@@ -111,6 +111,32 @@ test('should list the result after the delay, and display spinner during loading
   within(list).getByText('aze01');
   within(list).getByText('aze02');
   within(list).getByText('aze03');
+});
+
+test('should list items started with search term on top', async () => {
+  const searchFunction = async (s: string) => {
+    await new Promise(resolve => setTimeout(resolve, 100));
+    return ['z1' + s, s + '01', 'z0', s + '02', 'z2', s + '03'];
+  };
+  render(Typeahead, {
+    initialFocus: true,
+    searchFunction,
+    delay: 10,
+  });
+
+  const input = screen.getByRole('textbox');
+
+  await userEvent.type(input, 'aze');
+
+  await waitFor(() => {
+    const list = screen.getByRole('row');
+    const items = within(list).getAllByRole('button');
+    expect(items.length).toBe(6);
+    expect(items[0].textContent).toBe('aze01');
+    expect(items[1].textContent).toBe('aze02');
+    expect(items[2].textContent).toBe('aze03');
+    expect(items[3].textContent).toBe('z0');
+  });
 });
 
 test('should navigate in list with keys', async () => {

--- a/packages/renderer/src/lib/ui/Typeahead.svelte
+++ b/packages/renderer/src/lib/ui/Typeahead.svelte
@@ -146,12 +146,9 @@ function processInput(): void {
       if (disabled) {
         return;
       }
-      items.splice(0, items.length);
-      items.push(
-        ...result
-          .toSorted((a: string, b: string) => a.localeCompare(b))
-          .toSorted((a: string, b: string) => (a.startsWith(value) && !b.startsWith(value) ? -1 : 1)),
-      );
+      items = result
+        .toSorted((a: string, b: string) => a.localeCompare(b))
+        .toSorted((a: string, b: string) => (a.startsWith(value) && !b.startsWith(value) ? -1 : 1));
       highlightIndex = -1;
       open();
     })

--- a/packages/renderer/src/lib/ui/Typeahead.svelte
+++ b/packages/renderer/src/lib/ui/Typeahead.svelte
@@ -146,7 +146,12 @@ function processInput(): void {
       if (disabled) {
         return;
       }
-      items = result;
+      items.splice(0, items.length);
+      items.push(
+        ...result
+          .toSorted((a: string, b: string) => a.localeCompare(b))
+          .toSorted((a: string, b: string) => (a.startsWith(value) && !b.startsWith(value) ? -1 : 1)),
+      );
       highlightIndex = -1;
       open();
     })

--- a/packages/renderer/src/lib/ui/Typeahead.svelte
+++ b/packages/renderer/src/lib/ui/Typeahead.svelte
@@ -146,9 +146,17 @@ function processInput(): void {
       if (disabled) {
         return;
       }
-      items = result
-        .toSorted((a: string, b: string) => a.localeCompare(b))
-        .toSorted((a: string, b: string) => (a.startsWith(value) && !b.startsWith(value) ? -1 : 1));
+      items = result.toSorted((a: string, b: string) => {
+        const aStartsWithValue = a.startsWith(value);
+        const bStartsWithValue = b.startsWith(value);
+        if ((aStartsWithValue && bStartsWithValue) || (!aStartsWithValue && !bStartsWithValue)) {
+          return a.localeCompare(b);
+        } else if (aStartsWithValue && !bStartsWithValue) {
+          return -1;
+        } else {
+          return 1;
+        }
+      });
       highlightIndex = -1;
       open();
     })

--- a/tests/playwright/src/specs/image-search.spec.ts
+++ b/tests/playwright/src/specs/image-search.spec.ts
@@ -62,8 +62,7 @@ test.describe('Image search verification @smoke', () => {
     playExpect(searchResults.length).toBe(4);
   });
 
-  // TODO: This test is failing because the search results are not sorted by relevance as per https://github.com/containers/podman-desktop/issues/8929
-  test.fail('First search result needs to be the most relevant', async ({ navigationBar }) => {
+  test('First search result needs to be the most relevant', async ({ navigationBar }) => {
     const imagesPage = await navigationBar.openImages();
     await playExpect(imagesPage.heading).toBeVisible();
 


### PR DESCRIPTION
### What does this PR do?

Sorts list of images after search and move item that starts with search term on top of the list

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->


https://github.com/user-attachments/assets/d3068c75-46ee-4c58-8b31-fc0e956a0abe


### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Fix #8929.

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
