### PR TITLE
fix(k8s-port-forward): delete config if start fails

### DIFF
--- a/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
@@ -46,10 +46,10 @@ import type { FileSystemWatcher } from '@podman-desktop/api';
 import { beforeAll, beforeEach, describe, expect, type Mock, test, vi } from 'vitest';
 
 import type {
-  type KubernetesPortForwardService,
+  KubernetesPortForwardService,
   KubernetesPortForwardServiceProvider,
 } from '/@/plugin/kubernetes/kubernetes-port-forward-service.js';
-import type { ForwardConfig, type ForwardOptions, WorkloadKind } from '/@api/kubernetes-port-forward-model.js';
+import { type ForwardConfig, type ForwardOptions, WorkloadKind } from '/@api/kubernetes-port-forward-model.js';
 import type { V1Route } from '/@api/openshift-types.js';
 
 import type { ApiSenderType } from '../api.js';

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
@@ -21,6 +21,7 @@ import { homedir } from 'node:os';
 import { resolve } from 'node:path';
 import type { Readable, Writable } from 'node:stream';
 
+import * as clientNode from '@kubernetes/client-node';
 import {
   type AppsV1Api,
   BatchV1Api,
@@ -41,10 +42,14 @@ import {
   type V1Status,
   type Watch,
 } from '@kubernetes/client-node';
-import * as clientNode from '@kubernetes/client-node';
 import type { FileSystemWatcher } from '@podman-desktop/api';
 import { beforeAll, beforeEach, describe, expect, type Mock, test, vi } from 'vitest';
 
+import type {
+  type KubernetesPortForwardService,
+  KubernetesPortForwardServiceProvider,
+} from '/@/plugin/kubernetes/kubernetes-port-forward-service.js';
+import type { ForwardConfig, type ForwardOptions, WorkloadKind } from '/@api/kubernetes-port-forward-model.js';
 import type { V1Route } from '/@api/openshift-types.js';
 
 import type { ApiSenderType } from '../api.js';
@@ -264,6 +269,17 @@ const apiSender: ApiSenderType = {
   send: apiSenderSendMock,
   receive: vi.fn(),
 };
+
+const mocks = vi.hoisted(() => ({
+  getServiceMock: vi.fn(),
+}));
+
+vi.mock('/@/plugin/kubernetes/kubernetes-port-forward-service', () => ({
+  KubernetesPortForwardService: vi.fn(),
+  KubernetesPortForwardServiceProvider: vi.fn().mockReturnValue({
+    getService: mocks.getServiceMock,
+  } as unknown as KubernetesPortForwardServiceProvider),
+}));
 
 const execMock = vi.fn();
 beforeAll(() => {
@@ -2539,4 +2555,64 @@ test('test sync resources was called with no resourceVersion, uid, selfLink, or 
     undefined,
     'podman-desktop',
   );
+});
+
+describe('port forward', () => {
+  const serviceMock: KubernetesPortForwardService = {
+    createForward: vi.fn(),
+    startForward: vi.fn(),
+    deleteForward: vi.fn(),
+  } as unknown as KubernetesPortForwardService;
+
+  const DUMMY_FORWARD_OPTIONS: ForwardOptions = {
+    name: 'dummy-name',
+    namespace: 'dummy-ns',
+    kind: WorkloadKind.POD,
+    forward: {
+      localPort: 55_001,
+      remotePort: 80,
+    },
+  };
+
+  const DUMMY_FORWARD_CONFIG: ForwardConfig = {
+    ...DUMMY_FORWARD_OPTIONS,
+    id: 'dummy-id',
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mocks.getServiceMock.mockReturnValue(serviceMock);
+  });
+
+  test('expect forward to be returned', async () => {
+    vi.mocked(serviceMock.createForward).mockResolvedValue(DUMMY_FORWARD_CONFIG);
+
+    const client = createTestClient('default');
+
+    const result = await client.createPortForward(DUMMY_FORWARD_OPTIONS);
+    expect(result).toBe(DUMMY_FORWARD_CONFIG);
+
+    expect(serviceMock.createForward).toHaveBeenCalledWith(DUMMY_FORWARD_OPTIONS);
+    expect(serviceMock.startForward).toHaveBeenCalledWith(DUMMY_FORWARD_CONFIG);
+  });
+
+  test('expect forward to be deleted if start failed', async () => {
+    vi.mocked(serviceMock.createForward).mockResolvedValue(DUMMY_FORWARD_CONFIG);
+    vi.mocked(serviceMock.startForward).mockRejectedValue(new Error('host not reachable error'));
+
+    const client = createTestClient('default');
+    await expect(async () => {
+      await client.createPortForward({
+        name: 'dummy-name',
+        namespace: 'dummy-ns',
+        kind: WorkloadKind.POD,
+        forward: {
+          localPort: 55_001,
+          remotePort: 80,
+        },
+      });
+    }).rejects.toThrowError('host not reachable error');
+
+    expect(serviceMock.deleteForward).toHaveBeenCalledWith(DUMMY_FORWARD_CONFIG);
+  });
 });

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.ts
@@ -1768,8 +1768,13 @@ export class KubernetesClient {
   public async createPortForward(config: ForwardOptions): Promise<ForwardConfig> {
     const service = this.ensurePortForwardService();
     const newConfig = await service.createForward(config);
-    await service.startForward(newConfig);
-    return newConfig;
+    try {
+      await service.startForward(newConfig);
+      return newConfig;
+    } catch (err: unknown) {
+      await service.deleteForward(newConfig);
+      throw err;
+    }
   }
 
   public async deletePortForward(config: ForwardConfig): Promise<void> {


### PR DESCRIPTION
### What does this PR do?

Before we were creating the port forward even if an error was raised in the middle, this is because we are creating it in two phases. (creation, then starting).

If the start phase fail we should delete the port foward, as we are not able to show a failing state, but we handle the error, so we should only display the error

### Screenshot / video of UI

https://github.com/user-attachments/assets/bfbd6013-e5b0-454e-8f9c-8c8c30233c26

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/9640

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
