### PR TITLE
chore: call the command when wanting to display task manager

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesCliTool.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesCliTool.spec.ts
@@ -140,6 +140,7 @@ beforeAll(() => {
   Object.defineProperty(global, 'window', {
     value: {
       updateCliTool: vi.fn(),
+      executeCommand: vi.fn(),
       navigator: {
         clipboard: {
           writeText: vi.fn(),
@@ -236,6 +237,10 @@ describe('CLI Tool item', () => {
 
     const failedErrorButton2 = screen.getByRole('button', { name: `${cliToolInfoItem3.displayName} failed` });
     expect(failedErrorButton2).toBeInTheDocument();
+
+    // click on it
+    await userEvent.click(failedErrorButton2);
+    expect(window.executeCommand).toBeCalledWith('show-task-manager');
   });
 
   test('check version is sent to updateCliTool', async () => {

--- a/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
@@ -37,6 +37,11 @@ $: cliToolUninstallStatus = {
   action: 'uninstall',
 };
 
+async function showTaskManager(): Promise<void> {
+  // call the command show-task-manager'
+  await window.executeCommand('show-task-manager');
+}
+
 async function update(cliTool: CliToolInfo) {
   newVersion = cliTool.newVersion;
   if (!newVersion) {
@@ -297,7 +302,7 @@ function getLoggerHandler(_cliToolId: string): ConnectionCallback {
         padding="p-0"
         class="ml-1 text-sm"
         aria-label="{cliTool.displayName} failed"
-        on:click={() => window.events?.send('toggle-task-manager', '')}>Check why it failed</Button>
+        on:click={showTaskManager}>Check why it failed</Button>
     </div>
   {/if}
 </div>

--- a/packages/renderer/src/lib/statusbar/TaskIndicator.spec.ts
+++ b/packages/renderer/src/lib/statusbar/TaskIndicator.spec.ts
@@ -27,6 +27,7 @@ import { tasksInfo } from '/@/stores/tasks';
 beforeAll(() => {
   Object.defineProperty(global, 'window', {
     value: {
+      executeCommand: vi.fn(),
       events: {
         send: vi.fn(),
       },
@@ -47,7 +48,7 @@ test('should not be visible when no running tasks', async () => {
   expect(status).toBeNull();
 });
 
-test('clicking on task should send task manager toggle event', async () => {
+test('clicking on task should execute command to display the task manager', async () => {
   tasksInfo.set([
     {
       name: 'Dummy Task',
@@ -66,7 +67,7 @@ test('clicking on task should send task manager toggle event', async () => {
   await fireEvent.click(button);
 
   await vi.waitFor(() => {
-    expect(window.events.send).toHaveBeenCalledWith('toggle-task-manager', '');
+    expect(window.executeCommand).toHaveBeenCalledWith('show-task-manager');
   });
 });
 

--- a/packages/renderer/src/lib/statusbar/TaskIndicator.svelte
+++ b/packages/renderer/src/lib/statusbar/TaskIndicator.svelte
@@ -17,8 +17,8 @@ let progress: number | undefined = $derived.by(() => {
   return runningTasks[0].progress; // return task's progress value
 });
 
-function toggleTaskManager(): void {
-  return window.events?.send('toggle-task-manager', '');
+async function toggleTaskManager(): Promise<void> {
+  await window.executeCommand('show-task-manager');
 }
 </script>
 

--- a/packages/renderer/src/lib/ui/ConnectionErrorInfoButton.spec.ts
+++ b/packages/renderer/src/lib/ui/ConnectionErrorInfoButton.spec.ts
@@ -20,10 +20,23 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { render, screen } from '@testing-library/svelte';
-import { expect, test } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
 import ConnectionErrorInfoButton from './ConnectionErrorInfoButton.svelte';
+
+beforeAll(() => {
+  Object.defineProperty(global, 'window', {
+    value: {
+      executeCommand: vi.fn(),
+    },
+    writable: true,
+  });
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
 
 test('Expect nothing if status is undefined', async () => {
   render(ConnectionErrorInfoButton, {
@@ -48,6 +61,12 @@ test('Expect error button if status action and error are defined', async () => {
   // check element does exist
   const button = screen.getByRole('button', { name: 'action failed' });
   expect(button).toBeInTheDocument();
+
+  // click on button
+  await fireEvent.click(button);
+
+  // check method is called
+  expect(window.executeCommand).toHaveBeenCalledWith('show-task-manager');
 });
 
 test('Expect nothing if status action is not defined', async () => {

--- a/packages/renderer/src/lib/ui/ConnectionErrorInfoButton.svelte
+++ b/packages/renderer/src/lib/ui/ConnectionErrorInfoButton.svelte
@@ -2,11 +2,16 @@
 import type { IConnectionStatus } from '../preferences/Util';
 
 export let status: IConnectionStatus | undefined;
+
+async function showTaskManager(): Promise<void> {
+  // call the command show-task-manager'
+  await window.executeCommand('show-task-manager');
+}
 </script>
 
 {#if status?.action && status?.error}
   <button
     aria-label="{status.action} failed"
     class="ml-3 text-[9px] text-[var(--pd-state-error)] underline"
-    on:click={() => window.events?.send('toggle-task-manager', '')}>{status.action} failed</button>
+    on:click={showTaskManager}>{status.action} failed</button>
 {/if}


### PR DESCRIPTION
### What does this PR do?
rather than sending events, use the existing command. The command is in charge of calling the right event.
add unit tests to ensure we call the command


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/issues/9924

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
