### PR TITLE
fix: rely on configurationValues if it has the key value

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
@@ -394,7 +394,7 @@ describe.each([
 
 test(`Check itemsAudit receive updated values`, async () => {
   const callback = mockCallback(async () => {});
-  const auditSpy = vi.spyOn(window as any, 'auditConnectionParameters').mockImplementation(() => ({ records: [] }));
+  const auditSpy = vi.spyOn(window as any, 'auditConnectionParameters').mockResolvedValue({ records: [] });
   vi.spyOn(window as any, 'openDialog').mockResolvedValue(['somefile']);
   // eslint-disable-next-line @typescript-eslint/await-thenable
   render(PreferencesConnectionCreationOrEditRendering, {

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
@@ -213,9 +213,19 @@ async function handleValidComponent() {
     return;
   }
   const formData = new FormData(formEl);
+
   const data: { [key: string]: FormDataEntryValue } = {};
   for (let field of formData) {
-    const [key, value] = field;
+    let [key, value] = field;
+    // formData does not always contain the latest data selected/entered by the user (see https://github.com/podman-desktop/podman-desktop/issues/9767)
+    // However, as this function "handleValidComponent" is called from inside the PreferencesRenderingItemFormat component just after the configurationValues is updated
+    // we can be sure to audit the correct data by retrieving the value from there by using the key from the formData
+    if (configurationValues.has(key)) {
+      const configValueByKey = configurationValues.get(key);
+      if (configValueByKey) {
+        value = configValueByKey.value.toString();
+      }
+    }
     data[key] = value;
   }
 


### PR DESCRIPTION
### What does this PR do?

This patch fixes an issue when retrieving the values from the "create new machine" form that are used when auditing and then update the UI in certain scenarios (like hyperv/wsl)

### Screenshot / video of UI

![hyperv_create_3](https://github.com/user-attachments/assets/a50fb809-33c9-4ee7-bf78-e717441b5dd6)

### What issues does this PR fix or reference?

it fixes #9767 

### How to test this PR?

you can follow the issue explained at https://github.com/podman-desktop/podman-desktop/issues/9767
1.  run desktop as admin
2. go to create new page
3. select wsl or hyperv and play with the sliders/create new machine

- [ ] Tests are covering the bug fix or the new feature
