### PR TITLE
feat: allow to cancel a task that is cancellable

### DIFF
--- a/packages/renderer/src/lib/task-manager/LegacyTaskManagerItem.svelte
+++ b/packages/renderer/src/lib/task-manager/LegacyTaskManagerItem.svelte
@@ -4,10 +4,11 @@ import {
   faClose,
   faInfoCircle,
   faSquareCheck,
+  faTimesCircle,
   faTriangleExclamation,
   type IconDefinition,
 } from '@fortawesome/free-solid-svg-icons';
-import { TableDurationColumn } from '@podman-desktop/ui-svelte';
+import { TableDurationColumn, Tooltip } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 import Fa from 'svelte-fa';
 
@@ -43,6 +44,12 @@ onMount(() => {
   }
 });
 
+async function cancelTask(): Promise<void> {
+  if (task.cancellationTokenSourceId) {
+    await window.cancelToken(task.cancellationTokenSourceId);
+  }
+}
+
 async function closeCompleted(task: TaskInfo | NotificationTaskInfo) {
   // needs to delete the task from the svelte store
   return removeTask(task.id);
@@ -56,10 +63,19 @@ async function doExecuteAction(task: TaskInfo) {
 <!-- Display a task item-->
 <div class="flex flew-row w-full py-2">
   <!-- first column is the icon-->
-  <div class="flex w-3 {iconColor} justify-center">
+  <div class="flex w-3 flex-col {iconColor}">
     <div class="align-top" role="img" aria-label="{task.status} icon of task {task.name}">
     <Fa size="0.875x" icon={icon} />
     </div>
+    {#if task.state !== 'completed' && task.cancellable}
+      <div class="items-end flex flex-grow">
+        <Tooltip tip="Cancel the task" topRight>
+          <button class="cursor-pointer" on:click={cancelTask} aria-label="Cancel task {task.name}">
+            <Fa size="0.875x" icon={faTimesCircle} />
+          </button>
+        </Tooltip>
+      </div>
+    {/if}
   </div>
   <!-- second column is about the task-->
   <div class="flex flex-col w-full pl-2">


### PR DESCRIPTION
### What does this PR do?
Get a cancel icon in the task manager to be able to cancel a task flagged as cancellable.


### Screenshot / video of UI

https://github.com/user-attachments/assets/30d55ecb-2bf2-4947-a45d-10056cc7b670



### What issues does this PR fix or reference?

fixes https://github.com/podman-desktop/podman-desktop/issues/9092

### How to test this PR?

1. Install the extension from `quay.io/fbenoit/long-task-example:v1.0``
2. press `F1` key to bring the command palette
3. select `Dummy Long task` (type dummy it will highlight the task)
4. click enter
5. Now open the task manager, see the task progressing and click on the cancel button to cancel it

- [x] Tests are covering the bug fix or the new feature
