### PR TITLE
fix: use correct header for play kube operation

### DIFF
--- a/packages/main/src/plugin/dockerode/libpod-dockerode.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.ts
@@ -793,6 +793,26 @@ export class LibpodDockerode {
         options: {},
       };
 
+      // patch the modem to not send x-tar header as content-type
+      const originalBuildRequest = this.modem.buildRequest;
+      this.modem.buildRequest = function (
+        options: unknown,
+        context: unknown,
+        data: unknown,
+        callback: unknown,
+      ): Promise<unknown> {
+        // in case of kube play, docker-modem will send the header application/tar while it's basically the content of the file so it should be application/yaml
+        if (context && typeof context === 'object' && 'path' in context) {
+          if (String(context.path).includes('/libpod/play/kube')) {
+            if (options && typeof options === 'object' && 'headers' in options) {
+              options.headers = { 'Content-Type': 'application/yaml' };
+            }
+          }
+        }
+
+        return originalBuildRequest.call(this, options, context, data, callback);
+      };
+
       return new Promise((resolve, reject) => {
         this.modem.dial(optsf, (err: unknown, data: unknown) => {
           if (err) {


### PR DESCRIPTION
### What does this PR do?
there is a change in the latest releases of podman that is checking the headers provided when calling the play/kube operation.
https://github.com/containers/podman/commit/1dd90dbe20c280f8000919cea86c4cf48191a851#diff-5b8eed2974716af4dc1f528414ca9b3127e1b696b722a18b01d7d87dff178644R58

dockerode and docker-modem are assuming that if there is a file as parameter, it needs to be a application/tar content-type while now on the backend, you can submit yaml file or tar file.
For backward compatibility, we use yaml but then we need to provide the yaml content type

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/podman-desktop/podman-desktop/issues/10010


### How to test this PR?

use test case of the issue (or unit test)

- [x] Tests are covering the bug fix or the new feature
