### PR TITLE
feat: allow to cancel a task from the status bar

### DIFF
--- a/packages/renderer/src/lib/statusbar/TaskIndicator.spec.ts
+++ b/packages/renderer/src/lib/statusbar/TaskIndicator.spec.ts
@@ -18,16 +18,17 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { fireEvent, render } from '@testing-library/svelte';
+import { fireEvent, render, screen } from '@testing-library/svelte';
 import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
 import TaskIndicator from '/@/lib/statusbar/TaskIndicator.svelte';
-import { tasksInfo } from '/@/stores/tasks';
+import { type TaskInfoUI, tasksInfo } from '/@/stores/tasks';
 
 beforeAll(() => {
   Object.defineProperty(global, 'window', {
     value: {
       executeCommand: vi.fn(),
+      cancelToken: vi.fn(),
       events: {
         send: vi.fn(),
       },
@@ -151,4 +152,51 @@ test('task with undefined progress value should show indeterminate progress', as
   // expect the progress bar to have the indeterminate class
   const progressBar = getByRole('progressbar');
   expect(progressBar).toHaveClass('progress-bar-indeterminate');
+});
+
+test('cancellable task should display cancel button', async () => {
+  const cancellableTask: TaskInfoUI = {
+    name: 'Dummy Task',
+    state: 'running',
+    status: 'in-progress',
+    started: 0,
+    id: 'dummy-task',
+    progress: undefined, // indeterminate
+    cancellable: true,
+    cancellationTokenSourceId: 1234,
+  };
+
+  tasksInfo.set([cancellableTask]);
+
+  const { getByRole } = render(TaskIndicator);
+
+  // expect the cancel button to be there
+  const cancelButton = getByRole('button', { name: 'Cancel task Dummy Task' });
+  expect(cancelButton).toBeDefined();
+
+  // click on the cancel button
+  await fireEvent.click(cancelButton);
+
+  // expect the cancel token to be called
+  expect(window.cancelToken).toHaveBeenCalledWith(cancellableTask.cancellationTokenSourceId);
+});
+
+test('non cancellable task should not display cancel', async () => {
+  const nonCancellableTask: TaskInfoUI = {
+    name: 'Dummy Task',
+    state: 'running',
+    status: 'in-progress',
+    started: 0,
+    id: 'dummy-task',
+    progress: undefined, // indeterminate
+    cancellable: false,
+  };
+
+  tasksInfo.set([nonCancellableTask]);
+
+  render(TaskIndicator);
+
+  // expect the cancel button to be there
+  const cancelButton = screen.queryByRole('button', { name: 'Cancel task Dummy Task' });
+  expect(cancelButton).toBeNull();
 });

--- a/packages/renderer/src/lib/statusbar/TaskIndicator.spec.ts
+++ b/packages/renderer/src/lib/statusbar/TaskIndicator.spec.ts
@@ -196,7 +196,42 @@ test('non cancellable task should not display cancel', async () => {
 
   render(TaskIndicator);
 
-  // expect the cancel button to be there
+  // expect the cancel button not to be there
   const cancelButton = screen.queryByRole('button', { name: 'Cancel task Dummy Task' });
   expect(cancelButton).toBeNull();
+});
+
+test('if multiple tasks in progress, no cancel button is displayed', async () => {
+  const cancellableTask1: TaskInfoUI = {
+    name: 'Dummy Task 1',
+    state: 'running',
+    status: 'in-progress',
+    started: 0,
+    id: 'dummy-task1',
+    progress: undefined,
+    cancellable: true,
+    cancellationTokenSourceId: 1234,
+  };
+
+  const cancellableTask2: TaskInfoUI = {
+    name: 'Dummy Task 2',
+    state: 'running',
+    status: 'in-progress',
+    started: 0,
+    id: 'dummy-task2',
+    progress: undefined,
+    cancellable: true,
+    cancellationTokenSourceId: 2345,
+  };
+
+  tasksInfo.set([cancellableTask1, cancellableTask2]);
+
+  render(TaskIndicator);
+
+  // expect no cancel button not to be there
+  const allButtons = screen.queryAllByRole('button');
+  // filter all buttons starting with "Cancel task"
+  const cancelButtons = allButtons.filter(button => button.ariaLabel?.startsWith('Cancel task'));
+  // no button at all
+  expect(cancelButtons).toHaveLength(0);
 });

--- a/packages/renderer/src/lib/statusbar/TaskIndicator.svelte
+++ b/packages/renderer/src/lib/statusbar/TaskIndicator.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+import { faTimesCircle } from '@fortawesome/free-solid-svg-icons';
 import { Tooltip } from '@podman-desktop/ui-svelte';
+import Fa from 'svelte-fa';
 
 import ProgressBar from '/@/lib/task-manager/ProgressBar.svelte';
 import { tasksInfo } from '/@/stores/tasks';
@@ -12,13 +14,30 @@ let title: string | undefined = $derived.by(() => {
   return `${runningTasks.length} tasks running`;
 });
 
+// single task (if only one task is running)
+let singleCurrentTask = $derived.by(() => {
+  if (runningTasks.length !== 1) return undefined;
+  return runningTasks[0];
+});
+
 let progress: number | undefined = $derived.by(() => {
-  if (runningTasks.length !== 1) return undefined; // return indeterminate
-  return runningTasks[0].progress; // return task's progress value
+  return singleCurrentTask?.progress; // return task's progress value (if there is one)
+});
+
+let cancellableToken = $derived.by(() => {
+  return singleCurrentTask?.cancellationTokenSourceId && singleCurrentTask?.cancellable
+    ? singleCurrentTask.cancellationTokenSourceId
+    : undefined;
 });
 
 async function toggleTaskManager(): Promise<void> {
   await window.executeCommand('show-task-manager');
+}
+
+async function cancelTask() {
+  if (cancellableToken) {
+    await window.cancelToken(cancellableToken);
+  }
 }
 </script>
 
@@ -32,5 +51,15 @@ async function toggleTaskManager(): Promise<void> {
         </div>
       </button>
     </Tooltip>
+    {#if cancellableToken}
+      <div class="flex items-center ml-0.5">
+        <Tooltip top tip="Cancel task {title}">
+          <button class="cursor-pointer" onclick={cancelTask} aria-label="Cancel task {title}">
+          <Fa size="0.750x" icon={faTimesCircle} />
+        </button>
+        </Tooltip>
+      </div>
+    {/if}
   </div>
 {/if}
+


### PR DESCRIPTION
### What does this PR do?
allow to cancel a task from the status bar

### Screenshot / video of UI

https://github.com/user-attachments/assets/cf767f3a-81a5-4198-b57b-58d14b5839fd



### What issues does this PR fix or reference?

fixes https://github.com/podman-desktop/podman-desktop/issues/10162

### How to test this PR?

1. Install the extension from `quay.io/fbenoit/long-task-example:v1.0`
2. press F1 key to bring the command palette
3. select Dummy Long task (type dummy it will highlight the task)
4. click enter

- [x] Tests are covering the bug fix or the new feature
