### PR TITLE
refactor(ui): creating kube actions component

### DIFF
--- a/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretList.svelte
+++ b/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretList.svelte
@@ -14,6 +14,7 @@ import moment from 'moment';
 import { onDestroy, onMount } from 'svelte';
 import type { Unsubscriber } from 'svelte/store';
 
+import KubeActions from '/@/lib/kube/KubeActions.svelte';
 import KubernetesCurrentContextConnectionBadge from '/@/lib/ui/KubernetesCurrentContextConnectionBadge.svelte';
 import {
   configmapSearchPattern,
@@ -23,7 +24,6 @@ import {
 } from '/@/stores/kubernetes-contexts-state';
 
 import ConfigMapSecretIcon from '../images/ConfigMapSecretIcon.svelte';
-import KubeApplyYamlButton from '../kube/KubeApplyYAMLButton.svelte';
 import { ConfigMapSecretUtils } from './configmap-secret-utils';
 import ConfigMapSecretColumnActions from './ConfigMapSecretColumnActions.svelte';
 import ConfigMapSecretColumnName from './ConfigMapSecretColumnName.svelte';
@@ -150,7 +150,7 @@ const row = new TableRow<ConfigMapSecretUI>({ selectable: _configmapSecret => tr
 
 <NavPage bind:searchTerm={searchTerm} title="configmaps & secrets">
   <svelte:fragment slot="additional-actions">
-    <KubeApplyYamlButton />
+    <KubeActions />
   </svelte:fragment>
 
   <svelte:fragment slot="bottom-additional-actions">

--- a/packages/renderer/src/lib/deployments/DeploymentsList.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentsList.svelte
@@ -12,6 +12,7 @@ import {
 import moment from 'moment';
 import { onMount } from 'svelte';
 
+import KubeActions from '/@/lib/kube/KubeActions.svelte';
 import KubernetesCurrentContextConnectionBadge from '/@/lib/ui/KubernetesCurrentContextConnectionBadge.svelte';
 import {
   deploymentSearchPattern,
@@ -20,7 +21,6 @@ import {
 
 import { withBulkConfirmation } from '../actions/BulkActions';
 import DeploymentIcon from '../images/DeploymentIcon.svelte';
-import KubeApplyYamlButton from '../kube/KubeApplyYAMLButton.svelte';
 import { DeploymentUtils } from './deployment-utils';
 import DeploymentColumnActions from './DeploymentColumnActions.svelte';
 import DeploymentColumnConditions from './DeploymentColumnConditions.svelte';
@@ -113,7 +113,7 @@ const row = new TableRow<DeploymentUI>({ selectable: _deployment => true });
 
 <NavPage bind:searchTerm={searchTerm} title="deployments">
   <svelte:fragment slot="additional-actions">
-    <KubeApplyYamlButton />
+    <KubeActions />
   </svelte:fragment>
 
   <svelte:fragment slot="bottom-additional-actions">

--- a/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.svelte
@@ -13,6 +13,7 @@ import moment from 'moment';
 import { onDestroy, onMount } from 'svelte';
 import type { Unsubscriber } from 'svelte/store';
 
+import KubeActions from '/@/lib/kube/KubeActions.svelte';
 import KubernetesCurrentContextConnectionBadge from '/@/lib/ui/KubernetesCurrentContextConnectionBadge.svelte';
 import {
   ingressSearchPattern,
@@ -24,7 +25,6 @@ import type { V1Route } from '/@api/openshift-types';
 
 import { withBulkConfirmation } from '../actions/BulkActions';
 import IngressRouteIcon from '../images/IngressRouteIcon.svelte';
-import KubeApplyYamlButton from '../kube/KubeApplyYAMLButton.svelte';
 import { IngressRouteUtils } from './ingress-route-utils';
 import IngressRouteColumnActions from './IngressRouteColumnActions.svelte';
 import IngressRouteColumnBackend from './IngressRouteColumnBackend.svelte';
@@ -157,7 +157,7 @@ const row = new TableRow<IngressUI | RouteUI>({ selectable: _ingressRoute => tru
 
 <NavPage bind:searchTerm={searchTerm} title="ingresses & routes">
   <svelte:fragment slot="additional-actions">
-    <KubeApplyYamlButton />
+    <KubeActions />
   </svelte:fragment>
 
   <svelte:fragment slot="bottom-additional-actions">

--- a/packages/renderer/src/lib/kube/KubeActions.spec.ts
+++ b/packages/renderer/src/lib/kube/KubeActions.spec.ts
@@ -1,0 +1,74 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
+
+import KubeActions from '/@/lib/kube/KubeActions.svelte';
+
+// mock the router
+vi.mock('tinro', () => {
+  return {
+    router: {
+      goto: vi.fn(),
+    },
+  };
+});
+
+beforeAll(() => {
+  Object.defineProperty(global, 'window', {
+    value: {
+      // global needed
+      navigator: {
+        clipboard: {
+          writeText: vi.fn(),
+        },
+      },
+      // needed for the test
+      kubernetesGetCurrentContextName: vi.fn(),
+      openDialog: vi.fn(),
+    },
+    writable: true,
+  });
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  vi.mocked(window.kubernetesGetCurrentContextName).mockResolvedValue('dummy-context');
+});
+
+test('KubeApplyYAMLButton should redirect to', async () => {
+  const { getByTitle } = render(KubeActions);
+
+  const applyYAMLBtn = getByTitle('Apply YAML');
+  expect(applyYAMLBtn).toBeInTheDocument();
+
+  await userEvent.click(applyYAMLBtn);
+
+  await vi.waitFor(() => {
+    expect(window.openDialog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Select a .yaml file to apply',
+      }),
+    );
+  });
+});

--- a/packages/renderer/src/lib/kube/KubeActions.svelte
+++ b/packages/renderer/src/lib/kube/KubeActions.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+import KubeApplyYamlButton from '../kube/KubeApplyYAMLButton.svelte';
+</script>
+
+<div class="flex flex-row gap-x-2">
+  <KubeApplyYamlButton />
+</div>

--- a/packages/renderer/src/lib/kube/KubeActions.svelte
+++ b/packages/renderer/src/lib/kube/KubeActions.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
-import KubeApplyYamlButton from '../kube/KubeApplyYAMLButton.svelte';
+import KubeApplyYamlButton from '/@/lib/kube/KubeApplyYAMLButton.svelte';
 </script>
 
-<div class="flex flex-row gap-x-2">
-  <KubeApplyYamlButton />
-</div>
+<KubeApplyYamlButton />

--- a/packages/renderer/src/lib/node/NodesList.svelte
+++ b/packages/renderer/src/lib/node/NodesList.svelte
@@ -11,11 +11,11 @@ import {
 import moment from 'moment';
 import { onMount } from 'svelte';
 
+import KubeActions from '/@/lib/kube/KubeActions.svelte';
 import KubernetesCurrentContextConnectionBadge from '/@/lib/ui/KubernetesCurrentContextConnectionBadge.svelte';
 import { kubernetesCurrentContextNodesFiltered, nodeSearchPattern } from '/@/stores/kubernetes-contexts-state';
 
 import NodeIcon from '../images/NodeIcon.svelte';
-import KubeApplyYamlButton from '../kube/KubeApplyYAMLButton.svelte';
 import { NodeUtils } from './node-utils';
 import NodeColumnName from './NodeColumnName.svelte';
 import NodeColumnRoles from './NodeColumnRoles.svelte';
@@ -88,7 +88,7 @@ const row = new TableRow<NodeUI>({});
 
 <NavPage bind:searchTerm={searchTerm} title="nodes">
   <svelte:fragment slot="additional-actions">
-    <KubeApplyYamlButton />
+    <KubeActions />
   </svelte:fragment>
 
   <svelte:fragment slot="bottom-additional-actions">

--- a/packages/renderer/src/lib/pvc/PVCList.svelte
+++ b/packages/renderer/src/lib/pvc/PVCList.svelte
@@ -13,6 +13,7 @@ import {
 import moment from 'moment';
 import { onMount } from 'svelte';
 
+import KubeActions from '/@/lib/kube/KubeActions.svelte';
 import KubernetesCurrentContextConnectionBadge from '/@/lib/ui/KubernetesCurrentContextConnectionBadge.svelte';
 import {
   kubernetesCurrentContextPersistentVolumeClaimsFiltered,
@@ -21,7 +22,6 @@ import {
 
 import { withBulkConfirmation } from '../actions/BulkActions';
 import PVCIcon from '../images/PVCIcon.svelte';
-import KubeApplyYamlButton from '../kube/KubeApplyYAMLButton.svelte';
 import { PVCUtils } from './pvc-utils';
 import PVCColumnActions from './PVCColumnActions.svelte';
 import PvcColumnMode from './PVCColumnMode.svelte';
@@ -122,7 +122,7 @@ const row = new TableRow<PVCUI>({ selectable: _pvc => true });
 
 <NavPage bind:searchTerm={searchTerm} title="persistent volume claims">
   <svelte:fragment slot="additional-actions">
-    <KubeApplyYamlButton />
+    <KubeActions />
   </svelte:fragment>
 
   <svelte:fragment slot="bottom-additional-actions">

--- a/packages/renderer/src/lib/service/ServicesList.svelte
+++ b/packages/renderer/src/lib/service/ServicesList.svelte
@@ -13,12 +13,12 @@ import {
 import moment from 'moment';
 import { onMount } from 'svelte';
 
+import KubeActions from '/@/lib/kube/KubeActions.svelte';
 import KubernetesCurrentContextConnectionBadge from '/@/lib/ui/KubernetesCurrentContextConnectionBadge.svelte';
 import { kubernetesCurrentContextServicesFiltered, serviceSearchPattern } from '/@/stores/kubernetes-contexts-state';
 
 import { withBulkConfirmation } from '../actions/BulkActions';
 import ServiceIcon from '../images/ServiceIcon.svelte';
-import KubeApplyYamlButton from '../kube/KubeApplyYAMLButton.svelte';
 import { ServiceUtils } from './service-utils';
 import ServiceColumnActions from './ServiceColumnActions.svelte';
 import ServiceColumnName from './ServiceColumnName.svelte';
@@ -121,7 +121,7 @@ const row = new TableRow<ServiceUI>({ selectable: _service => true });
 
 <NavPage bind:searchTerm={searchTerm} title="services">
   <svelte:fragment slot="additional-actions">
-    <KubeApplyYamlButton />
+    <KubeActions />
   </svelte:fragment>
 
   <svelte:fragment slot="bottom-additional-actions">


### PR DESCRIPTION
### What does this PR do?

https://github.com/podman-desktop/podman-desktop/pull/10073 will add a new actions to kube, which will be displayed in each page, we can simplify by creating a shared `KubeActions` component, to ease adding/removing actions in the future.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Related to https://github.com/podman-desktop/podman-desktop/issues/8845

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
