### PR TITLE
chore(test): fix kubernetes pvcs test

### DIFF
--- a/tests/playwright/src/specs/kubernetes.spec.ts
+++ b/tests/playwright/src/specs/kubernetes.spec.ts
@@ -117,7 +117,7 @@ test.describe('Kubernetes resources End-to-End test', { tag: '@k8s_e2e' }, () =>
         await playExpect(pvcDetails.heading).toBeVisible();
         await playExpect
           .poll(async () => pvcDetails.getState(), { timeout: 50_000 })
-          .toEqual(KubernetesResourceState.Starting);
+          .toEqual(KubernetesResourceState.Stopped);
       });
       test('Bind the PVC to a pod', async ({ navigationBar }) => {
         const podsPage = await navigationBar.openPods();


### PR DESCRIPTION
Signed-off-by: Anton Misskii <amisskii@redhat.com>

### What does this PR do?

Updates the expected status of a PVC resource when it is not bound.

### What issues does this PR fix or reference?

https://github.com/podman-desktop/podman-desktop/issues/10132

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
