### PR TITLE
chore: display canceled task with a different color

### DIFF
--- a/packages/renderer/src/lib/task-manager/TaskManagerItem.spec.ts
+++ b/packages/renderer/src/lib/task-manager/TaskManagerItem.spec.ts
@@ -45,6 +45,16 @@ const IN_PROGRESS_TASK_2: TaskInfo = {
   cancellable: false,
 };
 
+const CANCELED_TASK: TaskInfo = {
+  id: '1',
+  name: 'Canceled Task 1',
+  state: 'completed',
+  status: 'canceled',
+  started,
+  cancellable: true,
+  cancellationTokenSourceId: 1,
+};
+
 test('Expect that the action button is visible', async () => {
   render(TaskManagerItem, {
     task: IN_PROGRESS_TASK,
@@ -75,4 +85,14 @@ test('Expect that the action button is hidden', async () => {
   // expect the tasks manager is not visible by default
   const actionBtn = screen.queryByRole('button', { name: 'action button' });
   expect(actionBtn).not.toBeInTheDocument();
+});
+
+test('Expect that the canceled state is displayed', async () => {
+  render(TaskManagerItem, {
+    task: CANCELED_TASK,
+  });
+  // expect the canceled task icon is displayed and color is the one specified
+  const canceledTaskIcon = screen.getByRole('img', { name: 'Icon status of task 1' });
+  expect(canceledTaskIcon).toBeInTheDocument();
+  expect(canceledTaskIcon.parentElement?.classList.contains('text-[var(--pd-status-exited)]')).toBeTruthy();
 });

--- a/packages/renderer/src/lib/task-manager/TaskManagerItem.spec.ts
+++ b/packages/renderer/src/lib/task-manager/TaskManagerItem.spec.ts
@@ -92,7 +92,7 @@ test('Expect that the canceled state is displayed', async () => {
     task: CANCELED_TASK,
   });
   // expect the canceled task icon is displayed and color is the one specified
-  const canceledTaskIcon = screen.getByRole('img', { name: 'Icon status of task 1' });
+  const canceledTaskIcon = screen.getByRole('img', { name: 'canceled icon of task Canceled Task 1' });
   expect(canceledTaskIcon).toBeInTheDocument();
   expect(canceledTaskIcon.parentElement?.classList.contains('text-[var(--pd-status-exited)]')).toBeTruthy();
 });

--- a/packages/renderer/src/lib/task-manager/TaskManagerItem.svelte
+++ b/packages/renderer/src/lib/task-manager/TaskManagerItem.svelte
@@ -57,7 +57,7 @@ async function doExecuteAction(task: TaskInfo) {
 <div class="flex flew-row w-full py-2">
   <!-- first column is the icon-->
   <div class="flex w-3 {iconColor} justify-center">
-    <div class="align-top" role="img" aria-label="Icon status of task {task.id}">
+    <div class="align-top" role="img" aria-label="{task.status} icon of task {task.name}">
     <Fa size="0.875x" icon={icon} />
     </div>
   </div>

--- a/packages/renderer/src/lib/task-manager/TaskManagerItem.svelte
+++ b/packages/renderer/src/lib/task-manager/TaskManagerItem.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import {
+  faCancel,
   faClose,
   faInfoCircle,
   faSquareCheck,
@@ -23,6 +24,10 @@ let icon: IconDefinition;
 let iconColor: string;
 onMount(() => {
   switch (task.status) {
+    case 'canceled':
+      icon = faCancel;
+      iconColor = 'text-[var(--pd-status-exited)]';
+      break;
     case 'in-progress':
       icon = faInfoCircle;
       iconColor = 'text-[var(--pd-invert-content-info-icon)]';
@@ -52,7 +57,9 @@ async function doExecuteAction(task: TaskInfo) {
 <div class="flex flew-row w-full py-2">
   <!-- first column is the icon-->
   <div class="flex w-3 {iconColor} justify-center">
+    <div class="align-top" role="img" aria-label="Icon status of task {task.id}">
     <Fa size="0.875x" icon={icon} />
+    </div>
   </div>
   <!-- second column is about the task-->
   <div class="flex flex-col w-full pl-2">


### PR DESCRIPTION
### What does this PR do?
change the color of canceled task

depends on 
- [x] : https://github.com/podman-desktop/podman-desktop/pull/10088

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/issues/9092

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
