### PR TITLE
chore(test): add @all tag for all tests that are run as part of test:e2e

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test:unit": "npm run test:main && npm run test:preload && npm run test:preload-docker-extension && npm run test:preload-webview && npm run test:ui && npm run test:renderer && npm run test:scripts:stylesheet && npm run test:tools && npm run test:extensions && npm run test:website",
     "test:e2e": "npm run test:e2e:build && npm run test:e2e:run",
     "test:e2e:build": "cross-env NODE_ENV=development MODE=development DEBUG=pw:browser npm run build",
-    "test:e2e:run": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- npx playwright test tests/playwright/src/specs/ --grep-invert '@update-install|@podman-remote'",
+    "test:e2e:run": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- npx playwright test tests/playwright/src/specs/ --grep @all",
     "test:e2e:smoke": "npm run test:e2e:build && npm run test:e2e:smoke:run",
     "test:e2e:smoke:run": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- npx playwright test tests/playwright/src/specs/ -g @smoke",
     "test:e2e:k8s": "npm run test:e2e:build && npm run test:e2e:k8s:run",

--- a/tests/playwright/src/specs/compose-onboarding-smoke.spec.ts
+++ b/tests/playwright/src/specs/compose-onboarding-smoke.spec.ts
@@ -47,7 +47,7 @@ test.afterAll(async ({ runner }) => {
   await runner.close();
 });
 
