### PR TITLE
fix: fetch all docker contexts

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -173,6 +173,7 @@ export default [
         'error',
         {
           ignoreConditionalTests: true,
+          ignoreMixedLogicalExpressions: true,
         },
       ],
       '@typescript-eslint/no-require-imports': 'off',

--- a/extensions/lima/package.json
+++ b/extensions/lima/package.json
@@ -20,6 +20,11 @@
           "default": "",
           "description": "Custom path to limactl binary (Default is blank)"
         },
+        "lima.home": {
+          "type": "string",
+          "default": "",
+          "description": "Lima home directory. See [documentation](https://lima-vm.io/docs/dev/internals/#lima-home-directory-lima_home)"
+        },
         "lima.type": {
           "type": "string",
           "default": "podman",

--- a/extensions/lima/src/extension.ts
+++ b/extensions/lima/src/extension.ts
@@ -95,8 +95,9 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   const engineType: string = configuration.getConfiguration('lima').get('type') ?? 'podman';
   const instanceName: string = configuration.getConfiguration('lima').get('name') ?? engineType;
   const socketName: string = configuration.getConfiguration('lima').get('socket') ?? engineType + '.sock';
+  const limaHome: string =
+    configuration.getConfiguration('lima').get('home') ?? process.env['LIMA_HOME'] ?? os.homedir() + '/.lima';
 
-  const limaHome = 'LIMA_HOME' in process.env ? process.env['LIMA_HOME'] : os.homedir() + '/.lima';
   const socketPath = path.resolve(limaHome ?? '', instanceName + '/sock/' + socketName);
   const configPath = path.resolve(limaHome ?? '', instanceName + '/copied-from-guest/kubeconfig.yaml');
 


### PR DESCRIPTION
### What does this PR do?

Fixes Docker Compatibility settings, by improving fetching docker context respecting `DOCKER_HOST` and `DOCKER_CONTEXT` env variables

### Screenshot / video of UI

https://github.com/user-attachments/assets/97e565f8-e10a-495b-aac6-142344c367da

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

https://github.com/podman-desktop/podman-desktop/issues/9351

### How to test this PR?

> [!IMPORTANT]
> all "export" steps means, that env variable will be exported in *rc, *env or *profile files
> (e.g.: .bashrc, .bash_profile, .zshrc, .zshenv, .zprofile, .profile, etc.)
> and may require Podman Desktop restart for reload shell state

- create multiple docker contexts via `docker context create`
- verify that all contexts displayed in UI
- export `DOCKER_CONFIG` with new any location, e.g. `~/some/new/dir/`
- move `~/.docker` directory to `DOCKER_CONFIG`, e.g. `~/some/new/dir/{contexts/, config.json}`
- verify that all contexts still displayed in UI
- export `DOCKER_HOST` with host different from your current context host
- verify that all contexts still displayed in UI and current context changed to defined via `DOCKER_HOST`
- export `DOCKER_CONTEXT` with other context name
- verify that all contexts still displayed in UI and current context changed to defined via `DOCKER_CONTEXT`


- [X] Tests are covering the bug fix or the new feature
