### PR TITLE
fix(flatpak): mimetype scheme

### DIFF
--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -186,6 +186,7 @@ const config = {
     category: 'Development',
     icon: './buildResources/icon-512x512.png',
     target: ['flatpak', 'tar.gz'],
+    mimeTypes: ['x-scheme-handler/podman-desktop'],
   },
   mac: {
     artifactName: `podman-desktop${artifactNameSuffix}-\${version}-\${arch}.\${ext}`,

--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -111,10 +111,19 @@ export const handleOpenUrl = (url: string): void => {
 };
 
 // do not use _args as it may contain additional arguments
-app.on('second-instance', (_event, _args, _workingDirectory, additionalData: unknown) => {
-  // if we are on Windows, we need to handle the protocol
-  if ((isWindows() || isLinux()) && additionalData && (additionalData as AdditionalData).argv) {
+app.on('second-instance', (_event, commandLine, _workingDirectory, additionalData: unknown) => {
+  /**
+   * Windows directly provide the extra argument in the additionalData.argv
+   */
+  if (isWindows() && additionalData && (additionalData as AdditionalData).argv) {
     handleAdditionalProtocolLauncherArgs((additionalData as AdditionalData).argv);
+  }
+
+  /**
+   * Linux provide an empty additionalData, so we use the commandLine
+   */
+  if (isLinux()) {
+    handleAdditionalProtocolLauncherArgs(commandLine);
   }
 
   restoreWindow().catch((error: unknown) => {

--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -37,7 +37,7 @@ import { StartupInstall } from './system/startup-install.js';
 import { WindowHandler } from './system/window/window-handler.js';
 import { AnimatedTray } from './tray-animate-icon.js';
 import { TrayMenu } from './tray-menu.js';
-import { isMac, isWindows, stoppedExtensions } from './util.js';
+import { isLinux, isMac, isWindows, stoppedExtensions } from './util.js';
 
 let extensionLoader: ExtensionLoader | undefined;
 
@@ -75,7 +75,7 @@ export function sanitizeProtocolForExtension(url: string): string {
 export const handleAdditionalProtocolLauncherArgs = (args: ReadonlyArray<string>): void => {
   // On Windows protocol handler will call the app with '<url>' args
   // on macOS it's done with 'open-url' event
-  if (isWindows()) {
+  if (isWindows() || isLinux()) {
     // now search if we have 'open-url' in the list of args and give it to the handler
     for (const arg of args) {
       const analyzedArg = sanitizeProtocolForExtension(arg);
@@ -113,7 +113,7 @@ export const handleOpenUrl = (url: string): void => {
 // do not use _args as it may contain additional arguments
 app.on('second-instance', (_event, _args, _workingDirectory, additionalData: unknown) => {
   // if we are on Windows, we need to handle the protocol
-  if (isWindows() && additionalData && (additionalData as AdditionalData).argv) {
+  if ((isWindows() || isLinux()) && additionalData && (additionalData as AdditionalData).argv) {
     handleAdditionalProtocolLauncherArgs((additionalData as AdditionalData).argv);
   }
 


### PR DESCRIPTION
### What does this PR do?

On linux when you install podman-desktop with flatpak the links in the browser do not works, as we only support windows and MacOS.

This PR add the support of linux.

#### References

- https://www.electronjs.org/docs/latest/api/app#event-second-instance

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/9807

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

> :information_source: testing `packages/main/src/index.ts` is **very** complicated. Since some listeners are registered on file import, we cannot use a `vi.mock()` for the `app.on` since all the calls history will be cleaned by `vi.resetAllMocks()`. 
> Instead I decided to add a `constants.appListeners` which store all the `app.on` calls. So tests can access them. If someone has a better solution I am open to a working and tested version.

**Testing manually**

On a Linux machine (fedora 4x).

1. checkout branch
2. pnpm compile:current
3. assert compile without error
4. in the explorer, open `podman-desktop/dist` folder
5. assert `podman-desktop-1.15.0-next.flatpak` exists
6. install it (double click) open the software 
7. install local
8. assert installed
9. Open the browser and type `podman-desktop:extension/podman-desktop.layers-explorer` in the url section
10. assert podman desktop open to the layers explorer page
