### PR TITLE
fix: fixed crash on windows when updating to latest version

### DIFF
--- a/packages/main/src/plugin/updater.spec.ts
+++ b/packages/main/src/plugin/updater.spec.ts
@@ -48,6 +48,7 @@ vi.mock('electron', () => ({
 
 vi.mock('electron-updater', () => ({
   autoUpdater: {
+    setFeedURL: vi.fn(),
     downloadUpdate: vi.fn(),
     quitAndInstall: vi.fn(),
     checkForUpdates: vi.fn(),

--- a/packages/main/src/plugin/updater.ts
+++ b/packages/main/src/plugin/updater.ts
@@ -246,6 +246,12 @@ export class Updater {
         this.#downloadTask.progress = 0;
 
         try {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          autoUpdater.setFeedURL({
+            repo: 'podman-desktop',
+            owner: 'podman-desktop',
+            provider: 'github',
+          });
           await autoUpdater.downloadUpdate();
         } catch (error: unknown) {
           console.error('Update error: ', error);
@@ -335,6 +341,14 @@ export class Updater {
     // Update the 'version' entry in the status bar to show that no update is available
     this.defaultVersionEntry();
     this.apiSender.send('app-update-available', false);
+  }
+
+  /**
+   * Handler for checking-for-update event.
+   */
+  private onUpdateCheckingForUpdate(): void {
+    this.#updateInProgress = false;
+    this.#updateAlreadyDownloaded = false;
   }
 
   /**
@@ -442,6 +456,7 @@ export class Updater {
     autoUpdater.on('update-downloaded', this.onUpdateDownloaded.bind(this));
     autoUpdater.on('error', this.onUpdateError.bind(this));
     autoUpdater.on('download-progress', this.onUpdateDownloadProgress.bind(this));
+    autoUpdater.on('checking-for-update', this.onUpdateCheckingForUpdate.bind(this));
 
     try {
       this.checkForUpdates();


### PR DESCRIPTION
### What does this PR do?
Fixes crash of PD when updating to latest version on Windows

### What issues does this PR fix or reference?
Closes #9358 

### How to test this PR?
1. checkout to branch 
2. change verion in package.json from 1.15.0-next to 1.14.0 (to enable updating)
3. run `pnpm install` and `pnpm compile --win nsis` 
4. Install and run the PD using installer in dist folder
5. delete `~/AppData/Local/podman-desktop-updater/` folder -> in this folder is stored the installer 
6. Try to download and update to latest version from PD 

**PD may go to "not responding" state for a sec, but should not crash** 
Needs to be tested on Windows and Mac (sincne Mac is using same update process)