### PR TITLE
fix: cache pod exec websockets

### DIFF
--- a/packages/main/src/plugin/kubernetes/kubernetes-exec-transmitter.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-exec-transmitter.ts
@@ -35,6 +35,14 @@ export class ExecStreamWriter extends Writable {
     this.transmitter = transmitter;
   }
 
+  get delegate(): Writable {
+    return this.transmitter;
+  }
+
+  set delegate(delegate: Writable) {
+    this.transmitter = delegate;
+  }
+
   override _write(chunk: unknown, encoding: BufferEncoding, callback: (error?: Error | null) => void): void {
     this.transmitter._write(chunk, encoding, callback);
   }

--- a/packages/renderer/src/lib/pod/KubernetesTerminal.svelte
+++ b/packages/renderer/src/lib/pod/KubernetesTerminal.svelte
@@ -48,7 +48,6 @@ onMount(async () => {
   // and then add a \r\n to the end of the terminal to ensure the cursor is on a new line.
   if (savedState?.terminal) {
     shellTerminal.write(savedState.terminal);
-    shellTerminal.write('\r\n');
     shellTerminal.focus();
   }
 });


### PR DESCRIPTION
Fixes #9467

### What does this PR do?

Caches the websocket connection when a terminal is created for a pod/container.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

#9467 

### How to test this PR?

1. Launch a Kubernetes
2. Switch from Kube to Terminal tabs several times
3. Verify the sh/bash is only launched once

- [x] Tests are covering the bug fix or the new feature
