### PR TITLE
fix: remove extra border in details page

### DIFF
--- a/packages/ui/src/lib/layouts/DetailsPage.svelte
+++ b/packages/ui/src/lib/layouts/DetailsPage.svelte
@@ -23,7 +23,7 @@ export let onbreadcrumbClick: () => void = () => {};
   <div slot="content" class="h-full bg-[var(--pd-details-bg)] min-h-0">
     <slot name="content" />
   </div>
-  <div slot="tabs" class="flex flex-row px-2 border-b border-[var(--pd-content-divider)]">
+  <div slot="tabs" class="flex flex-row px-2">
     <slot name="tabs" />
   </div>
   <svelte:fragment slot="icon">


### PR DESCRIPTION
### What does this PR do?

Remove some weird extra border on the DetailsPage.

### Screenshot / video of UI

**before**

![image](https://github.com/user-attachments/assets/5b26bcb6-d860-4787-83b3-d35c90952855)

**after**

![image](https://github.com/user-attachments/assets/3e418b7a-0fbc-451c-be45-8e9e7f935934)


### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/10049

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
