### PR TITLE
fix(extensions/kind): adjust contour download script for new octokit version

### DIFF
--- a/extensions/kind/scripts/download.ts
+++ b/extensions/kind/scripts/download.ts
@@ -19,7 +19,7 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { Octokit } from 'octokit';
+import { Octokit } from '@octokit/rest';
 import type { OctokitOptions } from '@octokit/core/dist-types/types';
 
 const CONTOUR_ORG = 'projectcontour';


### PR DESCRIPTION
the current version of octokit requires to use ESM imports