### PR TITLE
chore: introduce a new property to switch to the new task manager panel

### DIFF
--- a/packages/api/src/tasks-preferences.ts
+++ b/packages/api/src/tasks-preferences.ts
@@ -20,4 +20,5 @@ export enum ExperimentalTasksSettings {
   SectionName = 'tasks',
   StatusBar = 'StatusBar',
   Toast = 'Toast',
+  Manager = 'Manager',
 }

--- a/packages/main/src/plugin/tasks/task-manager.spec.ts
+++ b/packages/main/src/plugin/tasks/task-manager.spec.ts
@@ -72,6 +72,20 @@ test('task manager init should register a configuration option', async () => {
       }),
     ]),
   );
+
+  expect(configurationRegistry.registerConfigurations).toHaveBeenCalledWith(
+    expect.arrayContaining([
+      expect.objectContaining({
+        properties: expect.objectContaining({
+          'tasks.Manager': {
+            type: 'boolean',
+            description: 'Replace the current task manager widget by the new one',
+            default: false,
+          },
+        }),
+      }),
+    ]),
+  );
 });
 
 test('create task with title', async () => {

--- a/packages/main/src/plugin/tasks/task-manager.ts
+++ b/packages/main/src/plugin/tasks/task-manager.ts
@@ -47,7 +47,14 @@ export class TaskManager {
     this.setStatusBarEntry(false);
 
     this.commandRegistry.registerCommand('show-task-manager', () => {
-      this.apiSender.send('toggle-task-manager', '');
+      // get the current value of the configuration flag for the task manager
+      const useExperimentalTaskManager = this.configurationRegistry
+        .getConfiguration(ExperimentalTasksSettings.SectionName)
+        .get<boolean>(ExperimentalTasksSettings.Manager, false);
+
+      const showEventName = useExperimentalTaskManager ? 'toggle-task-manager' : 'toggle-legacy-task-manager';
+
+      this.apiSender.send(showEventName, '');
       this.setStatusBarEntry(false);
     });
 
@@ -64,6 +71,11 @@ export class TaskManager {
           },
           [`${ExperimentalTasksSettings.SectionName}.${ExperimentalTasksSettings.Toast}`]: {
             description: 'Display a notification toast when task is created',
+            type: 'boolean',
+            default: false,
+          },
+          [`${ExperimentalTasksSettings.SectionName}.${ExperimentalTasksSettings.Manager}`]: {
+            description: 'Replace the current task manager widget by the new one',
             type: 'boolean',
             default: false,
           },

--- a/packages/renderer/src/lib/task-manager/LegacyTaskManager.svelte
+++ b/packages/renderer/src/lib/task-manager/LegacyTaskManager.svelte
@@ -31,8 +31,8 @@ function handleEscape({ key }: any) {
   }
 }
 
-// listen to the event "toggle-task-manager" to toggle the task manager
-window.events?.receive('toggle-task-manager', () => {
+// listen to the event "toggle-legacy-task-manager" to toggle the task manager
+window.events?.receive('toggle-legacy-task-manager', () => {
   showTaskManager = !showTaskManager;
 });
 </script>


### PR DESCRIPTION
### What does this PR do?
Add a flag to be able to change the task manager UI implementation

note: there is no new UI, so clicking on the task manager icon with the flag being enabled will display nothing

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/issues/9924

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
