### PR TITLE
chore: remove ignore warning no longer raised

### DIFF
--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -375,7 +375,6 @@ const row = new TableRow<ContainerGroupInfoUI | ContainerInfoUI>({
 });
 
 let containersAndGroups: (ContainerGroupInfoUI | ContainerInfoUI)[];
-// svelte-ignore reactive_declaration_non_reactive_property
 $: containersAndGroups = containerGroups.map(group =>
   group?.type === ContainerGroupInfoTypeUI.STANDALONE ? group.containers[0] : group,
 );


### PR DESCRIPTION
Signed-off-by: Florent Benoit <fbenoit@redhat.com>

### What does this PR do?
Fix being applied to the dependabot branch

Cannot apply to main as with the existing version of svelte, if we remove the comment there is an error and with the new version of svelte, if we keep the comment, there is an error

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/pull/10234

### How to test this PR?

PR check should be ✅ 

- [x] Tests are covering the bug fix or the new feature
