### PR TITLE
fix: workaround of LIMA_HOME usage

### DIFF
--- a/extensions/lima/package.json
+++ b/extensions/lima/package.json
@@ -20,6 +20,11 @@
           "default": "",
           "description": "Custom path to limactl binary (Default is blank)"
         },
+        "lima.home": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Lima home directory. See [documentation](https://lima-vm.io/docs/dev/internals/#lima-home-directory-lima_home)"
+        },
         "lima.type": {
           "type": "string",
           "default": "podman",

--- a/extensions/lima/src/extension.ts
+++ b/extensions/lima/src/extension.ts
@@ -95,8 +95,9 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   const engineType: string = configuration.getConfiguration('lima').get('type') ?? 'podman';
   const instanceName: string = configuration.getConfiguration('lima').get('name') ?? engineType;
   const socketName: string = configuration.getConfiguration('lima').get('socket') ?? engineType + '.sock';
+  const limaHome: string =
+    configuration.getConfiguration('lima').get('home') ?? process.env['LIMA_HOME'] ?? os.homedir() + '/.lima';
 
-  const limaHome = 'LIMA_HOME' in process.env ? process.env['LIMA_HOME'] : os.homedir() + '/.lima';
   const socketPath = path.resolve(limaHome ?? '', instanceName + '/sock/' + socketName);
   const configPath = path.resolve(limaHome ?? '', instanceName + '/copied-from-guest/kubeconfig.yaml');
 


### PR DESCRIPTION
### What does this PR do?

### Screenshot / video of UI

<img width="783" alt="ext:lima" src="https://github.com/user-attachments/assets/770ddea2-b6d7-47dc-a219-ed7ef455840b">
<img width="370" alt="dash:lima" src="https://github.com/user-attachments/assets/7c935ff9-0535-4f3e-a332-963bcb8eb600">
<img width="463" alt="resources:lima" src="https://github.com/user-attachments/assets/580af6bc-17a3-4638-8848-7d21e9c6ee72">



### What issues does this PR fix or reference?

Resolves https://github.com/podman-desktop/podman-desktop/issues/10085

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Create lima virtual machine
- [ ] Place `LIMA_HOME` anywhere else than `HOME` dir
- [ ] Move `~/.lima` to new location defined in `LIMA_HOME`
- [ ] Open Settings->Preferences->Extension: Lima and set `LIMA_HOME` value to "Home" configuration
- [ ] Verify lima status on dashboard

### Additional info

Related to https://github.com/podman-desktop/podman-desktop/pull/10059#discussion_r1852562011 