### PR TITLE
feat(k8s): adding create resource page

### DIFF
--- a/packages/api/src/navigation-page.ts
+++ b/packages/api/src/navigation-page.ts
@@ -57,4 +57,5 @@ export enum NavigationPage {
   KUBERNETES_CONFIGMAPS_SECRETS = 'kubernetes-configmaps-secrets',
   KUBERNETES_CONFIGMAP = 'kubernetes-configmap',
   KUBERNETES_SECRET = 'kubernetes-secret',
+  KUBERNETES_RESOURCE_CREATE = 'kubernetes-resource-create',
 }

--- a/packages/api/src/navigation-request.ts
+++ b/packages/api/src/navigation-request.ts
@@ -60,6 +60,7 @@ export interface NavigationParameters {
   [NavigationPage.KUBERNETES_PVC]: { name: string; namespace: string };
   [NavigationPage.KUBERNETES_INGRESSES_ROUTES]: never;
   [NavigationPage.KUBERNETES_INGRESSES_ROUTE]: { name: string; namespace: string };
+  [NavigationPage.KUBERNETES_RESOURCE_CREATE]: never;
 }
 
 // the parameters property is optional when the NavigationParameters say it is

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -4,6 +4,7 @@ import '@fortawesome/fontawesome-free/css/all.min.css';
 
 import { router } from 'tinro';
 
+import CreateKubeResource from '/@/lib/kube/CreateKubeResource.svelte';
 import { handleNavigation } from '/@/navigation';
 import { NO_CURRENT_CONTEXT_ERROR } from '/@api/kubernetes-contexts-states';
 import type { NavigationRequest } from '/@api/navigation-request';
