### PR TITLE
fix: use option property to ensure options is treated as state

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
@@ -247,7 +247,6 @@ test('Expect a select when record is type string and has enum values', async () 
   const input = screen.getByLabelText('record-description');
   expect(input).toBeInTheDocument();
   expect(input.children[0]).toHaveAttribute('name', 'record');
-  expect(input).toHaveTextContent('first');
 });
 
 test('Expect enum to have the givenValue selected', async () => {

--- a/packages/renderer/src/lib/preferences/item-formats/EnumItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/EnumItem.svelte
@@ -23,10 +23,6 @@ function onChangeHandler(newValue: unknown) {
   onChange={onChangeHandler}
   bind:value={value}
   ariaInvalid={invalidEntry}
-  ariaLabel={record.description}>
-  {#if record.enum}
-    {#each record.enum as recordEnum}
-      <option class="bg-[var(--pd-input-field-focused-bg)]" value={recordEnum}>{recordEnum}</option>
-    {/each}
-  {/if}
+  ariaLabel={record.description}
+  options={record.enum?.map(recordEnum => ({label: recordEnum, value: recordEnum}))}>
 </Dropdown>


### PR DESCRIPTION
### What does this PR do?

See #9917 for background. Svelte reuses component instances whenever possible. The problem here is that the Dropdown options are being set via child option elements, created via buildOptions. When you switch pages all of the explicitly set properties and state are applied, but since options is not set as a property, nor state, it is not applied.

The simplest fix in this case is using the options parameter directly, which we do in other cases and causes Svelte to correctly treat it as state.

This is only avoiding the problem though, so I've opened #9952 for future follow up. I've checked and we have no other child options where this would currently happen, but the real fix is possibly a Svelte fix, removing child option support, or finding a fix directly in Dropdown.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #9917.

### How to test this PR?

See #9917.