### PR TITLE
fix: improve libpod API translation - extension

### DIFF
--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -4062,7 +4062,7 @@ describe('createContainerLibPod', () => {
       name: options.name,
       command: options.Cmd,
       devices: [{ path: 'nvidia.com/gpu=all' }],
-      entrypoint: options.Entrypoint,
+      entrypoint: [options.Entrypoint as string],
       env: {
         key: 'value',
       },
@@ -4115,6 +4115,27 @@ describe('createContainerLibPod', () => {
         return Promise.resolve();
       },
     );
+    await containerRegistry.createContainer('podman1', options);
+    expect(createPodmanContainerMock).toBeCalledWith(expectedOptions);
+
+    // check the case when an array is passed in for Entrypoint
+    createPodmanContainerMock.mockClear();
+    options.Entrypoint = ['array_entrypoint'];
+    expectedOptions.entrypoint = options.Entrypoint;
+    await containerRegistry.createContainer('podman1', options);
+    expect(createPodmanContainerMock).toBeCalledWith(expectedOptions);
+
+    // check the case when an undefined is passed in for Entrypoint
+    createPodmanContainerMock.mockClear();
+    options.Entrypoint = undefined;
+    expectedOptions.entrypoint = options.Entrypoint;
+    await containerRegistry.createContainer('podman1', options);
+    expect(createPodmanContainerMock).toBeCalledWith(expectedOptions);
+
+    // check the case when array with mulpile entries is passed as entrypoint
+    createPodmanContainerMock.mockClear();
+    options.Entrypoint = ['entrypoint', 'arg1'];
+    expectedOptions.entrypoint = options.Entrypoint;
     await containerRegistry.createContainer('podman1', options);
     expect(createPodmanContainerMock).toBeCalledWith(expectedOptions);
   });

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -2086,7 +2086,7 @@ export class ContainerProviderRegistry {
     const podmanOptions: PodmanContainerCreateOptions = {
       name: options.name,
       command: options.Cmd,
-      entrypoint: options.Entrypoint,
+      entrypoint: !options.Entrypoint || Array.isArray(options.Entrypoint) ? options.Entrypoint : [options.Entrypoint],
       env: updatedEnv,
       pod: options.pod,
       hostname: options.Hostname,


### PR DESCRIPTION
### What does this PR do?

fixes translation of entrypoint in options passed when the libPod API is used. From the spec - https://docs.podman.io/en/latest/_static/api.html#tag/containers/operation/ContainerCreateLibpod is must be an array and it did not work as a single string in my testing of a use case that needed to use it.

My assumption is that nothing within podman desktop had used the entrypoint passing in a string in the options whe the libPod API is used (the docker compat API options allow either a string or array of strings)).

Fixed the translation to ensure it is always an array when passed to the libPod API.

My assumption is that nothing within podman desktop had used the entrypoint passing in a string in the options whe the libPod API is used (the docker compat API options allow either a string or array of strings)).

See, https://github.com/podman-desktop/podman-desktop/pull/10166 for more context as to one of the use cases where this is needed. 

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

- [X] Tests are covering the bug fix or the new feature

Also tested as part of running [podman-desktop-extension-ai-lab](https://github.com/containers/podman-desktop-extension-ai-lab) with linux GPU acceleration as explained in https://github.com/podman-desktop/podman-desktop/pull/10166 