### PR TITLE
chore: show only one error enoent message untill podman machine reconnects

### DIFF
--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -3472,8 +3472,7 @@ test('setupConnectionAPI with errors', async () => {
 
   // filter calls to find the one with container-started-event
   const containerStartedEventCalls = allCalls.filter(call => call[0] === 'container-started-event');
-  expect(containerStartedEventCalls).toHaveLength(1);
-  expect(containerStartedEventCalls[0]?.[1]).toBe(fakeId);
+  expect(containerStartedEventCalls).toHaveLength(0);
 
   stream2.end();
 

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -373,6 +373,12 @@ export class ContainerProviderRegistry {
     });
   }
 
+  notifyConsole(message: string): void {
+    if (this.notify) {
+      console.log(message);
+    }
+  }
+
   // do not use inspect information
   async listSimpleContainers(abortController?: AbortController): Promise<SimpleContainerInfo[]> {
     let telemetryOptions = {};
@@ -397,9 +403,7 @@ export class ContainerProviderRegistry {
             }),
           );
         } catch (error) {
-          if (this.notify) {
-            console.log('error in engine', provider.name, error);
-          }
+          this.notifyConsole(`error in engine ${provider.name} ${error}`);
           telemetryOptions = { error: error };
           return [];
         }
@@ -558,9 +562,7 @@ export class ContainerProviderRegistry {
             }),
           );
         } catch (error) {
-          if (this.notify) {
-            console.log('error in engine', provider.name, error);
-          }
+          this.notifyConsole(`error in engine ${provider.name} ${error}`);
           telemetryOptions = { error: error };
           return [];
         }
@@ -599,9 +601,7 @@ export class ContainerProviderRegistry {
             return imageInfo;
           });
         } catch (error) {
-          if (this.notify) {
-            console.log('error in engine', provider.name, error);
-          }
+          this.notifyConsole(`error in engine ${provider.name} ${error}`);
           telemetryOptions = { error: error };
           return [];
         }
@@ -724,9 +724,7 @@ export class ContainerProviderRegistry {
             return podInfo;
           });
         } catch (error) {
-          if (this.notify) {
-            console.log('error in engine', provider.name, error);
-          }
+          this.notifyConsole(`error in engine ${provider.name} ${error}`);
           telemetryOptions = { error: error };
           return [];
         }
@@ -849,9 +847,7 @@ export class ContainerProviderRegistry {
           });
           return { Volumes: volumeInfos, Warnings: volumeListInfo.Warnings, engineName, engineId };
         } catch (error) {
-          if (this.notify) {
-            console.log('error in engine', provider.name, error);
-          }
+          this.notifyConsole(`error in engine ${provider.name} ${error}`);
           telemetryOptions = { error: error };
           return [];
         }

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -129,7 +129,7 @@ export class ContainerProviderRegistry {
 
   protected containerProviders: Map<string, containerDesktopAPI.ContainerProviderConnection> = new Map();
   protected internalProviders: Map<string, InternalContainerProvider> = new Map();
-  protected activeTimeouts: Map<string, NodeJS.Timeout | undefined> = new Map();
+  protected notify: boolean = true;
 
   // map of streams per container id
   protected streamsPerContainerId: Map<string, NodeJS.ReadWriteStream> = new Map();
@@ -148,6 +148,8 @@ export class ContainerProviderRegistry {
 
     eventEmitter.on('event', (jsonEvent: JSONEvent) => {
       nbEvents++;
+      // reconnected
+      this.notify = true;
       // do not log healthcheck(health_status) events
       // as it's too verbose/repeating a lot
       if (jsonEvent.status !== 'health_status') {
@@ -205,8 +207,11 @@ export class ContainerProviderRegistry {
 
     api.getEvents((err, stream) => {
       if (err) {
-        console.log('error is', err);
-        errorCallback(new Error('Error in handling events', err));
+        if (this.notify) {
+          console.log('error is', err);
+          errorCallback(new Error('Error in handling events', err));
+          this.notify = false;
+        }
       }
 
       stream?.on('error', error => {
@@ -291,22 +296,12 @@ export class ContainerProviderRegistry {
       internalProvider.api = undefined;
       internalProvider.libpodApi = undefined;
 
-      // if is the timeout running dont start other for events
-      // connect ENOENT \.\pipe\machine_name at PipeConnectWrap.afterConnect [as oncomplete]
-      if (this.activeTimeouts.get(containerProviderConnection.endpoint.socketPath)) {
-        return;
-      }
-
       // ok we had some errors so we need to reconnect the provider
       // delay the reconnection to avoid too many reconnections
       // retry in 5 seconds
-      this.activeTimeouts.set(
-        containerProviderConnection.endpoint.socketPath,
-        setTimeout(() => {
-          this.activeTimeouts.set(containerProviderConnection.endpoint.socketPath, undefined);
-          this.setupConnectionAPI(internalProvider, containerProviderConnection);
-        }, this.retryDelayEvents),
-      );
+      setTimeout(() => {
+        this.setupConnectionAPI(internalProvider, containerProviderConnection);
+      }, this.retryDelayEvents);
     };
 
     this.handleEvents(internalProvider.api, errorHandler);
@@ -402,7 +397,9 @@ export class ContainerProviderRegistry {
             }),
           );
         } catch (error) {
-          console.log('error in engine', provider.name, error);
+          if (this.notify) {
+            console.log('error in engine', provider.name, error);
+          }
           telemetryOptions = { error: error };
           return [];
         }
@@ -561,7 +558,9 @@ export class ContainerProviderRegistry {
             }),
           );
         } catch (error) {
-          console.log('error in engine', provider.name, error);
+          if (this.notify) {
+            console.log('error in engine', provider.name, error);
+          }
           telemetryOptions = { error: error };
           return [];
         }
@@ -600,7 +599,9 @@ export class ContainerProviderRegistry {
             return imageInfo;
           });
         } catch (error) {
-          console.log('error in engine', provider.name, error);
+          if (this.notify) {
+            console.log('error in engine', provider.name, error);
+          }
           telemetryOptions = { error: error };
           return [];
         }
@@ -723,7 +724,9 @@ export class ContainerProviderRegistry {
             return podInfo;
           });
         } catch (error) {
-          console.log('error in engine', provider.name, error);
+          if (this.notify) {
+            console.log('error in engine', provider.name, error);
+          }
           telemetryOptions = { error: error };
           return [];
         }
@@ -846,7 +849,9 @@ export class ContainerProviderRegistry {
           });
           return { Volumes: volumeInfos, Warnings: volumeListInfo.Warnings, engineName, engineId };
         } catch (error) {
-          console.log('error in engine', provider.name, error);
+          if (this.notify) {
+            console.log('error in engine', provider.name, error);
+          }
           telemetryOptions = { error: error };
           return [];
         }


### PR DESCRIPTION
### What does this PR do?
Reduces number of ENOENT error messages in console

### What issues does this PR fix or reference?
Closes #8681 

### How to test this PR?
On Windows, try to delete win_something_proxy process
OR
1. Delete all machines
2. Create machine1 using PD (default options)
3. Create machine2 using PD (default options)
4. Wait until both machines are started
5. Machine1 should be the default
6. Stop machine2 and immediately stop machine1


In both cases, you should see only limited number of "Assert you see the error is Error: connect ENOENT \\.\pipe\machine_name at PipeConnectWrap.afterConnect [as oncomplete] (node:net:1611:16)" messages in console.


- [x] Tests are covering the bug fix or the new feature
