### PR TITLE
chore: exclude one rule not working with eslint v9.15.0

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -236,6 +236,8 @@ export default [
       'etc/no-deprecated': 'off',
       // disable this rule as it's not compliant with eslint v9
       'etc/no-commented-out-code': 'off',
+      'sonarjs/no-unused-expressions': 'off',
+
       // disable as it's consuming too much time
       'etc/no-internal': 'off',
 


### PR DESCRIPTION
### What does this PR do?
sonarjs plugin is embedding its own version of the typescript-eslint parser and not relying on a dependency.
so sometimes upgrades are failing when the parser differs from the runtime objects.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

linter check should be ✅ 

- [ ] Tests are covering the bug fix or the new feature
