### PR TITLE
chore(ci): add junit reporter in e2e test workflows

### DIFF
--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -43,6 +43,9 @@ jobs:
   e2e-tests:
     name: Run All E2E tests
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      checks: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -115,6 +118,16 @@ jobs:
           export PODMAN_DESKTOP_BINARY_PATH=$path
           pnpm test:e2e
 
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v4
+        if: always() # always run even if the previous step fails
+        with:
+          fail_on_failure: true
+          include_passed: true
+          detailed_summary: true
+          require_tests:  true
+          report_paths: '**/*results.xml'
+
       - uses: actions/upload-artifact@v4
         if: always()
         with:
@@ -126,6 +139,9 @@ jobs:
   win-update-e2e-test:
     name: win update e2e tests
     runs-on: windows-2022
+    permissions:
+      contents: read
+      checks: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     timeout-minutes: 60
@@ -174,6 +190,16 @@ jobs:
         run: |
           echo "${{ env.PODMAN_DESKTOP_BINARY }}"
           pnpm test:e2e:update:run
+
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v4
+        if: always() # always run even if the previous step fails
+        with:
+          fail_on_failure: true
+          include_passed: true
+          detailed_summary: true
+          require_tests:  true
+          report_paths: '**/*results.xml'
 
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -43,9 +43,6 @@ jobs:
   e2e-tests:
     name: Run All E2E tests
     runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-      checks: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -125,6 +122,7 @@ jobs:
           fail_on_failure: true
           include_passed: true
           detailed_summary: true
+          annotate_only: true
           require_tests:  true
           report_paths: '**/*results.xml'
 
@@ -139,9 +137,6 @@ jobs:
   win-update-e2e-test:
     name: win update e2e tests
     runs-on: windows-2022
-    permissions:
-      contents: read
-      checks: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     timeout-minutes: 60
@@ -198,6 +193,7 @@ jobs:
           fail_on_failure: true
           include_passed: true
           detailed_summary: true
+          annotate_only: true
           require_tests:  true
           report_paths: '**/*results.xml'
 

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -295,9 +295,6 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'area/ci') || !github.event.pull_request.draft }}
     name: smoke e2e tests
     runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-      checks: write
     strategy:
       matrix:
         mode: [production, development]
@@ -409,9 +406,6 @@ jobs:
   run-update-e2e-test:
     name: win update e2e tests
     needs: detect_pnpm_changes
-    permissions:
-      contents: read
-      checks: write
     if: contains(github.event.pull_request.labels.*.name, 'area/update') || needs.detect_pnpm_changes.outputs.pnpm_lock_changed == 'true'
     runs-on: windows-2022
     timeout-minutes: 60

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -371,6 +371,7 @@ jobs:
           fail_on_failure: true
           include_passed: true
           detailed_summary: true
+          annotate_only: true
           require_tests:  true
           report_paths: '**/*results.xml'
 
@@ -460,6 +461,7 @@ jobs:
           fail_on_failure: true
           include_passed: true
           detailed_summary: true
+          annotate_only: true
           require_tests:  true
           report_paths: '**/*results.xml'
 

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -295,6 +295,9 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'area/ci') || !github.event.pull_request.draft }}
     name: smoke e2e tests
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      checks: write
     strategy:
       matrix:
         mode: [production, development]
@@ -361,6 +364,16 @@ jobs:
           fi
           pnpm test:e2e:smoke
 
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v4
+        if: always() # always run even if the previous step fails
+        with:
+          fail_on_failure: true
+          include_passed: true
+          detailed_summary: true
+          require_tests:  true
+          report_paths: '**/*results.xml'
+
       - uses: actions/upload-artifact@v4
         if: always()
         with:
@@ -395,6 +408,9 @@ jobs:
   run-update-e2e-test:
     name: win update e2e tests
     needs: detect_pnpm_changes
+    permissions:
+      contents: read
+      checks: write
     if: contains(github.event.pull_request.labels.*.name, 'area/update') || needs.detect_pnpm_changes.outputs.pnpm_lock_changed == 'true'
     runs-on: windows-2022
     timeout-minutes: 60
@@ -436,6 +452,16 @@ jobs:
         run: |
           echo "${{ env.PODMAN_DESKTOP_BINARY }}"
           pnpm test:e2e:update:run
+
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v4
+        if: always() # always run even if the previous step fails
+        with:
+          fail_on_failure: true
+          include_passed: true
+          detailed_summary: true
+          require_tests:  true
+          report_paths: '**/*results.xml'
 
       - uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
### What does this PR do?
Junit reporter is now part of e2e jobs in various workflows (e2e tests). Significantly improves test result visibility and readability without a need to download artifacts.
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#8847 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
Check E2E test workflow run results page on github checks.

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
