### PR TITLE
chore: refactor activate method of podman extension to have more things loaded lazily

### DIFF
--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -2594,7 +2594,7 @@ async function testAudit(path: string, uri: string, condition: typeof expect | t
     },
   );
   await extension.activate(contextMock);
-  expect(vi.mocked(provider.setContainerProviderConnectionFactory)).toBeCalled();
+  await vi.waitFor(() => expect(vi.mocked(provider.setContainerProviderConnectionFactory)).toBeCalled());
   expect(auditorInstance).toBeDefined();
   const auditRecords: extensionApi.AuditResult = await auditorInstance!.auditItems({
     'podman.factory.machine.cpus': '2',
@@ -2705,7 +2705,7 @@ describe.each(['windows', 'mac', 'linux'])('podman machine properties audit on %
         return orExistsSync(path);
       });
       await extension.activate(mockExtensionForAuditTests());
-      expect(vi.mocked(provider.setContainerProviderConnectionFactory)).not.toBeCalled();
+      await vi.waitFor(() => expect(vi.mocked(provider.setContainerProviderConnectionFactory)).not.toBeCalled());
     });
     return;
   }


### PR DESCRIPTION
### What does this PR do?
move some heavy operations to be done in the post activation part
only some lines of code have been moved

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/issues/9445

### How to test this PR?

should work as before, try the autostart on/off
look at the activation time, and see if now it's lower (look at the startup logs and check for podman extension)

- [x] Tests are covering the bug fix or the new feature

2 tests have been updated to wait longer than just the call to activate.
