### PR TITLE
feat: introduce an hidden option kubernetes.statesExperimental

### DIFF
--- a/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
@@ -20,7 +20,7 @@ import type { KubeConfig, KubernetesObject } from '@kubernetes/client-node';
 
 import type { ContextGeneralState, ResourceName } from '/@api/kubernetes-contexts-states.js';
 
-export class ContextsManagerV2 {
+export class ContextsManagerExperimental {
   async update(_kubeconfig: KubeConfig): Promise<void> {}
 
   getContextsGeneralState(): Map<string, ContextGeneralState> {

--- a/packages/main/src/plugin/kubernetes/contexts-manager-v2.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager-v2.ts
@@ -1,0 +1,51 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubeConfig, KubernetesObject } from '@kubernetes/client-node';
+
+import type { ContextGeneralState, ResourceName } from '/@api/kubernetes-contexts-states.js';
+
+export class ContextsManagerV2 {
+  async update(_kubeconfig: KubeConfig): Promise<void> {}
+
+  getContextsGeneralState(): Map<string, ContextGeneralState> {
+    return new Map<string, ContextGeneralState>();
+  }
+
+  getCurrentContextGeneralState(): ContextGeneralState {
+    return {
+      reachable: false,
+      resources: {
+        pods: 0,
+        deployments: 0,
+      },
+    };
+  }
+
+  registerGetCurrentContextResources(_resourceName: ResourceName): KubernetesObject[] {
+    return [];
+  }
+
+  unregisterGetCurrentContextResources(_resourceName: ResourceName): KubernetesObject[] {
+    return [];
+  }
+
+  dispose(): void {}
+
+  async refreshContextState(_contextName: string): Promise<void> {}
+}

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.ts
@@ -82,7 +82,7 @@ import type { FilesystemMonitoring } from '../filesystem-monitoring.js';
 import type { Telemetry } from '../telemetry/telemetry.js';
 import { Uri } from '../types/uri.js';
 import { ContextsManager } from './contexts-manager.js';
-import { ContextsManagerV2 } from './contexts-manager-v2.js';
+import { ContextsManagerExperimental } from './contexts-manager-experimental.js';
 import { BufferedStreamWriter, ResizableTerminalWriter, StringLineReader } from './kubernetes-exec-transmitter.js';
 
 interface ContextsManagerInterface {
@@ -228,7 +228,7 @@ export class KubernetesClient {
           format: 'file',
           readonly: false,
         },
-        ['kubernetes.statesV2']: {
+        ['kubernetes.statesExperimental']: {
           description: 'Use new version of Kubernetes states',
           type: 'boolean',
           default: false,
@@ -253,9 +253,9 @@ export class KubernetesClient {
       }
     }
 
-    const statesV2 = kubernetesConfiguration.get<boolean>('statesV2');
-    if (statesV2) {
-      this.contextsState = new ContextsManagerV2();
+    const statesExperimental = kubernetesConfiguration.get<boolean>('statesExperimental');
+    if (statesExperimental) {
+      this.contextsState = new ContextsManagerExperimental();
     }
 
     // Update the property on change


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Introduce an hidden option kubernetes.statesExperimental

As the epic #9818 will introduce many changes in the way the states of the contexts are managed, I propose to introduce an hidden preference `kubernetes.statesExperimental` (false by default) 
to work on this epic without removing the current way the states are managed.



### Screenshot / video of UI


### What issues does this PR fix or reference?

Part of #9818

### How to test this PR?

To test the new version, set this preference in `~/.local/share/containers/podman-desktop/configuration/settings.json`:

```
  "kubernetes.statesExperimental": true
```

For now, the new version does nothing. The state of the context is always `UNKNOWN` in Preferences > Kubernetes, and there are no Kubernetes resources in Nodes / Deployments / ...

- [ ] Tests are covering the bug fix or the new feature
