### PR TITLE
fix: flaky test waitForPodsDeletion

### DIFF
--- a/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
@@ -1832,7 +1832,7 @@ test('Should return false if the timeout is reached but pods still exist', async
   const selector = 'app=test-app';
   const timeout = 1000;
 
-  coreApiMock.listNamespacedPod = vi.fn().mockResolvedValueOnce({ items: [existingPodMock] });
+  coreApiMock.listNamespacedPod = vi.fn().mockResolvedValue({ items: [existingPodMock] });
 
   const result = await client.testWaitForPodsDeletion(coreApiMock, namespace, selector, timeout);
   expect(result).toBe(false);


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Fix flaky test waitForPodsDeletion

It could happen that the loop was called twice `while (Date.now() - startTime < timeout)`,
and the second time items will be undefined as `listNamespacedPod` was only mocked once.

Changing to mock listNamespacedPod as many times as it is called.


### What issues does this PR fix or reference?

Fixes #9367 

### How to test this PR?

- [ ] Tests are covering the bug fix or the new feature
