### PR TITLE
fix: add light mode color to toast text

### DIFF
--- a/packages/renderer/src/lib/toast/ToastCustomUi.svelte
+++ b/packages/renderer/src/lib/toast/ToastCustomUi.svelte
@@ -43,7 +43,7 @@ const executeAction = async (): Promise<void> => {
       {/if}
     </div>
 
-    <div class="font-bold text-ellipsis line-clamp-1 overflow-hidden">
+    <div class="font-bold text-ellipsis line-clamp-1 overflow-hidden text-[var(--pd-modal-text)]">
       {taskInfo.name}
     </div>
 
@@ -61,7 +61,7 @@ const executeAction = async (): Promise<void> => {
         {taskInfo.error}
       </p>
     {:else}
-    <p class="flex-1 text-sm text-ellipsis overflow-hidden">
+    <p class="flex-1 text-sm text-ellipsis overflow-hidden text-[var(--pd-modal-text)]">
       {taskInfo.name}
     </p>
     {/if}


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Adds light-mode compatible color from the color registry to some of the toast text

### Screenshot / video of UI
![Screenshot from 2024-11-14 22-54-29](https://github.com/user-attachments/assets/eda8087f-2f42-4bd4-b781-6fe8ae77dd74)
![Screenshot from 2024-11-14 22-52-07](https://github.com/user-attachments/assets/a2f82899-3734-46ea-ba29-ef50e40a9658)


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Fixes https://github.com/podman-desktop/podman-desktop/issues/9779
Fixes https://github.com/podman-desktop/podman-desktop/issues/9869

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
Create a Kubernetes provider or start a Podman Machine (or anything else that creates a task with a visible toast) and assert that all the toast's text is visible in light mode

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
