### PR TITLE
fix: move docker.io/${search-term} matches on top of proposal list

### DIFF
--- a/packages/renderer/src/lib/ui/Typeahead.spec.ts
+++ b/packages/renderer/src/lib/ui/Typeahead.spec.ts
@@ -143,6 +143,31 @@ test('should list items started with search term on top', async () => {
   });
 });
 
+test('should list items started with docker.io + search term on top', async () => {
+  const searchFunction = async () => {
+    await new Promise(resolve => setTimeout(resolve, 100));
+    return ['docker.io/aimage', 'docker.io/bimage', 'docker.io/cimage'];
+  };
+  render(Typeahead, {
+    initialFocus: true,
+    searchFunction,
+    delay: 10,
+  });
+
+  const input = screen.getByRole('textbox');
+
+  await userEvent.type(input, 'cimage');
+
+  await waitFor(() => {
+    const list = screen.getByRole('row');
+    const items = within(list).getAllByRole('button');
+    expect(items.length).toBe(3);
+    expect(items[0].textContent).toBe('docker.io/cimage');
+    expect(items[1].textContent).toBe('docker.io/aimage');
+    expect(items[2].textContent).toBe('docker.io/bimage');
+  });
+});
+
 test('should navigate in list with keys', async () => {
   const searchFunction = async (s: string) => {
     const result: string[] = [];

--- a/packages/renderer/src/lib/ui/Typeahead.svelte
+++ b/packages/renderer/src/lib/ui/Typeahead.svelte
@@ -149,8 +149,9 @@ function processInput(): void {
         return;
       }
       items = result.toSorted((a: string, b: string) => {
-        const aStartsWithValue = a.startsWith(value);
-        const bStartsWithValue = b.startsWith(value);
+        const dockerIoValue = `docker.io/${value}`;
+        const aStartsWithValue = a.startsWith(value) || a.startsWith(dockerIoValue);
+        const bStartsWithValue = b.startsWith(value) || b.startsWith(dockerIoValue);
         if ((aStartsWithValue && bStartsWithValue) || (!aStartsWithValue && !bStartsWithValue)) {
           return a.localeCompare(b);
         } else if (aStartsWithValue && !bStartsWithValue) {


### PR DESCRIPTION
### What does this PR do?

When you search for image by name without registry host, it moves default registry result on top

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

![image](https://github.com/user-attachments/assets/bf92964f-e880-4fa6-a335-7c611aa3621c)

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Fix #8929.

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
