### PR TITLE
feat: check permissions on resources

### DIFF
--- a/packages/main/src/plugin/kubernetes/context-health-checker.spec.ts
+++ b/packages/main/src/plugin/kubernetes/context-health-checker.spec.ts
@@ -16,21 +16,21 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { Cluster, Context, KubeConfig, User } from '@kubernetes/client-node';
+import type { Cluster, Context, User } from '@kubernetes/client-node';
 import { AbortError, Health } from '@kubernetes/client-node';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { ContextHealthChecker } from './context-health-checker.js';
+import type { KubeConfigSingleContext } from './kubeconfig-single-context.js';
 
 vi.mock('@kubernetes/client-node');
 
-const contexts = [
-  {
-    name: 'context1',
-    cluster: 'cluster1',
-    user: 'user1',
-  },
-] as Context[];
+const context1 = {
+  name: 'context1',
+  cluster: 'cluster1',
+  user: 'user1',
+};
+const contexts = [context1] as Context[];
 
 const clusters = [
   {
@@ -45,11 +45,13 @@ const users = [
 ] as User[];
 
 const config = {
-  contexts,
-  clusters,
-  users,
-  currentContext: 'context1',
-} as unknown as KubeConfig;
+  getKubeConfig: () => ({
+    contexts,
+    clusters,
+    users,
+    currentContext: 'context1',
+  }),
+} as KubeConfigSingleContext;
 
 beforeEach(() => {
   vi.mocked(Health).mockClear();
@@ -70,10 +72,21 @@ test('onStateChange is fired with result of readyz if no error', async () => {
 
   readyzMock.mockResolvedValue(true);
   await hc.start();
-  expect(onStateChangeCB).toHaveBeenCalledWith({ contextName: 'context1', checking: true, reachable: false });
-  expect(onStateChangeCB).toHaveBeenCalledWith({ contextName: 'context1', checking: false, reachable: true });
+  expect(onStateChangeCB).toHaveBeenCalledWith({
+    kubeConfig: config,
+    contextName: 'context1',
+    checking: true,
+    reachable: false,
+  });
+  expect(onStateChangeCB).toHaveBeenCalledWith({
+    kubeConfig: config,
+    contextName: 'context1',
+    checking: false,
+    reachable: true,
+  });
 
   expect(hc.getState()).toEqual({
+    kubeConfig: config,
     contextName: 'context1',
     checking: false,
     reachable: true,
@@ -83,10 +96,21 @@ test('onStateChange is fired with result of readyz if no error', async () => {
 
   readyzMock.mockResolvedValue(false);
   await hc.start();
-  expect(onStateChangeCB).toHaveBeenCalledWith({ contextName: 'context1', checking: true, reachable: false });
-  expect(onStateChangeCB).toHaveBeenCalledWith({ contextName: 'context1', checking: false, reachable: false });
+  expect(onStateChangeCB).toHaveBeenCalledWith({
+    kubeConfig: config,
+    contextName: 'context1',
+    checking: true,
+    reachable: false,
+  });
+  expect(onStateChangeCB).toHaveBeenCalledWith({
+    kubeConfig: config,
+    contextName: 'context1',
+    checking: false,
+    reachable: false,
+  });
 
   expect(hc.getState()).toEqual({
+    kubeConfig: config,
     contextName: 'context1',
     checking: false,
     reachable: false,
@@ -109,8 +133,14 @@ test('onStateChange is not fired when readyz is rejected with an abort error', a
   readyzMock.mockRejectedValue(new AbortError('a message'));
   await hc.start();
   expect(onStateChangeCB).toHaveBeenCalledOnce();
-  expect(onStateChangeCB).toHaveBeenCalledWith({ contextName: 'context1', checking: true, reachable: false });
+  expect(onStateChangeCB).toHaveBeenCalledWith({
+    kubeConfig: config,
+    contextName: 'context1',
+    checking: true,
+    reachable: false,
+  });
   expect(hc.getState()).toEqual({
+    kubeConfig: config,
     contextName: 'context1',
     checking: true,
     reachable: false,
@@ -132,9 +162,20 @@ test('onReadiness is called with false when readyz is rejected with a generic er
 
   readyzMock.mockRejectedValue(new Error('a generic error'));
   await hc.start();
-  expect(onStateChangeCB).toHaveBeenCalledWith({ contextName: 'context1', checking: true, reachable: false });
-  expect(onStateChangeCB).toHaveBeenCalledWith({ contextName: 'context1', checking: false, reachable: false });
+  expect(onStateChangeCB).toHaveBeenCalledWith({
+    kubeConfig: config,
+    contextName: 'context1',
+    checking: true,
+    reachable: false,
+  });
+  expect(onStateChangeCB).toHaveBeenCalledWith({
+    kubeConfig: config,
+    contextName: 'context1',
+    checking: false,
+    reachable: false,
+  });
   expect(hc.getState()).toEqual({
+    kubeConfig: config,
     contextName: 'context1',
     checking: false,
     reachable: false,

--- a/packages/main/src/plugin/kubernetes/context-health-checker.ts
+++ b/packages/main/src/plugin/kubernetes/context-health-checker.ts
@@ -43,8 +43,8 @@ export class ContextHealthChecker implements Disposable {
   #onStateChange = new Emitter<ContextHealthState>();
   onStateChange: Event<ContextHealthState> = this.#onStateChange.event;
 
-  #onReachable = new Emitter<void>();
-  onReachable: Event<void> = this.#onReachable.event;
+  #onReachable = new Emitter<ContextHealthState>();
+  onReachable: Event<ContextHealthState> = this.#onReachable.event;
 
   #contextName: string;
 
@@ -58,7 +58,7 @@ export class ContextHealthChecker implements Disposable {
     this.#currentState = { contextName: this.#contextName, checking: false, reachable: false };
     this.onStateChange((e: ContextHealthState) => {
       if (e.reachable) {
-        this.#onReachable.fire();
+        this.#onReachable.fire(e);
       }
     });
   }

--- a/packages/main/src/plugin/kubernetes/context-health-checker.ts
+++ b/packages/main/src/plugin/kubernetes/context-health-checker.ts
@@ -43,6 +43,9 @@ export class ContextHealthChecker implements Disposable {
   #onStateChange = new Emitter<ContextHealthState>();
   onStateChange: Event<ContextHealthState> = this.#onStateChange.event;
 
+  #onReachable = new Emitter<void>();
+  onReachable: Event<void> = this.#onReachable.event;
+
   #contextName: string;
 
   #currentState: ContextHealthState;
@@ -53,6 +56,11 @@ export class ContextHealthChecker implements Disposable {
     this.#health = new Health(kubeConfig);
     this.#contextName = kubeConfig.currentContext;
     this.#currentState = { contextName: this.#contextName, checking: false, reachable: false };
+    this.onStateChange((e: ContextHealthState) => {
+      if (e.reachable) {
+        this.#onReachable.fire();
+      }
+    });
   }
 
   // start checking the readiness
@@ -73,6 +81,7 @@ export class ContextHealthChecker implements Disposable {
 
   public dispose(): void {
     this.#onStateChange.dispose();
+    this.#onReachable.dispose();
     this.#abortController.abort();
   }
 

--- a/packages/main/src/plugin/kubernetes/context-health-checker.ts
+++ b/packages/main/src/plugin/kubernetes/context-health-checker.ts
@@ -16,14 +16,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { KubeConfig } from '@kubernetes/client-node';
 import { AbortError, Health } from '@kubernetes/client-node';
 import type { Disposable } from '@podman-desktop/api';
 
 import type { Event } from '../events/emitter.js';
 import { Emitter } from '../events/emitter.js';
+import type { KubeConfigSingleContext } from './kubeconfig-single-context.js';
 
 export interface ContextHealthState {
+  kubeConfig: KubeConfigSingleContext;
   contextName: string;
   checking: boolean;
   reachable: boolean;
@@ -47,15 +48,22 @@ export class ContextHealthChecker implements Disposable {
   onReachable: Event<ContextHealthState> = this.#onReachable.event;
 
   #contextName: string;
+  #kubeConfig: KubeConfigSingleContext;
 
   #currentState: ContextHealthState;
 
   // builds an HealthChecker which will check the cluster of the current context of the given kubeConfig
-  constructor(kubeConfig: KubeConfig) {
+  constructor(kubeConfig: KubeConfigSingleContext) {
+    this.#kubeConfig = kubeConfig;
     this.#abortController = new AbortController();
-    this.#health = new Health(kubeConfig);
-    this.#contextName = kubeConfig.currentContext;
-    this.#currentState = { contextName: this.#contextName, checking: false, reachable: false };
+    this.#health = new Health(kubeConfig.getKubeConfig());
+    this.#contextName = kubeConfig.getKubeConfig().currentContext;
+    this.#currentState = {
+      kubeConfig: this.#kubeConfig,
+      contextName: this.#contextName,
+      checking: false,
+      reachable: false,
+    };
     this.onStateChange((e: ContextHealthState) => {
       if (e.reachable) {
         this.#onReachable.fire(e);
@@ -65,15 +73,30 @@ export class ContextHealthChecker implements Disposable {
 
   // start checking the readiness
   public async start(opts?: ContextHealthCheckOptions): Promise<void> {
-    this.#currentState = { contextName: this.#contextName, checking: true, reachable: false };
+    this.#currentState = {
+      kubeConfig: this.#kubeConfig,
+      contextName: this.#contextName,
+      checking: true,
+      reachable: false,
+    };
     this.#onStateChange.fire(this.#currentState);
     try {
       const result = await this.#health.readyz({ signal: this.#abortController.signal, timeout: opts?.timeout });
-      this.#currentState = { contextName: this.#contextName, checking: false, reachable: result };
+      this.#currentState = {
+        kubeConfig: this.#kubeConfig,
+        contextName: this.#contextName,
+        checking: false,
+        reachable: result,
+      };
       this.#onStateChange.fire(this.#currentState);
     } catch (err: unknown) {
       if (!(err instanceof AbortError)) {
-        this.#currentState = { contextName: this.#contextName, checking: false, reachable: false };
+        this.#currentState = {
+          kubeConfig: this.#kubeConfig,
+          contextName: this.#contextName,
+          checking: false,
+          reachable: false,
+        };
         this.#onStateChange.fire(this.#currentState);
       }
     }

--- a/packages/main/src/plugin/kubernetes/context-permissions-checker.spec.ts
+++ b/packages/main/src/plugin/kubernetes/context-permissions-checker.spec.ts
@@ -1,0 +1,298 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import util from 'node:util';
+
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { ContextResourcePermission } from './context-permissions-checker.js';
+import { ContextPermissionsChecker } from './context-permissions-checker.js';
+import type { KubeConfigSingleContext } from './kubeconfig-single-context.js';
+
+describe('ContextPermissionsChecker is built with a non recursive request', async () => {
+  let permissionsChecker: ContextPermissionsChecker;
+  const createSelfSubjectAccessReviewMock = vi.fn();
+  const onPermissionResultCB = vi.fn();
+
+  let kubeConfig: KubeConfigSingleContext;
+
+  const attrs = {
+    namespace: 'ns1',
+    group: '*',
+    resource: '*',
+    verb: 'watch',
+  };
+  const resources = ['resource1', 'resource2'];
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    kubeConfig = {
+      getKubeConfig: vi.fn().mockReturnValue({
+        makeApiClient: vi.fn().mockReturnValue({
+          createSelfSubjectAccessReview: createSelfSubjectAccessReviewMock,
+        }),
+      }),
+    } as unknown as KubeConfigSingleContext;
+  });
+
+  describe('permission is allowed', async () => {
+    beforeEach(async () => {
+      createSelfSubjectAccessReviewMock.mockResolvedValue({
+        status: {
+          allowed: true,
+          reason: 'a reason',
+        },
+      });
+      permissionsChecker = new ContextPermissionsChecker(kubeConfig, {
+        attrs,
+        resources,
+      });
+      permissionsChecker.onPermissionResult(onPermissionResultCB);
+      await permissionsChecker.start();
+    });
+
+    test('onPermissionResult is fired with permitted true', async () => {
+      expect(onPermissionResultCB).toHaveBeenCalledWith({
+        attrs,
+        resources,
+        permitted: true,
+        reason: 'a reason',
+      });
+    });
+
+    test('getPermissions returns permitted true', async () => {
+      const permissions = permissionsChecker.getPermissions();
+      const expected = new Map<string, ContextResourcePermission>();
+      expected.set('resource1', {
+        attrs,
+        permitted: true,
+        reason: 'a reason',
+      });
+      expected.set('resource2', {
+        attrs,
+        permitted: true,
+        reason: 'a reason',
+      });
+      expect(permissions).toEqual(expected);
+    });
+  });
+
+  describe('permission is allowed and denied is true', async () => {
+    beforeEach(async () => {
+      createSelfSubjectAccessReviewMock.mockResolvedValue({
+        status: {
+          allowed: true,
+          denied: true,
+          reason: 'a reason',
+        },
+      });
+      permissionsChecker = new ContextPermissionsChecker(kubeConfig, {
+        attrs,
+        resources,
+      });
+      permissionsChecker.onPermissionResult(onPermissionResultCB);
+      await permissionsChecker.start();
+    });
+
+    test('onPermissionResult is fired with permitted false', async () => {
+      expect(onPermissionResultCB).toHaveBeenCalledWith({
+        attrs,
+        resources,
+        permitted: false,
+        reason: 'a reason',
+      });
+    });
+
+    test('getPermissions returns permitted false', async () => {
+      const permissions = permissionsChecker.getPermissions();
+      const expected = new Map<string, ContextResourcePermission>();
+      expected.set('resource1', {
+        attrs,
+        permitted: false,
+        reason: 'a reason',
+      });
+      expected.set('resource2', {
+        attrs,
+        permitted: false,
+        reason: 'a reason',
+      });
+      expect(permissions).toEqual(expected);
+    });
+  });
+
+  describe('permission is not allowed', async () => {
+    beforeEach(async () => {
+      createSelfSubjectAccessReviewMock.mockResolvedValue({
+        status: {
+          allowed: false,
+          reason: 'a reason',
+        },
+      });
+      permissionsChecker = new ContextPermissionsChecker(kubeConfig, {
+        attrs,
+        resources,
+      });
+      permissionsChecker.onPermissionResult(onPermissionResultCB);
+      await permissionsChecker.start();
+    });
+
+    test('onPermissionResult is fired with permitted false', async () => {
+      expect(onPermissionResultCB).toHaveBeenCalledWith({
+        attrs,
+        resources,
+        permitted: false,
+        reason: 'a reason',
+      });
+    });
+
+    test('getPermissions returns permitted false', async () => {
+      const permissions = permissionsChecker.getPermissions();
+      const expected = new Map<string, ContextResourcePermission>();
+      expected.set('resource1', {
+        attrs,
+        permitted: false,
+        reason: 'a reason',
+      });
+      expected.set('resource2', {
+        attrs,
+        permitted: false,
+        reason: 'a reason',
+      });
+      expect(permissions).toEqual(expected);
+    });
+  });
+});
+
+describe('ContextPermissionsChecker is built with a recursive request', async () => {
+  let permissionsChecker: ContextPermissionsChecker;
+  const createSelfSubjectAccessReviewMock = vi.fn();
+  const onPermissionResultCB = vi.fn();
+
+  let kubeConfig: KubeConfigSingleContext;
+
+  const attrs = {
+    namespace: 'ns1',
+    group: '*',
+    resource: '*',
+    verb: 'watch',
+  };
+  const resources = ['resource1', 'resource2'];
+
+  const attrsResource1 = {
+    namespace: 'ns1',
+    group: 'group1',
+    resource: 'resource1',
+    verb: 'watch',
+  };
+  const resources1 = ['resource1'];
+
+  const attrsResource2 = {
+    namespace: 'ns1',
+    group: 'group2',
+    resource: 'resource2',
+    verb: 'watch',
+  };
+  const resources2 = ['resource2'];
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    kubeConfig = {
+      getKubeConfig: vi.fn().mockReturnValue({
+        makeApiClient: vi.fn().mockReturnValue({
+          createSelfSubjectAccessReview: createSelfSubjectAccessReviewMock,
+        }),
+      }),
+    } as unknown as KubeConfigSingleContext;
+  });
+
+  describe('permission is denied globally, and allowed for resource1 only', async () => {
+    beforeEach(async () => {
+      createSelfSubjectAccessReviewMock.mockImplementation(param => {
+        if (util.isDeepStrictEqual(param.body.spec.resourceAttributes, attrs)) {
+          return {
+            status: {
+              allowed: false,
+              reason: 'a global reason',
+            },
+          };
+        } else if (util.isDeepStrictEqual(param.body.spec.resourceAttributes, attrsResource1)) {
+          return {
+            status: {
+              allowed: true,
+              reason: 'a reason 1',
+            },
+          };
+        }
+        console.log('==> ', param.body.spec.resourceAttributes);
+        return {
+          status: {
+            allowed: false,
+            reason: 'a reason 2',
+          },
+        };
+      });
+      permissionsChecker = new ContextPermissionsChecker(kubeConfig, {
+        attrs,
+        resources,
+        onDenyRequests: [
+          {
+            attrs: attrsResource1,
+            resources: resources1,
+          },
+          {
+            attrs: attrsResource2,
+            resources: resources2,
+          },
+        ],
+      });
+      permissionsChecker.onPermissionResult(onPermissionResultCB);
+      await permissionsChecker.start();
+    });
+
+    test('onPermissionResult is fired with permitted true for resource1 and false for resource2', async () => {
+      expect(onPermissionResultCB).toHaveBeenCalledWith({
+        attrs: attrsResource1,
+        resources: resources1,
+        permitted: true,
+        reason: 'a reason 1',
+      });
+      expect(onPermissionResultCB).toHaveBeenCalledWith({
+        attrs: attrsResource2,
+        resources: resources2,
+        permitted: false,
+        reason: 'a reason 2',
+      });
+    });
+
+    test('getPermissions returns permitted true for resource1 and false for resource2', async () => {
+      const permissions = permissionsChecker.getPermissions();
+      const expected = new Map<string, ContextResourcePermission>();
+      expected.set('resource1', {
+        attrs: attrsResource1,
+        permitted: true,
+        reason: 'a reason 1',
+      });
+      expected.set('resource2', {
+        attrs: attrsResource2,
+        permitted: false,
+        reason: 'a reason 2',
+      });
+      expect(permissions).toEqual(expected);
+    });
+  });
+});

--- a/packages/main/src/plugin/kubernetes/context-permissions-checker.spec.ts
+++ b/packages/main/src/plugin/kubernetes/context-permissions-checker.spec.ts
@@ -238,7 +238,6 @@ describe('ContextPermissionsChecker is built with a recursive request', async ()
             },
           };
         }
-        console.log('==> ', param.body.spec.resourceAttributes);
         return {
           status: {
             allowed: false,

--- a/packages/main/src/plugin/kubernetes/context-permissions-checker.ts
+++ b/packages/main/src/plugin/kubernetes/context-permissions-checker.ts
@@ -95,9 +95,9 @@ export class ContextPermissionsChecker implements Disposable {
 
   private saveAndFireResult(result: ContextPermissionResult): void {
     this.#onPermissionResult.fire(result);
-    for (const resource of this.#request.resources) {
+    for (const resource of result.resources) {
       this.#results.set(resource, {
-        attrs: this.#request.attrs,
+        attrs: result.attrs,
         permitted: result.permitted,
         reason: result.reason,
       });

--- a/packages/main/src/plugin/kubernetes/context-permissions-checker.ts
+++ b/packages/main/src/plugin/kubernetes/context-permissions-checker.ts
@@ -18,7 +18,6 @@
 
 import type {
   AuthorizationV1ApiCreateSelfSubjectAccessReviewRequest,
-  KubeConfig,
   V1ResourceAttributes,
   V1SubjectAccessReviewStatus,
 } from '@kubernetes/client-node';
@@ -27,6 +26,7 @@ import type { Disposable } from '@podman-desktop/api';
 
 import type { Event } from '../events/emitter.js';
 import { Emitter } from '../events/emitter.js';
+import type { KubeConfigSingleContext } from './kubeconfig-single-context.js';
 
 export interface ContextPermissionsRequest {
   // the request to send
@@ -51,7 +51,7 @@ export interface ContextPermissionResult extends ContextResourcePermission {
 }
 
 export class ContextPermissionsChecker implements Disposable {
-  #kubeconfig: KubeConfig;
+  #kubeconfig: KubeConfigSingleContext;
   #client: AuthorizationV1Api;
   #request: ContextPermissionsRequest;
   #subCheckers: ContextPermissionsChecker[] = [];
@@ -63,11 +63,11 @@ export class ContextPermissionsChecker implements Disposable {
   // builds a ContextPermissionsChecker which will check permissions on the current context of the given kubeConfig
   // The request will be made with `attrs` and if allowed, permissions will be given for `resources`
   // If the result is denied, `onDenyRequests` will be started
-  constructor(kubeconfig: KubeConfig, request: ContextPermissionsRequest) {
+  constructor(kubeconfig: KubeConfigSingleContext, request: ContextPermissionsRequest) {
     this.#kubeconfig = kubeconfig;
     this.#request = request;
     this.#results = new Map<string, ContextResourcePermission>();
-    this.#client = this.#kubeconfig.makeApiClient(AuthorizationV1Api);
+    this.#client = this.#kubeconfig.getKubeConfig().makeApiClient(AuthorizationV1Api);
   }
 
   public async start(): Promise<void> {

--- a/packages/main/src/plugin/kubernetes/context-permissions-checker.ts
+++ b/packages/main/src/plugin/kubernetes/context-permissions-checker.ts
@@ -1,0 +1,149 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type {
+  AuthorizationV1ApiCreateSelfSubjectAccessReviewRequest,
+  KubeConfig,
+  V1ResourceAttributes,
+  V1SubjectAccessReviewStatus,
+} from '@kubernetes/client-node';
+import { AuthorizationV1Api } from '@kubernetes/client-node';
+import type { Disposable } from '@podman-desktop/api';
+
+import type { Event } from '../events/emitter.js';
+import { Emitter } from '../events/emitter.js';
+import type { ContextHealthChecker, ContextHealthState } from './context-health-checker.js';
+
+export interface ContextPermissionsRequest {
+  // the request to send
+  attrs: V1ResourceAttributes;
+  // the resources covered by the request
+  resources: string[];
+  // list of more fine-grained requests to send in case of denied request
+  onDenyRequests?: ContextPermissionsRequest[];
+}
+
+// ContextResourcePermission is the permission for a specific resource
+export interface ContextResourcePermission {
+  attrs: V1ResourceAttributes;
+  // permitted if allowed and not denied
+  permitted: boolean;
+  reason?: string;
+}
+
+// ContextPermissionResult is the result of a request, which can cover several resources
+export interface ContextPermissionResult extends ContextResourcePermission {
+  resources: string[];
+}
+
+export class ContextPermissionsChecker implements Disposable {
+  #kubeconfig: KubeConfig;
+  #healthChecker: ContextHealthChecker;
+  #client: AuthorizationV1Api;
+  #request: ContextPermissionsRequest;
+  #subCheckers: ContextPermissionsChecker[] = [];
+  #results: Map<string, ContextResourcePermission>;
+
+  #onPermissionResult = new Emitter<ContextPermissionResult>();
+  onPermissionResult: Event<ContextPermissionResult> = this.#onPermissionResult.event;
+
+  // builds a ContextPermissionsChecker which will check permissions on the current context of the given kubeConfig
+  // The request will be made with `attrs` and if allowed, permissions will be given for `resources`
+  // If the result is denied, `onDenyRequests` will be started
+  constructor(kubeconfig: KubeConfig, healthChecker: ContextHealthChecker, request: ContextPermissionsRequest) {
+    this.#kubeconfig = kubeconfig;
+    this.#healthChecker = healthChecker;
+    this.#request = request;
+    this.#results = new Map<string, ContextResourcePermission>();
+    this.#client = this.#kubeconfig.makeApiClient(AuthorizationV1Api);
+  }
+
+  // start the permission check as soon as the health check gives a reachable state
+  public async startWhenHealthy(): Promise<void> {
+    if (this.#healthChecker.getState().reachable) {
+      return this.start();
+    }
+    this.#healthChecker.onStateChange(async (state: ContextHealthState) => {
+      if (state.reachable) {
+        await this.start();
+      }
+    });
+  }
+
+  private async start(): Promise<void> {
+    const result = await this.makeRequest(this.#request.attrs);
+    if ((!result.allowed || result.denied) && this.#request.onDenyRequests?.length) {
+      // if not permitted and sub-requests are defined, let start them and don't send any result
+      for (const subreq of this.#request.onDenyRequests) {
+        const subchecker = new ContextPermissionsChecker(this.#kubeconfig, this.#healthChecker, subreq);
+        this.#subCheckers.push(subchecker);
+        subchecker.onPermissionResult((permissionResult: ContextPermissionResult) => {
+          this.saveAndFireResult(permissionResult);
+        });
+        await subchecker.startWhenHealthy();
+      }
+    } else {
+      // send the result for resources concerned by the request
+      this.saveAndFireResult({
+        resources: this.#request.resources,
+        attrs: this.#request.attrs,
+        permitted: result.allowed && !result.denied,
+        reason: result.reason,
+      });
+    }
+  }
+
+  private saveAndFireResult(result: ContextPermissionResult): void {
+    this.#onPermissionResult.fire(result);
+    for (const resource of this.#request.resources) {
+      this.#results.set(resource, {
+        attrs: this.#request.attrs,
+        permitted: result.permitted,
+        reason: result.reason,
+      });
+    }
+  }
+
+  public getPermissions(): Map<string, ContextResourcePermission> {
+    return this.#results;
+  }
+
+  public dispose(): void {
+    this.#onPermissionResult.dispose();
+    for (const subchecker of this.#subCheckers) {
+      subchecker.dispose();
+    }
+  }
+
+  private async makeRequest(attrs: V1ResourceAttributes): Promise<V1SubjectAccessReviewStatus> {
+    const param: AuthorizationV1ApiCreateSelfSubjectAccessReviewRequest = {
+      body: {
+        spec: {
+          resourceAttributes: attrs,
+        },
+      },
+    };
+    const result = await this.#client.createSelfSubjectAccessReview(param);
+    if (!result.status) {
+      return {
+        allowed: false,
+      };
+    }
+    return result.status;
+  }
+}

--- a/packages/main/src/plugin/kubernetes/contexts-dispatcher.spec.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-dispatcher.spec.ts
@@ -21,6 +21,7 @@ import { KubeConfig } from '@kubernetes/client-node';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { ContextsDispatcher } from './contexts-dispatcher.js';
+import { KubeConfigSingleContext } from './kubeconfig-single-context.js';
 
 const contexts = [
   {
@@ -87,7 +88,10 @@ test('first call to update calls onAdd for each context', () => {
     clusters: [clusters[0]],
     currentContext: 'context1',
   });
-  expect(onAddMock).toHaveBeenCalledWith({ contextName: 'context1', config: kc1 });
+  expect(onAddMock).toHaveBeenCalledWith({
+    contextName: 'context1',
+    config: new KubeConfigSingleContext(kc1, contexts[0]!),
+  });
   const kc2 = new KubeConfig();
   kc2.loadFromOptions({
     contexts: [contexts[1]],
@@ -95,7 +99,10 @@ test('first call to update calls onAdd for each context', () => {
     clusters: [clusters[1]],
     currentContext: 'context2',
   });
-  expect(onAddMock).toHaveBeenCalledWith({ contextName: 'context2', config: kc2 });
+  expect(onAddMock).toHaveBeenCalledWith({
+    contextName: 'context2',
+    config: new KubeConfigSingleContext(kc2, contexts[1]!),
+  });
 });
 
 test('call update again with same kubeconfig calls nothing', () => {
@@ -140,7 +147,10 @@ test('call update with a missing context calls onDelete', () => {
     clusters: [clusters[1]],
     currentContext: 'context2',
   });
-  expect(onDeleteMock).toHaveBeenCalledWith({ contextName: 'context2', config: kcDeleted });
+  expect(onDeleteMock).toHaveBeenCalledWith({
+    contextName: 'context2',
+    config: new KubeConfigSingleContext(kcDeleted, contexts[1]!),
+  });
 });
 
 test('call update with a new context calls onAdd', () => {
@@ -180,7 +190,10 @@ test('call update with a new context calls onAdd', () => {
     clusters: [newCluster],
     currentContext: 'context3',
   });
-  expect(onAddMock).toHaveBeenCalledWith({ contextName: 'context3', config: kc3 });
+  expect(onAddMock).toHaveBeenCalledWith({
+    contextName: 'context3',
+    config: new KubeConfigSingleContext(kc3, newContext),
+  });
 });
 
 test('call update with a modifed context calls onUpdate', () => {
@@ -213,5 +226,8 @@ test('call update with a modifed context calls onUpdate', () => {
     clusters: [clusters[0]],
     currentContext: 'context1',
   });
-  expect(onUpdateMock).toHaveBeenCalledWith({ contextName: 'context1', config: kc1 });
+  expect(onUpdateMock).toHaveBeenCalledWith({
+    contextName: 'context1',
+    config: new KubeConfigSingleContext(kc1, contexts[0]!),
+  });
 });

--- a/packages/main/src/plugin/kubernetes/contexts-dispatcher.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-dispatcher.ts
@@ -24,7 +24,7 @@ import { KubeConfigSingleContext } from './kubeconfig-single-context.js';
 
 export interface DispatcherEvent {
   contextName: string;
-  config: KubeConfig;
+  config: KubeConfigSingleContext;
 }
 
 /**
@@ -54,7 +54,7 @@ export class ContextsDispatcher {
       const kubeconfigSingleContext = new KubeConfigSingleContext(kubeconfig, kubeContext);
 
       if (!this.#contexts.has(kubeContext.name)) {
-        this.#onAdd.fire({ contextName: kubeContext.name, config: kubeconfigSingleContext.get() });
+        this.#onAdd.fire({ contextName: kubeContext.name, config: kubeconfigSingleContext });
         this.#contexts.set(kubeContext.name, kubeconfigSingleContext);
         continue;
       }
@@ -64,7 +64,7 @@ export class ContextsDispatcher {
       }
 
       // context has changed
-      this.#onUpdate.fire({ contextName: kubeContext.name, config: kubeconfigSingleContext.get() });
+      this.#onUpdate.fire({ contextName: kubeContext.name, config: kubeconfigSingleContext });
       this.#contexts.set(kubeContext.name, kubeconfigSingleContext);
     }
 
@@ -73,7 +73,7 @@ export class ContextsDispatcher {
       if (!ctxToRemove) {
         throw new Error(`config for ${nameOfRemainingContext} not found, should not happen`);
       }
-      this.#onDelete.fire({ contextName: nameOfRemainingContext, config: ctxToRemove.get() });
+      this.#onDelete.fire({ contextName: nameOfRemainingContext, config: ctxToRemove });
       this.#contexts.delete(nameOfRemainingContext);
     }
   }

--- a/packages/main/src/plugin/kubernetes/contexts-manager-experimental.spec.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager-experimental.spec.ts
@@ -18,10 +18,11 @@
 
 import type { Cluster } from '@kubernetes/client-node';
 import { KubeConfig } from '@kubernetes/client-node';
-import { beforeEach, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { ContextHealthState } from './context-health-checker.js';
 import { ContextHealthChecker } from './context-health-checker.js';
+import { ContextPermissionsChecker } from './context-permissions-checker.js';
 import { ContextsManagerExperimental } from './contexts-manager-experimental.js';
 import { KubeConfigSingleContext } from './kubeconfig-single-context.js';
 
@@ -69,10 +70,12 @@ const kcWithContext2asDefault = {
 };
 
 vi.mock('./context-health-checker.js');
+vi.mock('./context-permissions-checker.js');
 
 let kcWith2contexts: KubeConfig;
 
 beforeEach(() => {
+  vi.clearAllMocks();
   kcWith2contexts = {
     contexts: [
       {
@@ -107,38 +110,79 @@ beforeEach(() => {
   } as unknown as KubeConfig;
 
   vi.mocked(ContextHealthChecker).mockClear();
+  vi.mocked(ContextPermissionsChecker).mockClear();
 });
 
-test('HealthChecker is built and start is called for each context the first time', async () => {
-  const kc = new KubeConfig();
-  kc.loadFromOptions(kcWith2contexts);
-  const manager = new ContextsManagerExperimental();
-
-  const startMock = vi.fn();
-  const disposeMock = vi.fn();
+describe('HealthChecker is built and start is called for each context the first time', async () => {
+  let kc: KubeConfig;
+  let manager: ContextsManagerExperimental;
+  const healthStartMock = vi.fn();
+  const healthDisposeMock = vi.fn();
   const onStateChangeMock = vi.fn();
+  const onreachableMock = vi.fn();
+  const permissionsStartMock = vi.fn();
 
-  vi.mocked(ContextHealthChecker).mockImplementation(
-    () =>
-      ({
-        start: startMock,
-        dispose: disposeMock,
-        onStateChange: onStateChangeMock,
-        onReachable: vi.fn(),
-      }) as unknown as ContextHealthChecker,
-  );
+  beforeEach(async () => {
+    kc = new KubeConfig();
+    kc.loadFromOptions(kcWith2contexts);
 
-  await manager.update(kc);
-  expect(ContextHealthChecker).toHaveBeenCalledTimes(2);
-  const kc1 = new KubeConfig();
-  kc1.loadFromOptions(kcWithContext1asDefault);
-  expect(ContextHealthChecker).toHaveBeenCalledWith(new KubeConfigSingleContext(kc1, context1));
-  const kc2 = new KubeConfig();
-  kc2.loadFromOptions(kcWithContext2asDefault);
-  expect(ContextHealthChecker).toHaveBeenCalledWith(new KubeConfigSingleContext(kc2, context2));
-  expect(startMock).toHaveBeenCalledTimes(2);
+    vi.mocked(ContextHealthChecker).mockImplementation(
+      () =>
+        ({
+          start: healthStartMock,
+          dispose: healthDisposeMock,
+          onStateChange: onStateChangeMock,
+          onReachable: onreachableMock,
+        }) as unknown as ContextHealthChecker,
+    );
 
-  expect(disposeMock).not.toHaveBeenCalled();
+    vi.mocked(ContextPermissionsChecker).mockImplementation(
+      () =>
+        ({
+          start: permissionsStartMock,
+          onPermissionResult: vi.fn(),
+        }) as unknown as ContextPermissionsChecker,
+    );
+    manager = new ContextsManagerExperimental();
+  });
+
+  test('when context is not reachable', async () => {
+    await manager.update(kc);
+    expect(ContextHealthChecker).toHaveBeenCalledTimes(2);
+    const kc1 = new KubeConfig();
+    kc1.loadFromOptions(kcWithContext1asDefault);
+    expect(ContextHealthChecker).toHaveBeenCalledWith(new KubeConfigSingleContext(kc1, context1));
+    const kc2 = new KubeConfig();
+    kc2.loadFromOptions(kcWithContext2asDefault);
+    expect(ContextHealthChecker).toHaveBeenCalledWith(new KubeConfigSingleContext(kc2, context2));
+    expect(healthStartMock).toHaveBeenCalledTimes(2);
+
+    expect(healthDisposeMock).not.toHaveBeenCalled();
+
+    expect(ContextPermissionsChecker).not.toHaveBeenCalled();
+  });
+
+  test('when context is reachable, persmissions checkers are created and started', async () => {
+    const kcSingle1 = new KubeConfigSingleContext(kc, context1);
+    const kcSingle2 = new KubeConfigSingleContext(kc, context2);
+    let call = 0;
+    onreachableMock.mockImplementation(f => {
+      call++;
+      f({
+        kubeConfig: call === 1 ? kcSingle1 : kcSingle2,
+        contextName: call === 1 ? 'context1' : 'context2',
+        checking: false,
+        reachable: true,
+      } as ContextHealthState);
+    });
+    await manager.update(kc);
+
+    expect(ContextPermissionsChecker).toHaveBeenCalledTimes(2);
+    expect(ContextPermissionsChecker).toHaveBeenCalledWith(kcSingle1, expect.anything());
+    expect(ContextPermissionsChecker).toHaveBeenCalledWith(kcSingle2, expect.anything());
+
+    expect(permissionsStartMock).toHaveBeenCalledTimes(2);
+  });
 });
 
 test('nothing is done when called again and kubeconfig does not change', async () => {
@@ -205,30 +249,52 @@ test('HealthChecker is built and start is called for each context being changed'
   expect(startMock).toHaveBeenCalledTimes(1);
 });
 
-test('HealthChecker is disposed for each context being removed', async () => {
+test('HealthChecker and PermissionsChecker are disposed for each context being removed', async () => {
   const kc = new KubeConfig();
   kc.loadFromOptions(kcWith2contexts);
   const manager = new ContextsManagerExperimental();
 
-  const startMock = vi.fn();
-  const disposeMock = vi.fn();
+  const healthStartMock = vi.fn();
+  const healthDisposeMock = vi.fn();
   const onStateChangeMock = vi.fn();
+  const permissionsStartMock = vi.fn();
+  const permissionsDisposeMock = vi.fn();
 
   vi.mocked(ContextHealthChecker).mockImplementation(
     () =>
       ({
-        start: startMock,
-        dispose: disposeMock,
+        start: healthStartMock,
+        dispose: healthDisposeMock,
         onStateChange: onStateChangeMock,
-        onReachable: vi.fn(),
+        onReachable: vi.fn().mockImplementation(f =>
+          f({
+            kubeConfig: {
+              getNamespace: vi.fn().mockReturnValue('context2'),
+            } as unknown as KubeConfigSingleContext,
+            contextName: 'context2',
+            checking: false,
+            reachable: true,
+          } as ContextHealthState),
+        ),
       }) as unknown as ContextHealthChecker,
+  );
+
+  vi.mocked(ContextPermissionsChecker).mockImplementation(
+    () =>
+      ({
+        start: permissionsStartMock,
+        dispose: permissionsDisposeMock,
+      }) as unknown as ContextPermissionsChecker,
   );
 
   await manager.update(kc);
 
   // check when kubeconfig changes
   vi.mocked(ContextHealthChecker).mockClear();
-  vi.mocked(startMock).mockClear();
+  vi.mocked(healthStartMock).mockClear();
+  vi.mocked(ContextPermissionsChecker).mockClear();
+  vi.mocked(permissionsStartMock).mockClear();
+  vi.mocked(permissionsDisposeMock).mockClear();
 
   const kc1 = {
     contexts: [kcWith2contexts.contexts[0]],
@@ -237,9 +303,11 @@ test('HealthChecker is disposed for each context being removed', async () => {
   } as unknown as KubeConfig;
   kc.loadFromOptions(kc1);
   await manager.update(kc);
-  expect(disposeMock).toHaveBeenCalledTimes(1);
+  expect(healthDisposeMock).toHaveBeenCalledTimes(1);
   expect(ContextHealthChecker).toHaveBeenCalledTimes(0);
-  expect(startMock).toHaveBeenCalledTimes(0);
+  expect(healthStartMock).toHaveBeenCalledTimes(0);
+
+  expect(permissionsDisposeMock).toHaveBeenCalledTimes(1);
 });
 
 test('getHealthCheckersStates calls getState for each health checker', async () => {
@@ -291,6 +359,56 @@ test('getHealthCheckersStates calls getState for each health checker', async () 
   expect(result).toEqual(expectedMap);
 });
 
+test('getPermissions calls getPermissions for each permissions checker', async () => {
+  const kc = new KubeConfig();
+  kc.loadFromOptions(kcWith2contexts);
+  const manager = new ContextsManagerExperimental();
+
+  const startMock = vi.fn();
+  const disposeMock = vi.fn();
+  const onStateChangeMock = vi.fn();
+  const onReachableMock = vi.fn();
+
+  vi.mocked(ContextHealthChecker).mockImplementation(
+    () =>
+      ({
+        start: startMock,
+        dispose: disposeMock,
+        onStateChange: onStateChangeMock,
+        onReachable: onReachableMock,
+        getState: vi.fn(),
+      }) as unknown as ContextHealthChecker,
+  );
+
+  const kcSingle1 = new KubeConfigSingleContext(kc, context1);
+  const kcSingle2 = new KubeConfigSingleContext(kc, context2);
+  let call = 0;
+  onReachableMock.mockImplementation(f => {
+    call++;
+    f({
+      kubeConfig: call === 1 ? kcSingle1 : kcSingle2,
+      contextName: call === 1 ? 'context1' : 'context2',
+      checking: false,
+      reachable: true,
+    } as ContextHealthState);
+  });
+
+  const getPermissionsMock = vi.fn();
+  vi.mocked(ContextPermissionsChecker).mockImplementation(
+    () =>
+      ({
+        start: vi.fn(),
+        getPermissions: getPermissionsMock,
+        onPermissionResult: vi.fn(),
+      }) as unknown as ContextPermissionsChecker,
+  );
+
+  await manager.update(kc);
+
+  manager.getPermissions();
+  expect(getPermissionsMock).toHaveBeenCalledTimes(2);
+});
+
 test('dispose calls dispose for each health checker', async () => {
   const kc = new KubeConfig();
   kc.loadFromOptions(kcWith2contexts);
@@ -314,4 +432,56 @@ test('dispose calls dispose for each health checker', async () => {
 
   manager.dispose();
   expect(disposeMock).toHaveBeenCalledTimes(2);
+});
+
+test('dispose calls dispose for each permissions checker', async () => {
+  const kc = new KubeConfig();
+  kc.loadFromOptions(kcWith2contexts);
+  const manager = new ContextsManagerExperimental();
+
+  const startMock = vi.fn();
+  const disposeMock = vi.fn();
+  const onStateChangeMock = vi.fn();
+  const onReachableMock = vi.fn();
+
+  vi.mocked(ContextHealthChecker).mockImplementation(
+    () =>
+      ({
+        start: startMock,
+        dispose: disposeMock,
+        onStateChange: onStateChangeMock,
+        onReachable: onReachableMock,
+      }) as unknown as ContextHealthChecker,
+  );
+
+  const kcSingle1 = new KubeConfigSingleContext(kc, context1);
+  const kcSingle2 = new KubeConfigSingleContext(kc, context2);
+  let call = 0;
+  onReachableMock.mockImplementation(f => {
+    call++;
+    f({
+      kubeConfig: call === 1 ? kcSingle1 : kcSingle2,
+      contextName: call === 1 ? 'context1' : 'context2',
+      checking: false,
+      reachable: true,
+    } as ContextHealthState);
+  });
+
+  const getPermissionsMock = vi.fn();
+  const permissionsDisposeMock = vi.fn();
+
+  vi.mocked(ContextPermissionsChecker).mockImplementation(
+    () =>
+      ({
+        start: vi.fn(),
+        getPermissions: getPermissionsMock,
+        onPermissionResult: vi.fn(),
+        dispose: permissionsDisposeMock,
+      }) as unknown as ContextPermissionsChecker,
+  );
+
+  await manager.update(kc);
+
+  manager.dispose();
+  expect(permissionsDisposeMock).toHaveBeenCalledTimes(2);
 });

--- a/packages/main/src/plugin/kubernetes/contexts-manager-experimental.spec.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager-experimental.spec.ts
@@ -30,6 +30,7 @@ const kcWithContext1asDefault = {
       name: 'context1',
       cluster: 'cluster1',
       user: 'user1',
+      namespace: 'ns1',
     },
   ],
   clusters: [
@@ -51,6 +52,7 @@ const kcWithContext2asDefault = {
       name: 'context2',
       cluster: 'cluster2',
       user: 'user2',
+      namespace: 'ns2',
     },
   ],
   clusters: [
@@ -77,11 +79,13 @@ beforeEach(() => {
         name: 'context1',
         cluster: 'cluster1',
         user: 'user1',
+        namespace: 'ns1',
       },
       {
         name: 'context2',
         cluster: 'cluster2',
         user: 'user2',
+        namespace: 'ns2',
       },
     ],
     clusters: [

--- a/packages/main/src/plugin/kubernetes/contexts-manager-experimental.spec.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager-experimental.spec.ts
@@ -120,7 +120,7 @@ test('HealthChecker is built and start is called for each context the first time
         start: startMock,
         dispose: disposeMock,
         onStateChange: onStateChangeMock,
-        getState: vi.fn().mockReturnValue({ reachable: false }),
+        onReachable: vi.fn(),
       }) as unknown as ContextHealthChecker,
   );
 
@@ -152,7 +152,7 @@ test('nothing is done when called again and kubeconfig does not change', async (
         start: startMock,
         dispose: disposeMock,
         onStateChange: onStateChangeMock,
-        getState: vi.fn().mockReturnValue({ reachable: false }),
+        onReachable: vi.fn(),
       }) as unknown as ContextHealthChecker,
   );
 
@@ -183,7 +183,7 @@ test('HealthChecker is built and start is called for each context being changed'
         start: startMock,
         dispose: disposeMock,
         onStateChange: onStateChangeMock,
-        getState: vi.fn().mockReturnValue({ reachable: false }),
+        onReachable: vi.fn(),
       }) as unknown as ContextHealthChecker,
   );
 
@@ -216,7 +216,7 @@ test('HealthChecker is disposed for each context being removed', async () => {
         start: startMock,
         dispose: disposeMock,
         onStateChange: onStateChangeMock,
-        getState: vi.fn().mockReturnValue({ reachable: false }),
+        onReachable: vi.fn(),
       }) as unknown as ContextHealthChecker,
   );
 
@@ -253,6 +253,7 @@ test('getHealthCheckersStates calls getState for each health checker', async () 
         start: startMock,
         dispose: disposeMock,
         onStateChange: onStateChangeMock,
+        onReachable: vi.fn(),
         getState: vi.fn().mockImplementation(() => {
           return {
             contextName: kubeConfig.currentContext,
@@ -287,7 +288,7 @@ test('dispose calls dispose for each health checker', async () => {
         start: startMock,
         dispose: disposeMock,
         onStateChange: onStateChangeMock,
-        getState: vi.fn().mockReturnValue({ reachable: false }),
+        onReachable: vi.fn(),
       }) as unknown as ContextHealthChecker,
   );
 

--- a/packages/main/src/plugin/kubernetes/contexts-manager-experimental.spec.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager-experimental.spec.ts
@@ -120,6 +120,7 @@ test('HealthChecker is built and start is called for each context the first time
         start: startMock,
         dispose: disposeMock,
         onStateChange: onStateChangeMock,
+        getState: vi.fn().mockReturnValue({ reachable: false }),
       }) as unknown as ContextHealthChecker,
   );
 
@@ -151,6 +152,7 @@ test('nothing is done when called again and kubeconfig does not change', async (
         start: startMock,
         dispose: disposeMock,
         onStateChange: onStateChangeMock,
+        getState: vi.fn().mockReturnValue({ reachable: false }),
       }) as unknown as ContextHealthChecker,
   );
 
@@ -181,6 +183,7 @@ test('HealthChecker is built and start is called for each context being changed'
         start: startMock,
         dispose: disposeMock,
         onStateChange: onStateChangeMock,
+        getState: vi.fn().mockReturnValue({ reachable: false }),
       }) as unknown as ContextHealthChecker,
   );
 
@@ -213,6 +216,7 @@ test('HealthChecker is disposed for each context being removed', async () => {
         start: startMock,
         dispose: disposeMock,
         onStateChange: onStateChangeMock,
+        getState: vi.fn().mockReturnValue({ reachable: false }),
       }) as unknown as ContextHealthChecker,
   );
 
@@ -253,7 +257,7 @@ test('getHealthCheckersStates calls getState for each health checker', async () 
           return {
             contextName: kubeConfig.currentContext,
             checking: kubeConfig.currentContext === 'context1' ? true : false,
-            reachable: kubeConfig.currentContext === 'context1' ? false : true,
+            reachable: false,
           };
         }),
       }) as unknown as ContextHealthChecker,
@@ -264,7 +268,7 @@ test('getHealthCheckersStates calls getState for each health checker', async () 
   const result = manager.getHealthCheckersStates();
   const expectedMap = new Map<string, ContextHealthState>();
   expectedMap.set('context1', { contextName: 'context1', checking: true, reachable: false });
-  expectedMap.set('context2', { contextName: 'context2', checking: false, reachable: true });
+  expectedMap.set('context2', { contextName: 'context2', checking: false, reachable: false });
   expect(result).toEqual(expectedMap);
 });
 
@@ -283,7 +287,7 @@ test('dispose calls dispose for each health checker', async () => {
         start: startMock,
         dispose: disposeMock,
         onStateChange: onStateChangeMock,
-        getState: vi.fn(),
+        getState: vi.fn().mockReturnValue({ reachable: false }),
       }) as unknown as ContextHealthChecker,
   );
 

--- a/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
@@ -24,6 +24,8 @@ import type { Event } from '../events/emitter.js';
 import { Emitter } from '../events/emitter.js';
 import type { ContextHealthState } from './context-health-checker.js';
 import { ContextHealthChecker } from './context-health-checker.js';
+import type { ContextPermissionResult, ContextResourcePermission } from './context-permissions-checker.js';
+import { ContextPermissionsChecker } from './context-permissions-checker.js';
 import type { DispatcherEvent } from './contexts-dispatcher.js';
 import { ContextsDispatcher } from './contexts-dispatcher.js';
 
@@ -40,15 +42,20 @@ const HEALTH_CHECK_TIMEOUT_MS = 5_000;
 export class ContextsManagerExperimental {
   #dispatcher: ContextsDispatcher;
   #healthCheckers: Map<string, ContextHealthChecker>;
+  #permissionsCheckers: Map<string, ContextPermissionsChecker>;
 
   #onContextHealthStateChange = new Emitter<ContextHealthState>();
   onContextHealthStateChange: Event<ContextHealthState> = this.#onContextHealthStateChange.event;
+
+  #onContextPermissionResult = new Emitter<ContextPermissionResult>();
+  onContextPermissionResult: Event<ContextPermissionResult> = this.#onContextPermissionResult.event;
 
   #onContextDelete = new Emitter<DispatcherEvent>();
   onContextDelete: Event<DispatcherEvent> = this.#onContextDelete.event;
 
   constructor() {
     this.#healthCheckers = new Map<string, ContextHealthChecker>();
+    this.#permissionsCheckers = new Map<string, ContextPermissionsChecker>();
     this.#dispatcher = new ContextsDispatcher();
     this.#dispatcher.onAdd(this.onAdd.bind(this));
     this.#dispatcher.onUpdate(this.onUpdate.bind(this));
@@ -61,27 +68,73 @@ export class ContextsManagerExperimental {
   }
 
   private async onAdd(event: DispatcherEvent): Promise<void> {
-    const previous = this.#healthCheckers.get(event.contextName);
-    previous?.dispose();
+    // register and start health checker
+    const previousHC = this.#healthCheckers.get(event.contextName);
+    previousHC?.dispose();
     const newHC = new ContextHealthChecker(event.config);
     newHC.onStateChange(this.onStateChange.bind(this));
     this.#healthCheckers.set(event.contextName, newHC);
+
+    // register and start permissions checker
+    const previousPC = this.#permissionsCheckers.get(event.contextName);
+    previousPC?.dispose();
+
+    const namespace = event.config.getContextObject(event.config.getCurrentContext())?.namespace ?? 'default';
+    const newPC = new ContextPermissionsChecker(event.config, newHC, {
+      attrs: {
+        namespace,
+        group: '*',
+        resource: '*',
+        verb: 'watch',
+      },
+      resources: ['pods', 'deployments'],
+      onDenyRequests: [
+        {
+          attrs: {
+            namespace,
+            verb: 'watch',
+            resource: 'pods',
+          },
+          resources: ['pods'],
+        },
+        {
+          attrs: {
+            namespace,
+            verb: 'watch',
+            group: 'apps',
+            resource: 'deployments',
+          },
+          resources: ['deployments'],
+        },
+      ],
+    });
+    newPC.onPermissionResult(this.onPermissionResult.bind(this));
+    await newPC.startWhenHealthy();
+    this.#permissionsCheckers.set(event.contextName, newPC);
+
     await newHC.start({ timeout: HEALTH_CHECK_TIMEOUT_MS });
   }
 
   private async onUpdate(event: DispatcherEvent): Promise<void> {
-    // we don't try to update the health checker, we recreate it
+    // we don't try to update the checkers, we recreate them
     return this.onAdd(event);
   }
 
   private onDelete(state: DispatcherEvent): void {
-    const previous = this.#healthCheckers.get(state.contextName);
-    previous?.dispose();
+    const previousHC = this.#healthCheckers.get(state.contextName);
+    previousHC?.dispose();
     this.#healthCheckers.delete(state.contextName);
+    const previousPC = this.#permissionsCheckers.get(state.contextName);
+    previousPC?.dispose();
+    this.#permissionsCheckers.delete(state.contextName);
   }
 
   private onStateChange(state: ContextHealthState): void {
     this.#onContextHealthStateChange.fire(state);
+  }
+
+  private onPermissionResult(event: ContextPermissionResult): void {
+    this.#onContextPermissionResult.fire(event);
   }
 
   /* getHealthCheckersStates returns the current state of the health checkers */
@@ -89,6 +142,15 @@ export class ContextsManagerExperimental {
     const result = new Map<string, ContextHealthState>();
     for (const [contextName, hc] of this.#healthCheckers.entries()) {
       result.set(contextName, hc.getState());
+    }
+    return result;
+  }
+
+  /* getPermissions returns the current permissions */
+  getPermissions(): Map</* contextName */ string, Map</* resource */ string, ContextResourcePermission>> {
+    const result = new Map<string, Map<string, ContextResourcePermission>>();
+    for (const [contextName, pc] of this.#permissionsCheckers.entries()) {
+      result.set(contextName, pc.getPermissions());
     }
     return result;
   }
@@ -118,17 +180,26 @@ export class ContextsManagerExperimental {
   /* dispose all disposable resources created by the instance */
   dispose(): void {
     this.disposeAllHealthChecks();
+    this.disposeAllPermissionsCheckers();
     this.#onContextHealthStateChange.dispose();
     this.#onContextDelete.dispose();
   }
 
   async refreshContextState(_contextName: string): Promise<void> {}
 
-  // abortAllHealthChecks aborts all health checks and removes them from registry
+  // disposeAllHealthChecks disposes all health checks and removes them from registry
   private disposeAllHealthChecks(): void {
     for (const [contextName, healthChecker] of this.#healthCheckers.entries()) {
       healthChecker.dispose();
       this.#healthCheckers.delete(contextName);
+    }
+  }
+
+  // disposeAllPermissionsCheckers disposes all permissions checkers and removes them from registry
+  private disposeAllPermissionsCheckers(): void {
+    for (const [contextName, permissionChecker] of this.#permissionsCheckers.entries()) {
+      permissionChecker.dispose();
+      this.#permissionsCheckers.delete(contextName);
     }
   }
 }

--- a/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
@@ -71,7 +71,7 @@ export class ContextsManagerExperimental {
     // register and start health checker
     const previousHealthChecker = this.#healthCheckers.get(event.contextName);
     previousHealthChecker?.dispose();
-    const newHealthChecker = new ContextHealthChecker(event.config.getKubeConfig());
+    const newHealthChecker = new ContextHealthChecker(event.config);
     this.#healthCheckers.set(event.contextName, newHealthChecker);
     newHealthChecker.onStateChange(this.onStateChange.bind(this));
 
@@ -80,8 +80,8 @@ export class ContextsManagerExperimental {
       const previousPermissionsChecker = this.#permissionsCheckers.get(state.contextName);
       previousPermissionsChecker?.dispose();
 
-      const namespace = event.config.getNamespace();
-      const newPermissionChecker = new ContextPermissionsChecker(event.config.getKubeConfig(), {
+      const namespace = state.kubeConfig.getNamespace();
+      const newPermissionChecker = new ContextPermissionsChecker(state.kubeConfig, {
         attrs: {
           namespace,
           group: '*',

--- a/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
@@ -72,8 +72,8 @@ export class ContextsManagerExperimental {
     const previousHC = this.#healthCheckers.get(event.contextName);
     previousHC?.dispose();
     const newHC = new ContextHealthChecker(event.config);
-    newHC.onStateChange(this.onStateChange.bind(this));
     this.#healthCheckers.set(event.contextName, newHC);
+    newHC.onStateChange(this.onStateChange.bind(this));
 
     newHC.onReachable(async () => {
       // register and start permissions checker
@@ -109,9 +109,9 @@ export class ContextsManagerExperimental {
           },
         ],
       });
+      this.#permissionsCheckers.set(event.contextName, newPC);
       newPC.onPermissionResult(this.onPermissionResult.bind(this));
       await newPC.start();
-      this.#permissionsCheckers.set(event.contextName, newPC);
     });
 
     await newHC.start({ timeout: HEALTH_CHECK_TIMEOUT_MS });

--- a/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
@@ -123,11 +123,11 @@ export class ContextsManagerExperimental {
   }
 
   private onDelete(state: DispatcherEvent): void {
-    const previousHealthChecker = this.#healthCheckers.get(state.contextName);
-    previousHealthChecker?.dispose();
+    const healthChecker = this.#healthCheckers.get(state.contextName);
+    healthChecker?.dispose();
     this.#healthCheckers.delete(state.contextName);
-    const previousPermissionsChecker = this.#permissionsCheckers.get(state.contextName);
-    previousPermissionsChecker?.dispose();
+    const permissionsChecker = this.#permissionsCheckers.get(state.contextName);
+    permissionsChecker?.dispose();
     this.#permissionsCheckers.delete(state.contextName);
   }
 

--- a/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.ts
@@ -17,6 +17,7 @@
  ***********************************************************************/
 
 import type { ContextHealthState } from './context-health-checker.js';
+import type { ContextPermissionResult } from './context-permissions-checker.js';
 import type { DispatcherEvent } from './contexts-dispatcher.js';
 import type { ContextsManagerExperimental } from './contexts-manager-experimental.js';
 
@@ -24,11 +25,19 @@ export class ContextsStatesDispatcher {
   constructor(private manager: ContextsManagerExperimental) {}
 
   init(): void {
-    this.manager.onContextHealthStateChange((_state: ContextHealthState) => this.update());
-    this.manager.onContextDelete((_state: DispatcherEvent) => this.update());
+    this.manager.onContextHealthStateChange((_state: ContextHealthState) => this.updateHealthStates());
+    this.manager.onContextPermissionResult((_permissions: ContextPermissionResult) => this.updatePermissions());
+    this.manager.onContextDelete((_state: DispatcherEvent) => {
+      this.updateHealthStates();
+      this.updatePermissions();
+    });
   }
 
-  update(): void {
+  updateHealthStates(): void {
     console.log('current health check states', this.manager.getHealthCheckersStates());
+  }
+
+  updatePermissions(): void {
+    console.log('current permissions', this.manager.getPermissions());
   }
 }

--- a/packages/main/src/plugin/kubernetes/kubeconfig-single-context.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubeconfig-single-context.spec.ts
@@ -83,3 +83,49 @@ test('KubeConfigSingleContext', () => {
 
   expect(single.equals(undefined)).toBeFalsy();
 });
+
+test('getNamespace', () => {
+  const contexts = [
+    {
+      name: 'context1',
+      cluster: 'cluster1',
+      user: 'user1',
+    },
+    {
+      name: 'context2',
+      cluster: 'cluster2',
+      user: 'user2',
+      namespace: 'ns2',
+    },
+  ] as Context[];
+
+  const clusters = [
+    {
+      name: 'cluster1',
+    },
+    {
+      name: 'cluster2',
+    },
+  ] as Cluster[];
+
+  const users = [
+    {
+      name: 'user1',
+    },
+    {
+      name: 'user2',
+    },
+  ] as User[];
+
+  const kcWith2contexts = {
+    contexts,
+    clusters,
+    users,
+  } as unknown as KubeConfig;
+
+  const single1 = new KubeConfigSingleContext(kcWith2contexts, contexts[0]!);
+  expect(single1.getNamespace()).toEqual('default');
+
+  const single2 = new KubeConfigSingleContext(kcWith2contexts, contexts[1]!);
+  expect(single2.getNamespace()).toEqual('ns2');
+});

--- a/packages/main/src/plugin/kubernetes/kubeconfig-single-context.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubeconfig-single-context.spec.ts
@@ -27,11 +27,13 @@ const contexts = [
     name: 'context1',
     cluster: 'cluster1',
     user: 'user1',
+    namespace: 'ns1',
   },
   {
     name: 'context2',
     cluster: 'cluster2',
     user: 'user2',
+    namespace: 'ns2',
   },
 ] as Context[];
 
@@ -69,7 +71,7 @@ test('KubeConfigSingleContext', () => {
     clusters: [clusters[0]],
     currentContext: 'context1',
   } as KubeConfig;
-  expect(single.get()).toEqual(expected);
+  expect(single.getKubeConfig()).toEqual(expected);
 
   const kcExpected = new KubeConfig();
   kcExpected.loadFromOptions(expected);


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

The kubernetes manager (experimental) checks the permissions to watch resources, to be able to start informers only on permitted resources.

The permission check starts as soon as the health check is done on each kube context.

For now, only the "pods" and "deployments" resources are checked, on all kube contexts.

> Note that for non standard resources (like Openshift routes), the permission check will return true, even if the resource does not exist in the API. A call to the discovery API will be necessary, 

The check is done by using the underlying resource [SelfSubjectAccessReview](https://kubernetes.io/docs/reference/kubernetes-api/authorization-resources/self-subject-access-review-v1/). This resource supports to do a request for all resources/groups or for a specific resource/group.

We use this capability to first do a single request for `*/*` (all resources in all groups). This is optimal for `kind` (and probably other local) clusters, as the permission in done for all.

In case of denial for this `*/*`, a series of more granular requests are done, one for each resource.

> Note that we may add a step, to request for all resources in each group: `*/apps`, `*/core`, etc, before to ask for each specific resource.

### Screenshot / video of UI

Backend only

### What issues does this PR fix or reference?

Part of #7629 

### How to test this PR?

To test the new version, set this preference in ~/.local/share/containers/podman-desktop/configuration/settings.json:

```
  "kubernetes.statesExperimental": true
```

- [x] Tests are covering the bug fix or the new feature
