### PR TITLE
chore: do not log health_status events

### DIFF
--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -146,7 +146,11 @@ export class ContainerProviderRegistry {
 
     eventEmitter.on('event', (jsonEvent: JSONEvent) => {
       nbEvents++;
-      console.log('event is', jsonEvent);
+      // do not log healthcheck(health_status) events
+      // as it's too verbose/repeating a lot
+      if (jsonEvent.status !== 'health_status') {
+        console.log('event is', jsonEvent);
+      }
       this._onEvent.fire(jsonEvent);
       if (jsonEvent.status === 'stop' && jsonEvent?.Type === 'container') {
         // need to notify that a container has been stopped


### PR DESCRIPTION
### What does this PR do?
some events are happening only once with low activity. But we have health check reports that may come every second or so so we've too many events being logged.
Here it's skipping the health_status events.


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fix https://github.com/podman-desktop/podman-desktop/issues/9417

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
