### PR TITLE
chore: update hardcoded colors to use color registry in CustomPick, Image, Preferences, task-manager, and move provider colors to ts file

### DIFF
--- a/packages/renderer/src/lib/dialogs/CustomPick.svelte
+++ b/packages/renderer/src/lib/dialogs/CustomPick.svelte
@@ -130,12 +130,15 @@ function dragMe(node: any) {
 {#if display}
   <!-- Create overlay-->
   <div
-    class="fixed top-0 left-0 right-0 bottom-0 bg-black pt-8 pb-3 bg-opacity-60 bg-blend-multiply h-full grid z-50 overflow-y-auto">
+    class="fixed top-0 left-0 right-0 bottom-0 pt-8 pb-3 h-full grid z-50 overflow-y-auto">
     <div
-      class="flex flex-col place-self-center w-[650px] rounded-xl bg-charcoal-800 shadow-xl shadow-black"
+      class="fixed top-0 left-0 w-full h-full bg-[var(--pd-modal-fade)] bg-blend-multiply opacity-60 z-40">
+    </div>
+    <div
+      class="flex flex-col place-self-center w-[650px] rounded-xl bg-[var(--pd-card-bg)] shadow-xl shadow-black z-50"
       class:w-[650px]={colsPerRow === 2}
       class:w-[800px]={colsPerRow === 3}>
-      <div class="flex flex-col items-center justify-between pl-4 pr-3 py-3 space-x-2 text-gray-400">
+      <div class="flex flex-col items-center justify-between pl-4 pr-3 py-3 space-x-2 text-[var(--pd-content-card-text)]">
         {#if icon}
           <div class="mb-2">
             {#if typeof icon === 'string'}
@@ -173,23 +176,23 @@ function dragMe(node: any) {
                   on:mousedown={e => handleSelection(e, innerItem)}>
                   {#if innerItem.selected}
                     <div class="relative">
-                      <div class="absolute right-0 m-3 text-xl text-purple-500">
+                      <div class="absolute right-0 m-3 text-xl text-[var(--pd-invert-content-info-icon)]">
                         <Fa icon={faCircleCheck} />
                       </div>
                     </div>
                   {/if}
 
                   <div
-                    class="px-4 pt-4 pb-2 bg-charcoal-500 group-hover:bg-purple-800 hover:bg-purple-800 group-hover:border-purple-500 hover:border-purple-500 rounded-t-md group-[.is-selected]:bg-purple-800 border-t-2 border-x-2 border-transparent"
+                    class="px-4 pt-4 pb-2 bg-[var(--pd-invert-content-card-bg)] group-hover:bg-[var(--pd-modal-dropdown-highlight)] hover:bg-[var(--pd-modal-dropdown-highlight)] group-hover:border-[var(--pd-tab-highlight)] hover:border-[var(--pd-tab-highlight)] rounded-t-md group-[.is-selected]:bg-[var(--pd-modal-dropdown-highlight)] border-t-2 border-x-2 border-transparent"
                     class:border-b-2={usePopperForDetails ||
                       itemSectionHiddenStatus.get((i / colsPerRow) * colsPerRow + j)}
                     class:rounded-b-md={usePopperForDetails ||
                       itemSectionHiddenStatus.get((i / colsPerRow) * colsPerRow + j)}
-                    class:bg-purple-800={innerItem.selected}>
+                    class:bg-[var(--pd-modal-dropdown-highlight)]={innerItem.selected}>
                     <div class="flex flex-row mb-1 gap-x-1">
                       <span class="text-md font-bold">{innerItem.title}</span>
                       {#if innerItem.description}
-                        <span class="text-xs text-gray-700">{innerItem.description}</span>
+                        <span class="text-xs text-[var(--pd-content-text)]">{innerItem.description}</span>
                       {/if}
                     </div>
 
@@ -230,7 +233,7 @@ function dragMe(node: any) {
                         class:left-[90px]={usePopperForDetails}
                         class:z-10={usePopperForDetails}
                         class:border-2={usePopperForDetails}
-                        class:border-purple-500={usePopperForDetails}
+                        class:border-[var(--pd-tab-highlight)]={usePopperForDetails}
                         class:w-[300px]={usePopperForDetails && colsPerRow === 2}
                         class:w-[250px]={usePopperForDetails && colsPerRow === 3}
                         use:dragMe>
@@ -242,20 +245,20 @@ function dragMe(node: any) {
                               </button>
                             </div>
                           </div>
-                          <div class="flex justify-center py-2 font-bold rounded-t-md bg-charcoal-800">
+                          <div class="flex justify-center py-2 font-bold rounded-t-md bg-[var(--pd-card-bg)]">
                             {innerItem.title}
                           </div>
                         {/if}
 
                         {#each innerItem.sections as section, i}
                           <div
-                            class="flex justify-center py-2 text-xs font-bold group-[.is-selected]:bg-purple-600 group-hover:bg-purple-600 border-x-2 border-transparent group-hover:border-purple-500
-                    bg-charcoal-300">
+                            class="flex justify-center py-2 text-xs font-bold group-[.is-selected]:bg-[var(--pd-tab-highlight)] group-hover:bg-[var(--pd-tab-highlight)] border-x-2 border-transparent group-hover:border-[var(--pd-tab-highlight)]
+                    bg-[var(--pd-label-bg)]">
                             {section.title}
                           </div>
                           {#if section.content}
                             <div
-                              class="bg-charcoal-500 group-hover:bg-purple-800 group-[.is-selected]:bg-purple-800 px-4 py-2 flex flex-col text-xs items-center border-x-2 border-transparent group-hover:border-purple-500"
+                              class="bg-[var(--pd-invert-content-card-bg)] group-hover:bg-[var(--pd-modal-dropdown-highlight)] group-[.is-selected]:bg-[var(--pd-modal-dropdown-highlight)] px-4 py-2 flex flex-col text-xs items-center border-x-2 border-transparent group-hover:border-[var(--pd-tab-highlight)]"
                               class:rounded-b-md={usePopperForDetails &&
                                 !section.markDownContent &&
                                 i === innerItem.sections.length - 1}>
@@ -264,7 +267,7 @@ function dragMe(node: any) {
                           {/if}
                           {#if section.markDownContent}
                             <div
-                              class="bg-charcoal-500 group-hover:bg-purple-800 group-[.is-selected]:bg-purple-800 px-4 py-2 flex flex-col text-xs border-x-2 border-transparent group-hover:border-purple-500"
+                              class="bg-[var(--pd-invert-content-card-bg)] group-hover:bg-[var(--pd-modal-dropdown-highlight)] group-[.is-selected]:bg-[var(--pd-modal-dropdown-highlight)] px-4 py-2 flex flex-col text-xs border-x-2 border-transparent group-hover:border-[var(--pd-tab-highlight)]"
                               class:rounded-b-md={usePopperForDetails && i === innerItem.sections.length - 1}>
                               <Markdown markdown={section.markDownContent} />
                             </div>
@@ -272,7 +275,7 @@ function dragMe(node: any) {
                         {/each}
                         {#if !usePopperForDetails && innerItem.sections.length > 0 && !itemSectionHiddenStatus.get((i / colsPerRow) * colsPerRow + j)}
                           <div
-                            class="p-4 bg-charcoal-500 group-hover:bg-purple-800 group-[.is-selected]:bg-purple-800 rounded-b-md text-xs flex justify-center border-x-2 border-b-2 border-transparent group-hover:border-purple-500">
+                            class="p-4 bg-[var(--pd-invert-content-card-bg)] group-hover:bg-[var(--pd-modal-dropdown-highlight)] group-[.is-selected]:bg-[var(--pd-modal-dropdown-highlight)] rounded-b-md text-xs flex justify-center border-x-2 border-b-2 border-transparent group-hover:border-[var(--pd-tab-highlight)]">
                             <Button
                               type="link"
                               aria-label="Less detail"

--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -650,7 +650,7 @@ const envDialogOptions: OpenDialogOptions = {
         <i class="fas fa-play fa-2x" aria-hidden="true"></i>
       </svelte:fragment>
       <div slot="content" class="space-y-2">
-        <div class="flex flex-row px-2 border-b border-charcoal-400">
+        <div class="flex flex-row px-2 border-b border-[var(--pd-content-divider)]">
           <Tab title="Basic" selected={isTabSelected($router.path, 'basic')} url={getTabUrl($router.path, 'basic')} />
           <Tab
             title="Advanced"
@@ -1125,7 +1125,7 @@ const envDialogOptions: OpenDialogOptions = {
           </Route>
         </div>
 
-        <div class="pt-2 border-zinc-600 border-t-2"></div>
+        <div class="pt-2 border-[var(--pd-content-divider)] border-t-2"></div>
         <Button
           on:click={() => startContainer()}
           class="w-full"

--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
@@ -240,7 +240,7 @@ async function removeExistingRegistry(registry: containerDesktopAPI.Registry) {
 
   <div class="container bg-[var(--pd-invert-content-card-bg)] rounded-md p-3">
     <!-- Registries table start -->
-    <div class="w-full border-t border-b border-gray-900" role="table" aria-label="Registries">
+    <div class="w-full border-t border-b border-[var(--pd-content-text)]" role="table" aria-label="Registries">
       <div
         class="flex w-full space-x-2 text-sm font-semibold text-[var(--pd-table-header-text)]"
         role="rowgroup"
@@ -254,7 +254,7 @@ async function removeExistingRegistry(registry: containerDesktopAPI.Registry) {
       {#each $registriesInfos as registry}
         <!-- containerDesktopAPI.Registry row start -->
         <div
-          class="flex flex-col w-full border-t border-gray-900 text-[var(--pd-invert-content-card-text)]"
+          class="flex flex-col w-full border-t border-[var(--pd-content-text)] text-[var(--pd-invert-content-card-text)]"
           role="row"
           aria-label={registry.name ? registry.name : registry.serverUrl}>
           <div class="flex flex-row items-center pt-4 pb-3 space-x-2">
@@ -381,7 +381,7 @@ async function removeExistingRegistry(registry: containerDesktopAPI.Registry) {
       {#each $registriesSuggestedInfos as registry, i (registry)}
         <!-- Add new registry form start -->
         <div
-          class="flex flex-col w-full border-t border-gray-900 text-[var(--pd-invert-content-card-text)]"
+          class="flex flex-col w-full border-t border-[var(--pd-content-text)] text-[var(--pd-invert-content-card-text)]"
           role="row"
           aria-label={registry.name ? registry.name : registry.url}>
           <div class="flex flex-row items-center pt-4 pb-3 space-x-2">

--- a/packages/renderer/src/lib/task-manager/LegacyTaskManager.svelte
+++ b/packages/renderer/src/lib/task-manager/LegacyTaskManager.svelte
@@ -58,11 +58,6 @@ window.events?.receive('toggle-legacy-task-manager', () => {
           <TaskIcon size="15" />
           <div class="text-xs uppercase ml-2">tasks</div>
           <div class="flex-1"></div>
-          <!--
-          <div title="Toggle Do Not Disturb Mode" class="cursor-pointer p-1">
-            <BellSlashIcon size="15" />
-          </div>
-          -->
           <button
             on:click={() => hide()}
             title="Hide (Escape)"

--- a/packages/renderer/src/lib/task-manager/LegacyTaskManager.svelte
+++ b/packages/renderer/src/lib/task-manager/LegacyTaskManager.svelte
@@ -59,7 +59,7 @@ window.events?.receive('toggle-legacy-task-manager', () => {
           <div class="text-xs uppercase ml-2">tasks</div>
           <div class="flex-1"></div>
           <!--
-          <div title="Toggle Do Not Disturb Mode" class="cursor-pointer hover:bg-charcoal-600 p-1">
+          <div title="Toggle Do Not Disturb Mode" class="cursor-pointer p-1">
             <BellSlashIcon size="15" />
           </div>
           -->

--- a/packages/renderer/src/lib/ui/ProviderInfoCircle.svelte
+++ b/packages/renderer/src/lib/ui/ProviderInfoCircle.svelte
@@ -3,12 +3,6 @@ import { providerColors } from './ProviderInfoCircle';
 
 let { type }: { type: 'kubernetes' | 'podman' | 'docker' | undefined } = $props();
 let color = $derived(providerColors[type ?? 'unknown']);
-
-// Each provider has a colour associated to it within tailwind, this is a map of those colours.
-// bg-purple-600 = podman
-// bg-sky-300    = docker
-// bg-sky-600    = kubernetes
-// bg-gray-900   = unknown
 </script>
 
 <div aria-label="Provider info circle" class="w-2 h-2 {color} rounded-full"></div>

--- a/packages/renderer/src/lib/ui/ProviderInfoCircle.svelte
+++ b/packages/renderer/src/lib/ui/ProviderInfoCircle.svelte
@@ -1,27 +1,14 @@
 <script lang="ts">
+import { providerColors } from './ProviderInfoCircle';
+
 let { type }: { type: 'kubernetes' | 'podman' | 'docker' | undefined } = $props();
-let color = $state('');
+let color = $derived(providerColors[type ?? 'unknown']);
 
 // Each provider has a colour associated to it within tailwind, this is a map of those colours.
 // bg-purple-600 = podman
 // bg-sky-300    = docker
 // bg-sky-600    = kubernetes
 // bg-gray-900   = unknown
-$effect(() => {
-  switch (type) {
-    case 'podman':
-      color = 'bg-purple-600';
-      break;
-    case 'docker':
-      color = 'bg-sky-400';
-      break;
-    case 'kubernetes':
-      color = 'bg-sky-600';
-      break;
-    default:
-      color = 'bg-gray-900';
-  }
-});
 </script>
 
 <div aria-label="Provider info circle" class="w-2 h-2 {color} rounded-full"></div>

--- a/packages/renderer/src/lib/ui/ProviderInfoCircle.ts
+++ b/packages/renderer/src/lib/ui/ProviderInfoCircle.ts
@@ -15,6 +15,11 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
+// Each provider has a colour associated to it within tailwind, this is a map of those colours.
+// bg-purple-600 = podman
+// bg-sky-300    = docker
+// bg-sky-600    = kubernetes
+// bg-gray-900   = unknown
 
 export const providerColors: Record<string, string> = {
   podman: 'bg-purple-600',

--- a/packages/renderer/src/lib/ui/ProviderInfoCircle.ts
+++ b/packages/renderer/src/lib/ui/ProviderInfoCircle.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2024 Red Hat, Inc.
+ * Copyright (C) 2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-// Each provider has a colour associated to it within tailwind, this is a map of those colours.
-// bg-purple-600 = podman
-// bg-sky-300    = docker
-// bg-sky-600    = kubernetes
-// bg-gray-900   = unknown
 
 export const providerColors: Record<string, string> = {
   podman: 'bg-purple-600',

--- a/packages/renderer/src/lib/ui/ProviderInfoCircle.ts
+++ b/packages/renderer/src/lib/ui/ProviderInfoCircle.ts
@@ -1,0 +1,24 @@
+/**********************************************************************
+ * Copyright (C) 2023-2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export const providerColors: Record<string, string> = {
+  podman: 'bg-purple-600',
+  docker: 'bg-sky-400',
+  kubernetes: 'bg-sky-600',
+  unknown: 'bg-gray-900',
+};


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR updates `CustomPick`, images, preferences, andtask-manager to use the color registry instead of hardcoded colors (with a small change to the faded background of CustomPick to include background opacity without affecting the other components )
It also includes moving the hardcoded provider colors to a separate .ts file as to not have any hardcoded colors is .svelte files

### Screenshot / video of UI
CustomPick after:
![Screenshot from 2024-11-19 17-25-40](https://github.com/user-attachments/assets/107e40e9-f5f9-471f-aa22-a1bc748032a9)
![Screenshot from 2024-11-19 17-25-28](https://github.com/user-attachments/assets/6289f715-e05d-495c-9763-469aba479d3a)


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/9080

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
