### PR TITLE
feat: add error visual indicator pull image input

### DIFF
--- a/packages/renderer/src/lib/image/PullImage.spec.ts
+++ b/packages/renderer/src/lib/image/PullImage.spec.ts
@@ -363,7 +363,7 @@ test('Expect latest tag warning is not displayed when the image has latest tag',
   expect(errorMesssage).toBeNull();
 });
 
-test('Expect isValidName to be truthy === error to be falsy', async () => {
+test('input component should not raise an error when the input is valid', async () => {
   setup();
   const pullImage = render(PullImage);
 
@@ -377,7 +377,7 @@ test('Expect isValidName to be truthy === error to be falsy', async () => {
   expect(parentInput).toHaveClass('hover:border-b-[var(--pd-input-field-hover-stroke)]');
 });
 
-test('Expect isValidName to be falsy === error to be truthy', async () => {
+test('input component should raise an error when the input is not valid', async () => {
   setup();
   const pullImage = render(PullImage);
 
@@ -391,7 +391,7 @@ test('Expect isValidName to be falsy === error to be truthy', async () => {
   expect(parentInput).not.toHaveClass('hover:border-b-[var(--pd-input-field-hover-stroke)]');
 });
 
-test('Expect isValidName to be falsy by error === error variable should be truthy', async () => {
+test('input component should raise an error when the input is not valid - error', async () => {
   setup();
   const pullImage = render(PullImage);
 

--- a/packages/renderer/src/lib/image/PullImage.spec.ts
+++ b/packages/renderer/src/lib/image/PullImage.spec.ts
@@ -362,3 +362,47 @@ test('Expect latest tag warning is not displayed when the image has latest tag',
   const errorMesssage = screen.queryByRole('alert', { name: 'Warning Message Content' });
   expect(errorMesssage).toBeNull();
 });
+
+test('Expect isValidName to be truthy === error to be falsy', async () => {
+  setup();
+  const pullImage = render(PullImage);
+
+  listImageTagsInRegistryMock.mockResolvedValue(['latest', 'other']);
+  await userEvent.keyboard('my-registry/image');
+
+  const cellOutsideInput = pullImage.getAllByRole('textbox');
+  const parentInput = cellOutsideInput[0].parentElement;
+  expect(parentInput).not.toHaveClass('border-b-[var(--pd-input-field-stroke-error)]');
+  expect(parentInput).not.toHaveClass('focus-within:border-[var(--pd-input-field-stroke-error)]');
+  expect(parentInput).toHaveClass('hover:border-b-[var(--pd-input-field-hover-stroke)]');
+});
+
+test('Expect isValidName to be falsy === error to be truthy', async () => {
+  setup();
+  const pullImage = render(PullImage);
+
+  listImageTagsInRegistryMock.mockResolvedValue({});
+  await userEvent.keyboard('my-registry/image');
+
+  const cellOutsideInput = pullImage.getAllByRole('textbox');
+  const parentInput = cellOutsideInput[0].parentElement;
+  expect(parentInput).toHaveClass('border-b-[var(--pd-input-field-stroke-error)]');
+  expect(parentInput).toHaveClass('focus-within:border-[var(--pd-input-field-stroke-error)]');
+  expect(parentInput).not.toHaveClass('hover:border-b-[var(--pd-input-field-hover-stroke)]');
+});
+
+test('Expect isValidName to be falsy by error === error variable should be truthy', async () => {
+  setup();
+  const pullImage = render(PullImage);
+
+  listImageTagsInRegistryMock.mockImplementation(() => {
+    throw Error('Error msg');
+  });
+  await userEvent.keyboard('my-registry/image');
+
+  const cellOutsideInput = pullImage.getAllByRole('textbox');
+  const parentInput = cellOutsideInput[0].parentElement;
+  expect(parentInput).toHaveClass('border-b-[var(--pd-input-field-stroke-error)]');
+  expect(parentInput).toHaveClass('focus-within:border-[var(--pd-input-field-stroke-error)]');
+  expect(parentInput).not.toHaveClass('hover:border-b-[var(--pd-input-field-hover-stroke)]');
+});

--- a/packages/renderer/src/lib/image/PullImage.spec.ts
+++ b/packages/renderer/src/lib/image/PullImage.spec.ts
@@ -35,6 +35,7 @@ import PullImage from './PullImage.svelte';
 const pullImageMock = vi.fn();
 const resolveShortnameImageMock = vi.fn();
 const listImageTagsInRegistryMock = vi.fn();
+const searchImageInRegistryMock = vi.fn();
 
 // fake the window.events object
 beforeAll(() => {
@@ -52,6 +53,7 @@ beforeAll(() => {
   (window as any).pullImage = pullImageMock;
   (window as any).resolveShortnameImage = resolveShortnameImageMock.mockResolvedValue(['docker.io/test1']);
   (window as any).listImageTagsInRegistry = listImageTagsInRegistryMock;
+  (window as any).searchImageInRegistry = searchImageInRegistryMock;
 
   Object.defineProperty(window, 'matchMedia', {
     value: () => {

--- a/packages/renderer/src/lib/image/PullImage.spec.ts
+++ b/packages/renderer/src/lib/image/PullImage.spec.ts
@@ -35,7 +35,6 @@ import PullImage from './PullImage.svelte';
 const pullImageMock = vi.fn();
 const resolveShortnameImageMock = vi.fn();
 const listImageTagsInRegistryMock = vi.fn();
-const searchImageInRegistryMock = vi.fn();
 
 // fake the window.events object
 beforeAll(() => {
@@ -53,7 +52,6 @@ beforeAll(() => {
   (window as any).pullImage = pullImageMock;
   (window as any).resolveShortnameImage = resolveShortnameImageMock.mockResolvedValue(['docker.io/test1']);
   (window as any).listImageTagsInRegistry = listImageTagsInRegistryMock;
-  (window as any).searchImageInRegistry = searchImageInRegistryMock;
 
   Object.defineProperty(window, 'matchMedia', {
     value: () => {

--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -28,6 +28,7 @@ let shortnameImages: string[] = [];
 let podmanFQN = '';
 let usePodmanFQN = false;
 let imageIsRecognized: boolean = true;
+let images: string[] = [];
 
 export let imageToPull: string | undefined = undefined;
 
@@ -205,6 +206,9 @@ async function searchImages(value: string): Promise<string[]> {
   result = searchResult.map(r => {
     return [options.registry, r.name].join('/');
   });
+
+  images = result;
+  await onResultChanged(value);
   return result;
 }
 
@@ -232,14 +236,13 @@ async function searchLatestTag(): Promise<void> {
 }
 
 async function onResultChanged(image: string): Promise<void> {
-  const items = await searchImages(image);
   // [] and '' => dont show error
-  if (!items && !image) {
+  if (!images && !image) {
     imageIsRecognized = true;
   } else {
     // e.g. "docker.io/fedora" is in list
     // or just "fedora" is not in list, but "fedora" is shortname
-    imageIsRecognized = items.includes(image) || (selectedProviderConnection?.type === 'podman' && Boolean(podmanFQN));
+    imageIsRecognized = images.includes(image) || (selectedProviderConnection?.type === 'podman' && Boolean(podmanFQN));
   }
 }
 </script>

--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -260,6 +260,7 @@ async function searchLatestTag(): Promise<void> {
           }}
           onEnter={pullImage}
           disabled={pullFinished || pullInProgress}
+          isShortName={selectedProviderConnection?.type === 'podman' && Boolean(podmanFQN)}
           required
           initialFocus />
         {#if selectedProviderConnection?.type === 'podman' && podmanFQN}

--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -210,7 +210,7 @@ async function searchImages(value: string): Promise<string[]> {
 
 let latestTagMessage: string | undefined = undefined;
 async function searchLatestTag(): Promise<void> {
-  if (imageNameIsInvalid || !imageToPull || imageToPull.includes(':')) {
+  if (imageNameIsInvalid || !imageToPull) {
     latestTagMessage = undefined;
     return;
   }
@@ -220,10 +220,16 @@ async function searchLatestTag(): Promise<void> {
       image = image.slice(DOCKER_PREFIX_WITH_SLASH.length);
     }
     const tags = await window.listImageTagsInRegistry({ image });
+    if (imageToPull.includes(':')) {
+      latestTagMessage = undefined;
+      checkIfTagExist(image, tags);
+      return;
+    }
     isValidName = Boolean(tags);
     const latestFound = tags.includes('latest');
     if (!latestFound) {
       latestTagMessage = '"latest" tag not found. You can search a tag by appending ":" to the image name';
+      isValidName = false;
     } else {
       latestTagMessage = undefined;
     }
@@ -231,6 +237,12 @@ async function searchLatestTag(): Promise<void> {
     isValidName = false;
     latestTagMessage = undefined;
   }
+}
+
+function checkIfTagExist(image: string, tags: string[]): void {
+  const tag = image.split(':')[1];
+
+  isValidName = tags.some(t => t === tag);
 }
 </script>
 

--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -27,7 +27,7 @@ let pullFinished = false;
 let shortnameImages: string[] = [];
 let podmanFQN = '';
 let usePodmanFQN = false;
-let isRecognized: boolean = true;
+let imageIsRecognized: boolean = true;
 
 export let imageToPull: string | undefined = undefined;
 
@@ -235,11 +235,11 @@ async function onResultChanged(image: string): Promise<void> {
   const items = await searchImages(image);
   // [] and '' => dont show error
   if (!items && !image) {
-    isRecognized = true;
+    imageIsRecognized = true;
   } else {
     // e.g. "docker.io/fedora" is in list
     // or just "fedora" is not in list, but "fedora" is shortname
-    isRecognized = items.includes(image) || (selectedProviderConnection?.type === 'podman' && Boolean(podmanFQN));
+    imageIsRecognized = items.includes(image) || (selectedProviderConnection?.type === 'podman' && Boolean(podmanFQN));
   }
 }
 </script>
@@ -274,7 +274,7 @@ async function onResultChanged(image: string): Promise<void> {
           }}
           onEnter={pullImage}
           disabled={pullFinished || pullInProgress}
-          {isRecognized}
+          error={!imageIsRecognized}
           required
           initialFocus />
         {#if selectedProviderConnection?.type === 'podman' && podmanFQN}

--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -27,8 +27,6 @@ let pullFinished = false;
 let shortnameImages: string[] = [];
 let podmanFQN = '';
 let usePodmanFQN = false;
-let imageIsRecognized: boolean = true;
-let images: string[] = [];
 
 export let imageToPull: string | undefined = undefined;
 
@@ -206,9 +204,6 @@ async function searchImages(value: string): Promise<string[]> {
   result = searchResult.map(r => {
     return [options.registry, r.name].join('/');
   });
-
-  images = result;
-  await onResultChanged(value);
   return result;
 }
 
@@ -232,17 +227,6 @@ async function searchLatestTag(): Promise<void> {
     }
   } catch {
     latestTagMessage = undefined;
-  }
-}
-
-async function onResultChanged(image: string): Promise<void> {
-  // [] and '' => dont show error
-  if (!images && !image) {
-    imageIsRecognized = true;
-  } else {
-    // e.g. "docker.io/fedora" is in list
-    // or just "fedora" is not in list, but "fedora" is shortname
-    imageIsRecognized = images.includes(image) || (selectedProviderConnection?.type === 'podman' && Boolean(podmanFQN));
   }
 }
 </script>
@@ -270,14 +254,12 @@ async function onResultChanged(image: string): Promise<void> {
           placeholder="Image name"
           searchFunction={searchImages}
           onChange={async (s: string) => {
-            await onResultChanged(s);
             validateImageName(s);
             await resolveShortname();
             await searchLatestTag();
           }}
           onEnter={pullImage}
           disabled={pullFinished || pullInProgress}
-          error={!imageIsRecognized}
           required
           initialFocus />
         {#if selectedProviderConnection?.type === 'podman' && podmanFQN}

--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -27,6 +27,7 @@ let pullFinished = false;
 let shortnameImages: string[] = [];
 let podmanFQN = '';
 let usePodmanFQN = false;
+let isValidName = true;
 
 export let imageToPull: string | undefined = undefined;
 
@@ -219,6 +220,7 @@ async function searchLatestTag(): Promise<void> {
       image = image.slice(DOCKER_PREFIX_WITH_SLASH.length);
     }
     const tags = await window.listImageTagsInRegistry({ image });
+    isValidName = Boolean(tags);
     const latestFound = tags.includes('latest');
     if (!latestFound) {
       latestTagMessage = '"latest" tag not found. You can search a tag by appending ":" to the image name';
@@ -226,6 +228,7 @@ async function searchLatestTag(): Promise<void> {
       latestTagMessage = undefined;
     }
   } catch {
+    isValidName = false;
     latestTagMessage = undefined;
   }
 }
@@ -260,6 +263,7 @@ async function searchLatestTag(): Promise<void> {
           }}
           onEnter={pullImage}
           disabled={pullFinished || pullInProgress}
+          error={!isValidName}
           required
           initialFocus />
         {#if selectedProviderConnection?.type === 'podman' && podmanFQN}

--- a/packages/renderer/src/lib/ui/Typeahead.svelte
+++ b/packages/renderer/src/lib/ui/Typeahead.svelte
@@ -45,6 +45,7 @@ function onInput(): void {
 }
 
 function onKeyDown(e: KeyboardEvent): void {
+  onChange(value);
   switch (e.key) {
     case 'ArrowDown':
       onDownKey(e);


### PR DESCRIPTION
### What does this PR do?
Adds border that will be red if the image specified does not exist

### Screenshot / video of UI

https://github.com/user-attachments/assets/d9fd79b3-2e29-44df-9f77-367006adfcbb

Follow up of https://github.com/podman-desktop/podman-desktop/pull/9782 - needs to be rebased 

### What issues does this PR fix or reference?
Closes #8926 
2/2 PRs
### How to test this PR?
Try to pull an image

- [x] Tests are covering the bug fix or the new feature
