### PR TITLE
feat: improve libpod API support - translate selinux_opts

### DIFF
--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -3959,7 +3959,7 @@ describe('createContainerLibPod', () => {
           },
         ],
         NetworkMode: 'mode',
-        SecurityOpt: ['default'],
+        SecurityOpt: ['default', 'label=disable'],
         PortBindings: {
           '8080': [
             {
@@ -4015,6 +4015,7 @@ describe('createContainerLibPod', () => {
         nsmode: 'mode',
       },
       seccomp_policy: 'default',
+      selinux_opts: ['disable'],
       portmappings: [
         {
           container_port: 8080,

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -2032,11 +2032,14 @@ export class ContainerProviderRegistry {
 
     let seccomp_policy: string | undefined;
     let seccomp_profile_path: string | undefined;
+    const selinux_opts: Array<string> = [];
     for (const secOpt of options.HostConfig?.SecurityOpt ?? []) {
       if (secOpt === 'empty' || secOpt === 'default' || secOpt === 'image') {
         seccomp_policy = secOpt;
       } else if (secOpt.startsWith('seccomp=')) {
         seccomp_profile_path = secOpt.substring(8).trim();
+      } else if (secOpt.startsWith('label=')) {
+        selinux_opts.push(secOpt.substring(6).trim());
       }
     }
 
@@ -2089,6 +2092,7 @@ export class ContainerProviderRegistry {
       remove: options.HostConfig?.AutoRemove,
       seccomp_policy: seccomp_policy,
       seccomp_profile_path: seccomp_profile_path,
+      selinux_opts: selinux_opts,
       cap_add: options.HostConfig?.CapAdd,
       cap_drop: options.HostConfig?.CapDrop,
       privileged: options.HostConfig?.Privileged,

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.ts
@@ -169,6 +169,7 @@ export interface ContainerCreateOptions {
   hostadd?: Array<string>;
   userns?: string;
   volumes?: Array<ContainerCreateNamedVolume>;
+  selinux_opts?: string[];
 }
 
 export interface PodRemoveOptions {


### PR DESCRIPTION
### What does this PR do?

adds support for selinux_opts in options passed when the libPod API is used.

See, https://github.com/podman-desktop/podman-desktop/pull/10166 for more context as to one of the use cases where this is needed. 

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

- [X] Tests are covering the bug fix or the new feature

Also tested as part of running [podman-desktop-extension-ai-lab](https://github.com/containers/podman-desktop-extension-ai-lab) with linux GPU acceleration as explained in https://github.com/podman-desktop/podman-desktop/pull/10166 
