### PR TITLE
fix(k8s-port-forward): delete config if start fails

### DIFF
--- a/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
@@ -21,6 +21,7 @@ import { homedir } from 'node:os';
 import { resolve } from 'node:path';
 import type { Readable, Writable } from 'node:stream';
 
+import * as clientNode from '@kubernetes/client-node';
 import {
   type AppsV1Api,
   BatchV1Api,
@@ -41,10 +42,12 @@ import {
   type V1Status,
   type Watch,
 } from '@kubernetes/client-node';
-import * as clientNode from '@kubernetes/client-node';
 import type { FileSystemWatcher } from '@podman-desktop/api';
 import { beforeAll, beforeEach, describe, expect, type Mock, test, vi } from 'vitest';
 
+import type { KubernetesPortForwardService } from '/@/plugin/kubernetes/kubernetes-port-forward-service.js';
+import { KubernetesPortForwardServiceProvider } from '/@/plugin/kubernetes/kubernetes-port-forward-service.js';
+import { type ForwardConfig, type ForwardOptions, WorkloadKind } from '/@api/kubernetes-port-forward-model.js';
 import type { V1Route } from '/@api/openshift-types.js';
 
 import type { ApiSenderType } from '../api.js';
@@ -264,6 +267,18 @@ const apiSender: ApiSenderType = {
   send: apiSenderSendMock,
   receive: vi.fn(),
 };
+
+vi.mock('/@/plugin/kubernetes/kubernetes-port-forward-service', async () => {
+  const singletonGetServiceMock = vi.fn();
+  return {
+    KubernetesPortForwardService: vi.fn(),
+    KubernetesPortForwardServiceProvider: vi.fn().mockImplementation(() => {
+      return {
+        getService: singletonGetServiceMock,
+      };
+    }),
+  };
+});
 
 const execMock = vi.fn();
 beforeAll(() => {
@@ -2539,4 +2554,65 @@ test('test sync resources was called with no resourceVersion, uid, selfLink, or 
     undefined,
     'podman-desktop',
   );
+});
+
+describe('port forward', () => {
+  const serviceMock: KubernetesPortForwardService = {
+    createForward: vi.fn(),
+    startForward: vi.fn(),
+    deleteForward: vi.fn(),
+  } as unknown as KubernetesPortForwardService;
+
+  const DUMMY_FORWARD_OPTIONS: ForwardOptions = {
+    name: 'dummy-name',
+    namespace: 'dummy-ns',
+    kind: WorkloadKind.POD,
+    forward: {
+      localPort: 55_001,
+      remotePort: 80,
+    },
+  };
+
+  const DUMMY_FORWARD_CONFIG: ForwardConfig = {
+    ...DUMMY_FORWARD_OPTIONS,
+    id: 'dummy-id',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const providerInstance = new KubernetesPortForwardServiceProvider();
+    vi.mocked(providerInstance.getService).mockReturnValue(serviceMock);
+  });
+
+  test('expect forward to be returned', async () => {
+    vi.mocked(serviceMock.createForward).mockResolvedValue(DUMMY_FORWARD_CONFIG);
+
+    const client = createTestClient('default');
+
+    const result = await client.createPortForward(DUMMY_FORWARD_OPTIONS);
+    expect(result).toBe(DUMMY_FORWARD_CONFIG);
+
+    expect(serviceMock.createForward).toHaveBeenCalledWith(DUMMY_FORWARD_OPTIONS);
+    expect(serviceMock.startForward).toHaveBeenCalledWith(DUMMY_FORWARD_CONFIG);
+  });
+
+  test('expect forward to be deleted if start failed', async () => {
+    vi.mocked(serviceMock.createForward).mockResolvedValue(DUMMY_FORWARD_CONFIG);
+    vi.mocked(serviceMock.startForward).mockRejectedValue(new Error('host not reachable error'));
+
+    const client = createTestClient('default');
+    await expect(async () => {
+      await client.createPortForward({
+        name: 'dummy-name',
+        namespace: 'dummy-ns',
+        kind: WorkloadKind.POD,
+        forward: {
+          localPort: 55_001,
+          remotePort: 80,
+        },
+      });
+    }).rejects.toThrowError('host not reachable error');
+
+    expect(serviceMock.deleteForward).toHaveBeenCalledWith(DUMMY_FORWARD_CONFIG);
+  });
 });

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.ts
@@ -1768,8 +1768,13 @@ export class KubernetesClient {
   public async createPortForward(config: ForwardOptions): Promise<ForwardConfig> {
     const service = this.ensurePortForwardService();
     const newConfig = await service.createForward(config);
-    await service.startForward(newConfig);
-    return newConfig;
+    try {
+      await service.startForward(newConfig);
+      return newConfig;
+    } catch (err: unknown) {
+      await service.deleteForward(newConfig);
+      throw err;
+    }
   }
 
   public async deletePortForward(config: ForwardConfig): Promise<void> {

--- a/packages/renderer/src/lib/statusbar/TaskIndicator.spec.ts
+++ b/packages/renderer/src/lib/statusbar/TaskIndicator.spec.ts
@@ -98,3 +98,20 @@ test('multiple tasks running should display them', async () => {
   expect(status).toBeDefined();
   expect(status.textContent).toBe('2 tasks running');
 });
+
+test('task with defined progress value should display it', async () => {
+  tasksInfo.set([
+    {
+      name: 'Dummy Task',
+      state: 'running',
+      status: 'in-progress',
+      started: 0,
+      id: 'dummy-task',
+      progress: 50,
+    },
+  ]);
+
+  const { getByText } = render(TaskIndicator);
+  const span = getByText('50%');
+  expect(span).toBeDefined();
+});

--- a/packages/renderer/src/lib/statusbar/TaskIndicator.svelte
+++ b/packages/renderer/src/lib/statusbar/TaskIndicator.svelte
@@ -13,7 +13,7 @@ let title: string | undefined = $derived.by(() => {
 });
 
 let progress: number | undefined = $derived.by(() => {
-  if (runningTasks.length !== 0) return undefined;
+  if (runningTasks.length === 0) return undefined;
   return runningTasks[0].progress ?? 0;
 });
 
@@ -29,7 +29,7 @@ function toggleTaskManager(): void {
         <div class="flex items-center gap-x-2">
           <span role="status" class="max-w-32 text-ellipsis overflow-hidden whitespace-nowrap">{title}</span>
           {#if (progress ?? 0) >= 0}
-            <ProgressBar height="h-1" width="w-20" progress={progress} />
+            <ProgressBar class="items-center" height="h-1" width="w-20" progress={progress} />
           {/if}
         </div>
       </button>

--- a/packages/renderer/src/lib/task-manager/ProgressBar.spec.ts
+++ b/packages/renderer/src/lib/task-manager/ProgressBar.spec.ts
@@ -40,3 +40,16 @@ test('Expect that the progress bar is incremental', async () => {
   expect(progressBar).toHaveClass('progress-bar-incremental');
   expect(progressBar.classList.contains('progress-bar-indeterminate')).toBe(false);
 });
+
+test('Expect class to be propagated', async () => {
+  const { container } = render(ProgressBar, { progress: 5, class: 'dummy-class' });
+
+  expect(container.children[0]).toHaveClass('dummy-class');
+});
+
+test('Expect aria-label to be propagated', async () => {
+  const { getByLabelText } = render(ProgressBar, { progress: 5, 'aria-label': 'hello-world' });
+
+  const container = getByLabelText('hello-world');
+  expect(container).toBeDefined();
+});

--- a/packages/renderer/src/lib/task-manager/ProgressBar.svelte
+++ b/packages/renderer/src/lib/task-manager/ProgressBar.svelte
@@ -29,12 +29,18 @@
 </style>
 
 <script lang="ts">
-export let progress: number | undefined;
-export let width: string = 'w-36';
-export let height: string = 'h-4';
+import type { HTMLAttributes } from 'svelte/elements';
+
+interface Props extends HTMLAttributes<HTMLElement> {
+  progress?: number;
+  width?: string;
+  height?: string;
+}
+
+let { progress, width = 'w-36', height = 'h-4', class: className, ...restProps }: Props = $props();
 </script>
 
-<div class="flex flex-row">
+<div class="flex flex-row {className}" {...restProps} >
   <div class="{width} {height} rounded-full bg-[var(--pd-progressBar-bg)] progress-bar overflow-hidden">
     {#if progress !== undefined}
       <div


### PR DESCRIPTION
### What does this PR do?

re-opening https://github.com/podman-desktop/podman-desktop/pull/9874 after it has been reverted after merging it by accident.

This new PR contain the same code, with the addition of a fix included in https://github.com/axel7083/podman-desktop/pull/2

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/9640

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
