### PR TITLE
chore: increase z-index order for tooltips

### DIFF
--- a/packages/ui/src/lib/tooltip/Tooltip.spec.ts
+++ b/packages/ui/src/lib/tooltip/Tooltip.spec.ts
@@ -39,3 +39,11 @@ test('tooltip is not empty string when tooltipHidden value false', async () => {
   await tick();
   expect(screen.queryByText('test 1')).toBeInTheDocument();
 });
+
+test('tooltip z order', async () => {
+  render(Tooltip, { tip: 'my tooltip' });
+
+  // get the tooltip
+  const tooltip = screen.getByText('my tooltip');
+  expect(tooltip.parentElement).toHaveClass('z-[60]');
+});

--- a/packages/ui/src/lib/tooltip/Tooltip.svelte
+++ b/packages/ui/src/lib/tooltip/Tooltip.svelte
@@ -68,7 +68,7 @@ export let left = false;
     <slot />
   </span>
   <div
-    class="whitespace-nowrap absolute tooltip opacity-0 inline-block transition-opacity duration-150 ease-in-out pointer-events-none text-sm z-[10]"
+    class="whitespace-nowrap absolute tooltip opacity-0 inline-block transition-opacity duration-150 ease-in-out pointer-events-none text-sm z-[60]"
     class:left={left}
     class:right={right}
     class:bottom={bottom}


### PR DESCRIPTION
### What does this PR do?
A lot of elements are using z-50 order, so pick an higher value

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/pull/9528#issuecomment-2482838257

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
