### PR TITLE
fix: compose installation via onboarding and cli tools

### DIFF
--- a/extensions/compose/src/extension.spec.ts
+++ b/extensions/compose/src/extension.spec.ts
@@ -87,6 +87,7 @@ const cliToolMock = {
   registerInstaller: vi.fn(),
   updateVersion: vi.fn(),
   dispose: vi.fn(),
+  onDidUpdateVersion: vi.fn(),
 } as unknown as CliTool;
 
 vi.mock('./cli-run', () => ({

--- a/extensions/compose/src/extension.ts
+++ b/extensions/compose/src/extension.ts
@@ -138,7 +138,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
 
         // register the cli tool if necessary
         if (!composeCliTool) {
-          await registerCLITool(composeDownload, detect);
+          await registerCLITool(composeDownload, detect, extensionContext);
         }
       } finally {
         // Make sure we log the telemetry even if we encounter an error
@@ -236,14 +236,18 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   // Push the CLI tool as well (but it will do it postActivation so it does not block the activate() function)
   // Post activation
   setTimeout(() => {
-    registerCLITool(composeDownload, detect).catch((error: unknown) => {
+    registerCLITool(composeDownload, detect, extensionContext).catch((error: unknown) => {
       console.error('Error activating extension', error);
     });
   }, 0);
 }
 
 // Activate the CLI tool (check version, etc) and register the CLi so it does not block activation.
-async function registerCLITool(composeDownload: ComposeDownload, detect: Detect): Promise<void> {
+async function registerCLITool(
+  composeDownload: ComposeDownload,
+  detect: Detect,
+  context: extensionApi.ExtensionContext,
+): Promise<void> {
   // build executable name for current platform
   const executable = os.isWindows() ? composeCliName + '.exe' : composeCliName;
 
@@ -350,11 +354,6 @@ async function registerCLITool(composeDownload: ComposeDownload, detect: Detect)
         installationSource: 'extension',
       });
       binaryVersion = releaseVersionToUpdateTo;
-      if (releaseVersionToUpdateTo === latestVersion) {
-        delete update.version;
-      } else {
-        update.version = latestVersion;
-      }
       releaseVersionToUpdateTo = undefined;
       releaseToUpdateTo = undefined;
     },
@@ -364,13 +363,15 @@ async function registerCLITool(composeDownload: ComposeDownload, detect: Detect)
   let releaseToInstall: ComposeGithubReleaseArtifactMetadata | undefined;
   let releaseVersionToInstall: string | undefined;
 
-  composeCliTool.onDidUpdateVersion((version: string) => {
-    if (version === latestVersion) {
-      delete update.version;
-    } else {
-      update.version = latestVersion;
-    }
-  });
+  context.subscriptions.push(
+    composeCliTool.onDidUpdateVersion((version: string) => {
+      if (version === latestVersion) {
+        delete update.version;
+      } else {
+        update.version = latestVersion;
+      }
+    }),
+  );
 
   composeCliToolInstallerDisposable = composeCliTool.registerInstaller({
     selectVersion: async () => {
@@ -400,13 +401,9 @@ async function registerCLITool(composeDownload: ComposeDownload, detect: Detect)
         installationSource: 'extension',
       });
       binaryVersion = releaseVersionToInstall;
-      if (releaseVersionToInstall === latestVersion) {
-        delete update.version;
-      } else {
-        update.version = latestVersion;
-      }
       releaseVersionToInstall = undefined;
       releaseToInstall = undefined;
+      extensionApi.context.setValue('compose.isComposeInstalledSystemWide', true);
     },
     doUninstall: async _logger => {
       if (!binaryVersion) {
@@ -424,6 +421,7 @@ async function registerCLITool(composeDownload: ComposeDownload, detect: Detect)
       // update the version to undefined
       binaryVersion = undefined;
       binaryPath = undefined;
+      extensionApi.context.setValue('compose.isComposeInstalledSystemWide', false);
     },
   });
 


### PR DESCRIPTION
### What does this PR do?

Fix compose onboarding install and CLI Tools preferences page install to work together.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

https://github.com/user-attachments/assets/94cbe680-ee64-42e9-9cae-192f9e7c0ae5

Onboarding status updates after installing and removing compose on CLI Pref Page

https://github.com/user-attachments/assets/7ae56a6c-d435-487a-b321-ee9fa496378a

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->
Fix #9763.

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
