### PR TITLE
chore: patch @kubernetes/client-node with async exec-auth

### DIFF
--- a/patches/@kubernetes__client-node@1.0.0-rc7.patch
+++ b/patches/@kubernetes__client-node@1.0.0-rc7.patch
@@ -14,6 +14,89 @@ index 3f7f6d2942d046a375f01a6c5a49d8b5cad8e2a7..f36613e12c280266768f5e7575c0970c
              case 'ADDED':
              case 'MODIFIED':
                  addOrUpdateObject(this.objects, obj, this.callbackCache[informer_1.ADD].slice(), this.callbackCache[informer_1.UPDATE].slice());
+diff --git a/dist/exec_auth.js b/dist/exec_auth.js
+index 3dad5f788ba10617405c6eea3f6e2e941d3bf03b..e0f778bb570f375e18326634d6e7d22f2da66aac 100644
+--- a/dist/exec_auth.js
++++ b/dist/exec_auth.js
+@@ -6,7 +6,7 @@ const node_child_process_1 = tslib_1.__importDefault(require("node:child_process
+ class ExecAuth {
+     constructor() {
+         this.tokenCache = {};
+-        this.execFn = node_child_process_1.default.spawnSync;
++        this.execFn = node_child_process_1.default.spawn;
+     }
+     isAuthProvider(user) {
+         if (!user) {
+@@ -21,7 +21,7 @@ class ExecAuth {
+         return (user.authProvider.name === 'exec' || !!(user.authProvider.config && user.authProvider.config.exec));
+     }
+     async applyAuthentication(user, opts) {
+-        const credential = this.getCredential(user);
++        const credential = await this.getCredential(user);
+         if (!credential) {
+             return;
+         }
+@@ -48,7 +48,7 @@ class ExecAuth {
+         }
+         return null;
+     }
+-    getCredential(user) {
++    async getCredential(user) {
+         // TODO: Add a unit test for token caching.
+         const cachedToken = this.tokenCache[user.name];
+         if (cachedToken) {
+@@ -77,16 +77,41 @@ class ExecAuth {
+             exec.env.forEach((elt) => (env[elt.name] = elt.value));
+             opts = { ...opts, env };
+         }
+-        const result = this.execFn(exec.command, exec.args, opts);
+-        if (result.error) {
+-            throw result.error;
+-        }
+-        if (result.status === 0) {
+-            const obj = JSON.parse(result.stdout.toString('utf8'));
+-            this.tokenCache[user.name] = obj;
+-            return obj;
+-        }
+-        throw new Error(result.stderr.toString('utf8'));
++        return new Promise((resolve, reject) => {
++            let stdoutData = '';
++            let stderrData = '';
++            let savedError = undefined;
++            const subprocess = this.execFn(exec.command, exec.args, opts);
++            subprocess.stdout.setEncoding('utf8');
++            subprocess.stderr.setEncoding('utf8');
++            subprocess.stdout.on('data', (data) => {
++                stdoutData += data;
++            });
++            subprocess.stderr.on('data', (data) => {
++                stderrData += data;
++            });
++            subprocess.on('error', (error) => {
++                savedError = error;
++            });
++            subprocess.on('close', (code) => {
++                if (savedError) {
++                    reject(savedError);
++                    return;
++                }
++                if (code !== 0) {
++                    reject(new Error(stderrData));
++                    return;
++                }
++                try {
++                    const obj = JSON.parse(stdoutData);
++                    this.tokenCache[user.name] = obj;
++                    resolve(obj);
++                }
++                catch (error) {
++                    reject(error);
++                }
++            });
++        });
+     }
+ }
+ exports.ExecAuth = ExecAuth;
 diff --git a/dist/health.d.ts b/dist/health.d.ts
 new file mode 100644
 index 0000000000000000000000000000000000000000..aeedff6524c952b712330d02738898a99071632d

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ overrides:
 
 patchedDependencies:
   '@kubernetes/client-node@1.0.0-rc7':
-    hash: itrsbkb3fr7spxemffsb4x737y
+    hash: qiizxg7xna3mgq7rborknvsqki
     path: patches/@kubernetes__client-node@1.0.0-rc7.patch
 
 importers:
@@ -27,7 +27,7 @@ importers:
         version: 0.3.4
       '@kubernetes/client-node':
         specifier: ^1.0.0-rc7
-        version: 1.0.0-rc7(patch_hash=itrsbkb3fr7spxemffsb4x737y)(encoding@0.1.13)
+        version: 1.0.0-rc7(patch_hash=qiizxg7xna3mgq7rborknvsqki)(encoding@0.1.13)
       '@segment/analytics-node':
         specifier: ^2.2.0
         version: 2.2.0(encoding@0.1.13)
@@ -15220,11 +15220,11 @@ snapshots:
 
   '@isaacs/cliui@8.0.2':
     dependencies:
-      string-width: 4.2.3
+      string-width: 5.1.2
       string-width-cjs: string-width@4.2.3
       strip-ansi: 7.1.0
       strip-ansi-cjs: strip-ansi@6.0.1
-      wrap-ansi: 7.0.0
+      wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
   '@isaacs/fs-minipass@4.0.1':
@@ -15276,7 +15276,7 @@ snapshots:
     dependencies:
       jsep: 1.4.0
 
-  '@kubernetes/client-node@1.0.0-rc7(patch_hash=itrsbkb3fr7spxemffsb4x737y)(encoding@0.1.13)':
+  '@kubernetes/client-node@1.0.0-rc7(patch_hash=qiizxg7xna3mgq7rborknvsqki)(encoding@0.1.13)':
     dependencies:
       '@types/js-yaml': 4.0.9
       '@types/node': 22.9.1


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Patch @kubernetes/client-node with async exec-auth (original PR https://github.com/kubernetes-client/javascript/pull/2046)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes #9880 
Fixes #8486


### How to test this PR?

Have a kind context defined in your kubeconfig file and adapt it to have something similar to the one below(specifically the `useer.exec` part), and start Podman Desktop in main branch and with this PR.

In main, the app should eventually start (after a few minutes, as several calls to the exec command are done). With this PR, the app should start immediately.


```
apiVersion: v1
kind: Config
clusters:
  - name: kind-kind-cluster
    cluster:
      server: /redacted/
      certificate-authority-data: /redacted/
      insecure-skip-tls-verify: false
users:
  - name: kind-kind-cluster
    user:
      exec:
        apiVersion: client.authentication.k8s.io/v1beta1
        args:
          - '-c'
          - 'sleep 10'
        command: bash
        provideClusterInfo: false
contexts:
  - name: kind-kind-cluster
    context:
      cluster: kind-kind-cluster
      name: kind-kind-cluster
      user: kind-kind-cluster
preferences: {}
current-context: kind-kind-cluster
```

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
