### PR TITLE
fix: ensure system path is created and show notification if not in PATH

### DIFF
--- a/extensions/compose/src/cli-run.ts
+++ b/extensions/compose/src/cli-run.ts
@@ -90,7 +90,7 @@ export async function installBinaryToSystem(binaryPath: string, binaryName: stri
     console.log(`Successfully installed '${binaryName}' binary.`);
     if (!process.env.PATH?.includes(destinationFolder)) {
       await extensionApi.window.showWarningMessage(
-        `The compose binary has been installed into ${destinationFolder} but it is not in the system path. You should add it manuaaly if you want to use compose from cli.`,
+        `The compose binary has been installed into ${destinationFolder} but it is not in the system path. You should add it manually if you want to use compose from cli.`,
         'OK',
       );
     }


### PR DESCRIPTION
Fixes #5776

### What does this PR do?

When installing compose system wide ensure the folder exists and if is not in PATH display a warning message

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

#5776

### How to test this PR?


- [x] Tests are covering the bug fix or the new feature