@@ -321,6 +322,9 @@ window.events?.receive('navigate', (navigationRequest: unknown) => {
           </Route>
           <Route path="/kubernetes/portForward" breadcrumb="Port Forwarding" navigationHint="root">
             <PortForwardingList />
+          </Route>
+          <Route path="/kubernetes/resources/create">
+            <CreateKubeResource/>
           </Route>
         {/if}
         <Route path="/preferences/*" breadcrumb="Settings">

--- a/packages/renderer/src/lib/kube/CreateKubeResource.spec.ts
+++ b/packages/renderer/src/lib/kube/CreateKubeResource.spec.ts
@@ -44,7 +44,7 @@ beforeAll(() => {
       getComputedStyle: vi.fn(),
       addEventListener: vi.fn(),
       removeEventListener: vi.fn(),
-      matchMedia: vi.fn().mockReturnValue({
+      matchMedia: () => ({
         matches: false,
         addEventListener: vi.fn(),
         removeEventListener: vi.fn(),
@@ -55,9 +55,6 @@ beforeAll(() => {
       kubernetesApplyResourcesFromYAML: vi.fn(),
     },
   });
-  vi.mocked(window.getComputedStyle).mockReturnValue({
-    getPropertyValue: vi.fn().mockReturnValue(''),
-  } as unknown as CSSStyleDeclaration);
 });
 
 const CURRENT_CONTEXT = 'dummy-context';
@@ -65,6 +62,9 @@ const CURRENT_CONTEXT = 'dummy-context';
 beforeEach(() => {
   vi.resetAllMocks();
   vi.mocked(window.kubernetesGetCurrentContextName).mockResolvedValue(CURRENT_CONTEXT);
+  vi.mocked(window.getComputedStyle).mockReturnValue({
+    getPropertyValue: vi.fn().mockReturnValue(''),
+  } as unknown as CSSStyleDeclaration);
 });
 
 test('expect close button to redirect to last page', async () => {

--- a/packages/renderer/src/lib/kube/CreateKubeResource.spec.ts
+++ b/packages/renderer/src/lib/kube/CreateKubeResource.spec.ts
@@ -1,0 +1,213 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import type { KubernetesObject } from '@kubernetes/client-node';
+import { render } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { router } from 'tinro';
+import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
+
+import CreateKubeResource from '/@/lib/kube/CreateKubeResource.svelte';
+
+vi.mock('tinro', () => ({
+  router: {
+    goto: vi.fn(),
+  },
+}));
+
+beforeAll(() => {
+  Object.defineProperty(global, 'window', {
+    value: {
+      // mandatory mock
+      navigator: {
+        clipboard: {
+          writeText: vi.fn(),
+        },
+      },
+      getComputedStyle: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      matchMedia: vi.fn().mockReturnValue({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      }),
+      // the event we need
+      kubernetesGetCurrentContextName: vi.fn(),
+      showMessageBox: vi.fn(),
+      kubernetesApplyResourcesFromYAML: vi.fn(),
+    },
+  });
+  vi.mocked(window.getComputedStyle).mockReturnValue({
+    getPropertyValue: vi.fn().mockReturnValue(''),
+  } as unknown as CSSStyleDeclaration);
+});
+
+const CURRENT_CONTEXT = 'dummy-context';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(window.kubernetesGetCurrentContextName).mockResolvedValue(CURRENT_CONTEXT);
+});
+
+test('expect close button to redirect to last page', async () => {
+  const { getByTitle } = render(CreateKubeResource);
+
+  const closeBtn = getByTitle('Close');
+  expect(closeBtn).toBeDefined();
+
+  expect(router.goto).not.toHaveBeenCalled();
+  await userEvent.click(closeBtn);
+
+  await vi.waitFor(() => {
+    expect(router.goto).toHaveBeenCalledWith('/');
+  });
+});
+
+test('expect warning message box if kubernetesApplyResourcesFromYAML return an empty array', async () => {
+  // return an empty array
+  vi.mocked(window.kubernetesApplyResourcesFromYAML).mockResolvedValue([]);
+
+  const { getByTitle } = render(CreateKubeResource);
+
+  const createBtn = getByTitle('Create Resource');
+  expect(createBtn).toBeDefined();
+
+  expect(router.goto).not.toHaveBeenCalled();
+  await userEvent.click(createBtn);
+
+  await vi.waitFor(() => {
+    expect(window.showMessageBox).toHaveBeenCalledWith({
+      title: 'Kubernetes',
+      type: 'warning',
+      message: `No resource(s) were applied.`,
+      buttons: ['OK'],
+    });
+  });
+  // no redirect
+  expect(router.goto).not.toHaveBeenCalled();
+});
+
+test('expect error message box if kubernetesApplyResourcesFromYAML reject', async () => {
+  // return an empty array
+  vi.mocked(window.kubernetesApplyResourcesFromYAML).mockRejectedValue(new Error('Dummy error'));
+
+  const { getByTitle } = render(CreateKubeResource);
+
+  const createBtn = getByTitle('Create Resource');
+  expect(createBtn).toBeDefined();
+
+  expect(router.goto).not.toHaveBeenCalled();
+  await userEvent.click(createBtn);
+
+  await vi.waitFor(() => {
+    expect(window.showMessageBox).toHaveBeenCalledWith({
+      title: 'Kubernetes',
+      type: 'error',
+      message: 'Could not apply Kubernetes YAML: Error: Dummy error',
+      buttons: ['OK'],
+    });
+  });
+  // no redirect
+  expect(router.goto).not.toHaveBeenCalled();
+});
+
+test('expect progress to be visible until kubernetesApplyResourcesFromYAML resolve', async () => {
+  let resolve: ((value: KubernetesObject[]) => void) | undefined;
+  const promise = new Promise<KubernetesObject[]>(res => {
+    resolve = res;
+  });
+  expect(resolve).toBeDefined();
+
+  // return an empty array
+  vi.mocked(window.kubernetesApplyResourcesFromYAML).mockReturnValue(promise);
+
+  const { getByTitle, queryByRole } = render(CreateKubeResource);
+
+  const createBtn = getByTitle('Create Resource');
+  expect(createBtn).toBeDefined();
+
+  expect(router.goto).not.toHaveBeenCalled();
+  await userEvent.click(createBtn);
+
+  // must be visible while kubernetesApplyResourcesFromYAML is pending
+  await vi.waitFor(() => {
+    const progress = queryByRole('progressbar');
+    expect(progress).toBeDefined();
+  });
+
+  // resolve kubernetesApplyResourcesFromYAML
+  resolve?.([]);
+
+  // must disappear after resolution
+  await vi.waitFor(() => {
+    const progress = queryByRole('progressbar');
+    expect(progress).toBeNull();
+  });
+});
+
+test.each([
+  {
+    kind: 'Pod',
+    href: '/pods',
+  },
+  {
+    kind: 'Service',
+    href: '/kubernetes/services',
+  },
+  {
+    kind: 'PersistentVolumeClaim',
+    href: '/kubernetes/persistentvolumeclaims',
+  },
+  {
+    kind: 'ConfigMap',
+    href: '/kubernetes/configmapsSecrets',
+  },
+  {
+    kind: 'Secret',
+    href: '/kubernetes/configmapsSecrets',
+  },
+  {
+    kind: 'Ingress',
+    href: '/kubernetes/ingressesRoutes',
+  },
+  {
+    kind: 'Deployment',
+    href: '/kubernetes/deployments',
+  },
+])('create $kind kubernetes resource should redirect to $href', async ({ kind, href }) => {
+  // mock resolved object with specific kind
+  vi.mocked(window.kubernetesApplyResourcesFromYAML).mockResolvedValue([
+    {
+      kind: kind,
+    },
+  ]);
+
+  const { getByTitle } = render(CreateKubeResource);
+
+  const createBtn = getByTitle('Create Resource');
+
+  expect(router.goto).not.toHaveBeenCalled();
+  await userEvent.click(createBtn);
+
+  await vi.waitFor(() => {
+    expect(router.goto).toHaveBeenCalledWith(href);
+  });
+});

--- a/packages/renderer/src/lib/kube/CreateKubeResource.svelte
+++ b/packages/renderer/src/lib/kube/CreateKubeResource.svelte
@@ -1,0 +1,124 @@
+<script lang="ts">
+import type { KubernetesObject } from '@kubernetes/client-node';
+import { Button } from '@podman-desktop/ui-svelte';
+import { router } from 'tinro';
+
+import MonacoEditor from '/@/lib/editor/MonacoEditor.svelte';
+import ProgressBar from '/@/lib/task-manager/ProgressBar.svelte';
+import DetailsPage from '/@/lib/ui/DetailsPage.svelte';
+import { handleNavigation } from '/@/navigation';
+import { lastPage } from '/@/stores/breadcrumb';
+import { NavigationPage } from '/@api/navigation-page';
+
+let loading: boolean = $state(false);
+
+let content: string = $state('');
+
+let editorContent: string = $state('');
+let changesDetected: boolean = $state(false);
+
+function onContentChange(event: CustomEvent<string>): void {
+  changesDetected = event.detail !== content;
+  editorContent = event.detail;
+}
+
+/**
+ * This function try to redirect to the page related to the
+ * kubernetes resources created
+ * E.g. if the user created a pod, we redirect to the pods page
+ */
+function smartRedirect(objects: KubernetesObject[]): void {
+  // do not try complicated guess, if multiple go back to last page
+  if (objects.length !== 1) return onClose();
+
+  // if only one resource is created, go to it
+  switch (objects[0].kind) {
+    case 'Pod':
+      return handleNavigation({
+        page: NavigationPage.PODS,
+      });
+    case 'Service':
+      return handleNavigation({
+        page: NavigationPage.KUBERNETES_SERVICES,
+      });
+    case 'PersistentVolumeClaim':
+      return handleNavigation({
+        page: NavigationPage.KUBERNETES_PVCS,
+      });
+    case 'ConfigMap':
+    case 'Secret':
+      return handleNavigation({
+        page: NavigationPage.KUBERNETES_CONFIGMAPS_SECRETS,
+      });
+    case 'Ingress':
+      return handleNavigation({
+        page: NavigationPage.KUBERNETES_INGRESSES_ROUTES,
+      });
+    case 'Deployment':
+      return handleNavigation({
+        page: NavigationPage.KUBERNETES_DEPLOYMENTS,
+      });
+    default:
+      onClose();
+  }
+}
+
+async function onCreate(): Promise<void> {
+  loading = true;
+  try {
+    let contextName = await window.kubernetesGetCurrentContextName();
+    if (!contextName) {
+      return;
+    }
+
+    let objects: KubernetesObject[] = await window.kubernetesApplyResourcesFromYAML(
+      contextName,
+      changesDetected ? editorContent : content,
+    );
+    if (objects.length === 0) {
+      await window.showMessageBox({
+        title: 'Kubernetes',
+        type: 'warning',
+        message: `No resource(s) were applied.`,
+        buttons: ['OK'],
+      });
+    } else {
+      // where to redirect
+      smartRedirect(objects);
+    }
+  } catch (error: unknown) {
+    // display error and do not close the page
+    await window.showMessageBox({
+      title: 'Kubernetes',
+      type: 'error',
+      message: 'Could not apply Kubernetes YAML: ' + error,
+      buttons: ['OK'],
+    });
+  } finally {
+    loading = false;
+  }
+}
+
+function onClose(): void {
+  router.goto($lastPage.path);
+}
+</script>
+
+<DetailsPage title="Create Resources">
+  <svelte:fragment slot="actions">
+    <!-- actions button -->
+    <Button disabled={loading} title="Create Resource" on:click={onCreate}>Create Resource</Button>
+  </svelte:fragment>
+  <!-- content -->
+  <svelte:fragment slot="content">
+    <div class="flex flex-col h-full">
+      <!-- loading indicator -->
+      {#if loading}
+        <ProgressBar class="w-full h-0.5" width="w-full" height="h-0.5"/>
+      {/if}
+
+      <!-- editor -->
+      <MonacoEditor readOnly={loading} on:contentChange={onContentChange} content={content} language="yaml" />
+    </div>
+  </svelte:fragment>
+</DetailsPage>

--- a/packages/renderer/src/lib/kube/CreateKubeResource.svelte
+++ b/packages/renderer/src/lib/kube/CreateKubeResource.svelte
@@ -87,6 +87,7 @@ async function onCreate(): Promise<void> {
       smartRedirect(objects);
     }
   } catch (error: unknown) {
+    console.error(error);
     // display error and do not close the page
     await window.showMessageBox({
       title: 'Kubernetes',
@@ -104,7 +105,7 @@ function onClose(): void {
 }
 </script>
 
-<DetailsPage title="Create Resources">
+<DetailsPage title="Create Resource">
   <svelte:fragment slot="actions">
     <!-- actions button -->
     <Button disabled={loading} title="Create Resource" on:click={onCreate}>Create Resource</Button>

--- a/packages/renderer/src/lib/kube/KubeActions.spec.ts
+++ b/packages/renderer/src/lib/kube/KubeActions.spec.ts
@@ -20,6 +20,7 @@ import '@testing-library/jest-dom/vitest';
 
 import { render } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
+import { router } from 'tinro';
 import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
 import KubeActions from '/@/lib/kube/KubeActions.svelte';
@@ -70,5 +71,18 @@ test('KubeApplyYAMLButton should redirect to', async () => {
         title: 'Select a .yaml file to apply',
       }),
     );
+  });
+});
+
+test('Create Resource button should redirect to kubernetes create resource page', async () => {
+  const { getByTitle } = render(KubeActions);
+
+  const createResourceBtn = getByTitle('Create Kubernetes Resource');
+  expect(createResourceBtn).toBeInTheDocument();
+
+  await userEvent.click(createResourceBtn);
+
+  await vi.waitFor(() => {
+    expect(router.goto).toHaveBeenCalledWith('/kubernetes/resources/create');
   });
 });

--- a/packages/renderer/src/lib/kube/KubeActions.svelte
+++ b/packages/renderer/src/lib/kube/KubeActions.svelte
@@ -1,5 +1,15 @@
 <script lang="ts">
+import { Button } from '@podman-desktop/ui-svelte';
+
 import KubeApplyYamlButton from '/@/lib/kube/KubeApplyYAMLButton.svelte';
+import { handleNavigation } from '/@/navigation';
+import { NavigationPage } from '/@api/navigation-page';
+
+function navigateToKubernetesResourceCreate(): void {
+  return handleNavigation({ page: NavigationPage.KUBERNETES_RESOURCE_CREATE });
+}
 </script>
 
 <KubeApplyYamlButton />
+<Button title="Create Kubernetes Resource" on:click={navigateToKubernetesResourceCreate}>Create Resource</Button>
+

--- a/packages/renderer/src/lib/kube/KubeActions.svelte
+++ b/packages/renderer/src/lib/kube/KubeActions.svelte
@@ -1,15 +1,8 @@
 <script lang="ts">
-import { Button } from '@podman-desktop/ui-svelte';
-
 import KubeApplyYamlButton from '/@/lib/kube/KubeApplyYAMLButton.svelte';
-import { handleNavigation } from '/@/navigation';
-import { NavigationPage } from '/@api/navigation-page';
-
-function navigateToKubernetesResourceCreate(): void {
-  return handleNavigation({ page: NavigationPage.KUBERNETES_RESOURCE_CREATE });
-}
+import KubeCreateResourceButton from '/@/lib/kube/KubeCreateResourceButton.svelte';
 </script>
 
 <KubeApplyYamlButton />
-<Button title="Create Kubernetes Resource" on:click={navigateToKubernetesResourceCreate}>Create Resource</Button>
+<KubeCreateResourceButton/>
 

--- a/packages/renderer/src/lib/kube/KubeCreateResourceButton.spec.ts
+++ b/packages/renderer/src/lib/kube/KubeCreateResourceButton.spec.ts
@@ -19,24 +19,34 @@
 import '@testing-library/jest-dom/vitest';
 
 import { render } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { router } from 'tinro';
 import { beforeEach, expect, test, vi } from 'vitest';
 
-import KubeActions from '/@/lib/kube/KubeActions.svelte';
+import KubeCreateResourceButton from '/@/lib/kube/KubeCreateResourceButton.svelte';
+
+// mock the router
+vi.mock('tinro', () => {
+  return {
+    router: {
+      goto: vi.fn(),
+    },
+  };
+});
 
 beforeEach(() => {
   vi.resetAllMocks();
 });
 
-test('KubeApplyYAMLButton should be visible', async () => {
-  const { getByTitle } = render(KubeActions);
-
-  const applyYAMLBtn = getByTitle('Apply YAML');
-  expect(applyYAMLBtn).toBeInTheDocument();
-});
-
-test('KubeCreateResourceButton should be visible', async () => {
-  const { getByTitle } = render(KubeActions);
+test('Create Resource button should redirect to kubernetes create resource page', async () => {
+  const { getByTitle } = render(KubeCreateResourceButton);
 
   const createResourceBtn = getByTitle('Create Kubernetes Resource');
   expect(createResourceBtn).toBeInTheDocument();
+
+  await userEvent.click(createResourceBtn);
+
+  await vi.waitFor(() => {
+    expect(router.goto).toHaveBeenCalledWith('/kubernetes/resources/create');
+  });
 });

--- a/packages/renderer/src/lib/kube/KubeCreateResourceButton.svelte
+++ b/packages/renderer/src/lib/kube/KubeCreateResourceButton.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+import { Button } from '@podman-desktop/ui-svelte';
+
+import { handleNavigation } from '/@/navigation';
+import { NavigationPage } from '/@api/navigation-page';
+
+function navigateToKubernetesResourceCreate(): void {
+  return handleNavigation({ page: NavigationPage.KUBERNETES_RESOURCE_CREATE });
+}
+</script>
+
+<Button title="Create Kubernetes Resource" on:click={navigateToKubernetesResourceCreate}>Create Resource</Button>

--- a/packages/renderer/src/navigation.ts
+++ b/packages/renderer/src/navigation.ts
@@ -167,5 +167,8 @@ export const handleNavigation = (request: InferredNavigationRequest<NavigationPa
         `/kubernetes/configmapsSecrets/secret/${request.parameters.name}/${request.parameters.namespace}/summary`,
       );
       break;
+    case NavigationPage.KUBERNETES_RESOURCE_CREATE:
+      router.goto(`/kubernetes/resources/create`);
+      break;
   }
 };


### PR DESCRIPTION
### What does this PR do?

In every Kubernetes page add a new `Create Resource` page.

> ℹ️ Might be better (follow-up PR) to have something like `KubernetesAction`, because the `KubeApplyYAMLButton` is also on every page, and this is a lot of repeated code to add the create button 🤔 

### Notable logic

If you deploy only one kubernetes resource (one pod, one service etc.) after clicking on `Create resource` you will be redirected to the corresponding podman-desktop page of the resource.

If you deploy multiple resources, you will be redirected to `$lastPage`.


### Known issue

The blue focus on the monaco editor see https://github.com/podman-desktop/podman-desktop/issues/10052 for the fix

### Screenshot / video of UI

![image](https://github.com/user-attachments/assets/5237f691-1301-4d2e-96e1-a0077ce2e643)

**Error handling**

![image](https://github.com/user-attachments/assets/da7f9338-cf40-4422-a19b-7b87a8302392)

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/8845
 
### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

**Manually**

1. checkout and pnpm watch
2. assert have a kubernetes cluster running
3. go to any kubernetes page (except pods)

4. click on `Create Resource`

![image](https://github.com/user-attachments/assets/9e76a952-fec1-4988-82bf-fc4a9fbe083d)

5. Copy paste any Kubernetes YAML (example bellow)
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: nginx
spec:
  containers:
  - name: nginx
    image: docker.io/library/nginx:1.14.2
    ports:
    - containerPort: 80
```

6. click on `Create Resource`

![image](https://github.com/user-attachments/assets/4627d908-c842-4689-8e87-5fe8133cdea5)
