### PR TITLE
chore: set status to canceled if a task has been canceled

### DIFF
--- a/packages/api/src/taskInfo.ts
+++ b/packages/api/src/taskInfo.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 export type TaskState = 'running' | 'completed';
-export type TaskStatus = 'in-progress' | 'success' | 'failure';
+export type TaskStatus = 'in-progress' | 'success' | 'failure' | 'canceled';
 
 export type NotificationTaskInfo = Omit<TaskInfo, 'progress' | 'error'> & {
   state: 'completed';

--- a/packages/main/src/plugin/tasks/progress-impl.ts
+++ b/packages/main/src/plugin/tasks/progress-impl.ts
@@ -135,11 +135,6 @@ export class ProgressImpl {
       action: this.getTaskAction(options),
     });
 
-    let cancelRequest = false;
-    cancellationToken.onCancellationRequested(() => {
-      cancelRequest = true;
-    });
-
     return task(
       {
         report: value => {
@@ -155,7 +150,7 @@ export class ProgressImpl {
     )
       .then(value => {
         // Middleware to capture the success of the task
-        if (cancelRequest) {
+        if (cancellationToken.isCancellationRequested) {
           t.status = 'canceled';
         } else {
           t.status = 'success';

--- a/packages/main/src/plugin/tasks/progress-impl.ts
+++ b/packages/main/src/plugin/tasks/progress-impl.ts
@@ -135,6 +135,11 @@ export class ProgressImpl {
       action: this.getTaskAction(options),
     });
 
+    let cancelRequest = false;
+    cancellationToken.onCancellationRequested(() => {
+      cancelRequest = true;
+    });
+
     return task(
       {
         report: value => {
@@ -150,7 +155,11 @@ export class ProgressImpl {
     )
       .then(value => {
         // Middleware to capture the success of the task
-        t.status = 'success';
+        if (cancelRequest) {
+          t.status = 'canceled';
+        } else {
+          t.status = 'success';
+        }
         // We propagate the result to the caller, so he can use the result
         return value;
       })

--- a/packages/main/src/plugin/tasks/task-impl.spec.ts
+++ b/packages/main/src/plugin/tasks/task-impl.spec.ts
@@ -105,6 +105,21 @@ describe('update field should send an update event', () => {
     });
   });
 
+  test('canceled should make it completed', () => {
+    const onUpdateListenerMock = vi.fn<(e: TaskUpdateEvent) => void>();
+    const task = new TaskImpl('test-id', 'Test name');
+    task.onUpdate(onUpdateListenerMock);
+
+    task.status = 'canceled';
+    expect(onUpdateListenerMock).toHaveBeenCalledWith({
+      action: 'update',
+      task: expect.objectContaining({
+        state: 'completed',
+        status: 'canceled',
+      }),
+    });
+  });
+
   test('cancellable', () => {
     const onUpdateListenerMock = vi.fn<(e: TaskUpdateEvent) => void>();
     const task = new TaskImpl('test-id', 'Test name');

--- a/packages/main/src/plugin/tasks/task-impl.ts
+++ b/packages/main/src/plugin/tasks/task-impl.ts
@@ -77,6 +77,7 @@ export class TaskImpl implements Task {
       case 'in-progress':
         this.mState = 'running';
         break;
+      case 'canceled':
       case 'failure':
       case 'success':
         this.mState = 'completed';


### PR DESCRIPTION

### What does this PR do?
if a user ask to cancel a task, today it'll end in a task having the success status. With this commit, it will make the status being canceled which is more accurate.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/issues/9092


### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
