### PR TITLE
feat(feedback): adding support to get sys info

### DIFF
--- a/packages/main/src/plugin/feedback-handler.spec.ts
+++ b/packages/main/src/plugin/feedback-handler.spec.ts
@@ -74,7 +74,7 @@ class FeedbackHandlerTest extends FeedbackHandler {
  * @param url
  * @param params
  */
-function toContainSearchParams(url: string | undefined, params: Record<string, string>): void {
+function containSearchParams(url: string | undefined, params: Record<string, string>): void {
   if (url === undefined) throw new Error('undefined url');
 
   const search = new URLSearchParams(new URL(url).search);
@@ -99,7 +99,7 @@ describe('openGitHubIssue', () => {
 
     // extract the first argument of the shell.openExternal call
     const url: string | undefined = vi.mocked(shell.openExternal).mock.calls[0]?.[0];
-    toContainSearchParams(url, {
+    containSearchParams(url, {
       template: 'bug_report.yml',
       title: 'PD is not working',
       'bug-description': 'bug description',
@@ -120,7 +120,7 @@ describe('openGitHubIssue', () => {
 
     // extract the first argument of the shell.openExternal call
     const url: string | undefined = vi.mocked(shell.openExternal).mock.calls[0]?.[0];
-    toContainSearchParams(url, {
+    containSearchParams(url, {
       template: 'feature_request.yml',
       title: 'new feature',
       solution: 'feature description',
@@ -145,7 +145,7 @@ describe('openGitHubIssue', () => {
 
     // extract the first argument of the shell.openExternal call
     const url: string | undefined = vi.mocked(shell.openExternal).mock.calls[0]?.[0];
-    toContainSearchParams(url, {
+    containSearchParams(url, {
       os: 'Linux - dummy-release',
     });
   });

--- a/packages/main/src/plugin/feedback-handler.spec.ts
+++ b/packages/main/src/plugin/feedback-handler.spec.ts
@@ -16,9 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { shell } from 'electron';
-import { beforeEach, expect, test, vi } from 'vitest';
+import { arch, release, version } from 'node:os';
 
+import { shell } from 'electron';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { isLinux, isMac, isWindows } from '/@/util.js';
 import type { GitHubIssue } from '/@api/feedback.js';
 
 import { FeedbackHandler } from './feedback-handler.js';
@@ -29,31 +32,184 @@ vi.mock('electron', () => ({
   },
 }));
 
+vi.mock('/@/util.js', () => ({
+  isLinux: vi.fn(),
+  isMac: vi.fn(),
+  isWindows: vi.fn(),
+}));
+
+vi.mock('node:os', () => ({
+  arch: vi.fn(),
+  release: vi.fn(),
+  version: vi.fn(),
+}));
+
 beforeEach(() => {
   vi.resetAllMocks();
+
+  // all false by default
+  vi.mocked(isLinux).mockReturnValue(false);
+  vi.mocked(isMac).mockReturnValue(false);
+  vi.mocked(isWindows).mockReturnValue(false);
 });
 
-test('Expect openExternal to be called with queryParams and bug report template', async () => {
-  const issueProperties: GitHubIssue = {
-    category: 'bug',
-    title: 'PD is not working',
-    description: 'bug description',
-  };
-  const queryParams = 'template=bug_report.yml&title=PD+is+not+working&bug-description=bug+description';
-  const feedbackHandler = new FeedbackHandler();
-  await feedbackHandler.openGitHubIssue(issueProperties);
-  expect(shell.openExternal).toBeCalledWith(`https://github.com/containers/podman-desktop/issues/new?${queryParams}`);
+class FeedbackHandlerTest extends FeedbackHandler {
+  public override getWindowsInfo(): string {
+    return super.getWindowsInfo();
+  }
+  public override getLinuxInfo(): string {
+    return super.getLinuxInfo();
+  }
+  public override getDarwinInfo(): string {
+    return super.getDarwinInfo();
+  }
+  public override getOsInfo(): string {
+    return super.getOsInfo();
+  }
+}
+
+/**
+ * Utility method to ensure an url provided contains the param provided
+ * as search values
+ * @param url
+ * @param params
+ */
+function toContainSearchParams(url: string | undefined, params: Record<string, string>): void {
+  if (url === undefined) throw new Error('undefined url');
+
+  const search = new URLSearchParams(new URL(url).search);
+  Object.entries(params).forEach(([key, value]) => {
+    expect(search.has(key)).toBeTruthy();
+    expect(search.get(key)).toBe(value);
+  });
+}
+
+describe('openGitHubIssue', () => {
+  test('Expect openExternal to be called with queryParams and bug report template', async () => {
+    const issueProperties: GitHubIssue = {
+      category: 'bug',
+      title: 'PD is not working',
+      description: 'bug description',
+    };
+
+    const feedbackHandler = new FeedbackHandler();
+    await feedbackHandler.openGitHubIssue(issueProperties);
+
+    expect(shell.openExternal).toHaveBeenCalledOnce();
+
+    // extract the first argument of the shell.openExternal call
+    const url: string | undefined = vi.mocked(shell.openExternal).mock.calls[0]?.[0];
+    toContainSearchParams(url, {
+      template: 'bug_report.yml',
+      title: 'PD is not working',
+      'bug-description': 'bug description',
+    });
+  });
+
+  test('Expect openExternal to be called with queryParams and feature request template', async () => {
+    const issueProperties: GitHubIssue = {
+      category: 'feature',
+      title: 'new feature',
+      description: 'feature description',
+    };
+
+    const feedbackHandler = new FeedbackHandler();
+    await feedbackHandler.openGitHubIssue(issueProperties);
+
+    expect(shell.openExternal).toHaveBeenCalledOnce();
+
+    // extract the first argument of the shell.openExternal call
+    const url: string | undefined = vi.mocked(shell.openExternal).mock.calls[0]?.[0];
+    toContainSearchParams(url, {
+      template: 'feature_request.yml',
+      title: 'new feature',
+      solution: 'feature description',
+    });
+  });
+
+  test('expect os info to be included if includeSystemInfo is true', async () => {
+    vi.mocked(isLinux).mockReturnValue(true);
+    vi.mocked(release).mockReturnValue('dummy-release');
+
+    const issueProperties: GitHubIssue = {
+      category: 'bug',
+      title: 'PD is not working',
+      description: 'bug description',
+      includeSystemInfo: true,
+    };
+
+    const feedbackHandler = new FeedbackHandler();
+    await feedbackHandler.openGitHubIssue(issueProperties);
+
+    expect(shell.openExternal).toHaveBeenCalledOnce();
+
+    // extract the first argument of the shell.openExternal call
+    const url: string | undefined = vi.mocked(shell.openExternal).mock.calls[0]?.[0];
+    toContainSearchParams(url, {
+      os: 'Linux - dummy-release',
+    });
+  });
 });
 
-test('Expect openExternal to be called with queryParams and feature request template', async () => {
-  const issueProperties: GitHubIssue = {
-    category: 'feature',
-    title: 'new feature',
-    description: 'feature description',
-  };
-  issueProperties.category = 'feature';
-  const queryParams = 'template=feature_request.yml&title=new+feature&solution=feature+description';
-  const feedbackHandler = new FeedbackHandler();
-  await feedbackHandler.openGitHubIssue(issueProperties);
-  expect(shell.openExternal).toBeCalledWith(`https://github.com/containers/podman-desktop/issues/new?${queryParams}`);
+describe('getOsInfo', () => {
+  let feedbackHandlerTest: FeedbackHandlerTest;
+  beforeEach(() => {
+    feedbackHandlerTest = new FeedbackHandlerTest();
+  });
+
+  test('windows should use os#version and os#arch', () => {
+    vi.mocked(isWindows).mockReturnValue(true);
+    vi.mocked(arch).mockReturnValue('x64');
+    vi.mocked(version).mockReturnValue('Windows 11 Home');
+
+    const result = feedbackHandlerTest.getWindowsInfo();
+
+    expect(release).not.toHaveBeenCalled();
+    expect(version).toHaveBeenCalled();
+    expect(arch).toHaveBeenCalled();
+
+    expect(result).toBe('Windows 11 Home - x64');
+  });
+
+  test('linux should use os#release', () => {
+    vi.mocked(isLinux).mockReturnValue(true);
+    vi.mocked(release).mockReturnValue('6.11.7-300.fc41.x86_64');
+
+    const result = feedbackHandlerTest.getLinuxInfo();
+
+    expect(release).toHaveBeenCalled();
+    expect(version).not.toHaveBeenCalled();
+    expect(arch).not.toHaveBeenCalled();
+
+    expect(result).toBe('Linux - 6.11.7-300.fc41.x86_64');
+  });
+
+  test('flatpak linux should include flatpak info', () => {
+    vi.mocked(isLinux).mockReturnValue(true);
+    vi.mocked(release).mockReturnValue('6.11.7-300.fc41.x86_64');
+
+    process.env['FLATPAK_ID'] = 'dummy-id';
+
+    const result = feedbackHandlerTest.getLinuxInfo();
+
+    expect(release).toHaveBeenCalled();
+    expect(version).not.toHaveBeenCalled();
+    expect(arch).not.toHaveBeenCalled();
+
+    expect(result).toBe('Linux - 6.11.7-300.fc41.x86_64 (flatpak)');
+  });
+
+  test('darwin should use os#release and os#arch', () => {
+    vi.mocked(isMac).mockReturnValue(true);
+    vi.mocked(release).mockReturnValue('23.9.4');
+    vi.mocked(arch).mockReturnValue('arm64');
+
+    const result = feedbackHandlerTest.getDarwinInfo();
+
+    expect(release).toHaveBeenCalled();
+    expect(version).not.toHaveBeenCalled();
+    expect(arch).toHaveBeenCalled();
+
+    expect(result).toBe('Darwin 23.9.4 - arm64');
+  });
 });

--- a/packages/main/src/plugin/feedback-handler.ts
+++ b/packages/main/src/plugin/feedback-handler.ts
@@ -16,8 +16,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { arch, release, version } from 'node:os';
+
 import { shell } from 'electron';
 
+import { isLinux, isMac, isWindows } from '/@/util.js';
 import type { GitHubIssue } from '/@api/feedback.js';
 
 export class FeedbackHandler {
@@ -27,20 +30,92 @@ export class FeedbackHandler {
     await shell.openExternal(link);
   }
 
+  /**
+   * According to the node documentation, we should be using the os#release
+   * but this has some problems with our current version of node
+   *
+   * Some node version do not report well the Windows 10 / 11 difference
+   * Ref https://github.com/nodejs/node/issues/40862
+   *
+   * E.g. on a Windows 11 x64 we would get `Windows 11 Home - x64`
+   *
+   * @remarks the type of license is important (Home / Pro) as we have different feature depending
+   * on the feature (HyperV support or not)
+   * @protected
+   */
+  protected getWindowsInfo(): string {
+    if (!isWindows()) throw new Error('only work on windows systems');
+    return `${version()} - ${arch()}`;
+  }
+
+  /**
+   * Getting more details about the distribution is not feasible through the node api.
+   * Online recommendation are to look at the `/etc/os-release` but let's avoid making this
+   * too complicated.
+   *
+   * The os#release on linux seems to contain the architecture as it use internally [`uname(3)`](https://linux.die.net/man/3/uname).
+   *
+   * E.g. on a fedora 41 x64 we would get `Linux - <kernel-version>.fc41.<arch>`
+   *
+   * @protected
+   */
+  protected getLinuxInfo(): string {
+    if (!isLinux()) throw new Error('only work on linux systems');
+
+    let result = `Linux - ${release()}`;
+
+    // the flatpak information is a very valuable information
+    if (process.env['FLATPAK_ID']) {
+      result += ' (flatpak)';
+    }
+    return result;
+  }
+
+  /**
+   * On Darwin system, we have too much information in the is os#version
+   * so we use release to get the os version (E.g. 24.1.0), and arch (E.g. arm64)
+   * @protected
+   */
+  protected getDarwinInfo(): string {
+    if (!isMac()) throw new Error('only work on darwin systems');
+    return `Darwin ${release()} - ${arch()}`;
+  }
+
+  /**
+   * Generic method to get the system info (system platform, architecture, version)
+   * @protected
+   */
+  protected getOsInfo(): string {
+    if (isWindows()) {
+      return this.getWindowsInfo();
+    } else if (isMac()) {
+      return this.getDarwinInfo();
+    } else if (isLinux()) {
+      return this.getLinuxInfo();
+    }
+    // default fallback - should not be reached, but we never know
+    return release();
+  }
+
   protected toQueryParameters(issue: GitHubIssue): Record<string, string> {
+    const result: Record<string, string> = {};
+    result['title'] = issue.title;
+
     switch (issue.category) {
       case 'feature':
-        return {
-          template: 'feature_request.yml',
-          title: issue.title,
-          solution: issue.description,
-        };
+        result['template'] = 'feature_request.yml';
+        result['solution'] = issue.description;
+        return result;
       case 'bug':
-        return {
-          template: 'bug_report.yml',
-          title: issue.title,
-          'bug-description': issue.description,
-        };
+        result['template'] = 'bug_report.yml';
+        result['bug-description'] = issue.description;
+
+        // include system info if authorised
+        if (issue.includeSystemInfo) {
+          result['os'] = this.getOsInfo();
+        }
+
+        return result;
       default:
         throw new Error(`unknown category ${issue.category}`);
     }

--- a/packages/main/src/plugin/feedback-handler.ts
+++ b/packages/main/src/plugin/feedback-handler.ts
@@ -16,14 +16,19 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { arch, release, version } from 'node:os';
-
 import { shell } from 'electron';
 
-import { isLinux, isMac, isWindows } from '/@/util.js';
+import type { SystemInfo } from '/@/plugin/util/sys-info.js';
+import { getSystemInfo } from '/@/plugin/util/sys-info.js';
 import type { GitHubIssue } from '/@api/feedback.js';
 
 export class FeedbackHandler {
+  #systemInfo: SystemInfo;
+
+  constructor() {
+    this.#systemInfo = getSystemInfo();
+  }
+
   async openGitHubIssue(issueProperties: GitHubIssue): Promise<void> {
     const urlSearchParams = new URLSearchParams(this.toQueryParameters(issueProperties)).toString();
     const link = `https://github.com/containers/podman-desktop/issues/new?${urlSearchParams}`;
@@ -31,66 +36,11 @@ export class FeedbackHandler {
   }
 
   /**
-   * According to the node documentation, we should be using the os#release
-   * but this has some problems with our current version of node
-   *
-   * Some node version do not report well the Windows 10 / 11 difference
-   * Ref https://github.com/nodejs/node/issues/40862
-   *
-   * E.g. on a Windows 11 x64 we would get `Windows 11 Home - x64`
-   *
-   * @remarks the type of license is important (Home / Pro) as we have different feature depending
-   * on the feature (HyperV support or not)
-   * @protected
-   */
-  protected getWindowsInfo(): string {
-    return `${version()} - ${arch()}`;
-  }
-
-  /**
-   * Getting more details about the distribution is not feasible through the node api.
-   * Online recommendation are to look at the `/etc/os-release` but let's avoid making this
-   * too complicated.
-   *
-   * The os#release on linux seems to contain the architecture as it use internally [`uname(3)`](https://linux.die.net/man/3/uname).
-   *
-   * E.g. on a fedora 41 x64 we would get `Linux - <kernel-version>.fc41.<arch>`
-   *
-   * @protected
-   */
-  protected getLinuxInfo(): string {
-    let result = `Linux - ${release()}`;
-
-    // the flatpak information is a very valuable information
-    if (process.env['FLATPAK_ID']) {
-      result += ' (flatpak)';
-    }
-    return result;
-  }
-
-  /**
-   * On Darwin system, we have too much information in the is os#version
-   * so we use release to get the os version (E.g. 24.1.0), and arch (E.g. arm64)
-   * @protected
-   */
-  protected getDarwinInfo(): string {
-    return `Darwin ${release()} - ${arch()}`;
-  }
-
-  /**
    * Generic method to get the system info (system platform, architecture, version)
    * @protected
    */
   protected getOsInfo(): string {
-    if (isWindows()) {
-      return this.getWindowsInfo();
-    } else if (isMac()) {
-      return this.getDarwinInfo();
-    } else if (isLinux()) {
-      return this.getLinuxInfo();
-    }
-    // default fallback - should not be reached, but we never know
-    return release();
+    return this.#systemInfo.getSystemName();
   }
 
   protected toQueryParameters(issue: GitHubIssue): Record<string, string> {

--- a/packages/main/src/plugin/feedback-handler.ts
+++ b/packages/main/src/plugin/feedback-handler.ts
@@ -44,7 +44,6 @@ export class FeedbackHandler {
    * @protected
    */
   protected getWindowsInfo(): string {
-    if (!isWindows()) throw new Error('only work on windows systems');
     return `${version()} - ${arch()}`;
   }
 
@@ -60,8 +59,6 @@ export class FeedbackHandler {
    * @protected
    */
   protected getLinuxInfo(): string {
-    if (!isLinux()) throw new Error('only work on linux systems');
-
     let result = `Linux - ${release()}`;
 
     // the flatpak information is a very valuable information
@@ -77,7 +74,6 @@ export class FeedbackHandler {
    * @protected
    */
   protected getDarwinInfo(): string {
-    if (!isMac()) throw new Error('only work on darwin systems');
     return `Darwin ${release()} - ${arch()}`;
   }
 

--- a/packages/main/src/plugin/util/sys-info.spec.ts
+++ b/packages/main/src/plugin/util/sys-info.spec.ts
@@ -1,0 +1,96 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { arch, release, version } from 'node:os';
+
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { getSystemInfo } from '/@/plugin/util/sys-info.js';
+import { isLinux, isMac, isWindows } from '/@/util.js';
+
+vi.mock('/@/util.js', () => ({
+  isLinux: vi.fn(),
+  isMac: vi.fn(),
+  isWindows: vi.fn(),
+}));
+
+vi.mock('node:os', () => ({
+  arch: vi.fn(),
+  release: vi.fn(),
+  version: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('windows should use os#version and os#arch', () => {
+  vi.mocked(isWindows).mockReturnValue(true);
+  vi.mocked(arch).mockReturnValue('x64');
+  vi.mocked(version).mockReturnValue('Windows 11 Home');
+
+  const result = getSystemInfo().getSystemName();
+
+  expect(release).not.toHaveBeenCalled();
+  expect(version).toHaveBeenCalled();
+  expect(arch).toHaveBeenCalled();
+
+  expect(result).toBe('Windows 11 Home - x64');
+});
+
+test('linux should use os#release', () => {
+  vi.mocked(isLinux).mockReturnValue(true);
+  vi.mocked(release).mockReturnValue('6.11.7-300.fc41.x86_64');
+
+  const result = getSystemInfo().getSystemName();
+
+  expect(release).toHaveBeenCalled();
+  expect(version).not.toHaveBeenCalled();
+  expect(arch).not.toHaveBeenCalled();
+
+  expect(result).toBe('Linux - 6.11.7-300.fc41.x86_64');
+});
+
+test('flatpak linux should include flatpak info', () => {
+  vi.mocked(isLinux).mockReturnValue(true);
+  vi.mocked(release).mockReturnValue('6.11.7-300.fc41.x86_64');
+
+  process.env['FLATPAK_ID'] = 'dummy-id';
+
+  const result = getSystemInfo().getSystemName();
+
+  expect(release).toHaveBeenCalled();
+  expect(version).not.toHaveBeenCalled();
+  expect(arch).not.toHaveBeenCalled();
+
+  expect(result).toBe('Linux - 6.11.7-300.fc41.x86_64 (flatpak)');
+});
+
+test('darwin should use os#release and os#arch', () => {
+  vi.mocked(isMac).mockReturnValue(true);
+  vi.mocked(release).mockReturnValue('23.9.4');
+  vi.mocked(arch).mockReturnValue('arm64');
+
+  const result = getSystemInfo().getSystemName();
+
+  expect(release).toHaveBeenCalled();
+  expect(version).not.toHaveBeenCalled();
+  expect(arch).toHaveBeenCalled();
+
+  expect(result).toBe('Darwin 23.9.4 - arm64');
+});

--- a/packages/main/src/plugin/util/sys-info.ts
+++ b/packages/main/src/plugin/util/sys-info.ts
@@ -1,0 +1,85 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { arch, platform, release, version } from 'node:os';
+
+import { isLinux, isMac, isWindows } from '/@/util.js';
+
+export abstract class SystemInfo {
+  abstract getSystemName(): string;
+}
+
+class WindowsInfo extends SystemInfo {
+  /**
+   * According to the node documentation, we should be using the os#release
+   * but this has some problems with our current version of node
+   *
+   * Some node version do not report well the Windows 10 / 11 difference
+   * Ref https://github.com/nodejs/node/issues/40862
+   *
+   * E.g. on a Windows 11 x64 we would get `Windows 11 Home - x64`
+   *
+   * @remarks the type of license is important (Home / Pro) as we have different feature depending
+   * on the feature (HyperV support or not)
+   */
+  override getSystemName(): string {
+    return `${version()} - ${arch()}`;
+  }
+}
+
+class LinuxInfo extends SystemInfo {
+  /**
+   * Getting more details about the distribution is not feasible through the node api.
+   * Online recommendation are to look at the `/etc/os-release` but let's avoid making this
+   * too complicated.
+   *
+   * The os#release on linux seems to contain the architecture as it use internally [`uname(3)`](https://linux.die.net/man/3/uname).
+   *
+   * E.g. on a fedora 41 x64 we would get `Linux - <kernel-version>.fc41.<arch>`
+   */
+  override getSystemName(): string {
+    let result = `Linux - ${release()}`;
+
+    // the flatpak information is a very valuable information
+    if (process.env['FLATPAK_ID']) {
+      result += ' (flatpak)';
+    }
+    return result;
+  }
+}
+
+class DarwinInfo extends SystemInfo {
+  /**
+   * On Darwin system, we have too much information in the is os#version
+   * so we use release to get the os version (E.g. 24.1.0), and arch (E.g. arm64)
+   */
+  override getSystemName(): string {
+    return `Darwin ${release()} - ${arch()}`;
+  }
+}
+
+export function getSystemInfo(): SystemInfo {
+  if (isWindows()) {
+    return new WindowsInfo();
+  } else if (isMac()) {
+    return new DarwinInfo();
+  } else if (isLinux()) {
+    return new LinuxInfo();
+  }
+  throw new Error(`unknown platform: ${platform()}`);
+}


### PR DESCRIPTION
### What does this PR do?

Backend part of https://github.com/podman-desktop/podman-desktop/issues/9585.

The goal is to have a `include my system information`

![image](https://github.com/user-attachments/assets/2a74d3de-b8ee-4ef4-b3ed-31ef83149e65)

That will prefill the GitHub bug issue with the system info.

(not included in this PR, only backend)

![image](https://github.com/user-attachments/assets/7e6ed021-5e24-4c69-924c-f042ff790ebb)

### Sidenote

Getting a short and usable system information through the node api is very annoying actually, depending on the platform we do not get the same information.

I added documentation above each function to precise how, and why we use certain node:os function for each platform.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
