### PR TITLE
refactor(github-feedback): removing test ids and factoring code

### DIFF
--- a/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.spec.ts
@@ -18,12 +18,12 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { render, screen } from '@testing-library/svelte';
+import { render, type RenderResult } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
-import { tick } from 'svelte';
+import { type Component, type ComponentProps } from 'svelte';
 import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
-import type { GitHubIssue } from '/@api/feedback';
+import type { FeedbackCategory } from '/@api/feedback';
 
 import GitHubIssueFeedback from './GitHubIssueFeedback.svelte';
 
@@ -49,98 +49,140 @@ beforeEach(() => {
   vi.resetAllMocks();
 });
 
-test('Expect feedback form to to be GitHub issue feedback form', async () => {
-  const renderObject = render(GitHubIssueFeedback, { category: 'bug', onCloseForm: vi.fn(), contentChange: vi.fn() });
+/**
+ * Utility method to query get GitHub issue inputs
+ * @param props
+ */
+function renderGitHubIssueFeedback(props: ComponentProps<typeof GitHubIssueFeedback>): {
+  title: HTMLInputElement;
+  description: HTMLTextAreaElement;
+  preview: HTMLButtonElement;
+} & RenderResult<Component<ComponentProps<typeof GitHubIssueFeedback>>> {
+  const { getByRole, queryByTitle, ...restResult } = render(GitHubIssueFeedback, props);
 
-  expect(screen.getByText('Title')).toBeInTheDocument();
-  expect(screen.getByText('Description')).toBeInTheDocument();
-  renderObject.unmount();
+  // text inputs
+  const title = getByRole('textbox', { name: 'Issue Title' });
+  expect(title).toBeInstanceOf(HTMLInputElement);
+
+  const description = getByRole('textbox', { name: 'Issue Description' });
+  expect(description).toBeInstanceOf(HTMLTextAreaElement);
+
+  // button
+  const preview = getByRole('button', { name: 'Preview on GitHub' });
+  expect(preview).toBeInstanceOf(HTMLButtonElement);
+
+  return {
+    title: title as HTMLInputElement,
+    description: description as HTMLTextAreaElement,
+    preview: preview as HTMLButtonElement,
+    getByRole,
+    queryByTitle,
+    ...restResult,
+  };
+}
+
+test('Expect feedback form to to be GitHub issue feedback form', async () => {
+  const { title, description } = renderGitHubIssueFeedback({
+    category: 'bug',
+    onCloseForm: vi.fn(),
+    contentChange: vi.fn(),
+  });
+
+  expect(title).toBeInTheDocument();
+  expect(description).toBeInTheDocument();
 });
 
 test('Expect Preview on GitHub button to be disabled if there is no title or description', async () => {
-  const renderObject = render(GitHubIssueFeedback, { category: 'bug', onCloseForm: vi.fn(), contentChange: vi.fn() });
-
-  expect(screen.getByRole('button', { name: 'Preview on GitHub' })).toBeDisabled();
-
-  const issueTitle = screen.getByTestId('issueTitle');
-  expect(issueTitle).toBeInTheDocument();
-  await userEvent.type(issueTitle, 'Bug title');
-
-  const issueDescription = screen.getByTestId('issueDescription');
-  expect(issueDescription).toBeInTheDocument();
-  await userEvent.type(issueDescription, 'Bug description');
-
-  await tick();
-  expect(screen.getByRole('button', { name: 'Preview on GitHub' })).toBeEnabled();
-  renderObject.unmount();
-});
-
-test('Expect to have different placeholders for bug vs feaure', async () => {
-  let renderObject = render(GitHubIssueFeedback, { category: 'bug', onCloseForm: vi.fn(), contentChange: vi.fn() });
-
-  let issueTitle = screen.getByTestId('issueTitle');
-  expect(issueTitle).toBeInTheDocument();
-  expect(issueTitle).toHaveProperty('placeholder', 'Bug Report Title');
-
-  let issueDescription = screen.getByTestId('issueDescription');
-  expect(issueDescription).toBeInTheDocument();
-  expect(issueDescription).toHaveProperty('placeholder', 'Bug description');
-
-  renderObject.unmount();
-
-  renderObject = render(GitHubIssueFeedback, { category: 'feature', onCloseForm: vi.fn(), contentChange: vi.fn() });
-
-  issueTitle = screen.getByTestId('issueTitle');
-  expect(issueTitle).toBeInTheDocument();
-  expect(issueTitle).toHaveProperty('placeholder', 'Feature name');
-
-  issueDescription = screen.getByTestId('issueDescription');
-  expect(issueDescription).toBeInTheDocument();
-  expect(issueDescription).toHaveProperty('placeholder', 'Feature description');
-  renderObject.unmount();
-});
-
-test('Expect to have different existing GitHub issues links for bug and feature categories', async () => {
-  let renderObject = render(GitHubIssueFeedback, { category: 'bug', onCloseForm: vi.fn(), contentChange: vi.fn() });
-  let existingIssues = screen.getByLabelText('GitHub issues');
-  expect(existingIssues).toBeInTheDocument();
-
-  await userEvent.click(existingIssues);
-  expect(openExternalMock).toHaveBeenCalledWith(
-    'https://github.com/podman-desktop/podman-desktop/issues?q=label%3A%22kind%2Fbug%20%F0%9F%90%9E%22',
-  );
-  renderObject.unmount();
-
-  renderObject = render(GitHubIssueFeedback, { category: 'feature', onCloseForm: vi.fn(), contentChange: vi.fn() });
-  existingIssues = screen.getByLabelText('GitHub issues');
-  expect(existingIssues).toBeInTheDocument();
-
-  await userEvent.click(existingIssues);
-  expect(openExternalMock).toHaveBeenCalledWith(
-    'https://github.com/podman-desktop/podman-desktop/issues?q=label%3A%22kind%2Ffeature%20%F0%9F%92%A1%22',
-  );
-  renderObject.unmount();
-});
-
-test('Expect the right category to be included in previewOnGitHub call', async () => {
-  const issueProperties: GitHubIssue = {
+  const { title, description, preview } = renderGitHubIssueFeedback({
     category: 'bug',
-    title: 'Bug title',
-    description: 'Bug description',
-  };
-  const renderObject = render(GitHubIssueFeedback, { category: 'bug', onCloseForm: vi.fn(), contentChange: vi.fn() });
-  const previewButton = screen.getByRole('button', { name: 'Preview on GitHub' });
+    onCloseForm: vi.fn(),
+    contentChange: vi.fn(),
+  });
 
-  const issueTitle = screen.getByTestId('issueTitle');
-  expect(issueTitle).toBeInTheDocument();
-  await userEvent.type(issueTitle, 'Bug title');
+  // default: disabled
+  expect(preview).toBeDisabled();
 
-  const issueDescription = screen.getByTestId('issueDescription');
-  expect(issueDescription).toBeInTheDocument();
-  await userEvent.type(issueDescription, 'Bug description');
+  await userEvent.type(title, 'Bug title');
+  await userEvent.type(description, 'Bug description');
 
-  await userEvent.click(previewButton);
+  await vi.waitFor(() => {
+    expect(preview).toBeEnabled();
+  });
+});
 
-  expect(previewOnGitHubMock).toHaveBeenCalledWith(issueProperties);
-  renderObject.unmount();
+test.each([
+  {
+    category: 'bug',
+    placeholders: {
+      title: 'Bug Report Title',
+      description: 'Bug description',
+    },
+    link: 'https://github.com/podman-desktop/podman-desktop/issues?q=label%3A%22kind%2Fbug%20%F0%9F%90%9E%22',
+  },
+  {
+    category: 'feature',
+    placeholders: {
+      title: 'Feature name',
+      description: 'Feature description',
+    },
+    link: 'https://github.com/podman-desktop/podman-desktop/issues?q=label%3A%22kind%2Ffeature%20%F0%9F%92%A1%22',
+  },
+])('$category should have specific placeholders', async ({ category, placeholders }) => {
+  const { title, description } = renderGitHubIssueFeedback({
+    category: category as FeedbackCategory,
+    onCloseForm: vi.fn(),
+    contentChange: vi.fn(),
+  });
+
+  expect(title).toHaveProperty('placeholder', placeholders.title);
+  expect(description).toHaveProperty('placeholder', placeholders.description);
+});
+
+test.each([
+  {
+    category: 'bug',
+    link: 'https://github.com/podman-desktop/podman-desktop/issues?q=label%3A%22kind%2Fbug%20%F0%9F%90%9E%22',
+  },
+  {
+    category: 'feature',
+    link: 'https://github.com/podman-desktop/podman-desktop/issues?q=label%3A%22kind%2Ffeature%20%F0%9F%92%A1%22',
+  },
+])('$category should have specific issues link', async ({ category, link }) => {
+  const { getByLabelText } = renderGitHubIssueFeedback({
+    category: category as FeedbackCategory,
+    onCloseForm: vi.fn(),
+    contentChange: vi.fn(),
+  });
+
+  const existingIssues = getByLabelText('GitHub issues');
+  expect(existingIssues).toBeInTheDocument();
+
+  await userEvent.click(existingIssues);
+  expect(openExternalMock).toHaveBeenCalledWith(link);
+});
+
+test.each(['bug', 'feature'])('Expect %s to be included in previewOnGitHub call', async category => {
+  const { preview, title, description } = renderGitHubIssueFeedback({
+    category: category as FeedbackCategory,
+    onCloseForm: vi.fn(),
+    contentChange: vi.fn(),
+  });
+
+  // type dummy data
+  await userEvent.type(title, 'Bug title');
+  await userEvent.type(description, 'Bug description');
+
+  // wait enable
+  await vi.waitFor(() => {
+    expect(preview).toBeEnabled();
+  });
+
+  // preview
+  await userEvent.click(preview);
+
+  expect(previewOnGitHubMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      category: category,
+    }),
+  );
 });

