### PR TITLE
refactor(podman-extension): uses api env.isWindows

### DIFF
--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -333,7 +333,7 @@ beforeEach(() => {
 
   (extensionApi.env.isMac as boolean) = true;
   (extensionApi.env.isLinux as boolean) = false;
-  (extensionApi.env.isWindows as boolean) = false;
+  vi.mocked(extensionApi.env).isWindows = false;
 
   const mock = vi.spyOn(compatibilityModeLib, 'getSocketCompatibility');
   mock.mockReturnValue({
@@ -2233,7 +2233,7 @@ describe('calcPodmanMachineSetting', () => {
   });
 
   test('setValue to true if OS is MacOS', async () => {
-    (extensionApi.env.isWindows as boolean) = false;
+    vi.mocked(extensionApi.env).isWindows = false;
     await extension.calcPodmanMachineSetting();
     expect(extensionApi.context.setValue).toBeCalledWith(extension.PODMAN_MACHINE_CPU_SUPPORTED_KEY, true);
     expect(extensionApi.context.setValue).toBeCalledWith(extension.PODMAN_MACHINE_MEMORY_SUPPORTED_KEY, true);
@@ -2439,7 +2439,7 @@ describe('sendTelemetryRecords', () => {
     );
     (extensionApi.env.isLinux as boolean) = true;
     (extensionApi.env.isMac as boolean) = false;
-    (extensionApi.env.isWindows as boolean) = false;
+    vi.mocked(extensionApi.env).isWindows = false;
 
     mocks.getQemuVersionMock.mockResolvedValue('5.5.5');
 
@@ -2467,7 +2467,7 @@ describe('sendTelemetryRecords', () => {
     );
     (extensionApi.env.isLinux as boolean) = true;
     (extensionApi.env.isMac as boolean) = false;
-    (extensionApi.env.isWindows as boolean) = false;
+    vi.mocked(extensionApi.env).isWindows = false;
 
     mocks.getQemuVersionMock.mockRejectedValue('command not found');
 
@@ -2609,7 +2609,7 @@ async function testAudit(path: string, uri: string, condition: typeof expect | t
 
 test('activate on mac register commands for setting compatibility moide ', async () => {
   vi.mocked(isMac).mockReturnValue(true);
-  (extensionApi.env.isWindows as boolean) = false;
+  vi.mocked(extensionApi.env).isWindows = false;
   vi.mocked(isLinux).mockReturnValue(false);
   vi.spyOn(PodmanInstall.prototype, 'checkForUpdate').mockResolvedValue({
     hasUpdate: false,
@@ -2722,7 +2722,7 @@ describe.each(['windows', 'mac', 'linux'])('podman machine properties audit on %
 });
 
 test('isHypervEnabled should return false if it is not windows', async () => {
-  (extensionApi.env.isWindows as boolean) = false;
+  vi.mocked(extensionApi.env).isWindows = false;
   const hypervEnabled = await extension.isHyperVEnabled();
   expect(hypervEnabled).toBeFalsy();
 });
@@ -2754,7 +2754,7 @@ test('isHypervEnabled should return true if hyperv is enabled', async () => {
 });
 
 test('isWSLEnabled should return false if it is not windows', async () => {
-  (extensionApi.env.isWindows as boolean) = false;
+  vi.mocked(extensionApi.env).isWindows = false;
   const wslEnabled = await extension.isWSLEnabled();
   expect(wslEnabled).toBeFalsy();
 });

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -354,7 +354,7 @@ afterEach(() => {
 describe.each(['macos', 'windows'])('verify create on %s', os => {
   const provider = os === 'macos' ? VMTYPE.APPLEHV : VMTYPE.WSL;
   beforeEach((): void => {
-    (extensionApi.env.isWindows as boolean) = os === 'windows';
+    vi.mocked(extensionApi.env).isWindows = os === 'windows';
 
     vi.mocked(util.isMac).mockReturnValue(os === 'macos');
     setWSLEnabled(true);
@@ -2120,7 +2120,7 @@ describe('registerOnboardingRemoveUnsupportedMachinesCommand', () => {
   });
 
   test('check with previous podman v4 config files on Windows', async () => {
-    (extensionApi.env.isWindows as boolean) = true;
+    vi.mocked(extensionApi.env).isWindows = true;
     vi.mocked(isMac).mockReturnValue(false);
 
     // mock confirmation window message to true
@@ -2240,7 +2240,7 @@ describe('calcPodmanMachineSetting', () => {
     expect(extensionApi.context.setValue).toBeCalledWith(extension.PODMAN_MACHINE_DISK_SUPPORTED_KEY, true);
   });
   test('setValue to true if OS is Windows and uses HyperV', async () => {
-    (extensionApi.env.isWindows as boolean) = true;
+    vi.mocked(extensionApi.env).isWindows = true;
     vi.spyOn(podmanCli, 'getPodmanInstallation').mockResolvedValue({
       version: '5.2.1',
     });
@@ -2261,7 +2261,7 @@ describe('calcPodmanMachineSetting', () => {
     expect(extensionApi.context.setValue).toBeCalledWith(extension.PODMAN_MACHINE_DISK_SUPPORTED_KEY, true);
   });
   test('setValue to true if OS is Windows and uses WSL', async () => {
-    (extensionApi.env.isWindows as boolean) = true;
+    vi.mocked(extensionApi.env).isWindows = true;
     process.env.CONTAINERS_MACHINE_PROVIDER = 'wsl';
     vi.spyOn(podmanConfiguration, 'matchRegexpInContainersConfig').mockResolvedValue(false);
     await extension.calcPodmanMachineSetting();
@@ -2690,8 +2690,7 @@ test('activate on mac register commands for setting compatibility moide ', async
 
 describe.each(['windows', 'mac', 'linux'])('podman machine properties audit on %s', os => {
   beforeEach(() => {
-    (extensionApi.env.isWindows as boolean) = os === 'windows';
-
+    vi.mocked(extensionApi.env).isWindows = os === 'windows';
     vi.mocked(util.isMac).mockReturnValue(os === 'mac');
     vi.mocked(util.isLinux).mockReturnValue(os === 'linux');
   });
@@ -2728,13 +2727,13 @@ test('isHypervEnabled should return false if it is not windows', async () => {
 });
 
 test('isHypervEnabled should return false if hyperv is not enabled', async () => {
-  (extensionApi.env.isWindows as boolean) = true;
+  vi.mocked(extensionApi.env).isWindows = true;
   const hypervEnabled = await extension.isHyperVEnabled();
   expect(hypervEnabled).toBeFalsy();
 });
 
 test('isHypervEnabled should return true if hyperv is enabled', async () => {
-  (extensionApi.env.isWindows as boolean) = true;
+  vi.mocked(extensionApi.env).isWindows = true;
   vi.spyOn(podmanCli, 'getPodmanInstallation').mockResolvedValue({
     version: '5.2.1',
   });
@@ -2760,7 +2759,7 @@ test('isWSLEnabled should return false if it is not windows', async () => {
 });
 
 test('isWSLEnabled should return false if wsl is not enabled', async () => {
-  (extensionApi.env.isWindows as boolean) = true;
+  vi.mocked(extensionApi.env).isWindows = true;
   vi.spyOn(extensionApi.process, 'exec').mockResolvedValue({
     stdout: 'unknown message: 1.2.5.0',
     stderr: '',
@@ -2771,7 +2770,7 @@ test('isWSLEnabled should return false if wsl is not enabled', async () => {
 });
 
 test('isWSLEnabled should return true if wsl is enabled', async () => {
-  (extensionApi.env.isWindows as boolean) = true;
+  vi.mocked(extensionApi.env).isWindows = true;
   vi.spyOn(extensionApi.process, 'exec').mockImplementation(command => {
     return new Promise<extensionApi.RunResult>(resolve => {
       if (command === 'wsl') {
@@ -2796,7 +2795,7 @@ test('isWSLEnabled should return true if wsl is enabled', async () => {
 });
 
 test('getJSONMachineList should only get machines from wsl if hyperv is not enabled', async () => {
-  (extensionApi.env.isWindows as boolean) = true;
+  vi.mocked(extensionApi.env).isWindows = true;
   vi.mocked(isMac).mockReturnValue(false);
   vi.spyOn(extensionApi.process, 'exec').mockImplementation((command, args) => {
     return new Promise<extensionApi.RunResult>(resolve => {
@@ -2860,7 +2859,7 @@ test('getJSONMachineList should only get machines from wsl if hyperv is not enab
 });
 
 test('getJSONMachineList should only get machines from hyperv if wsl is not enabled', async () => {
-  (extensionApi.env.isWindows as boolean) = true;
+  vi.mocked(extensionApi.env).isWindows = true;
   vi.mocked(isMac).mockReturnValue(false);
   vi.spyOn(podmanCli, 'getPodmanInstallation').mockResolvedValue({
     version: '5.2.1',
@@ -2926,7 +2925,7 @@ test('getJSONMachineList should only get machines from hyperv if wsl is not enab
 });
 
 test('getJSONMachineList should get machines from hyperv and wsl if both are enabled', async () => {
-  (extensionApi.env.isWindows as boolean) = true;
+  vi.mocked(extensionApi.env).isWindows = true;
   vi.mocked(isMac).mockReturnValue(false);
   vi.spyOn(podmanCli, 'getPodmanInstallation').mockResolvedValue({
     version: '5.2.1',

--- a/extensions/podman/packages/extension/src/podman-cli.ts
+++ b/extensions/podman/packages/extension/src/podman-cli.ts
@@ -17,13 +17,13 @@
  ***********************************************************************/
 import * as extensionApi from '@podman-desktop/api';
 
-import { isMac, isWindows } from './util';
+import { isMac } from './util';
 
 const macosExtraPath = '/opt/podman/bin:/usr/local/bin:/opt/homebrew/bin:/opt/local/bin';
 
 export function getInstallationPath(): string | undefined {
   const env = process.env;
-  if (isWindows()) {
+  if (extensionApi.env.isWindows) {
     return `c:\\Program Files\\RedHat\\Podman;${env.PATH}`;
   } else if (isMac()) {
     if (!env.PATH) {
@@ -43,7 +43,7 @@ export function getPodmanCli(): string {
     return customBinaryPath;
   }
 
-  if (isWindows()) {
+  if (extensionApi.env.isWindows) {
     return 'podman.exe';
   }
   return 'podman';

--- a/extensions/podman/packages/extension/src/podman-configuration.spec.ts
+++ b/extensions/podman/packages/extension/src/podman-configuration.spec.ts
@@ -22,6 +22,20 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { PodmanConfiguration } from './podman-configuration';
 
+// mock the API
+vi.mock('@podman-desktop/api', async () => {
+  return {
+    process: {
+      exec: vi.fn(),
+    },
+    env: {
+      isWindows: false,
+      isMac: false,
+      isLinux: false,
+    },
+  };
+});
+
 // allows to call protected methods
 class TestPodmanConfiguration extends PodmanConfiguration {
   readContainersConfigFile(): Promise<string> {

--- a/extensions/podman/packages/extension/src/podman-configuration.ts
+++ b/extensions/podman/packages/extension/src/podman-configuration.ts
@@ -24,7 +24,7 @@ import type { ProxySettings } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
 import * as toml from 'smol-toml';
 
-import { isLinux, isMac, isWindows } from './util';
+import { isLinux, isMac } from './util';
 
 const configurationRosetta = 'setting.rosetta';
 
@@ -319,7 +319,7 @@ export class PodmanConfiguration {
 
     if (isMac()) {
       podmanConfigContainersPath = path.resolve(os.homedir(), '.config', 'containers');
-    } else if (isWindows()) {
+    } else if (extensionApi.env.isWindows) {
       podmanConfigContainersPath = path.resolve(os.homedir(), 'AppData', 'Roaming', 'containers');
     } else if (isLinux()) {
       const xdgRuntimeDirectory = process.env['XDG_RUNTIME_DIR'] ?? '';

--- a/extensions/podman/packages/extension/src/registry-setup.ts
+++ b/extensions/podman/packages/extension/src/registry-setup.ts
@@ -22,7 +22,7 @@ import * as path from 'node:path';
 
 import * as extensionApi from '@podman-desktop/api';
 
-import { isLinux, isMac, isWindows } from './util';
+import { isLinux, isMac } from './util';
 
 export type ContainerAuthConfigEntry = {
   [key: string]: {
@@ -41,7 +41,7 @@ export class RegistrySetup {
   protected getAuthFileLocation(): string {
     let podmanConfigContainersPath = '';
 
-    if (isMac() || isWindows()) {
+    if (isMac() || extensionApi.env.isWindows) {
       podmanConfigContainersPath = path.resolve(os.homedir(), '.config/containers');
     } else if (isLinux()) {
       const xdgRuntimeDirectory = process.env['XDG_RUNTIME_DIR'] ?? '';

--- a/extensions/podman/packages/extension/src/util.spec.ts
+++ b/extensions/podman/packages/extension/src/util.spec.ts
@@ -46,6 +46,11 @@ vi.mock('@podman-desktop/api', () => {
     process: {
       exec: vi.fn(),
     },
+    env: {
+      isWindows: false,
+      isMac: false,
+      isLinux: false,
+    },
   };
 });
 

--- a/extensions/podman/packages/extension/src/util.ts
+++ b/extensions/podman/packages/extension/src/util.ts
@@ -23,10 +23,6 @@ import * as extensionApi from '@podman-desktop/api';
 
 import { getPodmanCli } from './podman-cli';
 
-const windows = os.platform() === 'win32';
-export function isWindows(): boolean {
-  return windows;
-}
 const mac = os.platform() === 'darwin';
 export function isMac(): boolean {
   return mac;


### PR DESCRIPTION
### What does this PR do?

Replace the `utils#isWindows` with the api `env.isWindows`.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Part 1/3 of https://github.com/podman-desktop/podman-desktop/issues/9617

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
