### PR TITLE
feat: improve libpod API support

### DIFF
--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -3947,6 +3947,13 @@ describe('createContainerLibPod', () => {
       pod: 'pod',
       name: 'name',
       HostConfig: {
+        Devices: [
+          {
+            PathOnHost: 'nvidia.com/gpu=all',
+            PathInContainer: '',
+            CgroupPermissions: '',
+          },
+        ],
         Mounts: [
           {
             Target: 'destination',
@@ -3959,7 +3966,7 @@ describe('createContainerLibPod', () => {
           },
         ],
         NetworkMode: 'mode',
-        SecurityOpt: ['default'],
+        SecurityOpt: ['default', 'label=disable'],
         PortBindings: {
           '8080': [
             {
@@ -3994,7 +4001,8 @@ describe('createContainerLibPod', () => {
     const expectedOptions: PodmanContainerCreateOptions = {
       name: options.name,
       command: options.Cmd,
-      entrypoint: options.Entrypoint,
+      devices: [{ path: 'nvidia.com/gpu=all' }],
+      entrypoint: [options.Entrypoint as string],
       env: {
         key: 'value',
       },
@@ -4015,6 +4023,7 @@ describe('createContainerLibPod', () => {
         nsmode: 'mode',
       },
       seccomp_policy: 'default',
+      selinux_opts: ['disable'],
       portmappings: [
         {
           container_port: 8080,

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.ts
@@ -140,6 +140,12 @@ export interface ContainerCreateNamedVolume {
   SubPath?: string;
 }
 
+// represents a device request through the libPod API
+// only path is currently translated
+export interface PodmanDevice {
+  path: string;
+}
+
 export interface ContainerCreateOptions {
   command?: string[];
   entrypoint?: string | string[];
@@ -169,6 +175,8 @@ export interface ContainerCreateOptions {
   hostadd?: Array<string>;
   userns?: string;
   volumes?: Array<ContainerCreateNamedVolume>;
+  selinux_opts?: string[];
+  devices?: PodmanDevice[];
 }
 
 export interface PodRemoveOptions {


### PR DESCRIPTION
### What does this PR do?

This PR improves use cases where LibPod is used by Podman desktop by:
1. adding support for some additinal configuration options that were not previously translated from the input options
2. forcing the use of LibPod if an nvidia gpu is requested on linux.  Requesting the device "nvidia.com/gpu=all" only works through the LibPod API, not the docker compatibility API. Therefore, force the use of LibPod over the compatiliby API if this device is requested.

These changes were needed for me to get GPU acceleration working on linux for [podman-desktop-extension-ai-lab](https://github.com/containers/podman-desktop-extension-ai-lab), however, I think they are just general improvements that are useful on their own in cases where containers are started and LibPod would have already been used as the API.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

The tests were updated to cover the additions in terms of the addional options translated into the podman options.

For live test, I tested this PR along with this PR to podman-desktop-extension-ai-lab  - https://github.com/containers/podman-desktop-extension-ai-lab/pull/2180, by creating a model service and validating that the service reported GPU acceleration, and used the GPU when submitted requests to the service.  I also tested with the chatbot Node.js recipe I was working on that it got GPU acceleration as well.

- [X] Tests are covering the bug fix or the new feature
