### PR TITLE
refactor: replace router goto containers by handle navigation

### DIFF
--- a/packages/api/src/navigation-page.ts
+++ b/packages/api/src/navigation-page.ts
@@ -24,6 +24,7 @@ export enum NavigationPage {
   CONTAINER_LOGS = 'container-logs',
   CONTAINER_INSPECT = 'container-inspect',
   CONTAINER_TERMINAL = 'container-terminal',
+  CONTAINER_TTY = 'container-tty',
   CONTAINER_KUBE = 'container-kube',
   IMAGES = 'images',
   IMAGE_BUILD = 'image-build',

--- a/packages/api/src/navigation-request.ts
+++ b/packages/api/src/navigation-request.ts
@@ -25,6 +25,7 @@ export interface NavigationParameters {
   [NavigationPage.CONTAINER]: { id: string };
   [NavigationPage.CONTAINER_EXPORT]: { id: string };
   [NavigationPage.CONTAINER_LOGS]: { id: string };
+  [NavigationPage.CONTAINER_TTY]: { id: string };
   [NavigationPage.CONTAINER_INSPECT]: { id: string };
   [NavigationPage.CONTAINER_TERMINAL]: { id: string };
   [NavigationPage.CONTAINER_KUBE]: { id: string };

--- a/packages/renderer/src/lib/compose/ComposeDetailsSummary.svelte
+++ b/packages/renderer/src/lib/compose/ComposeDetailsSummary.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 import { Link } from '@podman-desktop/ui-svelte';
-import { router } from 'tinro';
+
+import { handleNavigation } from '/@/navigation';
+import { NavigationPage } from '/@api/navigation-page';
 
 import DetailsCell from '../details/DetailsCell.svelte';
 import DetailsTable from '../details/DetailsTable.svelte';
@@ -10,7 +12,12 @@ import type { ComposeInfoUI } from './ComposeInfoUI';
 export let compose: ComposeInfoUI;
 
 function openContainer(containerID: string) {
-  router.goto(`/containers/${containerID}/logs`);
+  handleNavigation({
+    page: NavigationPage.CONTAINER_LOGS,
+    parameters: {
+      id: containerID,
+    },
+  });
 }
 </script>
 

--- a/packages/renderer/src/lib/container/ContainerColumnNameContainer.svelte
+++ b/packages/renderer/src/lib/container/ContainerColumnNameContainer.svelte
@@ -1,12 +1,18 @@
 <script lang="ts">
-import { router } from 'tinro';
+import { handleNavigation } from '/@/navigation';
+import { NavigationPage } from '/@api/navigation-page';
 
 import type { ContainerInfoUI } from './ContainerInfoUI';
 
 export let object: ContainerInfoUI;
 
 function openContainerDetails(container: ContainerInfoUI): void {
-  router.goto(`/containers/${container.id}/`);
+  handleNavigation({
+    page: NavigationPage.CONTAINER,
+    parameters: {
+      id: container.id,
+    },
+  });
 }
 </script>
 

--- a/packages/renderer/src/lib/container/ContainerExport.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerExport.spec.ts
@@ -100,7 +100,7 @@ test('Expect export function called when export button is clicked', async () => 
     id: container.Id,
     outputTarget: '/tmp/my/path',
   });
-  expect(goToMock).toBeCalledWith('/containers/');
+  expect(goToMock).toBeCalledWith('/containers');
 });
 
 test('Expect error shown if export function fails', async () => {

--- a/packages/renderer/src/lib/container/ContainerExport.svelte
+++ b/packages/renderer/src/lib/container/ContainerExport.svelte
@@ -2,7 +2,6 @@
 import { faDownload } from '@fortawesome/free-solid-svg-icons';
 import { Button, ErrorMessage, Input } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
-import { router } from 'tinro';
 
 import { ContainerUtils } from '/@/lib/container/container-utils';
 import { handleNavigation } from '/@/navigation';
@@ -76,7 +75,7 @@ async function exportContainer() {
       outputTarget: outputUri.fsPath,
     });
     // go back to containers list
-    router.goto('/containers/');
+    handleNavigation({ page: NavigationPage.CONTAINERS });
   } catch (error) {
     exportedError = String(error);
   } finally {

--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -6,8 +6,10 @@ import { onMount } from 'svelte';
 import { router } from 'tinro';
 
 import { array2String } from '/@/lib/string/string.js';
+import { handleNavigation } from '/@/navigation';
 import type { ContainerCreateOptions, DeviceMapping, HostConfig } from '/@api/container-info';
 import type { ImageInspectInfo } from '/@api/image-inspect-info';
+import { NavigationPage } from '/@api/navigation-page';
 import type { NetworkInspectInfo } from '/@api/network-info';
 
 import Route from '../../Route.svelte';
@@ -404,9 +406,14 @@ async function startContainer() {
 
     // redirect to containers if no tty, else redirect to the container details
     if (Tty && OpenStdin) {
-      router.goto(`/containers/${data.id}/tty`);
+      handleNavigation({
+        page: NavigationPage.CONTAINER_TTY,
+        parameters: {
+          id: data.id,
+        },
+      });
     } else {
-      router.goto('/containers');
+      handleNavigation({ page: NavigationPage.CONTAINERS });
     }
   } catch (e) {
     createError = String(e);

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
@@ -5,6 +5,8 @@ import { onDestroy, onMount } from 'svelte';
 import type { Unsubscriber } from 'svelte/store';
 import { router } from 'tinro';
 
+import { handleNavigation } from '/@/navigation';
+import { NavigationPage } from '/@api/navigation-page';
 import type { ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provider-info';
 
 import type { PodCreatePortOptions } from '../../../../main/src/plugin/dockerode/libpod-dockerode';
@@ -291,7 +293,7 @@ function getWarningText(): string {
 
       <div class="w-full grid justify-items-end mt-5">
         <div>
-          <Button type="link" on:click={() => router.goto('/containers')}>Close</Button>
+          <Button type="link" on:click={handleNavigation.bind(undefined, { page: NavigationPage.CONTAINERS })}>Close</Button>
           <Button
             icon={SolidPodIcon}
             bind:disabled={createInProgress}

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
@@ -210,6 +210,10 @@ function getWarningText(): string {
   });
   return text;
 }
+
+function navigateToContainers(): void {
+  return handleNavigation({ page: NavigationPage.CONTAINERS });
+}
 </script>
 
 <EngineFormPage title="Copy containers to a pod" inProgress={createInProgress}>
@@ -293,7 +297,7 @@ function getWarningText(): string {
 
       <div class="w-full grid justify-items-end mt-5">
         <div>
-          <Button type="link" on:click={handleNavigation.bind(undefined, { page: NavigationPage.CONTAINERS })}>Close</Button>
+          <Button type="link" on:click={navigateToContainers}>Close</Button>
           <Button
             icon={SolidPodIcon}
             bind:disabled={createInProgress}

--- a/packages/renderer/src/lib/pod/PodmanPodDetailsSummary.svelte
+++ b/packages/renderer/src/lib/pod/PodmanPodDetailsSummary.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 import { Link } from '@podman-desktop/ui-svelte';
-import { router } from 'tinro';
+
+import { handleNavigation } from '/@/navigation';
+import { NavigationPage } from '/@api/navigation-page';
 
 import DetailsCell from '../details/DetailsCell.svelte';
 import DetailsSubtitle from '../details/DetailsSubtitle.svelte';
@@ -50,7 +52,7 @@ if (pod) {
       {#each pod.containers as container}
         <tr>
           <DetailsSubtitle>
-            <Link on:click={() => router.goto(`/containers/${container.Id}/logs`)}>
+            <Link on:click={handleNavigation.bind(undefined, {page: NavigationPage.CONTAINER_LOGS,parameters: {id: container.Id }})}>
               {container.Names}
             </Link>
           </DetailsSubtitle>

--- a/packages/renderer/src/lib/pod/PodmanPodDetailsSummary.svelte
+++ b/packages/renderer/src/lib/pod/PodmanPodDetailsSummary.svelte
@@ -8,12 +8,16 @@ import DetailsCell from '../details/DetailsCell.svelte';
 import DetailsSubtitle from '../details/DetailsSubtitle.svelte';
 import DetailsTable from '../details/DetailsTable.svelte';
 import DetailsTitle from '../details/DetailsTitle.svelte';
-import type { PodInfoUI } from './PodInfoUI';
+import type { PodInfoContainerUI, PodInfoUI } from './PodInfoUI';
 
 export let pod: PodInfoUI | undefined;
 let creationTime: Date;
 if (pod) {
   creationTime = new Date(pod.created);
+}
+
+function navigateToLogs(container: PodInfoContainerUI): void {
+  return handleNavigation({ page: NavigationPage.CONTAINER_LOGS, parameters: { id: container.Id } });
 }
 </script>
 
@@ -52,7 +56,7 @@ if (pod) {
       {#each pod.containers as container}
         <tr>
           <DetailsSubtitle>
-            <Link on:click={handleNavigation.bind(undefined, {page: NavigationPage.CONTAINER_LOGS,parameters: {id: container.Id }})}>
+            <Link on:click={() => navigateToLogs(container)}>
               {container.Names}
             </Link>
           </DetailsSubtitle>

--- a/packages/renderer/src/lib/volume/VolumeDetailsSummary.svelte
+++ b/packages/renderer/src/lib/volume/VolumeDetailsSummary.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 import { Link } from '@podman-desktop/ui-svelte';
-import { router } from 'tinro';
+
+import { handleNavigation } from '/@/navigation';
+import { NavigationPage } from '/@api/navigation-page';
 
 import DetailsCell from '../details/DetailsCell.svelte';
 import DetailsTable from '../details/DetailsTable.svelte';
@@ -11,7 +13,12 @@ export let volume: VolumeInfoUI;
 const createdTime: Date = new Date(volume.created);
 
 function openContainer(containerID: string) {
-  router.goto(`/containers/${containerID}/logs`);
+  handleNavigation({
+    page: NavigationPage.CONTAINER_LOGS,
+    parameters: {
+      id: containerID,
+    },
+  });
 }
 </script>
 

--- a/packages/renderer/src/navigation.spec.ts
+++ b/packages/renderer/src/navigation.spec.ts
@@ -66,6 +66,12 @@ test(`Test navigationHandle for ${NavigationPage.CONTAINER_LOGS}`, () => {
   expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/containers/123/logs');
 });
 
+test(`Test navigationHandle for ${NavigationPage.CONTAINER_TTY}`, () => {
+  handleNavigation({ page: NavigationPage.CONTAINER_TTY, parameters: { id: '123' } });
+
+  expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/containers/123/tty');
+});
+
 test(`Test navigationHandle for ${NavigationPage.CONTAINER_INSPECT}`, () => {
   handleNavigation({ page: NavigationPage.CONTAINER_INSPECT, parameters: { id: '123' } });
 

--- a/packages/renderer/src/navigation.ts
+++ b/packages/renderer/src/navigation.ts
@@ -58,6 +58,9 @@ export const handleNavigation = (request: InferredNavigationRequest<NavigationPa
     case NavigationPage.CONTAINER_TERMINAL:
       router.goto(`/containers/${request.parameters.id}/terminal`);
       break;
+    case NavigationPage.CONTAINER_TTY:
+      router.goto(`/containers/${request.parameters.id}/tty`);
+      break;
     case NavigationPage.CONTAINER_KUBE:
       router.goto(`/containers/${request.parameters.id}/kube`);
       break;


### PR DESCRIPTION
### What does this PR do?

Refactor the `router.goto('/containers/*` to use the handleNavigation

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/8294

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
