### PR TITLE
fix(ui): round display progress value

### DIFF
--- a/packages/renderer/src/lib/task-manager/ProgressBar.spec.ts
+++ b/packages/renderer/src/lib/task-manager/ProgressBar.spec.ts
@@ -53,3 +53,10 @@ test('Expect aria-label to be propagated', async () => {
   const container = getByLabelText('hello-world');
   expect(container).toBeDefined();
 });
+
+test('Expect progress to be rounded', async () => {
+  const { getByText } = render(ProgressBar, { progress: 5 / 3, 'aria-label': 'hello-world' });
+
+  const progress = getByText('2%');
+  expect(progress).toBeDefined();
+});

--- a/packages/renderer/src/lib/task-manager/ProgressBar.svelte
+++ b/packages/renderer/src/lib/task-manager/ProgressBar.svelte
@@ -53,6 +53,6 @@ let { progress, width = 'w-36', height = 'h-4', class: className, ...restProps }
     {/if}
   </div>
   {#if progress !== undefined}
-    <div class="ml-2 text-xs">{progress}%</div>
+    <div class="ml-2 text-xs">{Math.round(progress)}%</div>
   {/if}
 </div>


### PR DESCRIPTION
### What does this PR do?

Update the `Progress` svelte component to round the display value of progress.

### Screenshot / video of UI

![image](https://github.com/user-attachments/assets/37587efe-7980-46d5-bd5c-681269f2af88)

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/9949

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

**Manually testing**

1. add to an extension activate the following
```ts
window.withProgress(
      { location: ProgressLocation.TASK_WIDGET, title: `Example` },
      async progress => {
        progress.report({ increment: 5/8 });

        return new Promise((resolve) => {
          setTimeout(resolve, 60_000);
        })
      },
    );
```
2. start podman desktop
3. assert status bar progress is at 1% and not 0.650

