### PR TITLE
chore: update extension badge text color and color name in the registry

### DIFF
--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -1458,7 +1458,7 @@ export class ColorRegistry {
       dark: colorPalette.sky[200],
       light: colorPalette.sky[200],
     });
-    this.registerColor(`${badge}builtin-extension-text`, {
+    this.registerColor(`${badge}text`, {
       dark: colorPalette.charcoal[800],
       light: colorPalette.charcoal[800],
     });

--- a/packages/renderer/src/lib/extensions/ExtensionBadge.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionBadge.svelte
@@ -13,7 +13,7 @@ export let extension: { type: 'dd' | 'pd'; removable: boolean };
     </Tooltip>
   {:else if !extension.removable}
     <Tooltip right tip="built-in Extension">
-      <Badge class="text-[8px] text-[var(--pd-badge-builtin-extension-text)]" color="bg-[var(--pd-badge-builtin-extension-bg)]" label="built-in Extension" />
+      <Badge class="text-[8px] text-[var(--pd-badge-text)]" color="bg-[var(--pd-badge-builtin-extension-bg)]" label="built-in Extension" />
     </Tooltip>
   {/if}
 </div>

--- a/packages/renderer/src/lib/ui/Badge.svelte
+++ b/packages/renderer/src/lib/ui/Badge.svelte
@@ -26,6 +26,6 @@ onMount(async () => {
 });
 </script>
 
-<div class="text-[var(--pd-card-bg)] text-xs me-2 px-1 py-0.5 rounded select-none {customClass} {$$props.class}" style={customStyle}>
+<div class="text-[var(--pd-badge-text)] text-xs me-2 px-1 py-0.5 rounded select-none {customClass} {$$props.class}" style={customStyle}>
   {label}
 </div>


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR updates the color of the text of the Badge component and builtin extension badge, and renames the color in the color registry to better match its usage

### Screenshot / video of UI
![Screenshot from 2024-11-11 18-27-37](https://github.com/user-attachments/assets/09f913a7-0591-44b3-8a03-b03c74a01a8a)


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Fixes https://github.com/podman-desktop/podman-desktop/issues/9772

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
