### PR TITLE
fix(ui): better handle errors on `KubePort` component

### DIFF
--- a/packages/renderer/src/lib/kube/details/KubePort.svelte
+++ b/packages/renderer/src/lib/kube/details/KubePort.svelte
@@ -59,11 +59,13 @@ async function removePortForward(): Promise<void> {
   if (!mapping) return;
   if (!forwardConfig) return;
   loading = true;
+  error = undefined;
 
   try {
     await window.deleteKubernetesPortForward(forwardConfig);
   } catch (err: unknown) {
     console.error(err);
+    error = String(err);
   } finally {
     loading = false;
   }


### PR DESCRIPTION
### What does this PR do?

Improve the error handling for the port forward actions (display delete errors if any, cleanup previous error when retrying)

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/9686

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
