### PR TITLE
chore: k8s - show pending PVCs as stopped icon

### DIFF
--- a/packages/renderer/src/lib/pvc/pvc-utils.spec.ts
+++ b/packages/renderer/src/lib/pvc/pvc-utils.spec.ts
@@ -61,4 +61,30 @@ describe('PVC UI conversion', () => {
     expect(pvcUI.selected).toEqual(false);
     expect(pvcUI.size).toEqual('1Gi');
   });
+
+  test('if phase is Pending then status is STOPPED', async () => {
+    const fakePVC = {
+      metadata: {
+        name: 'pvc-1',
+        namespace: 'default',
+        creationTimestamp: '2021-06-07T18:00:00Z',
+      },
+      spec: {
+        storageClassName: 'standard',
+        accessModes: ['ReadWriteOnce'],
+        resources: {
+          requests: {
+            storage: '1Gi',
+          },
+        },
+      },
+      status: {
+        phase: 'Pending',
+      },
+    } as unknown as V1PersistentVolumeClaim;
+
+    const pvcUI = pvcUtils.getPVCUI(fakePVC);
+
+    expect(pvcUI.status).toEqual('STOPPED');
+  });
 });

--- a/packages/renderer/src/lib/pvc/pvc-utils.ts
+++ b/packages/renderer/src/lib/pvc/pvc-utils.ts
@@ -29,13 +29,14 @@ export class PVCUtils {
     // PVC's only have "Pending", "Bound" and "Lost" as phases.
     // However, we can also determine if it is in the middle of deleting by
     // checking if the phase is "Terminating" through checking if the object has deletionTimestamp.
+    //
+    // Note: If it is "Pending" it will be considered as "STOPPED" as it is not yet bound, this
+    // is similar to how we handle Deployment statuses.
     let status = 'STOPPED';
     if (pvc.metadata?.deletionTimestamp) {
       status = 'TERMINATING';
     } else if (pvc.status?.phase === 'Bound') {
       status = 'RUNNING';
-    } else if (pvc.status?.phase === 'Pending') {
-      status = 'STARTING';
     } else if (pvc.status?.phase === 'Lost') {
       status = 'DEGRADED';
     }

--- a/packages/renderer/src/lib/pvc/pvc-utils.ts
+++ b/packages/renderer/src/lib/pvc/pvc-utils.ts
@@ -30,15 +30,19 @@ export class PVCUtils {
     // However, we can also determine if it is in the middle of deleting by
     // checking if the phase is "Terminating" through checking if the object has deletionTimestamp.
     //
-    // Note: If it is "Pending" it will be considered as "STOPPED" as it is not yet bound, this
-    // is similar to how we handle Deployment statuses.
-    let status = 'STOPPED';
+    let status: string;
     if (pvc.metadata?.deletionTimestamp) {
       status = 'TERMINATING';
     } else if (pvc.status?.phase === 'Bound') {
       status = 'RUNNING';
     } else if (pvc.status?.phase === 'Lost') {
       status = 'DEGRADED';
+      // Note: If it is "Pending" it will be considered as "STOPPED" as it is not yet bound, this
+      // is similar to how we handle Deployment statuses.
+    } else if (pvc.status?.phase === 'Pending') {
+      status = 'STOPPED';
+    } else {
+      status = 'STOPPED';
     }
 
     return {


### PR DESCRIPTION
chore: k8s - show pending PVCs as stopped icon

### What does this PR do?

* Pending PVCs show up as "green" / "active", when instead it should show
as "Stopped" as they are not yet in the Bound phase.
* Based upon the similar interface to Deployments

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->
![Screenshot 2024-11-19 at 9 56 40 AM](https://github.com/user-attachments/assets/aca7551d-9453-4079-b9a3-f9538b4700ca)



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/podman-desktop/issues/9322

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Deploy a PVC that is purposely pending:

```yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: task-pv-claim
spec:
  storageClassName: manual
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 3Gi
```

See that it's status is "Stopped" in the UI.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