--- a/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.spec.ts
@@ -117,7 +117,6 @@ test.each([
       title: 'Bug Report Title',
       description: 'Bug description',
     },
-    link: 'https://github.com/podman-desktop/podman-desktop/issues?q=label%3A%22kind%2Fbug%20%F0%9F%90%9E%22',
   },
   {
     category: 'feature',
@@ -125,7 +124,6 @@ test.each([
       title: 'Feature name',
       description: 'Feature description',
     },
-    link: 'https://github.com/podman-desktop/podman-desktop/issues?q=label%3A%22kind%2Ffeature%20%F0%9F%92%A1%22',
   },
 ])('$category should have specific placeholders', async ({ category, placeholders }) => {
   const { title, description } = renderGitHubIssueFeedback({

--- a/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.svelte
@@ -62,16 +62,26 @@ async function previewOnGitHub(): Promise<void> {
 <FeedbackForm>
   <svelte:fragment slot="content">
     <div class="text-sm text-[var(--pd-state-warning)]">You can search existing {category} issues on <Link aria-label="GitHub issues" onclick={openGitHubIssues}>github.com/podman-desktop/podman-desktop/issues</Link></div>
+    <!-- issue title -->
     <label for="issueTitle" class="block mt-4 mb-2 text-sm font-medium text-[var(--pd-modal-text)]">Title</label>
-    <input type="text" name="issueTitle" id="issueTitle" bind:value={issueTitle} data-testid="issueTitle" placeholder={titlePlaceholder} class="w-full p-2 outline-none text-sm bg-[var(--pd-input-field-focused-bg)] rounded-sm text-[var(--pd-input-field-focused-text)] placeholder-[var(--pd-input-field-placeholder-text)]"/>
+    <input
+      type="text"
+      name="issueTitle"
+      id="issueTitle"
+      aria-label="Issue Title"
+      bind:value={issueTitle}
+      placeholder={titlePlaceholder}
+      class="w-full p-2 outline-none text-sm bg-[var(--pd-input-field-focused-bg)] rounded-sm text-[var(--pd-input-field-focused-text)] placeholder-[var(--pd-input-field-placeholder-text)]"/>
+
+    <!-- issue body -->
     <label for="issueDescription" class="block mt-4 mb-2 text-sm font-medium text-[var(--pd-modal-text)]"
       >Description</label>
     <textarea
       rows="3"
       maxlength="1000"
       name="issueDescription"
+      aria-label="Issue Description"
       id="issueDescription"
-      data-testid="issueDescription"
       bind:value={issueDescription}
       class="w-full p-2 outline-none text-sm bg-[var(--pd-input-field-focused-bg)] rounded-sm text-[var(--pd-input-field-focused-text)] placeholder-[var(--pd-input-field-placeholder-text)]"
       placeholder={descriptionPlaceholder}></textarea>


### PR DESCRIPTION
### What does this PR do?

To be able to test https://github.com/podman-desktop/podman-desktop/pull/10116 I refactored the tests of the `GitHubFeedback` component, with the following changes

- Removing the `data-testid` (we should avoid using that)
- Creating an utility method `renderGitHubIssueFeedback` to factorise the code
- Remove `object.unmount` of the tests file (we should avoid using that)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