-test.describe.serial('Compose onboarding workflow verification', { tag: '@smoke' }, () => {
+test.describe.serial('Compose onboarding workflow verification', { tag: ['@smoke', '@all'] }, () => {
   test.afterEach(async ({ navigationBar }) => {
     await navigationBar.openDashboard();
   });

--- a/tests/playwright/src/specs/container-smoke.spec.ts
+++ b/tests/playwright/src/specs/container-smoke.spec.ts
@@ -71,7 +71,7 @@ test.afterAll(async ({ runner, page }) => {
   }
 });
 
-test.describe.serial('Verification of container creation workflow', { tag: '@smoke' }, () => {
+test.describe.serial('Verification of container creation workflow', { tag: ['@smoke', '@all'] }, () => {
   test.describe.configure({ retries: 2 });
 
   test(`Pulling of '${imageToPull}:${imageTag}' image`, async ({ navigationBar }) => {

--- a/tests/playwright/src/specs/deploy-to-kubernetes.spec.ts
+++ b/tests/playwright/src/specs/deploy-to-kubernetes.spec.ts
@@ -76,7 +76,7 @@ test.skip(
   'Tests suite should not run on Linux platform',
 );
 
-test.describe.serial('Deploy a container to the Kind cluster', { tag: ['@smoke', '@all'] }, () => {
+test.describe.serial('Deploy a container to the Kind cluster', { tag: ['@k8s_e2e', '@all'] }, () => {
   test('Pull an image and start a container', async ({ navigationBar }) => {
     const imagesPage = await navigationBar.openImages();
     const pullImagePage = await imagesPage.openPullImage();

--- a/tests/playwright/src/specs/deploy-to-kubernetes.spec.ts
+++ b/tests/playwright/src/specs/deploy-to-kubernetes.spec.ts
@@ -76,7 +76,7 @@ test.skip(
   'Tests suite should not run on Linux platform',
 );
 
-test.describe.serial('Deploy a container to the Kind cluster', { tag: '@k8s_e2e' }, () => {
+test.describe.serial('Deploy a container to the Kind cluster', { tag: ['@smoke', '@all'] }, () => {
   test('Pull an image and start a container', async ({ navigationBar }) => {
     const imagesPage = await navigationBar.openImages();
     const pullImagePage = await imagesPage.openPullImage();

--- a/tests/playwright/src/specs/extension-installation-smoke.spec.ts
+++ b/tests/playwright/src/specs/extension-installation-smoke.spec.ts
@@ -76,7 +76,7 @@ const extentionTypes = [
 ];
 
 for (const { extensionName, extensionType } of extentionTypes) {
-  test.describe.serial(`Extension installation for ${extensionType}`, { tag: '@smoke' }, () => {
+  test.describe.serial(`Extension installation for ${extensionType}`, { tag: ['@smoke', '@all'] }, () => {
     test.beforeAll(async () => {
       await _startup(extensionName);
     });

--- a/tests/playwright/src/specs/image-search.spec.ts
+++ b/tests/playwright/src/specs/image-search.spec.ts
@@ -34,7 +34,7 @@ test.afterAll(async ({ runner }) => {
   await runner.close();
 });
 
-test.describe('Image search verification', { tag: '@smoke' }, () => {
+test.describe('Image search verification', { tag: ['@smoke', '@all'] }, () => {
   test('Search for image and then clear field', async ({ navigationBar }) => {
     const imagesPage = await navigationBar.openImages();
     await playExpect(imagesPage.heading).toBeVisible();

--- a/tests/playwright/src/specs/image-smoke.spec.ts
+++ b/tests/playwright/src/specs/image-smoke.spec.ts
@@ -42,7 +42,7 @@ test.afterAll(async ({ runner }) => {
   await runner.close();
 });
 
-test.describe.serial('Image workflow verification', { tag: '@smoke' }, () => {
+test.describe.serial('Image workflow verification', { tag: ['@smoke', '@all'] }, () => {
   test('Pull image', async ({ navigationBar }) => {
     const imagesPage = await navigationBar.openImages();
     await playExpect(imagesPage.heading).toBeVisible();

--- a/tests/playwright/src/specs/kind.spec.ts
+++ b/tests/playwright/src/specs/kind.spec.ts
@@ -57,7 +57,7 @@ test.afterAll(async ({ runner, page }) => {
   }
 });
 
-test.describe.serial('Kind End-to-End Tests', { tag: '@k8s_e2e' }, () => {
+test.describe.serial('Kind End-to-End Tests', { tag: ['@smoke', '@all'] }, () => {
   test.describe
     .serial('Kind installation', () => {
       test('Install Kind CLI', async ({ page, navigationBar }) => {

--- a/tests/playwright/src/specs/kind.spec.ts
+++ b/tests/playwright/src/specs/kind.spec.ts
@@ -57,7 +57,7 @@ test.afterAll(async ({ runner, page }) => {
   }
 });
 
-test.describe.serial('Kind End-to-End Tests', { tag: ['@smoke', '@all'] }, () => {
+test.describe.serial('Kind End-to-End Tests', { tag: ['@k8s_e2e', '@all'] }, () => {
   test.describe
     .serial('Kind installation', () => {
       test('Install Kind CLI', async ({ page, navigationBar }) => {

--- a/tests/playwright/src/specs/kubernetes-context-smoke.spec.ts
+++ b/tests/playwright/src/specs/kubernetes-context-smoke.spec.ts
@@ -45,7 +45,7 @@ test.afterAll(async ({ runner }) => {
   await runner.close();
 });
 
-test.describe.serial('Verification of kube context management', { tag: ['@k8s_e2e', '@smoke'] }, () => {
+test.describe.serial('Verification of kube context management', { tag: ['@k8s_e2e', '@smoke', '@all'] }, () => {
   test('Load custom kubeconfig in Preferences', async ({ navigationBar }) => {
     // open preferences page
     const settingsBar = await navigationBar.openSettings();

--- a/tests/playwright/src/specs/kubernetes-edit-yaml.spec.ts
+++ b/tests/playwright/src/specs/kubernetes-edit-yaml.spec.ts
@@ -79,7 +79,7 @@ test.skip(
   'Tests suite should not run on Linux platform',
 );
 
-test.describe.serial('Kubernetes Edit YAML Feature E2E Test', { tag: '@k8s_e2e' }, () => {
+test.describe.serial('Kubernetes Edit YAML Feature E2E Test', { tag: ['@smoke', '@all'] }, () => {
   test('Create a Kubernetes deployment resource', async ({ navigationBar }) => {
     test.setTimeout(80_000);
     const podsPage = await navigationBar.openPods();

--- a/tests/playwright/src/specs/kubernetes-edit-yaml.spec.ts
+++ b/tests/playwright/src/specs/kubernetes-edit-yaml.spec.ts
@@ -79,7 +79,7 @@ test.skip(
   'Tests suite should not run on Linux platform',
 );
 
-test.describe.serial('Kubernetes Edit YAML Feature E2E Test', { tag: ['@smoke', '@all'] }, () => {
+test.describe.serial('Kubernetes Edit YAML Feature E2E Test', { tag: ['@k8s_e2e', '@all'] }, () => {
   test('Create a Kubernetes deployment resource', async ({ navigationBar }) => {
     test.setTimeout(80_000);
     const podsPage = await navigationBar.openPods();

--- a/tests/playwright/src/specs/kubernetes.spec.ts
+++ b/tests/playwright/src/specs/kubernetes.spec.ts
@@ -87,7 +87,7 @@ test.skip(
   'Tests suite should not run on Linux platform',
 );
 
-test.describe('Kubernetes resources End-to-End test', { tag: ['@smoke', '@all'] }, () => {
+test.describe('Kubernetes resources End-to-End test', { tag: ['@k8s_e2e', '@all'] }, () => {
   test('Kubernetes Nodes test', async ({ navigationBar }) => {
     const kubernetesBar = await navigationBar.openKubernetes();
     const nodesPage = await kubernetesBar.openTabPage(KubernetesResources.Nodes);

--- a/tests/playwright/src/specs/kubernetes.spec.ts
+++ b/tests/playwright/src/specs/kubernetes.spec.ts
@@ -87,7 +87,7 @@ test.skip(
   'Tests suite should not run on Linux platform',
 );
 
-test.describe('Kubernetes resources End-to-End test', { tag: '@k8s_e2e' }, () => {
+test.describe('Kubernetes resources End-to-End test', { tag: ['@smoke', '@all'] }, () => {
   test('Kubernetes Nodes test', async ({ navigationBar }) => {
     const kubernetesBar = await navigationBar.openKubernetes();
     const nodesPage = await kubernetesBar.openTabPage(KubernetesResources.Nodes);

--- a/tests/playwright/src/specs/pod-smoke.spec.ts
+++ b/tests/playwright/src/specs/pod-smoke.spec.ts
@@ -96,7 +96,7 @@ test.afterAll(async ({ page, runner }) => {
   }
 });
 
-test.describe.serial('Verification of pod creation workflow', { tag: '@smoke' }, () => {
+test.describe.serial('Verification of pod creation workflow', { tag: ['@smoke', '@all'] }, () => {
   test('Pulling images', async ({ navigationBar }) => {
     test.setTimeout(180_000);
 

--- a/tests/playwright/src/specs/podman-extension-smoke.spec.ts
+++ b/tests/playwright/src/specs/podman-extension-smoke.spec.ts
@@ -44,7 +44,7 @@ test.afterAll(async ({ runner }) => {
   await runner.close();
 });
 
-test.describe.serial('Verification of Podman extension', { tag: '@smoke' }, () => {
+test.describe.serial('Verification of Podman extension', { tag: ['@smoke', '@all'] }, () => {
   test('Podman is enabled and present', async () => {
     await verifyPodmanExtensionStatus(true);
   });

--- a/tests/playwright/src/specs/podman-machine-dashboard-onboarding.spec.ts
+++ b/tests/playwright/src/specs/podman-machine-dashboard-onboarding.spec.ts
@@ -52,20 +52,19 @@ test.afterAll(async ({ runner }) => {
   await runner.close();
 });
 
-test.describe
-  .serial(`Podman machine onboarding from Dashboard`, () => {
-    test('Create Podman machine from Dashboard', async ({ navigationBar }) => {
-      test.setTimeout(320000);
+test.describe.serial(`Podman machine onboarding from Dashboard`, { tag: ['@all'] }, () => {
+  test('Create Podman machine from Dashboard', async ({ navigationBar }) => {
+    test.setTimeout(320000);
 
-      console.log('Starting PD dashboard test');
-      const dashboardPage = await navigationBar.openDashboard();
-      await playExpect(dashboardPage.podmanInitilizeAndStartButton).toBeEnabled({ timeout: 60000 });
-      await dashboardPage.podmanInitilizeAndStartButton.click();
-      await playExpect(dashboardPage.podmanStatusLabel).toHaveText('RUNNING', { timeout: 300000 });
-    });
-
-    test('Clean Up Podman Machine', async ({ page }) => {
-      test.skip(process.env.MACHINE_CLEANUP !== 'true', 'Machine cleanup is disabled');
-      await deletePodmanMachine(page, PODMAN_MACHINE_NAME);
-    });
+    console.log('Starting PD dashboard test');
+    const dashboardPage = await navigationBar.openDashboard();
+    await playExpect(dashboardPage.podmanInitilizeAndStartButton).toBeEnabled({ timeout: 60000 });
+    await dashboardPage.podmanInitilizeAndStartButton.click();
+    await playExpect(dashboardPage.podmanStatusLabel).toHaveText('RUNNING', { timeout: 300000 });
   });
+
+  test('Clean Up Podman Machine', async ({ page }) => {
+    test.skip(process.env.MACHINE_CLEANUP !== 'true', 'Machine cleanup is disabled');
+    await deletePodmanMachine(page, PODMAN_MACHINE_NAME);
+  });
+});

--- a/tests/playwright/src/specs/podman-machine-onboarding.spec.ts
+++ b/tests/playwright/src/specs/podman-machine-onboarding.spec.ts
@@ -74,158 +74,150 @@ test.afterAll(async ({ runner }) => {
   await runner.close();
 });
 
-test.describe
-  .serial('Podman Machine verification', () => {
-    test.describe
-      .serial('Podman Machine onboarding workflow', () => {
-        test('Setup Podman push notification is present', async ({ navigationBar }) => {
-          dashboardPage = await navigationBar.openDashboard();
-          await playExpect(dashboardPage.mainPage).toBeVisible();
-          await playExpect(dashboardPage.notificationsBox).toBeVisible();
-          notificationPodmanSetup = dashboardPage.notificationsBox
-            .getByRole('region', { name: 'id:' })
-            .filter({ hasText: 'Podman needs to be set up' });
-          await playExpect(notificationPodmanSetup).toBeVisible();
-        });
+test.describe.serial('Podman Machine verification', { tag: ['@all'] }, () => {
+  test.describe
+    .serial('Podman Machine onboarding workflow', () => {
+      test('Setup Podman push notification is present', async ({ navigationBar }) => {
+        dashboardPage = await navigationBar.openDashboard();
+        await playExpect(dashboardPage.mainPage).toBeVisible();
+        await playExpect(dashboardPage.notificationsBox).toBeVisible();
+        notificationPodmanSetup = dashboardPage.notificationsBox
+          .getByRole('region', { name: 'id:' })
+          .filter({ hasText: 'Podman needs to be set up' });
+        await playExpect(notificationPodmanSetup).toBeVisible();
+      });
 
-        test.describe
-          .serial('Onboarding navigation', () => {
-            test('Open Podman Machine Onboarding through Setup Notification', async ({ page }) => {
-              await notificationPodmanSetup.getByTitle('Set up Podman').click();
-              podmanOnboardingPage = await checkPodmanMachineOnboardingPage(page);
-            });
-
-            test('Return to Dashboard', async ({ navigationBar }) => {
-              dashboardPage = await navigationBar.openDashboard();
-              await playExpect(dashboardPage.mainPage).toBeVisible();
-            });
-
-            test('Re-Open Podman Machine Onboarding through Settings Resources page', async ({
-              page,
-              navigationBar,
-            }) => {
-              settingsBar = await navigationBar.openSettings();
-              await settingsBar.resourcesTab.click();
-              resourcesPage = new ResourcesPage(page);
-              await playExpect.poll(async () => await resourcesPage.resourceCardIsVisible(RESOURCE_NAME)).toBeTruthy();
-              const podmanResourceCard = new ResourceConnectionCardPage(page, RESOURCE_NAME);
-              await podmanResourceCard.setupButton.click();
-              podmanOnboardingPage = await checkPodmanMachineOnboardingPage(page);
-            });
+      test.describe
+        .serial('Onboarding navigation', () => {
+          test('Open Podman Machine Onboarding through Setup Notification', async ({ page }) => {
+            await notificationPodmanSetup.getByTitle('Set up Podman').click();
+            podmanOnboardingPage = await checkPodmanMachineOnboardingPage(page);
           });
-        test('Verify Podman Autostart is enabled and proceed to next page', async () => {
-          await playExpect(podmanOnboardingPage.podmanAutostartToggle).toBeChecked({ timeout: 30_000 });
-          await podmanOnboardingPage.nextStepButton.click();
-        });
 
-        test('Expect no machine created message and proceed to next page', async () => {
-          await playExpect(podmanOnboardingPage.onboardingStatusMessage).toHaveText(
-            `We could not find any Podman machine. Let's create one!`,
-            { timeout: 30_000 },
-          );
-          await podmanOnboardingPage.nextStepButton.click();
-        });
+          test('Return to Dashboard', async ({ navigationBar }) => {
+            dashboardPage = await navigationBar.openDashboard();
+            await playExpect(dashboardPage.mainPage).toBeVisible();
+          });
 
-        test('Verify default podman machine settings', async () => {
-          await playExpect(podmanOnboardingPage.createMachinePageTitle).toHaveText(`Create a Podman machine`, {
+          test('Re-Open Podman Machine Onboarding through Settings Resources page', async ({ page, navigationBar }) => {
+            settingsBar = await navigationBar.openSettings();
+            await settingsBar.resourcesTab.click();
+            resourcesPage = new ResourcesPage(page);
+            await playExpect.poll(async () => await resourcesPage.resourceCardIsVisible(RESOURCE_NAME)).toBeTruthy();
+            const podmanResourceCard = new ResourceConnectionCardPage(page, RESOURCE_NAME);
+            await podmanResourceCard.setupButton.click();
+            podmanOnboardingPage = await checkPodmanMachineOnboardingPage(page);
+          });
+        });
+      test('Verify Podman Autostart is enabled and proceed to next page', async () => {
+        await playExpect(podmanOnboardingPage.podmanAutostartToggle).toBeChecked({ timeout: 30_000 });
+        await podmanOnboardingPage.nextStepButton.click();
+      });
+
+      test('Expect no machine created message and proceed to next page', async () => {
+        await playExpect(podmanOnboardingPage.onboardingStatusMessage).toHaveText(
+          `We could not find any Podman machine. Let's create one!`,
+          { timeout: 30_000 },
+        );
+        await podmanOnboardingPage.nextStepButton.click();
+      });
+
+      test('Verify default podman machine settings', async () => {
+        await playExpect(podmanOnboardingPage.createMachinePageTitle).toHaveText(`Create a Podman machine`, {
+          timeout: 30_000,
+        });
+        await playExpect(podmanOnboardingPage.machineCreationForm.podmanMachineConfiguration).toBeVisible();
+        await playExpect(podmanOnboardingPage.machineCreationForm.podmanMachineName).toHaveValue(
+          'podman-machine-default',
+        );
+        await playExpect(podmanOnboardingPage.machineCreationForm.imagePathBox).toHaveValue('');
+        await playExpect(podmanOnboardingPage.machineCreationForm.rootPriviledgesCheckbox).toBeChecked();
+        await playExpect(podmanOnboardingPage.machineCreationForm.startNowCheckbox).toBeChecked();
+
+        if (os.platform() === 'win32') {
+          await playExpect(podmanOnboardingPage.machineCreationForm.userModeNetworkingCheckbox).not.toBeChecked({
             timeout: 30_000,
           });
-          await playExpect(podmanOnboardingPage.machineCreationForm.podmanMachineConfiguration).toBeVisible();
-          await playExpect(podmanOnboardingPage.machineCreationForm.podmanMachineName).toHaveValue(
-            'podman-machine-default',
-          );
-          await playExpect(podmanOnboardingPage.machineCreationForm.imagePathBox).toHaveValue('');
-          await playExpect(podmanOnboardingPage.machineCreationForm.rootPriviledgesCheckbox).toBeChecked();
-          await playExpect(podmanOnboardingPage.machineCreationForm.startNowCheckbox).toBeChecked();
-
-          if (os.platform() === 'win32') {
-            await playExpect(podmanOnboardingPage.machineCreationForm.userModeNetworkingCheckbox).not.toBeChecked({
-              timeout: 30_000,
-            });
-          } else {
-            await playExpect(podmanOnboardingPage.machineCreationForm.podmanMachineCPUs).toBeVisible({
-              timeout: 30_000,
-            });
-            await playExpect(podmanOnboardingPage.machineCreationForm.podmanMachineMemory).toBeVisible();
-            await playExpect(podmanOnboardingPage.machineCreationForm.podmanMachineDiskSize).toBeVisible();
-          }
-        });
-      });
-    test.describe
-      .serial('Podman Machine creation and operations', () => {
-        test.skip(process.env.TEST_PODMAN_MACHINE !== 'true');
-
-        test('Create a default Podman machine', async () => {
-          test.setTimeout(PODMAN_FULL_STARTUP_TIMEOUT);
-          await podmanOnboardingPage.machineCreationForm.createMachineButton.click();
-          await playExpect(podmanOnboardingPage.podmanMachineShowLogsButton).toBeVisible();
-          await podmanOnboardingPage.podmanMachineShowLogsButton.click();
-          await playExpect(podmanOnboardingPage.onboardingStatusMessage).toBeVisible({
-            timeout: PODMAN_MACHINE_STARTUP_TIMEOUT,
+        } else {
+          await playExpect(podmanOnboardingPage.machineCreationForm.podmanMachineCPUs).toBeVisible({
+            timeout: 30_000,
           });
-          await playExpect(podmanOnboardingPage.onboardingStatusMessage).toHaveText('Podman installed');
-          await podmanOnboardingPage.nextStepButton.click();
-        });
-
-        test.describe
-          .serial('Podman machine operations', () => {
-            test.describe.configure({ timeout: 120000 });
-
-            test('Open podman machine details', async ({ page, navigationBar }) => {
-              dashboardPage = await navigationBar.openDashboard();
-              await playExpect(dashboardPage.mainPage).toBeVisible();
-              settingsBar = await navigationBar.openSettings();
-              await settingsBar.resourcesTab.click();
-              resourcesPage = new ResourcesPage(page);
-              await playExpect.poll(async () => await resourcesPage.resourceCardIsVisible(RESOURCE_NAME)).toBeTruthy();
-              const resourcesPodmanConnections = new ResourceConnectionCardPage(
-                page,
-                RESOURCE_NAME,
-                PODMAN_MACHINE_NAME,
-              );
-              await playExpect(resourcesPodmanConnections.providerConnections).toBeVisible({ timeout: 10_000 });
-              await playExpect(resourcesPodmanConnections.resourceElement).toBeVisible({ timeout: 20_000 });
-              await playExpect(resourcesPodmanConnections.resourceElementDetailsButton).toBeVisible();
-              await resourcesPodmanConnections.resourceElementDetailsButton.click();
-              const podmanMachineDetails = new PodmanMachineDetails(page, PODMAN_MACHINE_NAME);
-              await playExpect(podmanMachineDetails.podmanMachineStatus).toBeVisible();
-              await playExpect(podmanMachineDetails.podmanMachineConnectionActions).toBeVisible();
-              await playExpect(podmanMachineDetails.podmanMachineStartButton).toBeVisible();
-              await playExpect(podmanMachineDetails.podmanMachineRestartButton).toBeVisible();
-              await playExpect(podmanMachineDetails.podmanMachineStopButton).toBeVisible();
-              await playExpect(podmanMachineDetails.podmanMachineDeleteButton).toBeVisible();
-            });
-
-            test('Podman machine operations - STOP', async ({ page }) => {
-              const podmanMachineDetails = new PodmanMachineDetails(page, PODMAN_MACHINE_NAME);
-              await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('RUNNING', { timeout: 60_000 });
-              await playExpect(podmanMachineDetails.podmanMachineStopButton).toBeEnabled();
-              await podmanMachineDetails.podmanMachineStopButton.click();
-              await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('OFF', { timeout: 60_000 });
-            });
-
-            test('Podman machine operations - START', async ({ page }) => {
-              const podmanMachineDetails = new PodmanMachineDetails(page, PODMAN_MACHINE_NAME);
-              await playExpect(podmanMachineDetails.podmanMachineStartButton).toBeEnabled();
-              await podmanMachineDetails.podmanMachineStartButton.click();
-              await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('RUNNING', { timeout: 90_000 });
-            });
-
-            test('Podman machine operations - RESTART', async ({ page }) => {
-              const podmanMachineDetails = new PodmanMachineDetails(page, PODMAN_MACHINE_NAME);
-              await playExpect(podmanMachineDetails.podmanMachineRestartButton).toBeEnabled();
-              await podmanMachineDetails.podmanMachineRestartButton.click();
-              await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('OFF', { timeout: 60_000 });
-              await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('RUNNING', { timeout: 90_000 });
-            });
-          });
+          await playExpect(podmanOnboardingPage.machineCreationForm.podmanMachineMemory).toBeVisible();
+          await playExpect(podmanOnboardingPage.machineCreationForm.podmanMachineDiskSize).toBeVisible();
+        }
       });
-
-    test('Clean Up Podman Machine', async ({ page }) => {
-      test.skip(process.env.MACHINE_CLEANUP !== 'true', 'Machine cleanup is disabled');
-      await deletePodmanMachine(page, 'Podman Machine');
     });
+  test.describe
+    .serial('Podman Machine creation and operations', () => {
+      test.skip(process.env.TEST_PODMAN_MACHINE !== 'true');
+
+      test('Create a default Podman machine', async () => {
+        test.setTimeout(PODMAN_FULL_STARTUP_TIMEOUT);
+        await podmanOnboardingPage.machineCreationForm.createMachineButton.click();
+        await playExpect(podmanOnboardingPage.podmanMachineShowLogsButton).toBeVisible();
+        await podmanOnboardingPage.podmanMachineShowLogsButton.click();
+        await playExpect(podmanOnboardingPage.onboardingStatusMessage).toBeVisible({
+          timeout: PODMAN_MACHINE_STARTUP_TIMEOUT,
+        });
+        await playExpect(podmanOnboardingPage.onboardingStatusMessage).toHaveText('Podman installed');
+        await podmanOnboardingPage.nextStepButton.click();
+      });
+
+      test.describe
+        .serial('Podman machine operations', () => {
+          test.describe.configure({ timeout: 120000 });
+
+          test('Open podman machine details', async ({ page, navigationBar }) => {
+            dashboardPage = await navigationBar.openDashboard();
+            await playExpect(dashboardPage.mainPage).toBeVisible();
+            settingsBar = await navigationBar.openSettings();
+            await settingsBar.resourcesTab.click();
+            resourcesPage = new ResourcesPage(page);
+            await playExpect.poll(async () => await resourcesPage.resourceCardIsVisible(RESOURCE_NAME)).toBeTruthy();
+            const resourcesPodmanConnections = new ResourceConnectionCardPage(page, RESOURCE_NAME, PODMAN_MACHINE_NAME);
+            await playExpect(resourcesPodmanConnections.providerConnections).toBeVisible({ timeout: 10_000 });
+            await playExpect(resourcesPodmanConnections.resourceElement).toBeVisible({ timeout: 20_000 });
+            await playExpect(resourcesPodmanConnections.resourceElementDetailsButton).toBeVisible();
+            await resourcesPodmanConnections.resourceElementDetailsButton.click();
+            const podmanMachineDetails = new PodmanMachineDetails(page, PODMAN_MACHINE_NAME);
+            await playExpect(podmanMachineDetails.podmanMachineStatus).toBeVisible();
+            await playExpect(podmanMachineDetails.podmanMachineConnectionActions).toBeVisible();
+            await playExpect(podmanMachineDetails.podmanMachineStartButton).toBeVisible();
+            await playExpect(podmanMachineDetails.podmanMachineRestartButton).toBeVisible();
+            await playExpect(podmanMachineDetails.podmanMachineStopButton).toBeVisible();
+            await playExpect(podmanMachineDetails.podmanMachineDeleteButton).toBeVisible();
+          });
+
+          test('Podman machine operations - STOP', async ({ page }) => {
+            const podmanMachineDetails = new PodmanMachineDetails(page, PODMAN_MACHINE_NAME);
+            await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('RUNNING', { timeout: 60_000 });
+            await playExpect(podmanMachineDetails.podmanMachineStopButton).toBeEnabled();
+            await podmanMachineDetails.podmanMachineStopButton.click();
+            await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('OFF', { timeout: 60_000 });
+          });
+
+          test('Podman machine operations - START', async ({ page }) => {
+            const podmanMachineDetails = new PodmanMachineDetails(page, PODMAN_MACHINE_NAME);
+            await playExpect(podmanMachineDetails.podmanMachineStartButton).toBeEnabled();
+            await podmanMachineDetails.podmanMachineStartButton.click();
+            await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('RUNNING', { timeout: 90_000 });
+          });
+
+          test('Podman machine operations - RESTART', async ({ page }) => {
+            const podmanMachineDetails = new PodmanMachineDetails(page, PODMAN_MACHINE_NAME);
+            await playExpect(podmanMachineDetails.podmanMachineRestartButton).toBeEnabled();
+            await podmanMachineDetails.podmanMachineRestartButton.click();
+            await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('OFF', { timeout: 60_000 });
+            await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('RUNNING', { timeout: 90_000 });
+          });
+        });
+    });
+
+  test('Clean Up Podman Machine', async ({ page }) => {
+    test.skip(process.env.MACHINE_CLEANUP !== 'true', 'Machine cleanup is disabled');
+    await deletePodmanMachine(page, 'Podman Machine');
   });
+});
 
 async function checkPodmanMachineOnboardingPage(page: Page): Promise<PodmanOnboardingPage> {
   const onboardingPage = new PodmanOnboardingPage(page);

--- a/tests/playwright/src/specs/podman-machine-rootless.spec.ts
+++ b/tests/playwright/src/specs/podman-machine-rootless.spec.ts
@@ -71,111 +71,110 @@ test.afterAll(async ({ runner, page }) => {
   await runner.close();
 });
 
-test.describe
-  .serial('Rootless Podman machine Verification', () => {
-    test('Check data for available Podman Machine and stop machine', async ({ page, navigationBar }) => {
-      test.setTimeout(120_000);
-      const settingsBar = await navigationBar.openSettings();
-      await settingsBar.resourcesTab.click();
+test.describe.serial('Rootless Podman machine Verification', { tag: ['@all'] }, () => {
+  test('Check data for available Podman Machine and stop machine', async ({ page, navigationBar }) => {
+    test.setTimeout(120_000);
+    const settingsBar = await navigationBar.openSettings();
+    await settingsBar.resourcesTab.click();
 
-      const resourcesPage = new ResourcesPage(page);
-      await playExpect(resourcesPage.heading).toBeVisible();
-      await playExpect.poll(async () => await resourcesPage.resourceCardIsVisible(RESOURCE_NAME)).toBeTruthy();
-      const resourcesPodmanConnections = new ResourceConnectionCardPage(
-        page,
-        RESOURCE_NAME,
-        DEFAULT_PODMAN_MACHINE_VISIBLE,
-      );
+    const resourcesPage = new ResourcesPage(page);
+    await playExpect(resourcesPage.heading).toBeVisible();
+    await playExpect.poll(async () => await resourcesPage.resourceCardIsVisible(RESOURCE_NAME)).toBeTruthy();
+    const resourcesPodmanConnections = new ResourceConnectionCardPage(
+      page,
+      RESOURCE_NAME,
+      DEFAULT_PODMAN_MACHINE_VISIBLE,
+    );
 
-      await playExpect(resourcesPodmanConnections.resourceElementDetailsButton).toBeVisible({ timeout: 10_000 });
-      await resourcesPodmanConnections.resourceElementDetailsButton.click();
+    await playExpect(resourcesPodmanConnections.resourceElementDetailsButton).toBeVisible({ timeout: 10_000 });
+    await resourcesPodmanConnections.resourceElementDetailsButton.click();
 
-      const podmanMachineDetails = new PodmanMachineDetails(page, DEFAULT_PODMAN_MACHINE);
+    const podmanMachineDetails = new PodmanMachineDetails(page, DEFAULT_PODMAN_MACHINE);
 
-      await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('RUNNING', { timeout: 60_000 });
-      await playExpect(podmanMachineDetails.podmanMachineStopButton).toBeEnabled();
-      await podmanMachineDetails.podmanMachineStopButton.click();
-      await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('OFF', { timeout: 60_000 });
-    });
-
-    test('Create a rootless machine', async ({ page, navigationBar }) => {
-      test.setTimeout(200_000);
-
-      const settingsBar = await navigationBar.openSettings();
-      await settingsBar.resourcesTab.click();
-
-      const podmanResources = new ResourceConnectionCardPage(page, 'podman');
-      await podmanResources.createButton.click();
-
-      const createMachinePage = new CreateMachinePage(page);
-      const resourcePage = await createMachinePage.createMachine(PODMAN_MACHINE_NAME, {
-        isRootful: false,
-        setAsDefault: false,
-        startNow: false,
-      });
-
-      await playExpect(resourcePage.heading).toBeVisible();
-      const machineBox = new ResourceConnectionCardPage(page, 'podman', PODMAN_MACHINE_NAME); //does not work with visible name
-
-      await playExpect(machineBox.resourceElementDetailsButton).toBeVisible({ timeout: 30_000 });
-      await machineBox.resourceElementDetailsButton.click();
-
-      const podmanMachineDetails = new PodmanMachineDetails(page, ROOTLESS_PODMAN_MACHINE);
-      await playExpect(podmanMachineDetails.podmanMachineName).toBeVisible({ timeout: 30_000 });
-      await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('OFF');
-
-      await playExpect(podmanMachineDetails.podmanMachineStartButton).toBeEnabled();
-      await podmanMachineDetails.podmanMachineStartButton.click();
-
-      await playExpect(dialog).toBeVisible({ timeout: 60_000 });
-      await handleConfirmationDialog(page, 'Podman', true, 'Yes');
-      await handleConfirmationDialog(page, 'Podman', true, 'OK');
-
-      await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('RUNNING', { timeout: 90_000 });
-
-      await playExpect(podmanMachineDetails.podmanMachineStopButton).toBeEnabled();
-      await podmanMachineDetails.podmanMachineStopButton.click();
-      await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('OFF', { timeout: 60_000 });
-    });
-
-    test('Restart default podman machine', async ({ page, navigationBar }) => {
-      const dashboard = await navigationBar.openDashboard();
-      await playExpect(dashboard.heading).toBeVisible();
-      const settingsBar = await navigationBar.openSettings();
-      await settingsBar.resourcesTab.click();
-
-      const resourcesPage = new ResourcesPage(page);
-      await playExpect(resourcesPage.heading).toBeVisible();
-      await playExpect.poll(async () => await resourcesPage.resourceCardIsVisible(RESOURCE_NAME)).toBeTruthy();
-      const resourcesPodmanConnections = new ResourceConnectionCardPage(
-        page,
-        RESOURCE_NAME,
-        DEFAULT_PODMAN_MACHINE_VISIBLE,
-      );
-      await playExpect(resourcesPodmanConnections.resourceElementDetailsButton).toBeVisible();
-      await resourcesPodmanConnections.resourceElementDetailsButton.click();
-
-      const podmanMachineDetails = new PodmanMachineDetails(page, DEFAULT_PODMAN_MACHINE);
-
-      await playExpect(podmanMachineDetails.podmanMachineStartButton).toBeEnabled();
-      await podmanMachineDetails.podmanMachineStartButton.click();
-
-      await playExpect(dialog).toBeVisible({ timeout: 60_000 });
-      await handleConfirmationDialog(page, 'Podman', true, 'Yes');
-      await handleConfirmationDialog(page, 'Podman', true, 'OK');
-
-      await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('RUNNING', { timeout: 90_000 });
-    });
-
-    test('Clean up rootless machine', async ({ page }) => {
-      test.setTimeout(150_000);
-      await deletePodmanMachine(page, PODMAN_MACHINE_NAME);
-
-      try {
-        await handleConfirmationDialog(page, 'Podman', true, 'Yes');
-        await handleConfirmationDialog(page, 'Podman', true, 'OK');
-      } catch (error) {
-        console.log('No handing dialog displayed', error);
-      }
-    });
+    await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('RUNNING', { timeout: 60_000 });
+    await playExpect(podmanMachineDetails.podmanMachineStopButton).toBeEnabled();
+    await podmanMachineDetails.podmanMachineStopButton.click();
+    await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('OFF', { timeout: 60_000 });
   });
+
+  test('Create a rootless machine', async ({ page, navigationBar }) => {
+    test.setTimeout(200_000);
+
+    const settingsBar = await navigationBar.openSettings();
+    await settingsBar.resourcesTab.click();
+
+    const podmanResources = new ResourceConnectionCardPage(page, 'podman');
+    await podmanResources.createButton.click();
+
+    const createMachinePage = new CreateMachinePage(page);
+    const resourcePage = await createMachinePage.createMachine(PODMAN_MACHINE_NAME, {
+      isRootful: false,
+      setAsDefault: false,
+      startNow: false,
+    });
+
+    await playExpect(resourcePage.heading).toBeVisible();
+    const machineBox = new ResourceConnectionCardPage(page, 'podman', PODMAN_MACHINE_NAME); //does not work with visible name
+
+    await playExpect(machineBox.resourceElementDetailsButton).toBeVisible({ timeout: 30_000 });
+    await machineBox.resourceElementDetailsButton.click();
+
+    const podmanMachineDetails = new PodmanMachineDetails(page, ROOTLESS_PODMAN_MACHINE);
+    await playExpect(podmanMachineDetails.podmanMachineName).toBeVisible({ timeout: 30_000 });
+    await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('OFF');
+
+    await playExpect(podmanMachineDetails.podmanMachineStartButton).toBeEnabled();
+    await podmanMachineDetails.podmanMachineStartButton.click();
+
+    await playExpect(dialog).toBeVisible({ timeout: 60_000 });
+    await handleConfirmationDialog(page, 'Podman', true, 'Yes');
+    await handleConfirmationDialog(page, 'Podman', true, 'OK');
+
+    await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('RUNNING', { timeout: 90_000 });
+
+    await playExpect(podmanMachineDetails.podmanMachineStopButton).toBeEnabled();
+    await podmanMachineDetails.podmanMachineStopButton.click();
+    await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('OFF', { timeout: 60_000 });
+  });
+
+  test('Restart default podman machine', async ({ page, navigationBar }) => {
+    const dashboard = await navigationBar.openDashboard();
+    await playExpect(dashboard.heading).toBeVisible();
+    const settingsBar = await navigationBar.openSettings();
+    await settingsBar.resourcesTab.click();
+
+    const resourcesPage = new ResourcesPage(page);
+    await playExpect(resourcesPage.heading).toBeVisible();
+    await playExpect.poll(async () => await resourcesPage.resourceCardIsVisible(RESOURCE_NAME)).toBeTruthy();
+    const resourcesPodmanConnections = new ResourceConnectionCardPage(
+      page,
+      RESOURCE_NAME,
+      DEFAULT_PODMAN_MACHINE_VISIBLE,
+    );
+    await playExpect(resourcesPodmanConnections.resourceElementDetailsButton).toBeVisible();
+    await resourcesPodmanConnections.resourceElementDetailsButton.click();
+
+    const podmanMachineDetails = new PodmanMachineDetails(page, DEFAULT_PODMAN_MACHINE);
+
+    await playExpect(podmanMachineDetails.podmanMachineStartButton).toBeEnabled();
+    await podmanMachineDetails.podmanMachineStartButton.click();
+
+    await playExpect(dialog).toBeVisible({ timeout: 60_000 });
+    await handleConfirmationDialog(page, 'Podman', true, 'Yes');
+    await handleConfirmationDialog(page, 'Podman', true, 'OK');
+
+    await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('RUNNING', { timeout: 90_000 });
+  });
+
+  test('Clean up rootless machine', async ({ page }) => {
+    test.setTimeout(150_000);
+    await deletePodmanMachine(page, PODMAN_MACHINE_NAME);
+
+    try {
+      await handleConfirmationDialog(page, 'Podman', true, 'Yes');
+      await handleConfirmationDialog(page, 'Podman', true, 'OK');
+    } catch (error) {
+      console.log('No handing dialog displayed', error);
+    }
+  });
+});

--- a/tests/playwright/src/specs/podman-machine-tests.spec.ts
+++ b/tests/playwright/src/specs/podman-machine-tests.spec.ts
@@ -69,151 +69,100 @@ test.afterAll(async ({ runner, page }) => {
   await runner.close();
 });
 
-test.describe
-  .serial(`Podman machine switching validation `, () => {
-    test('Check data for available Podman Machine and stop machine', async ({ page, navigationBar }) => {
-      await test.step('Open resources page', async () => {
-        const settingsBar = await navigationBar.openSettings();
-        await settingsBar.resourcesTab.click();
-      });
-
-      await test.step('Check default podman machine', async () => {
-        const resourcesPage = new ResourcesPage(page);
-        await playExpect(resourcesPage.heading).toBeVisible();
-        await playExpect.poll(async () => await resourcesPage.resourceCardIsVisible(RESOURCE_NAME)).toBeTruthy();
-        const resourcesPodmanConnections = new ResourceConnectionCardPage(
-          page,
-          RESOURCE_NAME,
-          DEFAULT_PODMAN_MACHINE_VISIBLE,
-        );
-        await playExpect(resourcesPodmanConnections.providerConnections).toBeVisible({ timeout: 10_000 });
-        await playExpect(resourcesPodmanConnections.resourceElement).toBeVisible({ timeout: 20_000 });
-        await playExpect(resourcesPodmanConnections.resourceElementDetailsButton).toBeVisible();
-        await resourcesPodmanConnections.resourceElementDetailsButton.click();
-      });
-
-      await test.step('Check default podman machine details', async () => {
-        const podmanMachineDetails = new PodmanMachineDetails(page, DEFAULT_PODMAN_MACHINE);
-        await test.step('Ensure default podman machine is RUNNING', async () => {
-          await playExpect(podmanMachineDetails.podmanMachineStatus).toBeVisible();
-          await playExpect(podmanMachineDetails.podmanMachineConnectionActions).toBeVisible();
-          await playExpect(podmanMachineDetails.podmanMachineStartButton).toBeVisible();
-          await playExpect(podmanMachineDetails.podmanMachineRestartButton).toBeVisible();
-          await playExpect(podmanMachineDetails.podmanMachineStopButton).toBeVisible();
-          await playExpect(podmanMachineDetails.podmanMachineDeleteButton).toBeVisible();
-          await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('RUNNING', { timeout: 60_000 });
-        });
-
-        await test.step('Stop default podman machine', async () => {
-          await playExpect(podmanMachineDetails.podmanMachineStopButton).toBeEnabled();
-          await podmanMachineDetails.podmanMachineStopButton.click();
-          await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('OFF', { timeout: 60_000 });
-        });
-      });
+test.describe.serial(`Podman machine switching validation `, { tag: ['@all'] }, () => {
+  test('Check data for available Podman Machine and stop machine', async ({ page, navigationBar }) => {
+    await test.step('Open resources page', async () => {
+      const settingsBar = await navigationBar.openSettings();
+      await settingsBar.resourcesTab.click();
     });
 
-    test('Create rootless podman machine', async ({ page, navigationBar }) => {
-      test.setTimeout(200_000);
-
-      await test.step('Open resources page', async () => {
-        const dashboard = await navigationBar.openDashboard();
-        await playExpect(dashboard.heading).toBeVisible();
-        const settingsBar = await navigationBar.openSettings();
-        await settingsBar.resourcesTab.click();
-      });
-
+    await test.step('Check default podman machine', async () => {
       const resourcesPage = new ResourcesPage(page);
-      await test.step('Go to create new podman machine page', async () => {
-        await playExpect(resourcesPage.heading).toBeVisible();
-        await playExpect.poll(async () => await resourcesPage.resourceCardIsVisible(RESOURCE_NAME)).toBeTruthy();
-        await resourcesPage.goToCreateNewResourcePage(RESOURCE_NAME);
-      });
-
-      const podmanMachineCreatePage = new PodmanOnboardingPage(page);
-
-      await test.step('Create podman machine', async () => {
-        await podmanMachineCreatePage.machineCreationForm.setupAndCreateMachine(ROOTLESS_PODMAN_MACHINE_VISIBLE, {
-          isRootful: false,
-          enableUserNet: true,
-          startNow: false,
-        });
-        await playExpect(podmanMachineCreatePage.goBackButton).toBeEnabled({ timeout: 180_000 });
-        await podmanMachineCreatePage.goBackButton.click();
-      });
-
       await playExpect(resourcesPage.heading).toBeVisible();
+      await playExpect.poll(async () => await resourcesPage.resourceCardIsVisible(RESOURCE_NAME)).toBeTruthy();
+      const resourcesPodmanConnections = new ResourceConnectionCardPage(
+        page,
+        RESOURCE_NAME,
+        DEFAULT_PODMAN_MACHINE_VISIBLE,
+      );
+      await playExpect(resourcesPodmanConnections.providerConnections).toBeVisible({ timeout: 10_000 });
+      await playExpect(resourcesPodmanConnections.resourceElement).toBeVisible({ timeout: 20_000 });
+      await playExpect(resourcesPodmanConnections.resourceElementDetailsButton).toBeVisible();
+      await resourcesPodmanConnections.resourceElementDetailsButton.click();
     });
 
-    test('Switch to rootless podman machine', async ({ page }) => {
-      await test.step('Go to rootless podman machine details page', async () => {
-        const resourcesPodmanConnections = new ResourceConnectionCardPage(
-          page,
-          RESOURCE_NAME,
-          ROOTLESS_PODMAN_MACHINE_VISIBLE,
-        );
-
-        await playExpect(resourcesPodmanConnections.resourceElementDetailsButton).toBeVisible({ timeout: 30_000 });
-        await resourcesPodmanConnections.resourceElementDetailsButton.click();
+    await test.step('Check default podman machine details', async () => {
+      const podmanMachineDetails = new PodmanMachineDetails(page, DEFAULT_PODMAN_MACHINE);
+      await test.step('Ensure default podman machine is RUNNING', async () => {
+        await playExpect(podmanMachineDetails.podmanMachineStatus).toBeVisible();
+        await playExpect(podmanMachineDetails.podmanMachineConnectionActions).toBeVisible();
+        await playExpect(podmanMachineDetails.podmanMachineStartButton).toBeVisible();
+        await playExpect(podmanMachineDetails.podmanMachineRestartButton).toBeVisible();
+        await playExpect(podmanMachineDetails.podmanMachineStopButton).toBeVisible();
+        await playExpect(podmanMachineDetails.podmanMachineDeleteButton).toBeVisible();
+        await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('RUNNING', { timeout: 60_000 });
       });
 
-      await test.step('Check rootless podman machine details', async () => {
-        const podmanMachineDetails = new PodmanMachineDetails(page, ROOTLESS_PODMAN_MACHINE);
-        await test.step('Ensure rootless podman machine is OFF', async () => {
-          await playExpect(podmanMachineDetails.podmanMachineName).toBeVisible();
-          await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('OFF');
-        });
-
-        await test.step('Start rootless podman machine', async () => {
-          await playExpect(podmanMachineDetails.podmanMachineStartButton).toBeEnabled();
-          await podmanMachineDetails.podmanMachineStartButton.click();
-
-          await playExpect(dialog).toBeVisible({ timeout: 60_000 });
-          await handleConfirmationDialog(page, 'Podman', true, 'Yes');
-          await handleConfirmationDialog(page, 'Podman', true, 'OK');
-
-          await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('RUNNING', { timeout: 90_000 });
-        });
-      });
-    });
-
-    test('Stop rootless podman machine', async ({ page }) => {
-      const podmanMachineDetails = new PodmanMachineDetails(page, ROOTLESS_PODMAN_MACHINE);
-      await test.step('Ensure rootless podman machine is RUNNING', async () => {
-        await playExpect(podmanMachineDetails.podmanMachineName).toBeVisible();
-        await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('RUNNING');
-      });
-
-      await test.step('Stop rootless podman machine', async () => {
+      await test.step('Stop default podman machine', async () => {
         await playExpect(podmanMachineDetails.podmanMachineStopButton).toBeEnabled();
         await podmanMachineDetails.podmanMachineStopButton.click();
         await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('OFF', { timeout: 60_000 });
       });
     });
+  });
 
-    test('Restart default podman machine', async ({ page, navigationBar }) => {
-      await test.step('Open resources page', async () => {
-        const dashboard = await navigationBar.openDashboard();
-        await playExpect(dashboard.heading).toBeVisible();
-        const settingsBar = await navigationBar.openSettings();
-        await settingsBar.resourcesTab.click();
+  test('Create rootless podman machine', async ({ page, navigationBar }) => {
+    test.setTimeout(200_000);
+
+    await test.step('Open resources page', async () => {
+      const dashboard = await navigationBar.openDashboard();
+      await playExpect(dashboard.heading).toBeVisible();
+      const settingsBar = await navigationBar.openSettings();
+      await settingsBar.resourcesTab.click();
+    });
+
+    const resourcesPage = new ResourcesPage(page);
+    await test.step('Go to create new podman machine page', async () => {
+      await playExpect(resourcesPage.heading).toBeVisible();
+      await playExpect.poll(async () => await resourcesPage.resourceCardIsVisible(RESOURCE_NAME)).toBeTruthy();
+      await resourcesPage.goToCreateNewResourcePage(RESOURCE_NAME);
+    });
+
+    const podmanMachineCreatePage = new PodmanOnboardingPage(page);
+
+    await test.step('Create podman machine', async () => {
+      await podmanMachineCreatePage.machineCreationForm.setupAndCreateMachine(ROOTLESS_PODMAN_MACHINE_VISIBLE, {
+        isRootful: false,
+        enableUserNet: true,
+        startNow: false,
+      });
+      await playExpect(podmanMachineCreatePage.goBackButton).toBeEnabled({ timeout: 180_000 });
+      await podmanMachineCreatePage.goBackButton.click();
+    });
+
+    await playExpect(resourcesPage.heading).toBeVisible();
+  });
+
+  test('Switch to rootless podman machine', async ({ page }) => {
+    await test.step('Go to rootless podman machine details page', async () => {
+      const resourcesPodmanConnections = new ResourceConnectionCardPage(
+        page,
+        RESOURCE_NAME,
+        ROOTLESS_PODMAN_MACHINE_VISIBLE,
+      );
+
+      await playExpect(resourcesPodmanConnections.resourceElementDetailsButton).toBeVisible({ timeout: 30_000 });
+      await resourcesPodmanConnections.resourceElementDetailsButton.click();
+    });
+
+    await test.step('Check rootless podman machine details', async () => {
+      const podmanMachineDetails = new PodmanMachineDetails(page, ROOTLESS_PODMAN_MACHINE);
+      await test.step('Ensure rootless podman machine is OFF', async () => {
+        await playExpect(podmanMachineDetails.podmanMachineName).toBeVisible();
+        await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('OFF');
       });
 
-      await test.step('Go to default podman machine details page', async () => {
-        const resourcesPage = new ResourcesPage(page);
-        await playExpect(resourcesPage.heading).toBeVisible();
-        await playExpect.poll(async () => await resourcesPage.resourceCardIsVisible(RESOURCE_NAME)).toBeTruthy();
-        const resourcesPodmanConnections = new ResourceConnectionCardPage(
-          page,
-          RESOURCE_NAME,
-          DEFAULT_PODMAN_MACHINE_VISIBLE,
-        );
-        await playExpect(resourcesPodmanConnections.resourceElementDetailsButton).toBeVisible();
-        await resourcesPodmanConnections.resourceElementDetailsButton.click();
-      });
-
-      await test.step('Turn default podman machine on', async () => {
-        const podmanMachineDetails = new PodmanMachineDetails(page, DEFAULT_PODMAN_MACHINE);
-
+      await test.step('Start rootless podman machine', async () => {
         await playExpect(podmanMachineDetails.podmanMachineStartButton).toBeEnabled();
         await podmanMachineDetails.podmanMachineStartButton.click();
 
@@ -224,15 +173,65 @@ test.describe
         await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('RUNNING', { timeout: 90_000 });
       });
     });
+  });
 
-    test('Clean up rootless podman machine', async ({ page }) => {
-      await deletePodmanMachine(page, ROOTLESS_PODMAN_MACHINE_VISIBLE);
+  test('Stop rootless podman machine', async ({ page }) => {
+    const podmanMachineDetails = new PodmanMachineDetails(page, ROOTLESS_PODMAN_MACHINE);
+    await test.step('Ensure rootless podman machine is RUNNING', async () => {
+      await playExpect(podmanMachineDetails.podmanMachineName).toBeVisible();
+      await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('RUNNING');
+    });
 
-      try {
-        await handleConfirmationDialog(page, 'Podman', true, 'Yes');
-        await handleConfirmationDialog(page, 'Podman', true, 'OK');
-      } catch (error) {
-        console.log('No handling dialog displayed', error);
-      }
+    await test.step('Stop rootless podman machine', async () => {
+      await playExpect(podmanMachineDetails.podmanMachineStopButton).toBeEnabled();
+      await podmanMachineDetails.podmanMachineStopButton.click();
+      await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('OFF', { timeout: 60_000 });
     });
   });
+
+  test('Restart default podman machine', async ({ page, navigationBar }) => {
+    await test.step('Open resources page', async () => {
+      const dashboard = await navigationBar.openDashboard();
+      await playExpect(dashboard.heading).toBeVisible();
+      const settingsBar = await navigationBar.openSettings();
+      await settingsBar.resourcesTab.click();
+    });
+
+    await test.step('Go to default podman machine details page', async () => {
+      const resourcesPage = new ResourcesPage(page);
+      await playExpect(resourcesPage.heading).toBeVisible();
+      await playExpect.poll(async () => await resourcesPage.resourceCardIsVisible(RESOURCE_NAME)).toBeTruthy();
+      const resourcesPodmanConnections = new ResourceConnectionCardPage(
+        page,
+        RESOURCE_NAME,
+        DEFAULT_PODMAN_MACHINE_VISIBLE,
+      );
+      await playExpect(resourcesPodmanConnections.resourceElementDetailsButton).toBeVisible();
+      await resourcesPodmanConnections.resourceElementDetailsButton.click();
+    });
+
+    await test.step('Turn default podman machine on', async () => {
+      const podmanMachineDetails = new PodmanMachineDetails(page, DEFAULT_PODMAN_MACHINE);
+
+      await playExpect(podmanMachineDetails.podmanMachineStartButton).toBeEnabled();
+      await podmanMachineDetails.podmanMachineStartButton.click();
+
+      await playExpect(dialog).toBeVisible({ timeout: 60_000 });
+      await handleConfirmationDialog(page, 'Podman', true, 'Yes');
+      await handleConfirmationDialog(page, 'Podman', true, 'OK');
+
+      await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('RUNNING', { timeout: 90_000 });
+    });
+  });
+
+  test('Clean up rootless podman machine', async ({ page }) => {
+    await deletePodmanMachine(page, ROOTLESS_PODMAN_MACHINE_VISIBLE);
+
+    try {
+      await handleConfirmationDialog(page, 'Podman', true, 'Yes');
+      await handleConfirmationDialog(page, 'Podman', true, 'OK');
+    } catch (error) {
+      console.log('No handling dialog displayed', error);
+    }
+  });
+});

--- a/tests/playwright/src/specs/registry-image.spec.ts
+++ b/tests/playwright/src/specs/registry-image.spec.ts
@@ -51,52 +51,56 @@ test.afterAll(async ({ runner, page }) => {
   }
 });
 
-test.describe.serial('Pulling image from authenticated registry workflow verification', { tag: '@smoke' }, () => {
-  test('Cannot pull image from unauthenticated registry', async ({ page, navigationBar }) => {
-    const imagesPage = await navigationBar.openImages();
-    await playExpect(imagesPage.heading).toBeVisible({ timeout: 10_000 });
-
-    const fullImageTitle = imageUrl.concat(':' + imageTag);
-    const errorAlert = page.getByLabel('Error Message Content');
-
-    const pullImagePage = await imagesPage.openPullImage();
-    await playExpect(pullImagePage.heading).toBeVisible({ timeout: 10_000 });
-
-    await pullImagePage.imageNameInput.pressSequentially(fullImageTitle, { delay: 25 });
-    await playExpect(pullImagePage.imageNameInput).toHaveValue(fullImageTitle);
-    await playExpect(pullImagePage.pullImageButton).toBeEnabled();
-    await pullImagePage.pullImageButton.click();
-
-    await playExpect(errorAlert).toBeVisible({ timeout: 10_000 });
-    await playExpect(errorAlert).toContainText('Error while pulling image from');
-    await playExpect(errorAlert).toContainText(fullImageTitle);
-    await playExpect(errorAlert).toContainText('Can also be that the registry requires authentication');
-  });
-
-  test.describe.serial(() => {
-    test.skip(!canTestRegistry(), 'Registry tests are disabled');
-
-    test('Add registry', async ({ page, navigationBar }) => {
-      await navigationBar.openSettings();
-      const settingsBar = new SettingsBar(page);
-      const registryPage = await settingsBar.openTabPage(RegistriesPage);
-
-      await registryPage.createRegistry(registryUrl, registryUsername, registryPswdSecret);
-
-      const registryBox = registryPage.registriesTable.getByLabel('GitHub');
-      const username = registryBox.getByText(registryUsername);
-      await playExpect(username).toBeVisible();
-    });
-
-    test('Image pulling from authenticated registry verification', async ({ navigationBar }) => {
+test.describe.serial(
+  'Pulling image from authenticated registry workflow verification',
+  { tag: ['@smoke', '@all'] },
+  () => {
+    test('Cannot pull image from unauthenticated registry', async ({ page, navigationBar }) => {
       const imagesPage = await navigationBar.openImages();
+      await playExpect(imagesPage.heading).toBeVisible({ timeout: 10_000 });
 
       const fullImageTitle = imageUrl.concat(':' + imageTag);
-      const pullImagePage = await imagesPage.openPullImage();
-      const updatedImages = await pullImagePage.pullImage(fullImageTitle);
+      const errorAlert = page.getByLabel('Error Message Content');
 
-      const exists = await updatedImages.waitForImageExists(imageUrl);
-      playExpect(exists, fullImageTitle + ' image not present in the list of images').toBeTruthy();
+      const pullImagePage = await imagesPage.openPullImage();
+      await playExpect(pullImagePage.heading).toBeVisible({ timeout: 10_000 });
+
+      await pullImagePage.imageNameInput.pressSequentially(fullImageTitle, { delay: 25 });
+      await playExpect(pullImagePage.imageNameInput).toHaveValue(fullImageTitle);
+      await playExpect(pullImagePage.pullImageButton).toBeEnabled();
+      await pullImagePage.pullImageButton.click();
+
+      await playExpect(errorAlert).toBeVisible({ timeout: 10_000 });
+      await playExpect(errorAlert).toContainText('Error while pulling image from');
+      await playExpect(errorAlert).toContainText(fullImageTitle);
+      await playExpect(errorAlert).toContainText('Can also be that the registry requires authentication');
     });
-  });
-});
+
+    test.describe.serial(() => {
+      test.skip(!canTestRegistry(), 'Registry tests are disabled');
+
+      test('Add registry', async ({ page, navigationBar }) => {
+        await navigationBar.openSettings();
+        const settingsBar = new SettingsBar(page);
+        const registryPage = await settingsBar.openTabPage(RegistriesPage);
+
+        await registryPage.createRegistry(registryUrl, registryUsername, registryPswdSecret);
+
+        const registryBox = registryPage.registriesTable.getByLabel('GitHub');
+        const username = registryBox.getByText(registryUsername);
+        await playExpect(username).toBeVisible();
+      });
+
+      test('Image pulling from authenticated registry verification', async ({ navigationBar }) => {
+        const imagesPage = await navigationBar.openImages();
+
+        const fullImageTitle = imageUrl.concat(':' + imageTag);
+        const pullImagePage = await imagesPage.openPullImage();
+        const updatedImages = await pullImagePage.pullImage(fullImageTitle);
+
+        const exists = await updatedImages.waitForImageExists(imageUrl);
+        playExpect(exists, fullImageTitle + ' image not present in the list of images').toBeTruthy();
+      });
+    });
+  },
+);

--- a/tests/playwright/src/specs/registry.spec.ts
+++ b/tests/playwright/src/specs/registry.spec.ts
@@ -38,7 +38,7 @@ test.afterAll(async ({ runner }) => {
   await runner.close();
 });
 
-test.describe.serial('Registries handling verification', { tag: '@smoke' }, () => {
+test.describe.serial('Registries handling verification', { tag: ['@smoke', '@all'] }, () => {
   test('Check Registries page components and presence of default registries', async ({ navigationBar }) => {
     const settingsBar = await navigationBar.openSettings();
     const registryPage = await settingsBar.openTabPage(RegistriesPage);

--- a/tests/playwright/src/specs/volume-smoke.spec.ts
+++ b/tests/playwright/src/specs/volume-smoke.spec.ts
@@ -39,7 +39,7 @@ test.afterAll(async ({ runner }) => {
 
 const volumeName = 'e2eVolume';
 
-test.describe.serial('Volume workflow verification', { tag: '@smoke' }, () => {
+test.describe.serial('Volume workflow verification', { tag: ['@smoke', '@all'] }, () => {
   test('Create new Volume', async ({ navigationBar }) => {
     let volumesPage = await navigationBar.openVolumes();
     await playExpect(volumesPage.heading).toBeVisible();

--- a/tests/playwright/src/specs/welcome-page-smoke.spec.ts
+++ b/tests/playwright/src/specs/welcome-page-smoke.spec.ts
@@ -28,7 +28,7 @@ test.afterAll(async ({ runner }) => {
   await runner.close();
 });
 
-test.describe('Basic e2e verification of podman desktop start', { tag: '@smoke' }, () => {
+test.describe('Basic e2e verification of podman desktop start', { tag: ['@smoke', '@all'] }, () => {
   test.describe('Welcome page handling', () => {
     test('Check the Welcome page is displayed', async ({ welcomePage }) => {
       await playExpect(welcomePage.welcomeMessage).toBeVisible();

--- a/tests/playwright/src/specs/yaml-smoke.spec.ts
+++ b/tests/playwright/src/specs/yaml-smoke.spec.ts
@@ -48,66 +48,70 @@ test.afterAll(async ({ runner, page }) => {
   }
 });
 
-test.describe.serial(`Play yaml file to pull images and create pod for app ${podAppName}`, { tag: '@smoke' }, () => {
-  test.describe.configure({ timeout: 150_000 });
+test.describe.serial(
+  `Play yaml file to pull images and create pod for app ${podAppName}`,
+  { tag: ['@smoke', '@all'] },
+  () => {
+    test.describe.configure({ timeout: 150_000 });
 
-  test('Playing yaml', async ({ navigationBar }) => {
-    let podsPage = await navigationBar.openPods();
-    await playExpect(podsPage.heading).toBeVisible();
+    test('Playing yaml', async ({ navigationBar }) => {
+      let podsPage = await navigationBar.openPods();
+      await playExpect(podsPage.heading).toBeVisible();
 
-    const playYamlPage = await podsPage.openPlayKubeYaml();
-    await playExpect(playYamlPage.heading).toBeVisible();
+      const playYamlPage = await podsPage.openPlayKubeYaml();
+      await playExpect(playYamlPage.heading).toBeVisible();
 
-    const yamlFilePath = path.resolve(__dirname, '..', '..', 'resources', `${podAppName}.yaml`);
-    podsPage = await playYamlPage.playYaml(yamlFilePath);
-    await playExpect(podsPage.heading).toBeVisible();
-  });
-
-  test('Checking that created pod from yaml is correct', async ({ page, navigationBar }) => {
-    test.setTimeout(120_000);
-    const podsPage = await navigationBar.openPods();
-    await playExpect(podsPage.heading).toBeVisible();
-
-    await playExpect.poll(async () => await podsPage.podExists(podName), { timeout: 60_000 }).toBeTruthy();
-    await deletePod(page, podName);
-    await playExpect.poll(async () => await podsPage.podExists(podName), { timeout: 60_000 }).toBeFalsy();
-  });
-
-  test('Checking that pulled images from yaml are correct', async ({ navigationBar }) => {
-    test.setTimeout(120_000);
-
-    let imagesPage = await navigationBar.openImages();
-    await playExpect(imagesPage.heading).toBeVisible();
-
-    await test.step('Checking that images are pulled', async () => {
-      await playExpect.poll(async () => await imagesPage.waitForImageExists(backendImage)).toBeTruthy();
-      await playExpect.poll(async () => await imagesPage.waitForImageExists(frontendImage)).toBeTruthy();
-      await playExpect
-        .poll(async () => await imagesPage.getCurrentStatusOfImage(backendImage), { timeout: 15_000 })
-        .toBe('UNUSED');
-      await playExpect
-        .poll(async () => await imagesPage.getCurrentStatusOfImage(frontendImage), { timeout: 15_000 })
-        .toBe('UNUSED');
+      const yamlFilePath = path.resolve(__dirname, '..', '..', 'resources', `${podAppName}.yaml`);
+      podsPage = await playYamlPage.playYaml(yamlFilePath);
+      await playExpect(podsPage.heading).toBeVisible();
     });
 
-    await test.step(`Deleting image ${backendImage}`, async () => {
-      const imageDetailsPage = await imagesPage.openImageDetails(backendImage);
-      await playExpect(imageDetailsPage.heading).toContainText(backendImage);
-      imagesPage = await imageDetailsPage.deleteImage();
-      await playExpect(imagesPage.heading).toBeVisible({ timeout: 30_000 });
-      await playExpect
-        .poll(async () => await imagesPage.waitForImageDelete(backendImage), { timeout: 10_000 })
-        .toBeTruthy();
+    test('Checking that created pod from yaml is correct', async ({ page, navigationBar }) => {
+      test.setTimeout(120_000);
+      const podsPage = await navigationBar.openPods();
+      await playExpect(podsPage.heading).toBeVisible();
+
+      await playExpect.poll(async () => await podsPage.podExists(podName), { timeout: 60_000 }).toBeTruthy();
+      await deletePod(page, podName);
+      await playExpect.poll(async () => await podsPage.podExists(podName), { timeout: 60_000 }).toBeFalsy();
     });
 
-    await test.step(`Deleting image ${frontendImage}`, async () => {
-      const imageDetailsPage = await imagesPage.openImageDetails(frontendImage);
-      await playExpect(imageDetailsPage.heading).toContainText(frontendImage);
-      imagesPage = await imageDetailsPage.deleteImage();
-      await playExpect(imagesPage.heading).toBeVisible({ timeout: 30_000 });
-      await playExpect
-        .poll(async () => await imagesPage.waitForImageDelete(frontendImage), { timeout: 10_000 })
-        .toBeTruthy();
+    test('Checking that pulled images from yaml are correct', async ({ navigationBar }) => {
+      test.setTimeout(120_000);
+
+      let imagesPage = await navigationBar.openImages();
+      await playExpect(imagesPage.heading).toBeVisible();
+
+      await test.step('Checking that images are pulled', async () => {
+        await playExpect.poll(async () => await imagesPage.waitForImageExists(backendImage)).toBeTruthy();
+        await playExpect.poll(async () => await imagesPage.waitForImageExists(frontendImage)).toBeTruthy();
+        await playExpect
+          .poll(async () => await imagesPage.getCurrentStatusOfImage(backendImage), { timeout: 15_000 })
+          .toBe('UNUSED');
+        await playExpect
+          .poll(async () => await imagesPage.getCurrentStatusOfImage(frontendImage), { timeout: 15_000 })
+          .toBe('UNUSED');
+      });
+
+      await test.step(`Deleting image ${backendImage}`, async () => {
+        const imageDetailsPage = await imagesPage.openImageDetails(backendImage);
+        await playExpect(imageDetailsPage.heading).toContainText(backendImage);
+        imagesPage = await imageDetailsPage.deleteImage();
+        await playExpect(imagesPage.heading).toBeVisible({ timeout: 30_000 });
+        await playExpect
+          .poll(async () => await imagesPage.waitForImageDelete(backendImage), { timeout: 10_000 })
+          .toBeTruthy();
+      });
+
+      await test.step(`Deleting image ${frontendImage}`, async () => {
+        const imageDetailsPage = await imagesPage.openImageDetails(frontendImage);
+        await playExpect(imageDetailsPage.heading).toContainText(frontendImage);
+        imagesPage = await imageDetailsPage.deleteImage();
+        await playExpect(imagesPage.heading).toBeVisible({ timeout: 30_000 });
+        await playExpect
+          .poll(async () => await imagesPage.waitForImageDelete(frontendImage), { timeout: 10_000 })
+          .toBeTruthy();
+      });
     });
-  });
-});
+  },
+);


### PR DESCRIPTION
### What does this PR do?
Add @all tag to all e2e tests that should be run on `test:e2e`. And to fix problem with processing grep reg. exp on various platforms by different shells.
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#10054 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

`pnpm test:e2e` should run all expected tests on all platforms. no failures.
<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
