### PR TITLE
chore: add Preview on GitHub functionality

### DIFF
--- a/packages/api/src/feedback.ts
+++ b/packages/api/src/feedback.ts
@@ -25,10 +25,10 @@ export interface FeedbackProperties {
   contact?: string;
 }
 
-export interface GitHubIssueProperties {
+export interface GitHubIssue {
   category: FeedbackCategory;
-  issueTitle: string;
-  issueDescription: string;
+  title: string;
+  description: string;
   includeSystemInfo?: boolean;
   includeExtensionInfo?: boolean;
 }

--- a/packages/main/src/plugin/feedback-handler.spec.ts
+++ b/packages/main/src/plugin/feedback-handler.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import { shell } from 'electron';
-import { expect, test, vi } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
 
 import type { GitHubIssueProperties } from '/@api/feedback.js';
 
@@ -29,15 +29,30 @@ vi.mock('electron', () => ({
   },
 }));
 
-const issueProperties: GitHubIssueProperties = {
-  category: 'bug',
-  issueTitle: 'PD is not working',
-  issueDescription: 'bug description',
-};
+beforeEach(() => {
+  vi.resetAllMocks();
+});
 
-const queryParams = 'template=bug_report.yml&title=PD+is+not+working&bug-description=bug+description';
+test('Expect openExternal to be called with queryParams and bug report template', async () => {
+  const issueProperties: GitHubIssueProperties = {
+    category: 'bug',
+    issueTitle: 'PD is not working',
+    issueDescription: 'bug description',
+  };
+  const queryParams = 'template=bug_report.yml&title=PD+is+not+working&bug-description=bug+description';
+  const feedbackHandler = new FeedbackHandler();
+  await feedbackHandler.openGitHubIssue(issueProperties);
+  expect(shell.openExternal).toBeCalledWith(`https://github.com/containers/podman-desktop/issues/new?${queryParams}`);
+});
 
