### PR TITLE
fix(monaco): make vscode focus border transparent

### DIFF
--- a/packages/renderer/src/lib/editor/MonacoEditor.svelte
+++ b/packages/renderer/src/lib/editor/MonacoEditor.svelte
@@ -33,6 +33,8 @@ async function updateTheme(isDarkTheme: boolean) {
     rules: [{ token: 'custom-color', background: bgColor }],
     colors: {
       'editor.background': bgColor,
+      // make the --vscode-focusBorder transparent
+      focusBorder: '#00000000',
     },
   });
 }


### PR DESCRIPTION
### What does this PR do?

Make the vscode focus border transparent, as the blue is only visible on top and bottom, and just look weird ?

### Screenshot / video of UI

**Before**

![image](https://github.com/user-attachments/assets/3cb34d1a-07fb-4f10-a9c7-a8997c540802)

**After**

![image](https://github.com/user-attachments/assets/78973891-909a-4f6b-8875-117d75c2256b)

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/10052

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
