### PR TITLE
chore: enable unit tests on macOS for PR check job

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -272,7 +272,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2022, ubuntu-24.04]
+        os: [windows-2022, ubuntu-24.04, macos-15]
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4


### PR DESCRIPTION
### What does this PR do?
It looks like there is an issue with chokidar but only on macOS
if we have a unit tests for that, it won't be failing the PR check as we're not running tests on macOS

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

https://github.com/podman-desktop/podman-desktop/issues/9406#issuecomment-2505369469

### How to test this PR?

unit tests on macOS should be ✅ 

- [x] Tests are covering the bug fix or the new feature
