### PR TITLE
chore(test): Capture an error message that appears during the creation of the kind cluster and throw an error with that message

### DIFF
--- a/tests/playwright/src/model/pages/create-kind-cluster-page.ts
+++ b/tests/playwright/src/model/pages/create-kind-cluster-page.ts
@@ -120,12 +120,16 @@ export class CreateKindClusterPage extends BasePage {
 
   private async createCluster(timeout: number = 300_000): Promise<void> {
     return test.step('Create cluster', async () => {
-      await playExpect(this.clusterCreationButton).toBeVisible();
-      await this.clusterCreationButton.click();
-      await this.logsButton.scrollIntoViewIfNeeded();
-      await this.logsButton.click();
-      await playExpect(this.goBackButton).toBeVisible({ timeout: timeout });
-      await this.goBackButton.click();
+      try {
+        await playExpect(this.clusterCreationButton).toBeVisible();
+        await this.clusterCreationButton.click();
+        await this.logsButton.scrollIntoViewIfNeeded();
+        await this.logsButton.click();
+        await playExpect(this.goBackButton).toBeVisible({ timeout: timeout });
+        await this.goBackButton.click();
+      } catch (error) {
+        throw Error(`${await this.errorMessage.textContent()}`);
+      }
     });
   }
 

--- a/tests/playwright/src/model/pages/create-kind-cluster-page.ts
+++ b/tests/playwright/src/model/pages/create-kind-cluster-page.ts
@@ -120,16 +120,19 @@ export class CreateKindClusterPage extends BasePage {
 
   private async createCluster(timeout: number = 300_000): Promise<void> {
     return test.step('Create cluster', async () => {
-      try {
-        await playExpect(this.clusterCreationButton).toBeVisible();
-        await this.clusterCreationButton.click();
-        await this.logsButton.scrollIntoViewIfNeeded();
-        await this.logsButton.click();
-        await playExpect(this.goBackButton).toBeVisible({ timeout: timeout });
-        await this.goBackButton.click();
-      } catch (error) {
-        throw Error(`${await this.errorMessage.textContent()}`);
-      }
+      await Promise.race([
+        (async (): Promise<void> => {
+          await playExpect(this.clusterCreationButton).toBeVisible();
+          await this.clusterCreationButton.click();
+          await this.logsButton.scrollIntoViewIfNeeded();
+          await this.logsButton.click();
+          await playExpect(this.goBackButton).toBeVisible({ timeout: timeout });
+          await this.goBackButton.click();
+        })(),
+        this.errorMessage.waitFor({ state: 'visible', timeout: timeout }).then(async () => {
+          throw new Error(`${await this.errorMessage.textContent()}`);
+        }),
+      ]);
     });
   }
 


### PR DESCRIPTION
### What does this PR do?
Captures an error message that appears during the creation of the kind cluster and throws an error with that message

### What issues does this PR fix or reference?

https://github.com/podman-desktop/podman-desktop/issues/9859

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
