### PR TITLE
feat: informers for Kubernetes experimental 

### DIFF
--- a/packages/main/src/plugin/kubernetes/context-permissions-checker.spec.ts
+++ b/packages/main/src/plugin/kubernetes/context-permissions-checker.spec.ts
@@ -20,7 +20,7 @@ import util from 'node:util';
 
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-import type { ContextResourcePermission } from './context-permissions-checker.js';
+import type { ContextPermissionResult, ContextResourcePermission } from './context-permissions-checker.js';
 import { ContextPermissionsChecker } from './context-permissions-checker.js';
 import type { KubeConfigSingleContext } from './kubeconfig-single-context.js';
 
@@ -68,6 +68,7 @@ describe('ContextPermissionsChecker is built with a non recursive request', asyn
 
     test('onPermissionResult is fired with permitted true', async () => {
       expect(onPermissionResultCB).toHaveBeenCalledWith({
+        kubeConfig: expect.anything(),
         attrs,
         resources,
         permitted: true,
@@ -111,6 +112,7 @@ describe('ContextPermissionsChecker is built with a non recursive request', asyn
 
     test('onPermissionResult is fired with permitted false', async () => {
       expect(onPermissionResultCB).toHaveBeenCalledWith({
+        kubeConfig: expect.anything(),
         attrs,
         resources,
         permitted: false,
@@ -153,6 +155,7 @@ describe('ContextPermissionsChecker is built with a non recursive request', asyn
 
     test('onPermissionResult is fired with permitted false', async () => {
       expect(onPermissionResultCB).toHaveBeenCalledWith({
+        kubeConfig: expect.anything(),
         attrs,
         resources,
         permitted: false,
@@ -265,17 +268,19 @@ describe('ContextPermissionsChecker is built with a recursive request', async ()
 
     test('onPermissionResult is fired with permitted true for resource1 and false for resource2', async () => {
       expect(onPermissionResultCB).toHaveBeenCalledWith({
+        kubeConfig: expect.anything(),
         attrs: attrsResource1,
         resources: resources1,
         permitted: true,
         reason: 'a reason 1',
-      });
+      } as ContextPermissionResult);
       expect(onPermissionResultCB).toHaveBeenCalledWith({
+        kubeConfig: expect.anything(),
         attrs: attrsResource2,
         resources: resources2,
         permitted: false,
         reason: 'a reason 2',
-      });
+      } as ContextPermissionResult);
     });
 
     test('getPermissions returns permitted true for resource1 and false for resource2', async () => {

--- a/packages/main/src/plugin/kubernetes/context-permissions-checker.ts
+++ b/packages/main/src/plugin/kubernetes/context-permissions-checker.ts
@@ -47,6 +47,7 @@ export interface ContextResourcePermission {
 
 // ContextPermissionResult is the result of a request, which can cover several resources
 export interface ContextPermissionResult extends ContextResourcePermission {
+  kubeConfig: KubeConfigSingleContext;
   resources: string[];
 }
 
@@ -85,6 +86,7 @@ export class ContextPermissionsChecker implements Disposable {
     } else {
       // send the result for resources concerned by the request
       this.saveAndFireResult({
+        kubeConfig: this.#kubeconfig,
         resources: this.#request.resources,
         attrs: this.#request.attrs,
         permitted: result.allowed && !result.denied,

--- a/packages/main/src/plugin/kubernetes/context-resource-registry.spec.ts
+++ b/packages/main/src/plugin/kubernetes/context-resource-registry.spec.ts
@@ -1,0 +1,31 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test } from 'vitest';
+
+import { ContextResourceRegistry } from './context-resource-registry.js';
+
+test('ContextResourceRegistry', () => {
+  const registry = new ContextResourceRegistry<string>();
+
+  registry.set('context1', 'resource1', 'value1');
+  expect(registry.get('context1', 'resource1')).toEqual('value1');
+
+  registry.set('context1', 'resource2', 'value2');
+  expect(registry.getAll()).toEqual(['value1', 'value2']);
+});

--- a/packages/main/src/plugin/kubernetes/context-resource-registry.ts
+++ b/packages/main/src/plugin/kubernetes/context-resource-registry.ts
@@ -1,0 +1,41 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+// ContextResourceRegistry stores objects of type T for contexts and resources
+export class ContextResourceRegistry<T> {
+  #registry: Map<string, Map<string, T>> = new Map();
+
+  set(context: string, resource: string, object: T): void {
+    if (!this.#registry.get(context)) {
+      this.#registry.set(context, new Map());
+    }
+    this.#registry.get(context)?.set(resource, object);
+  }
+
+  get(context: string, resource: string): T | undefined {
+    return this.#registry.get(context)?.get(resource);
+  }
+
+  getAll(): T[] {
+    const result: T[] = [];
+    for (const contexts of this.#registry.values()) {
+      result.push(...contexts.values());
+    }
+    return result;
+  }
+}

--- a/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
@@ -110,18 +110,18 @@ export class ContextsManagerExperimental {
                 `a permission for resource ${resource} has been received but no factory is handling it, this should not happen`,
               );
             }
-            if (!factory.getInformer) {
+            if (!factory.informer) {
               // no informer for this factory, skipping
               // (we may want to check permissions on some resource, without having to start an informer)
               continue;
             }
-            const informer = factory.getInformer(event.kubeConfig);
+            const informer = factory.informer.createInformer(event.kubeConfig);
             this.#informers.set(contextName, resource, informer);
             informer.onCacheUpdated((_e: CacheUpdatedEvent) => {
               /* just log for now */
               const list = this.#objectCaches.get(contextName, resource)?.list();
               console.log(
-                `==> ${resource} in ${contextName}`,
+                `${resource} in ${contextName}`,
                 list?.map(o => o.metadata?.name),
               );
               /* send event to dispatcher */

--- a/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.spec.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.spec.ts
@@ -1,0 +1,90 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test, vi } from 'vitest';
+
+import type { ContextsManagerExperimental } from './contexts-manager-experimental.js';
+import { ContextsStatesDispatcher } from './contexts-states-dispatcher.js';
+
+test('ContextsStatesDispatcher should call updateHealthStates when onContextHealthStateChange event is fired', () => {
+  const onContextHealthStateChangeMock = vi.fn();
+  const onContextPermissionResultMock = vi.fn();
+  const manager: ContextsManagerExperimental = {
+    onContextHealthStateChange: onContextHealthStateChangeMock,
+    onContextPermissionResult: onContextPermissionResultMock,
+    onContextDelete: vi.fn(),
+    getHealthCheckersStates: vi.fn(),
+    getPermissions: vi.fn(),
+  } as unknown as ContextsManagerExperimental;
+  const dispatcher = new ContextsStatesDispatcher(manager);
+  const updateHealthStatesSpy = vi.spyOn(dispatcher, 'updateHealthStates');
+  const updatePermissionsSpy = vi.spyOn(dispatcher, 'updatePermissions');
+  dispatcher.init();
+  expect(updateHealthStatesSpy).not.toHaveBeenCalled();
+  expect(updatePermissionsSpy).not.toHaveBeenCalled();
+
+  onContextHealthStateChangeMock.mockImplementation(f => f());
+  dispatcher.init();
+  expect(updateHealthStatesSpy).toHaveBeenCalled();
+  expect(updatePermissionsSpy).not.toHaveBeenCalled();
+});
+
+test('ContextsStatesDispatcher should call updatePermissions when onContextPermissionResult event is fired', () => {
+  const onContextHealthStateChangeMock = vi.fn();
+  const onContextPermissionResultMock = vi.fn();
+  const manager: ContextsManagerExperimental = {
+    onContextHealthStateChange: onContextHealthStateChangeMock,
+    onContextPermissionResult: onContextPermissionResultMock,
+    onContextDelete: vi.fn(),
+    getHealthCheckersStates: vi.fn(),
+    getPermissions: vi.fn(),
+  } as unknown as ContextsManagerExperimental;
+  const dispatcher = new ContextsStatesDispatcher(manager);
+  const updateHealthStatesSpy = vi.spyOn(dispatcher, 'updateHealthStates');
+  const updatePermissionsSpy = vi.spyOn(dispatcher, 'updatePermissions');
+  dispatcher.init();
+  expect(updateHealthStatesSpy).not.toHaveBeenCalled();
+  expect(updatePermissionsSpy).not.toHaveBeenCalled();
+
+  onContextPermissionResultMock.mockImplementation(f => f());
+  dispatcher.init();
+  expect(updateHealthStatesSpy).not.toHaveBeenCalled();
+  expect(updatePermissionsSpy).toHaveBeenCalled();
+});
+
+test('ContextsStatesDispatcher should call updateHealthStates and updatePermissions when onContextDelete event is fired', () => {
+  const onContextDeleteMock = vi.fn();
+  const manager: ContextsManagerExperimental = {
+    onContextHealthStateChange: vi.fn(),
+    onContextPermissionResult: vi.fn(),
+    onContextDelete: onContextDeleteMock,
+    getHealthCheckersStates: vi.fn(),
+    getPermissions: vi.fn(),
+  } as unknown as ContextsManagerExperimental;
+  const dispatcher = new ContextsStatesDispatcher(manager);
+  const updateHealthStatesSpy = vi.spyOn(dispatcher, 'updateHealthStates');
+  const updatePermissionsSpy = vi.spyOn(dispatcher, 'updatePermissions');
+  dispatcher.init();
+  expect(updateHealthStatesSpy).not.toHaveBeenCalled();
+  expect(updatePermissionsSpy).not.toHaveBeenCalled();
+
+  onContextDeleteMock.mockImplementation(f => f());
+  dispatcher.init();
+  expect(updateHealthStatesSpy).toHaveBeenCalled();
+  expect(updatePermissionsSpy).toHaveBeenCalled();
+});

--- a/packages/main/src/plugin/kubernetes/deployments-resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/deployments-resource-factory.ts
@@ -16,27 +16,33 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { V1Deployment, V1DeploymentList, V1ResourceAttributes } from '@kubernetes/client-node';
+import type { V1Deployment, V1DeploymentList } from '@kubernetes/client-node';
 import { AppsV1Api } from '@kubernetes/client-node';
 
 import type { KubeConfigSingleContext } from './kubeconfig-single-context.js';
+import type { ResourceFactory } from './resource-factory-handler.js';
+import { ResourceFactoryBase } from './resource-factory-handler.js';
 import { ResourceInformer } from './resource-informer.js';
 
-export class DeploymentsResourceFactory {
-  resource = 'deployments';
-  isNamespaced = true;
-  permissionsRequests: V1ResourceAttributes[] = [
-    {
-      group: '*',
-      resource: '*',
-      verb: 'watch',
-    },
-    {
-      verb: 'watch',
-      group: 'apps',
+export class DeploymentsResourceFactory extends ResourceFactoryBase implements ResourceFactory {
+  constructor() {
+    super({
       resource: 'deployments',
-    },
-  ];
+      isNamespaced: true,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          verb: 'watch',
+          group: 'apps',
+          resource: 'deployments',
+        },
+      ],
+    });
+  }
 
   getInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1Deployment> {
     const namespace = kubeconfig.getNamespace();

--- a/packages/main/src/plugin/kubernetes/deployments-resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/deployments-resource-factory.ts
@@ -20,14 +20,17 @@ import type { V1Deployment, V1DeploymentList } from '@kubernetes/client-node';
 import { AppsV1Api } from '@kubernetes/client-node';
 
 import type { KubeConfigSingleContext } from './kubeconfig-single-context.js';
-import type { ResourceFactory } from './resource-factory-handler.js';
-import { ResourceFactoryBase } from './resource-factory-handler.js';
+import type { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryBase } from './resource-factory.js';
 import { ResourceInformer } from './resource-informer.js';
 
 export class DeploymentsResourceFactory extends ResourceFactoryBase implements ResourceFactory {
   constructor() {
     super({
       resource: 'deployments',
+    });
+
+    this.setPermissions({
       isNamespaced: true,
       permissionsRequests: [
         {
@@ -42,9 +45,12 @@ export class DeploymentsResourceFactory extends ResourceFactoryBase implements R
         },
       ],
     });
+    this.setInformer({
+      createInformer: this.createInformer,
+    });
   }
 
-  getInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1Deployment> {
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1Deployment> {
     const namespace = kubeconfig.getNamespace();
     const apiClient = kubeconfig.getKubeConfig().makeApiClient(AppsV1Api);
     const listFn = (): Promise<V1DeploymentList> => apiClient.listNamespacedDeployment({ namespace });

--- a/packages/main/src/plugin/kubernetes/deployments-resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/deployments-resource-factory.ts
@@ -1,0 +1,48 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1Deployment, V1DeploymentList, V1ResourceAttributes } from '@kubernetes/client-node';
+import { AppsV1Api } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from './kubeconfig-single-context.js';
+import { ResourceInformer } from './resource-informer.js';
+
+export class DeploymentsResourceFactory {
+  resource = 'deployments';
+  isNamespaced = true;
+  permissionsRequests: V1ResourceAttributes[] = [
+    {
+      group: '*',
+      resource: '*',
+      verb: 'watch',
+    },
+    {
+      verb: 'watch',
+      group: 'apps',
+      resource: 'deployments',
+    },
+  ];
+
+  getInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1Deployment> {
+    const namespace = kubeconfig.getNamespace();
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(AppsV1Api);
+    const listFn = (): Promise<V1DeploymentList> => apiClient.listNamespacedDeployment({ namespace });
+    const path = `/apis/apps/v1/namespaces/${namespace}/deployments`;
+    return new ResourceInformer<V1Deployment>(kubeconfig, path, listFn, 'deployments');
+  }
+}

--- a/packages/main/src/plugin/kubernetes/pods-resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/pods-resource-factory.ts
@@ -20,14 +20,17 @@ import type { V1Pod, V1PodList } from '@kubernetes/client-node';
 import { CoreV1Api } from '@kubernetes/client-node';
 
 import type { KubeConfigSingleContext } from './kubeconfig-single-context.js';
-import type { ResourceFactory } from './resource-factory-handler.js';
-import { ResourceFactoryBase } from './resource-factory-handler.js';
+import type { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryBase } from './resource-factory.js';
 import { ResourceInformer } from './resource-informer.js';
 
 export class PodsResourceFactory extends ResourceFactoryBase implements ResourceFactory {
   constructor() {
     super({
       resource: 'pods',
+    });
+
+    this.setPermissions({
       isNamespaced: true,
       permissionsRequests: [
         {
@@ -41,9 +44,12 @@ export class PodsResourceFactory extends ResourceFactoryBase implements Resource
         },
       ],
     });
+    this.setInformer({
+      createInformer: this.createInformer,
+    });
   }
 
-  getInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1Pod> {
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1Pod> {
     const namespace = kubeconfig.getNamespace();
     const apiClient = kubeconfig.getKubeConfig().makeApiClient(CoreV1Api);
     const listFn = (): Promise<V1PodList> => apiClient.listNamespacedPod({ namespace });

--- a/packages/main/src/plugin/kubernetes/pods-resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/pods-resource-factory.ts
@@ -16,26 +16,32 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { V1Pod, V1PodList, V1ResourceAttributes } from '@kubernetes/client-node';
+import type { V1Pod, V1PodList } from '@kubernetes/client-node';
 import { CoreV1Api } from '@kubernetes/client-node';
 
 import type { KubeConfigSingleContext } from './kubeconfig-single-context.js';
+import type { ResourceFactory } from './resource-factory-handler.js';
+import { ResourceFactoryBase } from './resource-factory-handler.js';
 import { ResourceInformer } from './resource-informer.js';
 
-export class PodsResourceFactory {
-  resource = 'pods';
-  isNamespaced = true;
-  permissionsRequests: V1ResourceAttributes[] = [
-    {
-      group: '*',
-      resource: '*',
-      verb: 'watch',
-    },
-    {
-      verb: 'watch',
+export class PodsResourceFactory extends ResourceFactoryBase implements ResourceFactory {
+  constructor() {
+    super({
       resource: 'pods',
-    },
-  ];
+      isNamespaced: true,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          verb: 'watch',
+          resource: 'pods',
+        },
+      ],
+    });
+  }
 
   getInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1Pod> {
     const namespace = kubeconfig.getNamespace();

--- a/packages/main/src/plugin/kubernetes/pods-resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/pods-resource-factory.ts
@@ -1,0 +1,47 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1Pod, V1PodList, V1ResourceAttributes } from '@kubernetes/client-node';
+import { CoreV1Api } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from './kubeconfig-single-context.js';
+import { ResourceInformer } from './resource-informer.js';
+
+export class PodsResourceFactory {
+  resource = 'pods';
+  isNamespaced = true;
+  permissionsRequests: V1ResourceAttributes[] = [
+    {
+      group: '*',
+      resource: '*',
+      verb: 'watch',
+    },
+    {
+      verb: 'watch',
+      resource: 'pods',
+    },
+  ];
+
+  getInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1Pod> {
+    const namespace = kubeconfig.getNamespace();
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(CoreV1Api);
+    const listFn = (): Promise<V1PodList> => apiClient.listNamespacedPod({ namespace });
+    const path = `/api/v1/namespaces/${namespace}/pods`;
+    return new ResourceInformer<V1Pod>(kubeconfig, path, listFn, 'pods');
+  }
+}

--- a/packages/main/src/plugin/kubernetes/resource-factory-handler.spec.ts
+++ b/packages/main/src/plugin/kubernetes/resource-factory-handler.spec.ts
@@ -20,34 +20,38 @@ import { expect, test } from 'vitest';
 
 import { DeploymentsResourceFactory } from './deployments-resource-factory.js';
 import { PodsResourceFactory } from './pods-resource-factory.js';
-import { ResourceFactoryHandler } from './resource-factory-handler.js';
+import { ResourceFactoryBase, ResourceFactoryHandler } from './resource-factory-handler.js';
 
 test('with 1 level and same request', () => {
   const factoryHandler = new ResourceFactoryHandler();
 
-  factoryHandler.add({
-    resource: 'resource1',
-    isNamespaced: true,
-    permissionsRequests: [
-      {
-        group: '*',
-        resource: '*',
-        verb: 'watch',
-      },
-    ],
-  });
+  factoryHandler.add(
+    new ResourceFactoryBase({
+      resource: 'resource1',
+      isNamespaced: true,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+      ],
+    }),
+  );
 
-  factoryHandler.add({
-    resource: 'resource2',
-    isNamespaced: true,
-    permissionsRequests: [
-      {
-        group: '*',
-        resource: '*',
-        verb: 'watch',
-      },
-    ],
-  });
+  factoryHandler.add(
+    new ResourceFactoryBase({
+      resource: 'resource2',
+      isNamespaced: true,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+      ],
+    }),
+  );
 
   const requests = factoryHandler.getPermissionsRequests('ns');
   expect(requests).toEqual([
@@ -66,29 +70,33 @@ test('with 1 level and same request', () => {
 test('with 1 level and different requests', () => {
   const factoryHandler = new ResourceFactoryHandler();
 
-  factoryHandler.add({
-    resource: 'resource1',
-    isNamespaced: true,
-    permissionsRequests: [
-      {
-        group: 'group1',
-        resource: '*',
-        verb: 'watch',
-      },
-    ],
-  });
+  factoryHandler.add(
+    new ResourceFactoryBase({
+      resource: 'resource1',
+      isNamespaced: true,
+      permissionsRequests: [
+        {
+          group: 'group1',
+          resource: '*',
+          verb: 'watch',
+        },
+      ],
+    }),
+  );
 
-  factoryHandler.add({
-    resource: 'resource2',
-    isNamespaced: true,
-    permissionsRequests: [
-      {
-        group: 'group2',
-        resource: '*',
-        verb: 'watch',
-      },
-    ],
-  });
+  factoryHandler.add(
+    new ResourceFactoryBase({
+      resource: 'resource2',
+      isNamespaced: true,
+      permissionsRequests: [
+        {
+          group: 'group2',
+          resource: '*',
+          verb: 'watch',
+        },
+      ],
+    }),
+  );
 
   const requests = factoryHandler.getPermissionsRequests('ns');
   expect(requests).toEqual([
@@ -116,38 +124,42 @@ test('with 1 level and different requests', () => {
 test('with 2 levels and same request at first level', () => {
   const factoryHandler = new ResourceFactoryHandler();
 
-  factoryHandler.add({
-    resource: 'resource1',
-    isNamespaced: true,
-    permissionsRequests: [
-      {
-        group: '*',
-        resource: '*',
-        verb: 'watch',
-      },
-      {
-        verb: 'watch',
-        resource: 'resource1',
-      },
-    ],
-  });
+  factoryHandler.add(
+    new ResourceFactoryBase({
+      resource: 'resource1',
+      isNamespaced: true,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          verb: 'watch',
+          resource: 'resource1',
+        },
+      ],
+    }),
+  );
 
-  factoryHandler.add({
-    resource: 'resource2',
-    isNamespaced: true,
-    permissionsRequests: [
-      {
-        group: '*',
-        resource: '*',
-        verb: 'watch',
-      },
-      {
-        verb: 'watch',
-        group: 'group2',
-        resource: 'resource2',
-      },
-    ],
-  });
+  factoryHandler.add(
+    new ResourceFactoryBase({
+      resource: 'resource2',
+      isNamespaced: true,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          verb: 'watch',
+          group: 'group2',
+          resource: 'resource2',
+        },
+      ],
+    }),
+  );
 
   const requests = factoryHandler.getPermissionsRequests('ns');
   expect(requests).toEqual([
@@ -185,29 +197,33 @@ test('with 2 levels and same request at first level', () => {
 test('with 1 level and same request, non namespaced', () => {
   const factoryHandler = new ResourceFactoryHandler();
 
-  factoryHandler.add({
-    resource: 'resource1',
-    isNamespaced: false,
-    permissionsRequests: [
-      {
-        group: '*',
-        resource: '*',
-        verb: 'watch',
-      },
-    ],
-  });
+  factoryHandler.add(
+    new ResourceFactoryBase({
+      resource: 'resource1',
+      isNamespaced: false,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+      ],
+    }),
+  );
 
-  factoryHandler.add({
-    resource: 'resource2',
-    isNamespaced: false,
-    permissionsRequests: [
-      {
-        group: '*',
-        resource: '*',
-        verb: 'watch',
-      },
-    ],
-  });
+  factoryHandler.add(
+    new ResourceFactoryBase({
+      resource: 'resource2',
+      isNamespaced: false,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+      ],
+    }),
+  );
 
   const requests = factoryHandler.getPermissionsRequests('ns');
   expect(requests).toEqual([
@@ -225,29 +241,33 @@ test('with 1 level and same request, non namespaced', () => {
 test('with 1 level and different requests, non namespaced', () => {
   const factoryHandler = new ResourceFactoryHandler();
 
-  factoryHandler.add({
-    resource: 'resource1',
-    isNamespaced: false,
-    permissionsRequests: [
-      {
-        group: 'group1',
-        resource: '*',
-        verb: 'watch',
-      },
-    ],
-  });
+  factoryHandler.add(
+    new ResourceFactoryBase({
+      resource: 'resource1',
+      isNamespaced: false,
+      permissionsRequests: [
+        {
+          group: 'group1',
+          resource: '*',
+          verb: 'watch',
+        },
+      ],
+    }),
+  );
 
-  factoryHandler.add({
-    resource: 'resource2',
-    isNamespaced: false,
-    permissionsRequests: [
-      {
-        group: 'group2',
-        resource: '*',
-        verb: 'watch',
-      },
-    ],
-  });
+  factoryHandler.add(
+    new ResourceFactoryBase({
+      resource: 'resource2',
+      isNamespaced: false,
+      permissionsRequests: [
+        {
+          group: 'group2',
+          resource: '*',
+          verb: 'watch',
+        },
+      ],
+    }),
+  );
 
   const requests = factoryHandler.getPermissionsRequests('ns');
   expect(requests).toEqual([
@@ -273,38 +293,42 @@ test('with 1 level and different requests, non namespaced', () => {
 test('with 2 levels and same request at first level, non namespaced', () => {
   const factoryHandler = new ResourceFactoryHandler();
 
-  factoryHandler.add({
-    resource: 'resource1',
-    isNamespaced: false,
-    permissionsRequests: [
-      {
-        group: '*',
-        resource: '*',
-        verb: 'watch',
-      },
-      {
-        verb: 'watch',
-        resource: 'resource1',
-      },
-    ],
-  });
+  factoryHandler.add(
+    new ResourceFactoryBase({
+      resource: 'resource1',
+      isNamespaced: false,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          verb: 'watch',
+          resource: 'resource1',
+        },
+      ],
+    }),
+  );
 
-  factoryHandler.add({
-    resource: 'resource2',
-    isNamespaced: false,
-    permissionsRequests: [
-      {
-        group: '*',
-        resource: '*',
-        verb: 'watch',
-      },
-      {
-        verb: 'watch',
-        group: 'group2',
-        resource: 'resource2',
-      },
-    ],
-  });
+  factoryHandler.add(
+    new ResourceFactoryBase({
+      resource: 'resource2',
+      isNamespaced: false,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          verb: 'watch',
+          group: 'group2',
+          resource: 'resource2',
+        },
+      ],
+    }),
+  );
 
   const requests = factoryHandler.getPermissionsRequests('ns');
   expect(requests).toEqual([
@@ -339,29 +363,33 @@ test('with 2 levels and same request at first level, non namespaced', () => {
 test('with 1 level and same request, both namespaced ant not namespaced', () => {
   const factoryHandler = new ResourceFactoryHandler();
 
-  factoryHandler.add({
-    resource: 'resource1',
-    isNamespaced: true,
-    permissionsRequests: [
-      {
-        group: '*',
-        resource: '*',
-        verb: 'watch',
-      },
-    ],
-  });
+  factoryHandler.add(
+    new ResourceFactoryBase({
+      resource: 'resource1',
+      isNamespaced: true,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+      ],
+    }),
+  );
 
-  factoryHandler.add({
-    resource: 'resource2',
-    isNamespaced: false,
-    permissionsRequests: [
-      {
-        group: '*',
-        resource: '*',
-        verb: 'watch',
-      },
-    ],
-  });
+  factoryHandler.add(
+    new ResourceFactoryBase({
+      resource: 'resource2',
+      isNamespaced: false,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+      ],
+    }),
+  );
 
   const requests = factoryHandler.getPermissionsRequests('ns');
   expect(requests).toEqual([

--- a/packages/main/src/plugin/kubernetes/resource-factory-handler.spec.ts
+++ b/packages/main/src/plugin/kubernetes/resource-factory-handler.spec.ts
@@ -20,7 +20,8 @@ import { expect, test } from 'vitest';
 
 import { DeploymentsResourceFactory } from './deployments-resource-factory.js';
 import { PodsResourceFactory } from './pods-resource-factory.js';
-import { ResourceFactoryBase, ResourceFactoryHandler } from './resource-factory-handler.js';
+import { ResourceFactoryBase } from './resource-factory.js';
+import { ResourceFactoryHandler } from './resource-factory-handler.js';
 
 test('with 1 level and same request', () => {
   const factoryHandler = new ResourceFactoryHandler();
@@ -28,6 +29,7 @@ test('with 1 level and same request', () => {
   factoryHandler.add(
     new ResourceFactoryBase({
       resource: 'resource1',
+    }).setPermissions({
       isNamespaced: true,
       permissionsRequests: [
         {
@@ -42,6 +44,7 @@ test('with 1 level and same request', () => {
   factoryHandler.add(
     new ResourceFactoryBase({
       resource: 'resource2',
+    }).setPermissions({
       isNamespaced: true,
       permissionsRequests: [
         {
@@ -73,6 +76,7 @@ test('with 1 level and different requests', () => {
   factoryHandler.add(
     new ResourceFactoryBase({
       resource: 'resource1',
+    }).setPermissions({
       isNamespaced: true,
       permissionsRequests: [
         {
@@ -87,6 +91,7 @@ test('with 1 level and different requests', () => {
   factoryHandler.add(
     new ResourceFactoryBase({
       resource: 'resource2',
+    }).setPermissions({
       isNamespaced: true,
       permissionsRequests: [
         {
@@ -127,6 +132,7 @@ test('with 2 levels and same request at first level', () => {
   factoryHandler.add(
     new ResourceFactoryBase({
       resource: 'resource1',
+    }).setPermissions({
       isNamespaced: true,
       permissionsRequests: [
         {
@@ -145,6 +151,7 @@ test('with 2 levels and same request at first level', () => {
   factoryHandler.add(
     new ResourceFactoryBase({
       resource: 'resource2',
+    }).setPermissions({
       isNamespaced: true,
       permissionsRequests: [
         {
@@ -200,6 +207,7 @@ test('with 1 level and same request, non namespaced', () => {
   factoryHandler.add(
     new ResourceFactoryBase({
       resource: 'resource1',
+    }).setPermissions({
       isNamespaced: false,
       permissionsRequests: [
         {
@@ -214,6 +222,7 @@ test('with 1 level and same request, non namespaced', () => {
   factoryHandler.add(
     new ResourceFactoryBase({
       resource: 'resource2',
+    }).setPermissions({
       isNamespaced: false,
       permissionsRequests: [
         {
@@ -244,6 +253,7 @@ test('with 1 level and different requests, non namespaced', () => {
   factoryHandler.add(
     new ResourceFactoryBase({
       resource: 'resource1',
+    }).setPermissions({
       isNamespaced: false,
       permissionsRequests: [
         {
@@ -258,6 +268,7 @@ test('with 1 level and different requests, non namespaced', () => {
   factoryHandler.add(
     new ResourceFactoryBase({
       resource: 'resource2',
+    }).setPermissions({
       isNamespaced: false,
       permissionsRequests: [
         {
@@ -296,6 +307,7 @@ test('with 2 levels and same request at first level, non namespaced', () => {
   factoryHandler.add(
     new ResourceFactoryBase({
       resource: 'resource1',
+    }).setPermissions({
       isNamespaced: false,
       permissionsRequests: [
         {
@@ -314,6 +326,7 @@ test('with 2 levels and same request at first level, non namespaced', () => {
   factoryHandler.add(
     new ResourceFactoryBase({
       resource: 'resource2',
+    }).setPermissions({
       isNamespaced: false,
       permissionsRequests: [
         {
@@ -366,6 +379,7 @@ test('with 1 level and same request, both namespaced ant not namespaced', () => 
   factoryHandler.add(
     new ResourceFactoryBase({
       resource: 'resource1',
+    }).setPermissions({
       isNamespaced: true,
       permissionsRequests: [
         {
@@ -380,6 +394,7 @@ test('with 1 level and same request, both namespaced ant not namespaced', () => 
   factoryHandler.add(
     new ResourceFactoryBase({
       resource: 'resource2',
+    }).setPermissions({
       isNamespaced: false,
       permissionsRequests: [
         {

--- a/packages/main/src/plugin/kubernetes/resource-factory-handler.spec.ts
+++ b/packages/main/src/plugin/kubernetes/resource-factory-handler.spec.ts
@@ -20,12 +20,12 @@ import { expect, test } from 'vitest';
 
 import { DeploymentsResourceFactory } from './deployments-resource-factory.js';
 import { PodsResourceFactory } from './pods-resource-factory.js';
-import { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryHandler } from './resource-factory-handler.js';
 
 test('with 1 level and same request', () => {
-  const factory = new ResourceFactory();
+  const factoryHandler = new ResourceFactoryHandler();
 
-  factory.add({
+  factoryHandler.add({
     resource: 'resource1',
     isNamespaced: true,
     permissionsRequests: [
@@ -37,7 +37,7 @@ test('with 1 level and same request', () => {
     ],
   });
 
-  factory.add({
+  factoryHandler.add({
     resource: 'resource2',
     isNamespaced: true,
     permissionsRequests: [
@@ -49,7 +49,7 @@ test('with 1 level and same request', () => {
     ],
   });
 
-  const requests = factory.getPermissionsRequests('ns');
+  const requests = factoryHandler.getPermissionsRequests('ns');
   expect(requests).toEqual([
     {
       attrs: {
@@ -64,9 +64,9 @@ test('with 1 level and same request', () => {
 });
 
 test('with 1 level and different requests', () => {
-  const factory = new ResourceFactory();
+  const factoryHandler = new ResourceFactoryHandler();
 
-  factory.add({
+  factoryHandler.add({
     resource: 'resource1',
     isNamespaced: true,
     permissionsRequests: [
@@ -78,7 +78,7 @@ test('with 1 level and different requests', () => {
     ],
   });
 
-  factory.add({
+  factoryHandler.add({
     resource: 'resource2',
     isNamespaced: true,
     permissionsRequests: [
@@ -90,7 +90,7 @@ test('with 1 level and different requests', () => {
     ],
   });
 
-  const requests = factory.getPermissionsRequests('ns');
+  const requests = factoryHandler.getPermissionsRequests('ns');
   expect(requests).toEqual([
     {
       attrs: {
@@ -114,9 +114,9 @@ test('with 1 level and different requests', () => {
 });
 
 test('with 2 levels and same request at first level', () => {
-  const factory = new ResourceFactory();
+  const factoryHandler = new ResourceFactoryHandler();
 
-  factory.add({
+  factoryHandler.add({
     resource: 'resource1',
     isNamespaced: true,
     permissionsRequests: [
@@ -132,7 +132,7 @@ test('with 2 levels and same request at first level', () => {
     ],
   });
 
-  factory.add({
+  factoryHandler.add({
     resource: 'resource2',
     isNamespaced: true,
     permissionsRequests: [
@@ -149,7 +149,7 @@ test('with 2 levels and same request at first level', () => {
     ],
   });
 
-  const requests = factory.getPermissionsRequests('ns');
+  const requests = factoryHandler.getPermissionsRequests('ns');
   expect(requests).toEqual([
     {
       attrs: {
@@ -183,9 +183,9 @@ test('with 2 levels and same request at first level', () => {
 });
 
 test('with 1 level and same request, non namespaced', () => {
-  const factory = new ResourceFactory();
+  const factoryHandler = new ResourceFactoryHandler();
 
-  factory.add({
+  factoryHandler.add({
     resource: 'resource1',
     isNamespaced: false,
     permissionsRequests: [
@@ -197,7 +197,7 @@ test('with 1 level and same request, non namespaced', () => {
     ],
   });
 
-  factory.add({
+  factoryHandler.add({
     resource: 'resource2',
     isNamespaced: false,
     permissionsRequests: [
@@ -209,7 +209,7 @@ test('with 1 level and same request, non namespaced', () => {
     ],
   });
 
-  const requests = factory.getPermissionsRequests('ns');
+  const requests = factoryHandler.getPermissionsRequests('ns');
   expect(requests).toEqual([
     {
       attrs: {
@@ -223,9 +223,9 @@ test('with 1 level and same request, non namespaced', () => {
 });
 
 test('with 1 level and different requests, non namespaced', () => {
-  const factory = new ResourceFactory();
+  const factoryHandler = new ResourceFactoryHandler();
 
-  factory.add({
+  factoryHandler.add({
     resource: 'resource1',
     isNamespaced: false,
     permissionsRequests: [
@@ -237,7 +237,7 @@ test('with 1 level and different requests, non namespaced', () => {
     ],
   });
 
-  factory.add({
+  factoryHandler.add({
     resource: 'resource2',
     isNamespaced: false,
     permissionsRequests: [
@@ -249,7 +249,7 @@ test('with 1 level and different requests, non namespaced', () => {
     ],
   });
 
-  const requests = factory.getPermissionsRequests('ns');
+  const requests = factoryHandler.getPermissionsRequests('ns');
   expect(requests).toEqual([
     {
       attrs: {
@@ -271,9 +271,9 @@ test('with 1 level and different requests, non namespaced', () => {
 });
 
 test('with 2 levels and same request at first level, non namespaced', () => {
-  const factory = new ResourceFactory();
+  const factoryHandler = new ResourceFactoryHandler();
 
-  factory.add({
+  factoryHandler.add({
     resource: 'resource1',
     isNamespaced: false,
     permissionsRequests: [
@@ -289,7 +289,7 @@ test('with 2 levels and same request at first level, non namespaced', () => {
     ],
   });
 
-  factory.add({
+  factoryHandler.add({
     resource: 'resource2',
     isNamespaced: false,
     permissionsRequests: [
@@ -306,7 +306,7 @@ test('with 2 levels and same request at first level, non namespaced', () => {
     ],
   });
 
-  const requests = factory.getPermissionsRequests('ns');
+  const requests = factoryHandler.getPermissionsRequests('ns');
   expect(requests).toEqual([
     {
       attrs: {
@@ -337,9 +337,9 @@ test('with 2 levels and same request at first level, non namespaced', () => {
 });
 
 test('with 1 level and same request, both namespaced ant not namespaced', () => {
-  const factory = new ResourceFactory();
+  const factoryHandler = new ResourceFactoryHandler();
 
-  factory.add({
+  factoryHandler.add({
     resource: 'resource1',
     isNamespaced: true,
     permissionsRequests: [
@@ -351,7 +351,7 @@ test('with 1 level and same request, both namespaced ant not namespaced', () => 
     ],
   });
 
-  factory.add({
+  factoryHandler.add({
     resource: 'resource2',
     isNamespaced: false,
     permissionsRequests: [
@@ -363,7 +363,7 @@ test('with 1 level and same request, both namespaced ant not namespaced', () => 
     ],
   });
 
-  const requests = factory.getPermissionsRequests('ns');
+  const requests = factoryHandler.getPermissionsRequests('ns');
   expect(requests).toEqual([
     {
       attrs: {
@@ -386,11 +386,11 @@ test('with 1 level and same request, both namespaced ant not namespaced', () => 
 });
 
 test('real pods and deployments', () => {
-  const factory = new ResourceFactory();
+  const factoryHandler = new ResourceFactoryHandler();
 
-  factory.add(new PodsResourceFactory());
-  factory.add(new DeploymentsResourceFactory());
-  const requests = factory.getPermissionsRequests('ns');
+  factoryHandler.add(new PodsResourceFactory());
+  factoryHandler.add(new DeploymentsResourceFactory());
+  const requests = factoryHandler.getPermissionsRequests('ns');
   expect(requests).toEqual([
     {
       attrs: {

--- a/packages/main/src/plugin/kubernetes/resource-factory-handler.ts
+++ b/packages/main/src/plugin/kubernetes/resource-factory-handler.ts
@@ -34,8 +34,8 @@ export class ResourceFactoryHandler {
 
   getPermissionsRequests(namespace: string): ContextPermissionsRequest[] {
     return [
-      ...this.getNamespacedOrNotPermissionsRequests(this.#resourceFactories, true, namespace),
-      ...this.getNamespacedOrNotPermissionsRequests(this.#resourceFactories, false),
+      ...this.getNamespacedOrNotPermissionsRequests(this.#resourceFactories, namespace),
+      ...this.getNamespacedOrNotPermissionsRequests(this.#resourceFactories),
     ];
   }
 
@@ -45,15 +45,9 @@ export class ResourceFactoryHandler {
 
   private getNamespacedOrNotPermissionsRequests(
     factories: ResourceFactory[],
-    isNamespaced: boolean,
     namespace?: string,
   ): ContextPermissionsRequest[] {
-    if (!isNamespaced && !!namespace) {
-      throw new Error('request for non-namespaced must not define a namespace');
-    }
-    if (isNamespaced && !namespace) {
-      throw new Error('request for namespaced must define a namespace');
-    }
+    const isNamespaced = !!namespace;
     const filteredResourceFactories = factories
       .filter(isResourceFactoryWithPermissions)
       .filter(f => f.permissions.isNamespaced === isNamespaced);
@@ -89,11 +83,11 @@ export class ResourceFactoryHandler {
         remainings.push(filteredResourceFactory);
       }
     }
-    const childrenRequests = this.getNamespacedOrNotPermissionsRequests(children, isNamespaced, namespace);
+    const childrenRequests = this.getNamespacedOrNotPermissionsRequests(children, namespace);
     if (childrenRequests.length) {
       newRequest.onDenyRequests = childrenRequests;
     }
 
-    return [newRequest, ...this.getNamespacedOrNotPermissionsRequests(remainings, isNamespaced, namespace)];
+    return [newRequest, ...this.getNamespacedOrNotPermissionsRequests(remainings, namespace)];
   }
 }

--- a/packages/main/src/plugin/kubernetes/resource-factory.spec.ts
+++ b/packages/main/src/plugin/kubernetes/resource-factory.spec.ts
@@ -1,0 +1,90 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { V1Pod } from '@kubernetes/client-node';
+import { expect, test } from 'vitest';
+
+import type { KubeConfigSingleContext } from './kubeconfig-single-context.js';
+import { isResourceFactoryWithPermissions, ResourceFactoryBase } from './resource-factory.js';
+import type { ResourceInformer } from './resource-informer.js';
+
+test('ResourceFactoryBase set permissions', () => {
+  const factory = new ResourceFactoryBase({ resource: 'resource1' });
+
+  const permissionsRequests = [
+    {
+      group: '*',
+      resource: '*',
+      verb: 'watch',
+    },
+    {
+      verb: 'watch',
+      resource: 'resource1',
+    },
+  ];
+  factory.setPermissions({
+    isNamespaced: true,
+    permissionsRequests,
+  });
+  expect(factory.permissions?.isNamespaced).toBeTruthy();
+  expect(factory.permissions?.permissionsRequests).toEqual(permissionsRequests);
+  expect(factory.informer).toBeUndefined();
+
+  expect(isResourceFactoryWithPermissions(factory)).toBeTruthy();
+});
+
+test('copyWithSlicedPermissions', () => {
+  const factory = new ResourceFactoryBase({ resource: 'resource1' });
+
+  const permissionsRequests = [
+    {
+      group: '*',
+      resource: '*',
+      verb: 'watch',
+    },
+    {
+      verb: 'watch',
+      resource: 'resource1',
+    },
+  ];
+  factory.setPermissions({
+    isNamespaced: true,
+    permissionsRequests,
+  });
+
+  const copy = factory.copyWithSlicedPermissions();
+  expect(copy.permissions?.isNamespaced).toBeTruthy();
+  expect(copy.permissions?.permissionsRequests).toEqual([
+    {
+      verb: 'watch',
+      resource: 'resource1',
+    },
+  ]);
+});
+
+test('ResourceFactoryBase set informer', () => {
+  const factory = new ResourceFactoryBase({ resource: 'resource1' });
+  const createInformer = (_kubeconfig: KubeConfigSingleContext): ResourceInformer<V1Pod> => {
+    return {} as ResourceInformer<V1Pod>;
+  };
+  factory.setInformer({
+    createInformer,
+  });
+
+  expect(factory.informer?.createInformer).toEqual(createInformer);
+  expect(isResourceFactoryWithPermissions(factory)).toBeFalsy();
+});

--- a/packages/main/src/plugin/kubernetes/resource-factory.spec.ts
+++ b/packages/main/src/plugin/kubernetes/resource-factory.spec.ts
@@ -1,0 +1,424 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test } from 'vitest';
+
+import { DeploymentsResourceFactory } from './deployments-resource-factory.js';
+import { PodsResourceFactory } from './pods-resource-factory.js';
+import { ResourceFactory } from './resource-factory.js';
+
+test('with 1 level and same request', () => {
+  const factory = new ResourceFactory();
+
+  factory.add({
+    resource: 'resource1',
+    isNamespaced: true,
+    permissionsRequests: [
+      {
+        group: '*',
+        resource: '*',
+        verb: 'watch',
+      },
+    ],
+  });
+
+  factory.add({
+    resource: 'resource2',
+    isNamespaced: true,
+    permissionsRequests: [
+      {
+        group: '*',
+        resource: '*',
+        verb: 'watch',
+      },
+    ],
+  });
+
+  const requests = factory.getPermissionsRequests('ns');
+  expect(requests).toEqual([
+    {
+      attrs: {
+        namespace: 'ns',
+        group: '*',
+        resource: '*',
+        verb: 'watch',
+      },
+      resources: ['resource1', 'resource2'],
+    },
+  ]);
+});
+
+test('with 1 level and different requests', () => {
+  const factory = new ResourceFactory();
+
+  factory.add({
+    resource: 'resource1',
+    isNamespaced: true,
+    permissionsRequests: [
+      {
+        group: 'group1',
+        resource: '*',
+        verb: 'watch',
+      },
+    ],
+  });
+
+  factory.add({
+    resource: 'resource2',
+    isNamespaced: true,
+    permissionsRequests: [
+      {
+        group: 'group2',
+        resource: '*',
+        verb: 'watch',
+      },
+    ],
+  });
+
+  const requests = factory.getPermissionsRequests('ns');
+  expect(requests).toEqual([
+    {
+      attrs: {
+        namespace: 'ns',
+        group: 'group1',
+        resource: '*',
+        verb: 'watch',
+      },
+      resources: ['resource1'],
+    },
+    {
+      attrs: {
+        namespace: 'ns',
+        group: 'group2',
+        resource: '*',
+        verb: 'watch',
+      },
+      resources: ['resource2'],
+    },
+  ]);
+});
+
+test('with 2 levels and same request at first level', () => {
+  const factory = new ResourceFactory();
+
+  factory.add({
+    resource: 'resource1',
+    isNamespaced: true,
+    permissionsRequests: [
+      {
+        group: '*',
+        resource: '*',
+        verb: 'watch',
+      },
+      {
+        verb: 'watch',
+        resource: 'resource1',
+      },
+    ],
+  });
+
+  factory.add({
+    resource: 'resource2',
+    isNamespaced: true,
+    permissionsRequests: [
+      {
+        group: '*',
+        resource: '*',
+        verb: 'watch',
+      },
+      {
+        verb: 'watch',
+        group: 'group2',
+        resource: 'resource2',
+      },
+    ],
+  });
+
+  const requests = factory.getPermissionsRequests('ns');
+  expect(requests).toEqual([
+    {
+      attrs: {
+        namespace: 'ns',
+        group: '*',
+        resource: '*',
+        verb: 'watch',
+      },
+      resources: ['resource1', 'resource2'],
+      onDenyRequests: [
+        {
+          attrs: {
+            namespace: 'ns',
+            verb: 'watch',
+            resource: 'resource1',
+          },
+          resources: ['resource1'],
+        },
+        {
+          attrs: {
+            namespace: 'ns',
+            verb: 'watch',
+            group: 'group2',
+            resource: 'resource2',
+          },
+          resources: ['resource2'],
+        },
+      ],
+    },
+  ]);
+});
+
+test('with 1 level and same request, non namespaced', () => {
+  const factory = new ResourceFactory();
+
+  factory.add({
+    resource: 'resource1',
+    isNamespaced: false,
+    permissionsRequests: [
+      {
+        group: '*',
+        resource: '*',
+        verb: 'watch',
+      },
+    ],
+  });
+
+  factory.add({
+    resource: 'resource2',
+    isNamespaced: false,
+    permissionsRequests: [
+      {
+        group: '*',
+        resource: '*',
+        verb: 'watch',
+      },
+    ],
+  });
+
+  const requests = factory.getPermissionsRequests('ns');
+  expect(requests).toEqual([
+    {
+      attrs: {
+        group: '*',
+        resource: '*',
+        verb: 'watch',
+      },
+      resources: ['resource1', 'resource2'],
+    },
+  ]);
+});
+
+test('with 1 level and different requests, non namespaced', () => {
+  const factory = new ResourceFactory();
+
+  factory.add({
+    resource: 'resource1',
+    isNamespaced: false,
+    permissionsRequests: [
+      {
+        group: 'group1',
+        resource: '*',
+        verb: 'watch',
+      },
+    ],
+  });
+
+  factory.add({
+    resource: 'resource2',
+    isNamespaced: false,
+    permissionsRequests: [
+      {
+        group: 'group2',
+        resource: '*',
+        verb: 'watch',
+      },
+    ],
+  });
+
+  const requests = factory.getPermissionsRequests('ns');
+  expect(requests).toEqual([
+    {
+      attrs: {
+        group: 'group1',
+        resource: '*',
+        verb: 'watch',
+      },
+      resources: ['resource1'],
+    },
+    {
+      attrs: {
+        group: 'group2',
+        resource: '*',
+        verb: 'watch',
+      },
+      resources: ['resource2'],
+    },
+  ]);
+});
+
+test('with 2 levels and same request at first level, non namespaced', () => {
+  const factory = new ResourceFactory();
+
+  factory.add({
+    resource: 'resource1',
+    isNamespaced: false,
+    permissionsRequests: [
+      {
+        group: '*',
+        resource: '*',
+        verb: 'watch',
+      },
+      {
+        verb: 'watch',
+        resource: 'resource1',
+      },
+    ],
+  });
+
+  factory.add({
+    resource: 'resource2',
+    isNamespaced: false,
+    permissionsRequests: [
+      {
+        group: '*',
+        resource: '*',
+        verb: 'watch',
+      },
+      {
+        verb: 'watch',
+        group: 'group2',
+        resource: 'resource2',
+      },
+    ],
+  });
+
+  const requests = factory.getPermissionsRequests('ns');
+  expect(requests).toEqual([
+    {
+      attrs: {
+        group: '*',
+        resource: '*',
+        verb: 'watch',
+      },
+      resources: ['resource1', 'resource2'],
+      onDenyRequests: [
+        {
+          attrs: {
+            verb: 'watch',
+            resource: 'resource1',
+          },
+          resources: ['resource1'],
+        },
+        {
+          attrs: {
+            verb: 'watch',
+            group: 'group2',
+            resource: 'resource2',
+          },
+          resources: ['resource2'],
+        },
+      ],
+    },
+  ]);
+});
+
+test('with 1 level and same request, both namespaced ant not namespaced', () => {
+  const factory = new ResourceFactory();
+
+  factory.add({
+    resource: 'resource1',
+    isNamespaced: true,
+    permissionsRequests: [
+      {
+        group: '*',
+        resource: '*',
+        verb: 'watch',
+      },
+    ],
+  });
+
+  factory.add({
+    resource: 'resource2',
+    isNamespaced: false,
+    permissionsRequests: [
+      {
+        group: '*',
+        resource: '*',
+        verb: 'watch',
+      },
+    ],
+  });
+
+  const requests = factory.getPermissionsRequests('ns');
+  expect(requests).toEqual([
+    {
+      attrs: {
+        namespace: 'ns',
+        group: '*',
+        resource: '*',
+        verb: 'watch',
+      },
+      resources: ['resource1'],
+    },
+    {
+      attrs: {
+        group: '*',
+        resource: '*',
+        verb: 'watch',
+      },
+      resources: ['resource2'],
+    },
+  ]);
+});
+
+test('real pods and deployments', () => {
+  const factory = new ResourceFactory();
+
+  factory.add(new PodsResourceFactory());
+  factory.add(new DeploymentsResourceFactory());
+  const requests = factory.getPermissionsRequests('ns');
+  expect(requests).toEqual([
+    {
+      attrs: {
+        namespace: 'ns',
+        group: '*',
+        resource: '*',
+        verb: 'watch',
+      },
+      resources: ['pods', 'deployments'],
+      onDenyRequests: [
+        {
+          attrs: {
+            namespace: 'ns',
+            verb: 'watch',
+            resource: 'pods',
+          },
+          resources: ['pods'],
+        },
+        {
+          attrs: {
+            namespace: 'ns',
+            verb: 'watch',
+            group: 'apps',
+            resource: 'deployments',
+          },
+          resources: ['deployments'],
+        },
+      ],
+    },
+  ]);
+});

--- a/packages/main/src/plugin/kubernetes/resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/resource-factory.ts
@@ -1,0 +1,101 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { KubernetesObject, V1ResourceAttributes } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from './kubeconfig-single-context.js';
+import type { ResourceInformer } from './resource-informer.js';
+
+export interface ResourcePermissionsFactory {
+  get permissionsRequests(): V1ResourceAttributes[];
+  get isNamespaced(): boolean;
+}
+
+export interface ResourceInformerFactory {
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<KubernetesObject>;
+}
+
+export class ResourceFactoryBase {
+  #resource: string;
+  #permissions: ResourcePermissionsFactory | undefined;
+  #informer: ResourceInformerFactory | undefined;
+
+  constructor(options: {
+    resource: string;
+  }) {
+    this.#resource = options.resource;
+  }
+
+  setPermissions(options: {
+    permissionsRequests: V1ResourceAttributes[];
+    isNamespaced: boolean;
+  }): ResourceFactoryBase {
+    this.#permissions = {
+      permissionsRequests: options.permissionsRequests,
+      isNamespaced: options.isNamespaced,
+    };
+    return this;
+  }
+
+  setInformer(options: {
+    createInformer: (kubeconfig: KubeConfigSingleContext) => ResourceInformer<KubernetesObject>;
+  }): ResourceFactoryBase {
+    this.#informer = {
+      createInformer: options.createInformer,
+    };
+    return this;
+  }
+
+  get resource(): string {
+    return this.#resource;
+  }
+
+  get permissions(): ResourcePermissionsFactory | undefined {
+    return this.#permissions;
+  }
+
+  get informer(): ResourceInformerFactory | undefined {
+    return this.#informer;
+  }
+
+  copyWithSlicedPermissions(): ResourceFactory {
+    if (!this.#permissions) {
+      throw new Error('permission must be defined before calling copyWithSlicedPermissions');
+    }
+    return new ResourceFactoryBase({
+      resource: this.#resource,
+    }).setPermissions({
+      permissionsRequests: this.#permissions.permissionsRequests.slice(1),
+      isNamespaced: this.#permissions.isNamespaced,
+    });
+  }
+}
+
+export interface ResourceFactory {
+  get resource(): string;
+  permissions?: ResourcePermissionsFactory;
+  informer?: ResourceInformerFactory;
+  copyWithSlicedPermissions(): ResourceFactory;
+}
+
+export function isResourceFactoryWithPermissions(object: ResourceFactory): object is ResourceFactoryWithPermissions {
+  return !!object.permissions;
+}
+
+interface ResourceFactoryWithPermissions extends ResourceFactory {
+  permissions: ResourcePermissionsFactory;
+}

--- a/packages/main/src/plugin/kubernetes/resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/resource-factory.ts
@@ -1,0 +1,112 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import util from 'node:util';
+
+import type { KubernetesObject, V1ResourceAttributes } from '@kubernetes/client-node';
+
+import type { ContextPermissionsRequest } from './context-permissions-checker.js';
+import type { KubeConfigSingleContext } from './kubeconfig-single-context.js';
+import type { ResourceInformer } from './resource-informer.js';
+
+export interface ResourceFactoryObject {
+  get resource(): string;
+  get permissionsRequests(): V1ResourceAttributes[];
+  get isNamespaced(): boolean;
+  getInformer?(kubeconfig: KubeConfigSingleContext): ResourceInformer<KubernetesObject>;
+}
+
+export class ResourceFactory {
+  #resourceFactories: ResourceFactoryObject[] = [];
+
+  add(factory: ResourceFactoryObject): void {
+    if (this.getResourceFactoryByResourceName(factory.resource)) {
+      throw new Error(`a factory for resource ${factory.resource} has already been added`);
+    }
+    this.#resourceFactories.push(factory);
+  }
+
+  getPermissionsRequests(namespace: string): ContextPermissionsRequest[] {
+    return [
+      ...this.getNamespacedOrNotPermissionsRequests(this.#resourceFactories, true, namespace),
+      ...this.getNamespacedOrNotPermissionsRequests(this.#resourceFactories, false),
+    ];
+  }
+
+  getResourceFactoryByResourceName(resource: string): ResourceFactoryObject | undefined {
+    return this.#resourceFactories.find(f => f.resource === resource);
+  }
+
+  private getNamespacedOrNotPermissionsRequests(
+    factories: ResourceFactoryObject[],
+    isNamespaced: boolean,
+    namespace?: string,
+  ): ContextPermissionsRequest[] {
+    if (!isNamespaced && !!namespace) {
+      throw new Error('request for non-namespaced must not define a namespace');
+    }
+    if (isNamespaced && !namespace) {
+      throw new Error('request for namespaced must define a namespace');
+    }
+    const filteredResourceFactories = factories.filter(f => f.isNamespaced === isNamespaced);
+    if (!filteredResourceFactories[0]) {
+      return [];
+    }
+    const firstFilteredResourceFactory = filteredResourceFactories[0];
+    if (!firstFilteredResourceFactory.permissionsRequests[0]) {
+      return [];
+    }
+    const children: ResourceFactoryObject[] = [];
+    const newRequest: ContextPermissionsRequest = {
+      attrs: {
+        namespace: isNamespaced ? namespace : undefined,
+        ...firstFilteredResourceFactory.permissionsRequests[0],
+      },
+      resources: [firstFilteredResourceFactory.resource],
+    };
+    const clone = {
+      ...structuredClone(firstFilteredResourceFactory),
+      permissionsRequests: firstFilteredResourceFactory.permissionsRequests.slice(1),
+    };
+    children.push(clone);
+    const remainings: ResourceFactoryObject[] = [];
+    for (const filteredResourceFactory of filteredResourceFactories.slice(1)) {
+      if (
+        util.isDeepStrictEqual(
+          filteredResourceFactory.permissionsRequests[0],
+          firstFilteredResourceFactory.permissionsRequests[0],
+        )
+      ) {
+        newRequest.resources.push(filteredResourceFactory.resource);
+        const clone = {
+          ...structuredClone(filteredResourceFactory),
+          permissionsRequests: filteredResourceFactory.permissionsRequests.slice(1),
+        };
+        children.push(clone);
+      } else {
+        remainings.push(filteredResourceFactory);
+      }
+    }
+    const childrenRequests = this.getNamespacedOrNotPermissionsRequests(children, isNamespaced, namespace);
+    if (childrenRequests.length) {
+      newRequest.onDenyRequests = childrenRequests;
+    }
+
+    return [newRequest, ...this.getNamespacedOrNotPermissionsRequests(remainings, isNamespaced, namespace)];
+  }
+}

--- a/packages/main/src/plugin/kubernetes/resource-informer.spec.ts
+++ b/packages/main/src/plugin/kubernetes/resource-informer.spec.ts
@@ -1,0 +1,215 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type {
+  Cluster,
+  Context,
+  KubernetesObject,
+  ListPromise,
+  ListWatch,
+  User,
+  V1ObjectMeta,
+} from '@kubernetes/client-node';
+import { ERROR, KubeConfig } from '@kubernetes/client-node';
+import { expect, test, vi } from 'vitest';
+
+import { KubeConfigSingleContext } from './kubeconfig-single-context.js';
+import { ResourceInformer } from './resource-informer.js';
+
+interface MyResource {
+  apiVersion?: string;
+  kind?: string;
+  metadata?: V1ObjectMeta;
+}
+
+class TestResourceInformer<T extends KubernetesObject> extends ResourceInformer<T> {
+  override getListWatch(path: string, listFn: ListPromise<T>): ListWatch<T> {
+    return super.getListWatch(path, listFn);
+  }
+}
+
+const contexts = [
+  {
+    name: 'context1',
+    cluster: 'cluster1',
+    user: 'user1',
+    namespace: 'ns1',
+  },
+  {
+    name: 'context2',
+    cluster: 'cluster2',
+    user: 'user2',
+  },
+] as Context[];
+
+const clusters = [
+  {
+    name: 'cluster1',
+  },
+  {
+    name: 'cluster2',
+  },
+] as Cluster[];
+
+const users = [
+  {
+    name: 'user1',
+  },
+  {
+    name: 'user2',
+  },
+] as User[];
+
+const kcWith2contexts = {
+  contexts,
+  clusters,
+  users,
+} as unknown as KubeConfig;
+
+test('ResourceInformer should eventually return the list of resources', async () => {
+  const kc = new KubeConfig();
+  kc.loadFromOptions(kcWith2contexts);
+  const listFn = vi.fn();
+  const kubeconfig = new KubeConfigSingleContext(kc, contexts[0]!);
+  const items = [{ metadata: { name: 'res1', namespace: 'ns1' } }, { metadata: { name: 'res2', namespace: 'ns1' } }];
+  listFn.mockResolvedValue({ items: items });
+  const informer = new ResourceInformer<MyResource>(kubeconfig, '/a/path', listFn, 'myresource');
+  const result = informer.start();
+  await vi.waitFor(() => {
+    const list = result.list();
+    expect(list).toEqual(items);
+  });
+});
+
+test('ResourceInformer should fire onCacheUpdated event', async () => {
+  const kc = new KubeConfig();
+  kc.loadFromOptions(kcWith2contexts);
+  const listFn = vi.fn();
+  const kubeconfig = new KubeConfigSingleContext(kc, contexts[0]!);
+  const items = [{ metadata: { name: 'res1', namespace: 'ns1' } }, { metadata: { name: 'res2', namespace: 'ns1' } }];
+  listFn.mockResolvedValue({ items: items });
+  const informer = new ResourceInformer<MyResource>(kubeconfig, '/a/path', listFn, 'myresource');
+  const onCacheUpdatedCB = vi.fn();
+  informer.onCacheUpdated(onCacheUpdatedCB);
+  informer.start();
+  await vi.waitFor(() => {
+    expect(onCacheUpdatedCB).toHaveBeenCalledWith({ kubeconfig, resourceName: 'myresource' });
+  });
+});
+
+test('ResourceInformer should fire onOffline event is informer fails', async () => {
+  const kc = new KubeConfig();
+  kc.loadFromOptions(kcWith2contexts);
+  const listFn = vi.fn();
+  const kubeconfig = new KubeConfigSingleContext(kc, contexts[0]!);
+  const informer = new TestResourceInformer<MyResource>(kubeconfig, '/a/path', listFn, 'myresource');
+  const onCB = vi.fn();
+  vi.spyOn(informer, 'getListWatch').mockReturnValue({
+    on: onCB,
+    start: vi.fn().mockResolvedValue({}),
+  } as unknown as ListWatch<MyResource>);
+  const onOfflineCB = vi.fn();
+  onCB.mockImplementation((e: string, f) => {
+    if (e === ERROR) {
+      f('an error');
+    }
+  });
+  informer.onOffline(onOfflineCB);
+  informer.start();
+  expect(onOfflineCB).toHaveBeenCalledWith({
+    kubeconfig,
+    offline: true,
+    reason: 'an error',
+    resourceName: 'myresource',
+  });
+});
+
+test('reconnect should do nothing if there is no error', async () => {
+  const kc = new KubeConfig();
+  kc.loadFromOptions(kcWith2contexts);
+  const listFn = vi.fn();
+  const kubeconfig = new KubeConfigSingleContext(kc, contexts[0]!);
+  const informer = new TestResourceInformer<MyResource>(kubeconfig, '/a/path', listFn, 'myresource');
+  const onCB = vi.fn();
+  const startMock = vi.fn().mockResolvedValue({});
+  vi.spyOn(informer, 'getListWatch').mockReturnValue({
+    on: onCB,
+    start: startMock,
+  } as unknown as ListWatch<MyResource>);
+  const onOfflineCB = vi.fn();
+  onCB.mockImplementation((e: string, _f) => {
+    if (e === ERROR) {
+      // do nothing
+    }
+  });
+  informer.onOffline(onOfflineCB);
+  informer.start();
+  expect(startMock).toHaveBeenCalledOnce();
+  startMock.mockClear();
+  informer.reconnect();
+  expect(startMock).not.toHaveBeenCalled();
+});
+
+test('reconnect should call start again if there is an error', async () => {
+  const kc = new KubeConfig();
+  kc.loadFromOptions(kcWith2contexts);
+  const listFn = vi.fn();
+  const kubeconfig = new KubeConfigSingleContext(kc, contexts[0]!);
+  const informer = new TestResourceInformer<MyResource>(kubeconfig, '/a/path', listFn, 'myresource');
+  const onCB = vi.fn();
+  const startMock = vi.fn().mockResolvedValue({});
+  vi.spyOn(informer, 'getListWatch').mockReturnValue({
+    on: onCB,
+    start: startMock,
+  } as unknown as ListWatch<MyResource>);
+  const onOfflineCB = vi.fn();
+  onCB.mockImplementation((e: string, f) => {
+    if (e === ERROR) {
+      f('an error');
+    }
+  });
+  informer.onOffline(onOfflineCB);
+  informer.start();
+  expect(startMock).toHaveBeenCalledOnce();
+  startMock.mockClear();
+  informer.reconnect();
+  expect(startMock).toHaveBeenCalled();
+});
+
+test('informer is stopped when disposed', async () => {
+  const kc = new KubeConfig();
+  kc.loadFromOptions(kcWith2contexts);
+  const listFn = vi.fn();
+  const kubeconfig = new KubeConfigSingleContext(kc, contexts[0]!);
+  const informer = new TestResourceInformer<MyResource>(kubeconfig, '/a/path', listFn, 'myresource');
+  const onCB = vi.fn();
+  const startMock = vi.fn().mockResolvedValue({});
+  const stopMock = vi.fn().mockResolvedValue({});
+  vi.spyOn(informer, 'getListWatch').mockReturnValue({
+    on: onCB,
+    start: startMock,
+    stop: stopMock,
+  } as unknown as ListWatch<MyResource>);
+  const onOfflineCB = vi.fn();
+  informer.onOffline(onOfflineCB);
+  informer.start();
+  expect(startMock).toHaveBeenCalledOnce();
+  startMock.mockClear();
+  informer.dispose();
+  expect(stopMock).toHaveBeenCalled();
+});

--- a/packages/main/src/plugin/kubernetes/resource-informer.ts
+++ b/packages/main/src/plugin/kubernetes/resource-informer.ts
@@ -110,7 +110,7 @@ export class ResourceInformer<T extends KubernetesObject> implements Disposable 
     }
   }
 
-  private getListWatch(path: string, listFn: ListPromise<T>): ListWatch<T> {
+  protected getListWatch(path: string, listFn: ListPromise<T>): ListWatch<T> {
     const watch = new Watch(this.#kubeConfig.getKubeConfig());
     return new ListWatch<T>(path, watch, listFn, false);
   }

--- a/packages/main/src/plugin/kubernetes/resource-informer.ts
+++ b/packages/main/src/plugin/kubernetes/resource-informer.ts
@@ -1,0 +1,152 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type {
+  Informer,
+  KubernetesObject,
+  ListPromise,
+  ObjectCache,
+  V1Deployment,
+  V1DeploymentList,
+  V1Pod,
+  V1PodList,
+} from '@kubernetes/client-node';
+import { AppsV1Api, CHANGE, CoreV1Api, ERROR, ListWatch, Watch } from '@kubernetes/client-node';
+import type { Disposable } from '@podman-desktop/api';
+
+import type { Event } from '../events/emitter.js';
+import { Emitter } from '../events/emitter.js';
+import type { KubeConfigSingleContext } from './kubeconfig-single-context.js';
+
+interface BaseEvent {
+  kubeconfig: KubeConfigSingleContext;
+  resourceName: string;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface CacheUpdatedEvent extends BaseEvent {}
+
+export interface OfflineEvent extends BaseEvent {
+  offline: boolean;
+  reason?: string;
+}
+
+export class ResourceInformer<T extends KubernetesObject> implements Disposable {
+  #kubeConfig: KubeConfigSingleContext;
+  #path: string;
+  #listFn: ListPromise<T>;
+  #resourceName: string;
+  #informer: Informer<T> | undefined;
+  #offline: boolean = false;
+
+  #onCacheUpdated = new Emitter<CacheUpdatedEvent>();
+  onCacheUpdated: Event<CacheUpdatedEvent> = this.#onCacheUpdated.event;
+
+  #onOffline = new Emitter<OfflineEvent>();
+  onOffline: Event<OfflineEvent> = this.#onOffline.event;
+
+  constructor(kubeconfig: KubeConfigSingleContext, path: string, listFn: ListPromise<T>, resourceName: string) {
+    this.#kubeConfig = kubeconfig;
+    this.#path = path;
+    this.#listFn = listFn;
+    this.#resourceName = resourceName;
+  }
+
+  // start the informer and returns a cache to the data
+  // The cache will be active all the time, even if an error happens
+  // and the informer becomes offline
+  start(): ObjectCache<T> {
+    // internalInformer extends both Informer and ObjectCache
+    const internalInformer = this.getListWatch(this.#path, this.#listFn);
+    this.#informer = internalInformer;
+
+    // We may replace the unique CHANGE handler
+    // by the ADD/UPDATE/DELETE handlers to get more fine-grained information on changes
+    this.#informer.on(CHANGE, (_obj: T) => {
+      this.#onCacheUpdated.fire({
+        kubeconfig: this.#kubeConfig,
+        resourceName: this.#resourceName,
+      });
+    });
+    // This is issued when there is an error
+    this.#informer.on(ERROR, (error: unknown) => {
+      this.#offline = true;
+      this.#onOffline.fire({
+        kubeconfig: this.#kubeConfig,
+        resourceName: this.#resourceName,
+        offline: true,
+        reason: String(error),
+      });
+    });
+    this.#informer.start().catch((err: unknown) => {
+      console.error(
+        `error starting the informer for resource ${this.#resourceName} on context ${this.#kubeConfig.getKubeConfig().currentContext}: ${String(err)}`,
+      );
+    });
+    return internalInformer;
+  }
+
+  // reconnect tries to start the informer again if it is marked as offline
+  // (after an error happens)
+  reconnect(): void {
+    if (!!this.#informer && this.#offline) {
+      this.#offline = false;
+      this.#onOffline.fire({
+        kubeconfig: this.#kubeConfig,
+        resourceName: this.#resourceName,
+        offline: false,
+      });
+      this.#informer.start().catch((err: unknown) => {
+        console.error(
+          `error starting the informer for resource ${this.#resourceName} on context ${this.#kubeConfig.getKubeConfig().currentContext}: ${String(err)}`,
+        );
+      });
+    }
+  }
+
+  private getListWatch(path: string, listFn: ListPromise<T>): ListWatch<T> {
+    const watch = new Watch(this.#kubeConfig.getKubeConfig());
+    return new ListWatch<T>(path, watch, listFn, false);
+  }
+
+  dispose(): void {
+    this.#onCacheUpdated.dispose();
+    this.#onOffline.dispose();
+    this.#informer?.stop().catch((err: unknown) => {
+      console.error(
+        `error stopping the informer for resource ${this.#resourceName} on context ${this.#kubeConfig.getKubeConfig().currentContext}: ${String(err)}`,
+      );
+    });
+  }
+}
+
+export function newPodInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1Pod> {
+  const namespace = kubeconfig.getNamespace();
+  const apiClient = kubeconfig.getKubeConfig().makeApiClient(CoreV1Api);
+  const listFn = (): Promise<V1PodList> => apiClient.listNamespacedPod({ namespace });
+  const path = `/api/v1/namespaces/${namespace}/pods`;
+  return new ResourceInformer<V1Pod>(kubeconfig, path, listFn, 'pods');
+}
+
+export function newDeploymentInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1Deployment> {
+  const namespace = kubeconfig.getNamespace();
+  const apiClient = kubeconfig.getKubeConfig().makeApiClient(AppsV1Api);
+  const listFn = (): Promise<V1DeploymentList> => apiClient.listNamespacedDeployment({ namespace });
+  const path = `/apis/apps/v1/namespaces/${namespace}/deployments`;
+  return new ResourceInformer<V1Deployment>(kubeconfig, path, listFn, 'deployments');
+}

--- a/packages/main/src/plugin/kubernetes/resource-informer.ts
+++ b/packages/main/src/plugin/kubernetes/resource-informer.ts
@@ -16,17 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type {
-  Informer,
-  KubernetesObject,
-  ListPromise,
-  ObjectCache,
-  V1Deployment,
-  V1DeploymentList,
-  V1Pod,
-  V1PodList,
-} from '@kubernetes/client-node';
-import { AppsV1Api, CHANGE, CoreV1Api, ERROR, ListWatch, Watch } from '@kubernetes/client-node';
+import type { Informer, KubernetesObject, ListPromise, ObjectCache } from '@kubernetes/client-node';
+import { CHANGE, ERROR, ListWatch, Watch } from '@kubernetes/client-node';
 import type { Disposable } from '@podman-desktop/api';
 
 import type { Event } from '../events/emitter.js';
@@ -133,20 +124,4 @@ export class ResourceInformer<T extends KubernetesObject> implements Disposable 
       );
     });
   }
-}
-
-export function newPodInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1Pod> {
-  const namespace = kubeconfig.getNamespace();
-  const apiClient = kubeconfig.getKubeConfig().makeApiClient(CoreV1Api);
-  const listFn = (): Promise<V1PodList> => apiClient.listNamespacedPod({ namespace });
-  const path = `/api/v1/namespaces/${namespace}/pods`;
-  return new ResourceInformer<V1Pod>(kubeconfig, path, listFn, 'pods');
-}
-
-export function newDeploymentInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1Deployment> {
-  const namespace = kubeconfig.getNamespace();
-  const apiClient = kubeconfig.getKubeConfig().makeApiClient(AppsV1Api);
-  const listFn = (): Promise<V1DeploymentList> => apiClient.listNamespacedDeployment({ namespace });
-  const path = `/apis/apps/v1/namespaces/${namespace}/deployments`;
-  return new ResourceInformer<V1Deployment>(kubeconfig, path, listFn, 'deployments');
 }


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Start informers for Kubernetes experimental.

By accessing the underlying cache of the informer, the get/list methods of the cache can be exposed to the world. If the cluster is offline, the cache is still accessible an exposing the latest known resources.

The informer trigger an event every time the cache is updated. For now, only a generic CacheUpdated event, but can be upgraded to [Add/Update/Delete]Resource events if necessary.

The informers trigger an `offline` event when they are disconnected, and expose a `reconnect` method, so they can be restarted (by the user, after some time, etc - not implemented in this PR)

### What issues does this PR fix or reference?

Part of #9938

### How to test this PR?

To test the new version, set this preference in ~/.local/share/containers/podman-desktop/configuration/settings.json:

```
  "kubernetes.statesExperimental": true
```

- [x] Tests are covering the bug fix or the new feature