-test('Expect openExternal to be called with queryParams', async () => {
+test('Expect openExternal to be called with queryParams and feature request template', async () => {
+  const issueProperties: GitHubIssueProperties = {
+    category: 'feature',
+    issueTitle: 'new feature',
+    issueDescription: 'feature description',
+  };
+  issueProperties.category = 'feature';
+  const queryParams = 'template=feature_request.yml&title=new+feature&solution=feature+description';
   const feedbackHandler = new FeedbackHandler();
   await feedbackHandler.openGitHubIssue(issueProperties);
   expect(shell.openExternal).toBeCalledWith(`https://github.com/containers/podman-desktop/issues/new?${queryParams}`);

--- a/packages/main/src/plugin/feedback-handler.spec.ts
+++ b/packages/main/src/plugin/feedback-handler.spec.ts
@@ -1,0 +1,46 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { shell } from 'electron';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { GitHubIssueProperties } from '/@api/feedback.js';
+
+import { FeedbackHandler } from './feedback-handler.js';
+
+beforeEach(() => {
+  vi.mock('electron', () => ({
+    shell: {
+      openExternal: vi.fn(),
+    },
+  }));
+});
+
+const issueProperties: GitHubIssueProperties = {
+  category: 'bug',
+  issueTitle: 'PD is not working',
+  issueDescription: 'bug description',
+};
+
+const queryParams = 'template=bug_report.yml&title=PD+is+not+working&bug-description=bug+description';
+
+test('Expect openExternal to be called with queryParams', async () => {
+  const feedbackHandler = new FeedbackHandler();
+  await feedbackHandler.openGitHubIssue(issueProperties);
+  expect(shell.openExternal).toBeCalledWith(`https://github.com/containers/podman-desktop/issues/new?${queryParams}`);
+});

--- a/packages/main/src/plugin/feedback-handler.spec.ts
+++ b/packages/main/src/plugin/feedback-handler.spec.ts
@@ -17,19 +17,17 @@
  ***********************************************************************/
 
 import { shell } from 'electron';
-import { beforeEach, expect, test, vi } from 'vitest';
+import { expect, test, vi } from 'vitest';
 
 import type { GitHubIssueProperties } from '/@api/feedback.js';
 
 import { FeedbackHandler } from './feedback-handler.js';
 
-beforeEach(() => {
-  vi.mock('electron', () => ({
-    shell: {
-      openExternal: vi.fn(),
-    },
-  }));
-});
+vi.mock('electron', () => ({
+  shell: {
+    openExternal: vi.fn(),
+  },
+}));
 
 const issueProperties: GitHubIssueProperties = {
   category: 'bug',

--- a/packages/main/src/plugin/feedback-handler.spec.ts
+++ b/packages/main/src/plugin/feedback-handler.spec.ts
@@ -19,7 +19,7 @@
 import { shell } from 'electron';
 import { beforeEach, expect, test, vi } from 'vitest';
 
-import type { GitHubIssueProperties } from '/@api/feedback.js';
+import type { GitHubIssue } from '/@api/feedback.js';
 
 import { FeedbackHandler } from './feedback-handler.js';
 
@@ -34,10 +34,10 @@ beforeEach(() => {
 });
 
 test('Expect openExternal to be called with queryParams and bug report template', async () => {
-  const issueProperties: GitHubIssueProperties = {
+  const issueProperties: GitHubIssue = {
     category: 'bug',
-    issueTitle: 'PD is not working',
-    issueDescription: 'bug description',
+    title: 'PD is not working',
+    description: 'bug description',
   };
   const queryParams = 'template=bug_report.yml&title=PD+is+not+working&bug-description=bug+description';
   const feedbackHandler = new FeedbackHandler();
@@ -46,10 +46,10 @@ test('Expect openExternal to be called with queryParams and bug report template'
 });
 
 test('Expect openExternal to be called with queryParams and feature request template', async () => {
-  const issueProperties: GitHubIssueProperties = {
+  const issueProperties: GitHubIssue = {
     category: 'feature',
-    issueTitle: 'new feature',
-    issueDescription: 'feature description',
+    title: 'new feature',
+    description: 'feature description',
   };
   issueProperties.category = 'feature';
   const queryParams = 'template=feature_request.yml&title=new+feature&solution=feature+description';

--- a/packages/main/src/plugin/feedback-handler.ts
+++ b/packages/main/src/plugin/feedback-handler.ts
@@ -18,27 +18,31 @@
 
 import { shell } from 'electron';
 
-import type { GitHubIssueProperties } from '/@api/feedback.js';
+import type { GitHubIssue } from '/@api/feedback.js';
 
 export class FeedbackHandler {
-  async openGitHubIssue(issueProperties: GitHubIssueProperties): Promise<void> {
-    let urlSearchParams = '';
-    if (issueProperties.category === 'bug') {
-      const params = {
-        template: 'bug_report.yml',
-        title: issueProperties.issueTitle,
-        'bug-description': issueProperties.issueDescription,
-      };
-      urlSearchParams = new URLSearchParams(params).toString();
-    } else if (issueProperties.category === 'feature') {
-      const params = {
-        template: 'feature_request.yml',
-        title: issueProperties.issueTitle,
-        solution: issueProperties.issueDescription,
-      };
-      urlSearchParams = new URLSearchParams(params).toString();
-    }
+  async openGitHubIssue(issueProperties: GitHubIssue): Promise<void> {
+    const urlSearchParams = new URLSearchParams(this.toQueryParameters(issueProperties)).toString();
     const link = `https://github.com/containers/podman-desktop/issues/new?${urlSearchParams}`;
     await shell.openExternal(link);
+  }
+
+  protected toQueryParameters(issue: GitHubIssue): Record<string, string> {
+    switch (issue.category) {
+      case 'feature':
+        return {
+          template: 'feature_request.yml',
+          title: issue.title,
+          solution: issue.description,
+        };
+      case 'bug':
+        return {
+          template: 'bug_report.yml',
+          title: issue.title,
+          'bug-description': issue.description,
+        };
+      default:
+        throw new Error(`unknown category ${issue.category}`);
+    }
   }
 }

--- a/packages/main/src/plugin/feedback-handler.ts
+++ b/packages/main/src/plugin/feedback-handler.ts
@@ -30,6 +30,13 @@ export class FeedbackHandler {
         'bug-description': issueProperties.issueDescription,
       };
       urlSearchParams = new URLSearchParams(params).toString();
+    } else if (issueProperties.category === 'feature') {
+      const params = {
+        template: 'feature_request.yml',
+        title: issueProperties.issueTitle,
+        solution: issueProperties.issueDescription,
+      };
+      urlSearchParams = new URLSearchParams(params).toString();
     }
     const link = `https://github.com/containers/podman-desktop/issues/new?${urlSearchParams}`;
     await shell.openExternal(link);

--- a/packages/main/src/plugin/feedback-handler.ts
+++ b/packages/main/src/plugin/feedback-handler.ts
@@ -16,19 +16,22 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-export type FeedbackCategory = 'developers' | 'feature' | 'bug';
+import { shell } from 'electron';
 
-export interface FeedbackProperties {
-  category: FeedbackCategory;
-  rating: number;
-  comment?: string;
-  contact?: string;
-}
+import type { GitHubIssueProperties } from '/@api/feedback.js';
 
-export interface GitHubIssueProperties {
-  category: FeedbackCategory;
-  issueTitle: string;
-  issueDescription: string;
-  includeSystemInfo?: boolean;
-  includeExtensionInfo?: boolean;
+export class FeedbackHandler {
+  async openGitHubIssue(issueProperties: GitHubIssueProperties): Promise<void> {
+    let urlSearchParams = '';
+    if (issueProperties.category === 'bug') {
+      const params = {
+        template: 'bug_report.yml',
+        title: issueProperties.issueTitle,
+        'bug-description': issueProperties.issueDescription,
+      };
+      urlSearchParams = new URLSearchParams(params).toString();
+    }
+    const link = `https://github.com/containers/podman-desktop/issues/new?${urlSearchParams}`;
+    await shell.openExternal(link);
+  }
 }

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -78,7 +78,7 @@ import type { ContainerStatsInfo } from '/@api/container-stats-info.js';
 import type { ContributionInfo } from '/@api/contribution-info.js';
 import type { DockerContextInfo, DockerSocketMappingStatusInfo } from '/@api/docker-compatibility-info.js';
 import type { ExtensionInfo } from '/@api/extension-info.js';
-import type { GitHubIssueProperties } from '/@api/feedback.js';
+import type { GitHubIssue } from '/@api/feedback.js';
 import type { HistoryInfo } from '/@api/history-info.js';
 import type { IconInfo } from '/@api/icon-info.js';
 import type { ImageCheckerInfo } from '/@api/image-checker-info.js';
@@ -2627,7 +2627,7 @@ export class PluginSystem {
       return telemetry.sendFeedback(feedbackProperties);
     });
 
-    this.ipcHandle('feedback:GitHubPreview', async (_listener, properties: GitHubIssueProperties): Promise<void> => {
+    this.ipcHandle('feedback:GitHubPreview', async (_listener, properties: GitHubIssue): Promise<void> => {
       return feedback.openGitHubIssue(properties);
     });
 

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -78,6 +78,7 @@ import type { ContainerStatsInfo } from '/@api/container-stats-info.js';
 import type { ContributionInfo } from '/@api/contribution-info.js';
 import type { DockerContextInfo, DockerSocketMappingStatusInfo } from '/@api/docker-compatibility-info.js';
 import type { ExtensionInfo } from '/@api/extension-info.js';
+import type { GitHubIssueProperties } from '/@api/feedback.js';
 import type { HistoryInfo } from '/@api/history-info.js';
 import type { IconInfo } from '/@api/icon-info.js';
 import type { ImageCheckerInfo } from '/@api/image-checker-info.js';
@@ -146,6 +147,7 @@ import type { CatalogExtension } from './extensions-catalog/extensions-catalog-a
 import { ExtensionsUpdater } from './extensions-updater/extensions-updater.js';
 import { Featured } from './featured/featured.js';
 import type { FeaturedExtension } from './featured/featured-api.js';
+import { FeedbackHandler } from './feedback-handler.js';
 import { FilesystemMonitoring } from './filesystem-monitoring.js';
 import { IconRegistry } from './icon-registry.js';
 import { ImageCheckerImpl } from './image-checker.js';
@@ -469,6 +471,8 @@ export class PluginSystem {
 
     const telemetry = new Telemetry(configurationRegistry);
     await telemetry.init();
+
+    const feedback = new FeedbackHandler();
 
     const exec = new Exec(proxy);
 
@@ -2621,6 +2625,10 @@ export class PluginSystem {
 
     this.ipcHandle('feedback:send', async (_listener, feedbackProperties: unknown): Promise<void> => {
       return telemetry.sendFeedback(feedbackProperties);
+    });
+
+    this.ipcHandle('feedback:GitHubPreview', async (_listener, properties: GitHubIssueProperties): Promise<void> => {
+      return feedback.openGitHubIssue(properties);
     });
 
     this.ipcHandle('cancellableTokenSource:create', async (): Promise<number> => {

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -58,7 +58,7 @@ import type { ContainerStatsInfo } from '/@api/container-stats-info';
 import type { ContributionInfo } from '/@api/contribution-info';
 import type { DockerContextInfo, DockerSocketMappingStatusInfo } from '/@api/docker-compatibility-info';
 import type { ExtensionInfo } from '/@api/extension-info';
-import type { FeedbackProperties } from '/@api/feedback';
+import type { FeedbackProperties, GitHubIssueProperties } from '/@api/feedback';
 import type { HistoryInfo } from '/@api/history-info';
 import type { IconInfo } from '/@api/icon-info';
 import type { ImageCheckerInfo } from '/@api/image-checker-info';
@@ -2186,6 +2186,10 @@ export function initExposure(): void {
 
   contextBridge.exposeInMainWorld('sendFeedback', async (feedback: FeedbackProperties): Promise<void> => {
     return ipcInvoke('feedback:send', feedback);
+  });
+
+  contextBridge.exposeInMainWorld('previewOnGitHub', async (feedback: GitHubIssueProperties): Promise<void> => {
+    return ipcInvoke('feedback:GitHubPreview', feedback);
   });
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -58,7 +58,7 @@ import type { ContainerStatsInfo } from '/@api/container-stats-info';
 import type { ContributionInfo } from '/@api/contribution-info';
 import type { DockerContextInfo, DockerSocketMappingStatusInfo } from '/@api/docker-compatibility-info';
 import type { ExtensionInfo } from '/@api/extension-info';
-import type { FeedbackProperties, GitHubIssueProperties } from '/@api/feedback';
+import type { FeedbackProperties, GitHubIssue } from '/@api/feedback';
 import type { HistoryInfo } from '/@api/history-info';
 import type { IconInfo } from '/@api/icon-info';
 import type { ImageCheckerInfo } from '/@api/image-checker-info';
@@ -2188,7 +2188,7 @@ export function initExposure(): void {
     return ipcInvoke('feedback:send', feedback);
   });
 
-  contextBridge.exposeInMainWorld('previewOnGitHub', async (feedback: GitHubIssueProperties): Promise<void> => {
+  contextBridge.exposeInMainWorld('previewOnGitHub', async (feedback: GitHubIssue): Promise<void> => {
     return ipcInvoke('feedback:GitHubPreview', feedback);
   });
 

--- a/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.spec.ts
@@ -23,7 +23,7 @@ import userEvent from '@testing-library/user-event';
 import { tick } from 'svelte';
 import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
-import type { GitHubIssueProperties } from '/@api/feedback';
+import type { GitHubIssue } from '/@api/feedback';
 
 import GitHubIssueFeedback from './GitHubIssueFeedback.svelte';
 
@@ -123,10 +123,10 @@ test('Expect to have different existing GitHub issues links for bug and feature 
 });
 
 test('Expect the right category to be included in previewOnGitHub call', async () => {
-  const issueProperties: GitHubIssueProperties = {
+  const issueProperties: GitHubIssue = {
     category: 'bug',
-    issueTitle: 'Bug title',
-    issueDescription: 'Bug description',
+    title: 'Bug title',
+    description: 'Bug description',
   };
   const renderObject = render(GitHubIssueFeedback, { category: 'bug' });
   const previewButton = screen.getByRole('button', { name: 'Preview on GitHub' });

--- a/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.spec.ts
@@ -23,11 +23,25 @@ import userEvent from '@testing-library/user-event';
 import { tick } from 'svelte';
 import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
+import type { GitHubIssueProperties } from '/@api/feedback';
+
 import GitHubIssueFeedback from './GitHubIssueFeedback.svelte';
 
+const openExternalMock = vi.fn();
+const previewOnGitHubMock = vi.fn();
+
 beforeAll(() => {
-  Object.defineProperty(window, 'openExternal', {
-    value: vi.fn(),
+  Object.defineProperty(global, 'window', {
+    value: {
+      openExternal: openExternalMock,
+      previewOnGitHub: previewOnGitHubMock,
+      navigator: {
+        clipboard: {
+          writeText: vi.fn(),
+        },
+      },
+    },
+    writable: true,
   });
 });
 
@@ -36,14 +50,15 @@ beforeEach(() => {
 });
 
 test('Expect feedback form to to be GitHub issue feedback form', async () => {
-  render(GitHubIssueFeedback, { category: 'bug' });
+  const renderObject = render(GitHubIssueFeedback, { category: 'bug' });
 
   expect(screen.getByText('Title')).toBeInTheDocument();
   expect(screen.getByText('Description')).toBeInTheDocument();
+  renderObject.unmount();
 });
 
 test('Expect Preview on GitHub button to be disabled if there is no title or description', async () => {
-  render(GitHubIssueFeedback, { category: 'bug' });
+  const renderObject = render(GitHubIssueFeedback, { category: 'bug' });
 
   expect(screen.getByRole('button', { name: 'Preview on GitHub' })).toBeDisabled();
 
@@ -57,10 +72,12 @@ test('Expect Preview on GitHub button to be disabled if there is no title or des
 
   await tick();
   expect(screen.getByRole('button', { name: 'Preview on GitHub' })).toBeEnabled();
+  renderObject.unmount();
 });
 
 test('Expect to have different placeholders for bug vs feaure', async () => {
-  const renderObject = render(GitHubIssueFeedback, { category: 'bug' });
+  let renderObject = render(GitHubIssueFeedback, { category: 'bug' });
+
   let issueTitle = screen.getByTestId('issueTitle');
   expect(issueTitle).toBeInTheDocument();
   expect(issueTitle).toHaveProperty('placeholder', 'Bug Report Title');
@@ -71,7 +88,7 @@ test('Expect to have different placeholders for bug vs feaure', async () => {
 
   renderObject.unmount();
 
-  render(GitHubIssueFeedback, { category: 'feature' });
+  renderObject = render(GitHubIssueFeedback, { category: 'feature' });
 
   issueTitle = screen.getByTestId('issueTitle');
   expect(issueTitle).toBeInTheDocument();
@@ -80,25 +97,50 @@ test('Expect to have different placeholders for bug vs feaure', async () => {
   issueDescription = screen.getByTestId('issueDescription');
   expect(issueDescription).toBeInTheDocument();
   expect(issueDescription).toHaveProperty('placeholder', 'Feature description');
+  renderObject.unmount();
 });
 
 test('Expect to have different existing GitHub issues links for bug and feature categories', async () => {
-  const renderObject = render(GitHubIssueFeedback, { category: 'bug' });
+  let renderObject = render(GitHubIssueFeedback, { category: 'bug' });
   let existingIssues = screen.getByLabelText('GitHub issues');
   expect(existingIssues).toBeInTheDocument();
 
   await userEvent.click(existingIssues);
-  expect(window.openExternal).toHaveBeenCalledWith(
+  expect(openExternalMock).toHaveBeenCalledWith(
     'https://github.com/podman-desktop/podman-desktop/issues?q=label%3A%22kind%2Fbug%20%F0%9F%90%9E%22',
   );
   renderObject.unmount();
 
-  render(GitHubIssueFeedback, { category: 'feature' });
+  renderObject = render(GitHubIssueFeedback, { category: 'feature' });
   existingIssues = screen.getByLabelText('GitHub issues');
   expect(existingIssues).toBeInTheDocument();
 
   await userEvent.click(existingIssues);
-  expect(window.openExternal).toHaveBeenCalledWith(
+  expect(openExternalMock).toHaveBeenCalledWith(
     'https://github.com/podman-desktop/podman-desktop/issues?q=label%3A%22kind%2Ffeature%20%F0%9F%92%A1%22',
   );
+  renderObject.unmount();
+});
+
+test('Expect the right category to be included in previewOnGitHub call', async () => {
+  const issueProperties: GitHubIssueProperties = {
+    category: 'bug',
+    issueTitle: 'Bug title',
+    issueDescription: 'Bug description',
+  };
+  const renderObject = render(GitHubIssueFeedback, { category: 'bug' });
+  const previewButton = screen.getByRole('button', { name: 'Preview on GitHub' });
+
+  const issueTitle = screen.getByTestId('issueTitle');
+  expect(issueTitle).toBeInTheDocument();
+  await userEvent.type(issueTitle, 'Bug title');
+
+  const issueDescription = screen.getByTestId('issueDescription');
+  expect(issueDescription).toBeInTheDocument();
+  await userEvent.type(issueDescription, 'Bug description');
+
+  await userEvent.click(previewButton);
+
+  expect(previewOnGitHubMock).toHaveBeenCalledWith(issueProperties);
+  renderObject.unmount();
 });

--- a/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.svelte
@@ -33,16 +33,17 @@ export let onCloseForm = () => {};
 
 async function openGitHubIssues(): Promise<void> {
   onCloseForm();
-<<<<<<< HEAD
   await window.openExternal(existingIssuesLink);
-=======
+}
+
+async function previewOnGitHub(): Promise<void> {
+  onCloseForm();
   const issueProperties: GitHubIssueProperties = {
-    category: 'bug',
+    category: category,
     issueTitle: issueTitle,
     issueDescription: issueDescription,
   };
   await window.previewOnGitHub(issueProperties);
->>>>>>> 7b1b0dc8 (chore: add Preview on GitHub functionality)
 }
 </script>
 
@@ -71,6 +72,6 @@ async function openGitHubIssues(): Promise<void> {
   </svelte:fragment>
   <svelte:fragment slot="buttons">
     <Button class="underline" type="link" aria-label="Cancel" on:click={() => onCloseForm()}>Cancel</Button>
-    <Button aria-label="Preview on GitHub" on:click={() => openGitHubIssues()} disabled={!issueTitle || !issueDescription}>Preview on GitHub</Button>
+    <Button aria-label="Preview on GitHub" on:click={previewOnGitHub} disabled={!issueTitle || !issueDescription}>Preview on GitHub</Button>
   </svelte:fragment>
 </FeedbackForm>

--- a/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.svelte
@@ -2,7 +2,7 @@
 import { Button, ErrorMessage, Link } from '@podman-desktop/ui-svelte';
 
 import FeedbackForm from '/@/lib/feedback/FeedbackForm.svelte';
-import type { FeedbackCategory } from '/@api/feedback';
+import type { FeedbackCategory, GitHubIssueProperties } from '/@api/feedback';
 
 export let category: FeedbackCategory = 'bug';
 let issueTitle = '';
@@ -33,7 +33,16 @@ export let onCloseForm = () => {};
 
 async function openGitHubIssues(): Promise<void> {
   onCloseForm();
+<<<<<<< HEAD
   await window.openExternal(existingIssuesLink);
+=======
+  const issueProperties: GitHubIssueProperties = {
+    category: 'bug',
+    issueTitle: issueTitle,
+    issueDescription: issueDescription,
+  };
+  await window.previewOnGitHub(issueProperties);
+>>>>>>> 7b1b0dc8 (chore: add Preview on GitHub functionality)
 }
 </script>
 

--- a/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.svelte
@@ -2,7 +2,7 @@
 import { Button, ErrorMessage, Link } from '@podman-desktop/ui-svelte';
 
 import FeedbackForm from '/@/lib/feedback/FeedbackForm.svelte';
-import type { FeedbackCategory, GitHubIssueProperties } from '/@api/feedback';
+import type { FeedbackCategory, GitHubIssue } from '/@api/feedback';
 
 export let category: FeedbackCategory = 'bug';
 let issueTitle = '';
@@ -37,13 +37,17 @@ async function openGitHubIssues(): Promise<void> {
 }
 
 async function previewOnGitHub(): Promise<void> {
-  onCloseForm();
-  const issueProperties: GitHubIssueProperties = {
+  const issueProperties: GitHubIssue = {
     category: category,
-    issueTitle: issueTitle,
-    issueDescription: issueDescription,
+    title: issueTitle,
+    description: issueDescription,
   };
-  await window.previewOnGitHub(issueProperties);
+  try {
+    await window.previewOnGitHub(issueProperties);
+    onCloseForm();
+  } catch (error: unknown) {
+    console.error('There was a problem with preview on GitHub', error);
+  }
 }
 </script>
 


### PR DESCRIPTION
### What does this PR do?
This PR adds the functionality to preview a GitHub bug report issue prefilled with some information from the bug feedback form in Podman Desktop.

(Waiting for https://github.com/podman-desktop/podman-desktop/issues/9583 to be approved and merged to update this PR)

### Screenshot / video of UI
[Screencast from 2024-11-20 13-34-10.webm](https://github.com/user-attachments/assets/ed2f6d4c-403d-4a91-8dda-4df65bc9dc63)

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
related to https://github.com/podman-desktop/podman-desktop/issues/9584
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
