### PR TITLE
feat: port-forward on deployments

### DIFF
--- a/packages/renderer/src/lib/deployments/DeploymentDetailsSummary.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentDetailsSummary.svelte
@@ -25,7 +25,7 @@ basic information -->
   {#if deployment}
     <KubeObjectMetaArtifact artifact={deployment.metadata} />
     <KubeDeploymentStatusArtifact artifact={deployment.status} />
-    <KubeDeploymentArtifact artifact={deployment.spec} />
+    <KubeDeploymentArtifact deploymentName={deployment.metadata?.name} namespace={deployment.metadata?.namespace} artifact={deployment.spec} />
     <KubeEventsArtifact events={events} />
   {:else}
     <p class="text-[var(--pd-state-info)] font-medium">Loading ...</p>

--- a/packages/renderer/src/lib/kube/details/KubeContainerArtifact.svelte
+++ b/packages/renderer/src/lib/kube/details/KubeContainerArtifact.svelte
@@ -2,16 +2,17 @@
 import type { V1Container } from '@kubernetes/client-node';
 
 import Cell from '/@/lib/details/DetailsCell.svelte';
-import { WorkloadKind } from '/@api/kubernetes-port-forward-model';
+import type { WorkloadKind } from '/@api/kubernetes-port-forward-model';
 
 import KubePortsList from './KubePortsList.svelte';
 
 interface Props {
+  kind: WorkloadKind.POD | WorkloadKind.DEPLOYMENT;
   artifact?: V1Container;
-  podName?: string;
+  resourceName?: string;
   namespace?: string;
 }
-let { artifact, podName, namespace }: Props = $props();
+let { kind, artifact, resourceName, namespace }: Props = $props();
 </script>
 
 {#if artifact}
@@ -27,7 +28,7 @@ let { artifact, podName, namespace }: Props = $props();
     <Cell>Image Pull Policy</Cell>
     <Cell>{artifact.imagePullPolicy}</Cell>
   </tr>
-  <KubePortsList namespace={namespace} resourceName={podName} kind={WorkloadKind.POD} ports={artifact.ports?.map((port) => ({
+  <KubePortsList namespace={namespace} resourceName={resourceName} kind={kind} ports={artifact.ports?.map((port) => ({
     name: port.name,
     value: port.containerPort,
     protocol: port.protocol,

--- a/packages/renderer/src/lib/kube/details/KubeDeploymentArtifact.svelte
+++ b/packages/renderer/src/lib/kube/details/KubeDeploymentArtifact.svelte
@@ -2,9 +2,18 @@
 import type { V1DeploymentSpec } from '@kubernetes/client-node';
 
 import Cell from '/@/lib/details/DetailsCell.svelte';
+import Subtitle from '/@/lib/details/DetailsSubtitle.svelte';
 import Title from '/@/lib/details/DetailsTitle.svelte';
+import { WorkloadKind } from '/@api/kubernetes-port-forward-model';
 
-export let artifact: V1DeploymentSpec | undefined;
+import Container from './KubeContainerArtifact.svelte';
+
+interface Props {
+  artifact?: V1DeploymentSpec;
+  deploymentName?: string;
+  namespace?: string;
+}
+let { artifact, deploymentName, namespace }: Props = $props();
 </script>
 
 {#if artifact}
@@ -31,4 +40,16 @@ export let artifact: V1DeploymentSpec | undefined;
       <Cell>{artifact.strategy.type}</Cell>
     </tr>
   {/if}
+  {#if artifact.template.spec?.containers}
+    <tr>
+      <Title>Containers</Title>
+    </tr>
+    {#each artifact.template.spec?.containers as container}
+      <tr>
+        <Subtitle>{container.name}</Subtitle>
+      </tr>
+      <Container kind={WorkloadKind.DEPLOYMENT} namespace={namespace} resourceName={deploymentName} artifact={container} />
+    {/each}
+  {/if}
+
 {/if}

--- a/packages/renderer/src/lib/kube/details/KubePodSpecArtifact.svelte
+++ b/packages/renderer/src/lib/kube/details/KubePodSpecArtifact.svelte
@@ -4,6 +4,7 @@ import type { V1PodSpec } from '@kubernetes/client-node';
 import Cell from '/@/lib/details/DetailsCell.svelte';
 import Subtitle from '/@/lib/details/DetailsSubtitle.svelte';
 import Title from '/@/lib/details/DetailsTitle.svelte';
+import { WorkloadKind } from '/@api/kubernetes-port-forward-model';
 
 import Container from './KubeContainerArtifact.svelte';
 import Volume from './KubeVolumeArtifact.svelte';
@@ -45,7 +46,7 @@ let { artifact, podName, namespace }: Props = $props();
       <tr>
         <Subtitle>{container.name}</Subtitle>
       </tr>
-      <Container namespace={namespace} podName={podName} artifact={container} />
+      <Container kind={WorkloadKind.POD} namespace={namespace} resourceName={podName} artifact={container} />
     {/each}
   {/if}
 


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Port-forward on deployments (will port forward on the first pod managed by the deployment)

### Screenshot / video of UI

https://github.com/user-attachments/assets/b8db3ac9-9925-4aaa-9dea-637498fd8c27



### What issues does this PR fix or reference?

Fixes #9661 

### How to test this PR?

Start a deployment with one or several pods, go to the Deployment Summary and create the port forward.

If the deployment has several replicas, check that the port forward is done in a specific pod.


- [x] Tests are covering the bug fix or the new feature
