### PR TITLE
chore: add experimental flag setting for showing providers in statusbar

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -166,6 +166,7 @@ import { Proxy } from './proxy.js';
 import { RecommendationsRegistry } from './recommendations/recommendations-registry.js';
 import { ReleaseNotesBannerInit } from './release-notes-banner-init.js';
 import { SafeStorageRegistry } from './safe-storage/safe-storage-registry.js';
+import { StatusbarProvidersInit } from './statusbar/statusbar-providers-init.js';
 import type { StatusBarEntryDescriptor } from './statusbar/statusbar-registry.js';
 import { StatusBarRegistry } from './statusbar/statusbar-registry.js';
 import { NotificationRegistry } from './tasks/notification-registry.js';
@@ -502,6 +503,9 @@ export class PluginSystem {
 
     const dockerCompatibility = new DockerCompatibility(configurationRegistry, providerRegistry);
     dockerCompatibility.init();
+
+    const statusbarProviders = new StatusbarProvidersInit(configurationRegistry);
+    statusbarProviders.init();
 
     const messageBox = new MessageBox(apiSender);
 

--- a/packages/main/src/plugin/statusbar/statusbar-providers-init.spec.ts
+++ b/packages/main/src/plugin/statusbar/statusbar-providers-init.spec.ts
@@ -1,0 +1,55 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { expect, test, vi } from 'vitest';
+
+import type { ConfigurationRegistry } from '../configuration-registry.js';
+import { StatusbarProvidersInit } from './statusbar-providers-init.js';
+
+const registerConfigurationsMock = vi.fn();
+const configurationRegistryMock = {
+  registerConfigurations: registerConfigurationsMock,
+} as unknown as ConfigurationRegistry;
+
+test('should register a configuration', async () => {
+  vi.stubEnv('DEV', true);
+  const statusbarProvidersInit = new StatusbarProvidersInit(configurationRegistryMock);
+  statusbarProvidersInit.init();
+
+  expect(configurationRegistryMock.registerConfigurations).toBeCalled();
+  const configurationNode = vi.mocked(configurationRegistryMock.registerConfigurations).mock.calls[0]?.[0][0];
+  expect(configurationNode?.id).toBe('preferences.experimental.statusbarProviders');
+  expect(configurationNode?.title).toBe('Experimental (Statusbar Providers)');
+  expect(configurationNode?.properties).toBeDefined();
+  expect(Object.keys(configurationNode?.properties ?? {}).length).toBe(1);
+  expect(configurationNode?.properties?.['statusbarProviders.show']).toBeDefined();
+  expect(configurationNode?.properties?.['statusbarProviders.show']?.type).toBe('boolean');
+  expect(configurationNode?.properties?.['statusbarProviders.show']?.default).toBe(true);
+});
+
+test('False should be default if not in dev env', () => {
+  vi.resetAllMocks();
+  vi.stubEnv('DEV', false);
+  const statusbarProvidersInit = new StatusbarProvidersInit(configurationRegistryMock);
+  statusbarProvidersInit.init();
+
+  expect(configurationRegistryMock.registerConfigurations).toBeCalled();
+  const configurationNode = vi.mocked(configurationRegistryMock.registerConfigurations).mock.calls[0]?.[0][0];
+
+  expect(configurationNode?.properties?.['statusbarProviders.show']?.default).toBe(false);
+});

--- a/packages/main/src/plugin/statusbar/statusbar-providers-init.spec.ts
+++ b/packages/main/src/plugin/statusbar/statusbar-providers-init.spec.ts
@@ -37,9 +37,9 @@ test('should register a configuration', async () => {
   expect(configurationNode?.title).toBe('Experimental (Statusbar Providers)');
   expect(configurationNode?.properties).toBeDefined();
   expect(Object.keys(configurationNode?.properties ?? {}).length).toBe(1);
-  expect(configurationNode?.properties?.['statusbarProviders.show']).toBeDefined();
-  expect(configurationNode?.properties?.['statusbarProviders.show']?.type).toBe('boolean');
-  expect(configurationNode?.properties?.['statusbarProviders.show']?.default).toBe(true);
+  expect(configurationNode?.properties?.['statusbarProviders.showProviders']).toBeDefined();
+  expect(configurationNode?.properties?.['statusbarProviders.showProviders']?.type).toBe('boolean');
+  expect(configurationNode?.properties?.['statusbarProviders.showProviders']?.default).toBe(true);
 });
 
 test('False should be default if not in dev env', () => {
@@ -51,5 +51,5 @@ test('False should be default if not in dev env', () => {
   expect(configurationRegistryMock.registerConfigurations).toBeCalled();
   const configurationNode = vi.mocked(configurationRegistryMock.registerConfigurations).mock.calls[0]?.[0][0];
 
-  expect(configurationNode?.properties?.['statusbarProviders.show']?.default).toBe(false);
+  expect(configurationNode?.properties?.['statusbarProviders.showProviders']?.default).toBe(false);
 });

--- a/packages/main/src/plugin/statusbar/statusbar-providers-init.ts
+++ b/packages/main/src/plugin/statusbar/statusbar-providers-init.ts
@@ -27,7 +27,7 @@ export class StatusbarProvidersInit {
       title: 'Experimental (Statusbar Providers)',
       type: 'object',
       properties: {
-        [`statusbarProviders.show`]: {
+        [`statusbarProviders.showProviders`]: {
           description: 'Show providers in statusbar',
           type: 'boolean',
           default: import.meta.env.DEV ? true : false,

--- a/packages/main/src/plugin/statusbar/statusbar-providers-init.ts
+++ b/packages/main/src/plugin/statusbar/statusbar-providers-init.ts
@@ -1,0 +1,40 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { IConfigurationNode, IConfigurationRegistry } from './configuration-registry.js';
+
+export class StatusbarProvidersInit {
+  constructor(private configurationRegistry: IConfigurationRegistry) {}
+
+  init(): void {
+    const statusbarProvidersConfiguration: IConfigurationNode = {
+      id: `preferences.experimental.statusbarProviders`,
+      title: 'Experimental (Statusbar Providers)',
+      type: 'object',
+      properties: {
+        [`statusbarProviders.show`]: {
+          description: 'Show providers in statusbar',
+          type: 'boolean',
+          default: import.meta.env.DEV ? true : false,
+        },
+      },
+    };
+
+    this.configurationRegistry.registerConfigurations([statusbarProvidersConfiguration]);
+  }
+}

--- a/packages/main/src/plugin/statusbar/statusbar-providers-init.ts
+++ b/packages/main/src/plugin/statusbar/statusbar-providers-init.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { IConfigurationNode, IConfigurationRegistry } from './configuration-registry.js';
+import type { IConfigurationNode, IConfigurationRegistry } from '../configuration-registry.js';
 
 export class StatusbarProvidersInit {
   constructor(private configurationRegistry: IConfigurationRegistry) {}


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Adds an experimental flag for showing the providers in the statusbar

### Screenshot / video of UI
![Screenshot from 2024-11-21 12-19-41](https://github.com/user-attachments/assets/ef99c288-849d-4c0f-8df1-d834d09baffe)

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/pull/9724

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
