### PR TITLE
chore: fix spaces in experimental section website

### DIFF
--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -204,24 +204,24 @@ function Extensibility(): JSX.Element {
             </p>
             <ul className="list-disc list-inside text-center">
               <li>
-                Explore our
+                Explore our{' '}
                 <Link title="catalog of extensions" to="/extensions">
                   catalog of extensions
                 </Link>
                 .
               </li>
               <li>
-                Learn to
+                Learn to{' '}
                 <Link title="develop your own extensions" to="/docs/extensions/developing">
                   develop your own extensions
                 </Link>
                 .
               </li>
               <li>
-                Want to use a Docker Desktop extension? Extensions such as
+                Want to use a Docker Desktop extension? Extensions such as{' '}
                 <Link title="trivy" to="https://github.com/aquasecurity/trivy-docker-extension">
                   Trivy
-                </Link>
+                </Link>{' '}
                 work out of the box with Podman Desktop.
               </li>
             </ul>


### PR DESCRIPTION
Signed-off-by: Matt Demyttenaere <mdemytte@redhat.com>

### What does this PR do?
Adds spaces around the links in the experimental section

### Screenshot / video of UI
After:
![image](https://github.com/user-attachments/assets/896200c1-902c-47b4-9a24-3f988b1ddb55)


Fixing this: 
Before
![image](https://github.com/user-attachments/assets/3a887882-2443-4d28-8e20-7b164b345a07)

### What issues does this PR fix or reference?

### How to test this PR?

