### PR TITLE
feat: force use of libPod if nvidia device requested

### DIFF
--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -4009,7 +4009,7 @@ describe('createContainerLibPod', () => {
       HostConfig: {
         Devices: [
           {
-            PathOnHost: 'nvidia.com/gpu=all',
+            PathOnHost: 'device1',
             PathInContainer: '',
             CgroupPermissions: '',
           },
@@ -4061,7 +4061,7 @@ describe('createContainerLibPod', () => {
     const expectedOptions: PodmanContainerCreateOptions = {
       name: options.name,
       command: options.Cmd,
-      devices: [{ path: 'nvidia.com/gpu=all' }],
+      devices: [{ path: 'device1' }],
       entrypoint: [options.Entrypoint as string],
       env: {
         key: 'value',
@@ -4136,6 +4136,100 @@ describe('createContainerLibPod', () => {
     createPodmanContainerMock.mockClear();
     options.Entrypoint = ['entrypoint', 'arg1'];
     expectedOptions.entrypoint = options.Entrypoint;
+    await containerRegistry.createContainer('podman1', options);
+    expect(createPodmanContainerMock).toBeCalledWith(expectedOptions);
+  });
+
+  test('check that use of libPod is forced by request for nvidia device', async () => {
+    const dockerAPI = new Dockerode({ protocol: 'http', host: 'localhost' });
+
+    const libpod = new LibpodDockerode();
+    libpod.enhancePrototypeWithLibPod();
+    containerRegistry.addInternalProvider('podman1', {
+      name: 'podman',
+      id: 'podman1',
+      api: dockerAPI,
+      libpodApi: dockerAPI,
+      connection: {
+        type: 'podman',
+      },
+    } as unknown as InternalContainerProvider);
+
+    const createPodmanContainerMock = vi
+      .spyOn(dockerAPI as unknown as LibPod, 'createPodmanContainer')
+      .mockImplementation(_options =>
+        Promise.resolve({
+          Id: 'id',
+          Warnings: [],
+        }),
+      );
+    vi.spyOn(dockerAPI as unknown as Dockerode, 'getContainer').mockImplementation((_id: string) => {
+      return {
+        start: () => {},
+      } as unknown as Dockerode.Container;
+    });
+    // use minimum set as the full of options is validated in the previous test
+    const options: ContainerCreateOptions = {
+      Image: 'image',
+      name: 'name',
+      HostConfig: {
+        Devices: [
+          {
+            PathOnHost: 'nvidia.com/gpu=all',
+            PathInContainer: '',
+            CgroupPermissions: '',
+          },
+        ],
+        NetworkMode: 'mode',
+        AutoRemove: true,
+      },
+      Cmd: ['cmd'],
+      Entrypoint: 'entrypoint',
+      User: 'user',
+    };
+    const expectedOptions: PodmanContainerCreateOptions = {
+      image: options.Image,
+      name: options.name,
+      devices: [{ path: 'nvidia.com/gpu=all' }],
+      netns: {
+        nsmode: 'mode',
+      },
+      command: options.Cmd,
+      entrypoint: [options.Entrypoint as string],
+      user: options.User,
+      cap_add: undefined,
+      cap_drop: undefined,
+      dns_server: undefined,
+      env: undefined,
+      healthconfig: undefined,
+      hostadd: undefined,
+      hostname: undefined,
+      labels: undefined,
+      mounts: undefined,
+      pod: undefined,
+      portmappings: undefined,
+      privileged: undefined,
+      read_only_filesystem: undefined,
+      remove: true,
+      restart_policy: undefined,
+      restart_tries: undefined,
+      seccomp_policy: undefined,
+      seccomp_profile_path: undefined,
+      selinux_opts: [],
+      stop_timeout: undefined,
+      userns: undefined,
+      work_dir: undefined,
+    };
+    vi.spyOn(containerRegistry, 'attachToContainer').mockImplementation(
+      (
+        _engine: InternalContainerProvider,
+        _container: Dockerode.Container,
+        _hasTty?: boolean,
+        _openStdin?: boolean,
+      ) => {
+        return Promise.resolve();
+      },
+    );
     await containerRegistry.createContainer('podman1', options);
     expect(createPodmanContainerMock).toBeCalledWith(expectedOptions);
   });

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -1941,7 +1941,18 @@ export class ContainerProviderRegistry {
     let telemetryOptions = {};
     try {
       let container: Dockerode.Container;
-      if (options.pod) {
+      let forceLibPod = false;
+
+      // the device option requesting an nvidia gpu on linux only works
+      // if the LibPod API is used. Check if such a device is requested
+      // and if so force the use of LibPod
+      for (const device of options.HostConfig?.Devices ?? []) {
+        if (device.PathOnHost === 'nvidia.com/gpu=all') {
+          forceLibPod = true;
+          break;
+        }
+      }
+      if (options.pod ?? forceLibPod) {
         container = await this.createContainerLibPod(engineId, options);
       } else {
         container = await this.createContainerDockerode(engineId, options);


### PR DESCRIPTION
### What does this PR do?

Requesting an nvidia device through the container toolkit is only supported through the libPod API not the compatibility API. Recognize the request and force libPod in a similar manner to what's done when the container is associated with a pod (it seems like a similar situation in that association with a pod is only available through libPod and not the compatibility API) .

This is the issue I used to ask about how to request an nvidia device available through the container toolkit in podman - https://github.com/containers/podman/issues/24687. From that, my understanding is that it only works through the libPod API and I don't see an interest on the podman side to change that.

See, https://github.com/podman-desktop/podman-desktop/pull/10166 for more context as to one of the use cases where this is needed.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
