### PR TITLE
fix: do console logging only if app is not quitting

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -303,11 +303,11 @@ export class PluginSystem {
         .then(extName => {
           if (extName) args.unshift(extName);
 
-          // still display as before by invoking original method
-          originalConsoleMethod(...args);
-
           // but also send the content remotely
           if (!this.isQuitting) {
+            // still display as before by invoking original method
+            originalConsoleMethod(...args);
+
             try {
               this.getWebContentsSender().send('console:output', logType, ...args);
             } catch (err) {


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR possibly fixes the javascript epipe error that sometimes pops up when closing PD with `ctrl + c` after `pnpm watch` by logging in the console only if the app is not quitting.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
