### PR TITLE
chore: update extension's featured badge bg color and font style

### DIFF
--- a/packages/renderer/src/lib/extensions/CatalogExtension.svelte
+++ b/packages/renderer/src/lib/extensions/CatalogExtension.svelte
@@ -24,7 +24,7 @@ function openExtensionDetails() {
   <!-- if featured need to display a top banner -->
 
   {#if catalogExtensionUI.isFeatured}
-    <div class="bg-[var(--pd-content-card-border-selected)] text-[var(--pd-card-header-text)] rounded-t-md px-2 font-light text-sm min-h-6 flex flex-row items-center">
+    <div class="bg-[var(--pd-badge-purple)] text-[var(--pd-card-header-text)] rounded-t-md px-2 font text-sm min-h-6 flex flex-row items-center">
       Featured
     </div>
   {/if}

--- a/packages/renderer/src/lib/extensions/CatalogExtension.svelte
+++ b/packages/renderer/src/lib/extensions/CatalogExtension.svelte
@@ -24,7 +24,7 @@ function openExtensionDetails() {
   <!-- if featured need to display a top banner -->
 
   {#if catalogExtensionUI.isFeatured}
-    <div class="bg-[var(--pd-badge-purple)] text-[var(--pd-card-header-text)] rounded-t-md px-2 font text-sm min-h-6 flex flex-row items-center">
+    <div class="bg-[var(--pd-badge-purple)] text-[var(--pd-card-header-text)] rounded-t-md px-2 text-sm min-h-6 flex flex-row items-center">
       Featured
     </div>
   {/if}


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR updates the background color of the featured badge of extensions to be lighter in light mode and updates the font style to be more visible

### Screenshot / video of UI
![Screenshot from 2024-11-20 15-21-37](https://github.com/user-attachments/assets/41a911e3-d75a-47b2-9223-2adfa10695eb)
![Screenshot from 2024-11-20 15-21-28](https://github.com/user-attachments/assets/83a38121-a471-4eb8-bd85-1d04cce1b794)


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Fixes https://github.com/podman-desktop/podman-desktop/issues/9901

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
