### PR TITLE
chore: api change, add platform option to pullImage

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -3871,11 +3871,13 @@ declare module '@podman-desktop/api' {
      * @param containerProviderConnection the connection to the local engine to use for pulling the image
      * @param imageName the name of the image to pull
      * @param callback the function called when new logs are emitted during the pull operation
+     * @param platform the platform of the image to pull (optional, by default it will pull the same architecture as the host)
      */
     export function pullImage(
       containerProviderConnection: ContainerProviderConnection,
       imageName: string,
       callback: (event: PullEvent) => void,
+      platform?: string,
     ): Promise<void>;
 
     /**

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -1220,12 +1220,9 @@ test('pull unknown image fails with error 403', async () => {
   );
 });
 
-test('pulling an image with platform=linux/arm64 will add the platform to the pull options', async () => {
-  const getMatchingEngineFromConnectionSpy = vi.spyOn(containerRegistry, 'getMatchingEngineFromConnection');
-  //vi.spyOn(containerRegistry, 'pullImage').mockReturnValue(Promise.resolve());
-
+test('pulling an image with platform linux/arm64 will add platform to pull options', async () => {
+  // Mock the pulling and dockerode
   const pullMock = vi.fn();
-
   const fakeDockerode = {
     pull: pullMock,
     modem: {
@@ -1233,19 +1230,49 @@ test('pulling an image with platform=linux/arm64 will add the platform to the pu
     },
   } as unknown as Dockerode;
 
+  // This is important, if we do the standard mock of vi.fn(), it WILL get caught in a 5 second timeout
+  // so instead we "fake" the progress to be completed.
+  vi.spyOn(fakeDockerode.modem, 'followProgress').mockImplementation((_s, f, _p) => {
+    return f(null, []);
+  });
+
+  // Add the internal provider
+  containerRegistry.addInternalProvider('podman1', {
+    name: 'podman1',
+    id: 'podman1',
+    connection: {
+      type: 'podman',
+      endpoint: {
+        socketPath: '/podman1.socket',
+      },
+    },
+    api: fakeDockerode,
+    libpodApi: fakeDockerode,
+  } as unknown as InternalContainerProvider);
+
+  // Connection information & testing it
+  const getMatchingEngineFromConnectionSpy = vi.spyOn(containerRegistry, 'getMatchingEngineFromConnection');
   getMatchingEngineFromConnectionSpy.mockReturnValue(fakeDockerode);
+  const connection = containerRegistry.getFirstRunningPodmanContainerProvider();
+  expect(connection).toBeDefined();
+  const providerConnectionInfo: ProviderContainerConnectionInfo = {
+    name: 'podman1',
+    type: 'podman1',
+    endpoint: {
+      socketPath: '/podman1.socket',
+    },
+    status: 'started',
+  } as unknown as ProviderContainerConnectionInfo;
 
-  const containerConnectionInfo = {} as ProviderContainerConnectionInfo;
+  // Pull the image and check that we were able to
+  const engine = {
+    getImage: vi.fn().mockReturnValue({ push: vi.fn().mockResolvedValue({ on: vi.fn() }) }),
+  };
+  vi.spyOn(containerRegistry, 'getMatchingEngine').mockReturnValue(engine as unknown as Dockerode);
+  const result = await containerRegistry.pullImage(providerConnectionInfo, 'unknown-image', () => {}, 'linux/arm64');
+  expect(result).toBeUndefined();
 
-  pullMock.mockResolvedValue({ statusCode: 201 });
-
-  const callback = vi.fn();
-
-  // Expect pull image to pass
-  // we use .catch to avoid an unhandled promise rejection, we don't care about the result, we just
-  // want to check that the call was made with the correct platform
-  containerRegistry.pullImage(containerConnectionInfo, 'unknown-image', callback, 'linux/arm64').catch(() => {});
-
+  // Check that linux/arm64 was passed in
   expect(pullMock).toHaveBeenCalledWith('unknown-image', {
     abortSignal: undefined,
     authconfig: undefined,

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -1220,6 +1220,37 @@ test('pull unknown image fails with error 403', async () => {
   );
 });
 
+test('pulling an image with platform=linux/arm64 will add the platform to the pull options', async () => {
+  const getMatchingEngineFromConnectionSpy = vi.spyOn(containerRegistry, 'getMatchingEngineFromConnection');
+
+  const pullMock = vi.fn();
+
+  const fakeDockerode = {
+    pull: pullMock,
+    modem: {
+      followProgress: vi.fn(),
+    },
+  } as unknown as Dockerode;
+
+  getMatchingEngineFromConnectionSpy.mockReturnValue(fakeDockerode);
+
+  const containerConnectionInfo = {} as ProviderContainerConnectionInfo;
+
+  pullMock.mockResolvedValue({ statusCode: 201 });
+
+  const callback = vi.fn();
+
+  // Ignore no floating promises warning as we just care about the pullMock call, not the promise
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
+  containerRegistry.pullImage(containerConnectionInfo, 'unknown-image', callback, 'linux/arm64');
+
+  expect(pullMock).toHaveBeenCalledWith('unknown-image', {
+    abortSignal: undefined,
+    authconfig: undefined,
+    platform: 'linux/arm64',
+  });
+});
+
 test('pull unknown image fails with error 401', async () => {
   const getMatchingEngineFromConnectionSpy = vi.spyOn(containerRegistry, 'getMatchingEngineFromConnection');
 

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -1222,6 +1222,7 @@ test('pull unknown image fails with error 403', async () => {
 
 test('pulling an image with platform=linux/arm64 will add the platform to the pull options', async () => {
   const getMatchingEngineFromConnectionSpy = vi.spyOn(containerRegistry, 'getMatchingEngineFromConnection');
+  //vi.spyOn(containerRegistry, 'pullImage').mockReturnValue(Promise.resolve());
 
   const pullMock = vi.fn();
 
@@ -1240,9 +1241,10 @@ test('pulling an image with platform=linux/arm64 will add the platform to the pu
 
   const callback = vi.fn();
 
-  // Ignore no floating promises warning as we just care about the pullMock call, not the promise
-  // eslint-disable-next-line @typescript-eslint/no-floating-promises
-  containerRegistry.pullImage(containerConnectionInfo, 'unknown-image', callback, 'linux/arm64');
+  // Expect pull image to pass
+  // we use .catch to avoid an unhandled promise rejection, we don't care about the result, we just
+  // want to check that the call was made with the correct platform
+  containerRegistry.pullImage(containerConnectionInfo, 'unknown-image', callback, 'linux/arm64').catch(() => {});
 
   expect(pullMock).toHaveBeenCalledWith('unknown-image', {
     abortSignal: undefined,

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -1127,6 +1127,7 @@ export class ContainerProviderRegistry {
     providerContainerConnectionInfo: ProviderContainerConnectionInfo | containerDesktopAPI.ContainerProviderConnection,
     imageName: string,
     callback: (event: PullEvent) => void,
+    platform?: string,
     abortController?: AbortController,
   ): Promise<void> {
     let telemetryOptions = {};
@@ -1135,6 +1136,7 @@ export class ContainerProviderRegistry {
       const matchingEngine = this.getMatchingEngineFromConnection(providerContainerConnectionInfo);
       const pullStream = await matchingEngine.pull(imageName, {
         authconfig,
+        platform,
         abortSignal: abortController?.signal,
       });
       let resolve: () => void;

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -1144,8 +1144,9 @@ export class ExtensionLoader {
         providerContainerConnection: containerDesktopAPI.ContainerProviderConnection,
         imageName: string,
         callback: (event: containerDesktopAPI.PullEvent) => void,
+        platform?: string,
       ): Promise<void> {
-        return containerProviderRegistry.pullImage(providerContainerConnection, imageName, callback);
+        return containerProviderRegistry.pullImage(providerContainerConnection, imageName, callback, platform);
       },
       tagImage(engineId: string, imageId: string, repo: string, tag: string | undefined): Promise<void> {
         return containerProviderRegistry.tagImage(engineId, imageId, repo, tag);

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1082,10 +1082,16 @@ export class PluginSystem {
         providerContainerConnectionInfo: ProviderContainerConnectionInfo,
         imageName: string,
         callbackId: number,
+        platform?: string,
       ): Promise<void> => {
-        return containerProviderRegistry.pullImage(providerContainerConnectionInfo, imageName, (event: PullEvent) => {
-          this.getWebContentsSender().send('container-provider-registry:pullImage-onData', callbackId, event);
-        });
+        return containerProviderRegistry.pullImage(
+          providerContainerConnectionInfo,
+          imageName,
+          (event: PullEvent) => {
+            this.getWebContentsSender().send('container-provider-registry:pullImage-onData', callbackId, event);
+          },
+          platform,
+        );
       },
     );
     this.ipcHandle(

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -398,6 +398,7 @@ export function initExposure(): void {
       providerContainerConnectionInfo: ProviderContainerConnectionInfo,
       imageName: string,
       callback: (event: PullEvent) => void,
+      platform?: string,
     ): Promise<void> => {
       onDataCallbacksPullImageId++;
       onDataCallbacksPullImage.set(onDataCallbacksPullImageId, callback);
@@ -406,6 +407,7 @@ export function initExposure(): void {
         providerContainerConnectionInfo,
         imageName,
         onDataCallbacksPullImageId,
+        platform,
       );
     },
   );


### PR DESCRIPTION
chore: api change, add platform option to pullImage

### What does this PR do?

* Adds option to use `platform` for pulling images
* Incorporates to pullImage API where you simply specify platform:
  `linux/arm64`, etc.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/podman-desktop/issues/9387

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

1. Change this line:

   https://github.com/cdrage/podman-desktop/blob/fa8cf9f4ac636829483b4c23393dd5d6ee4f89ed/packages/renderer/src/lib/image/PullImage.svelte#L132-L133
   to: `await window.pullImage(selectedProviderConnection,
   imageToPull.trim(), callback, 'linux/arm64');`
2. Pull an image that has a different architecture than your host
   (example, arm64). Good example is `https://quay.io/podman/hello`
3. See that the image is pulled successfully.
4. Inspect the image within PD and see it is arm64.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
