### PR TITLE
fix: push modal dialog error processing

### DIFF
--- a/packages/main/src/plugin/index.spec.ts
+++ b/packages/main/src/plugin/index.spec.ts
@@ -20,10 +20,11 @@
 import { EventEmitter } from 'node:events';
 import { tmpdir } from 'node:os';
 
-import type { BrowserWindow, WebContents } from 'electron';
-import { clipboard, shell } from 'electron';
+import type { WebContents } from 'electron';
+import { app, BrowserWindow, clipboard, ipcMain, shell } from 'electron';
 import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
+import { Updater } from '/@/plugin/updater.js';
 import type { NotificationCardOptions } from '/@api/notification.js';
 
 import { securityRestrictionCurrentHandler } from '../security-restrictions-handler.js';
@@ -31,11 +32,14 @@ import type { TrayMenu } from '../tray-menu.js';
 import type { ApiSenderType } from './api.js';
 import { CancellationTokenRegistry } from './cancellation-token-registry.js';
 import type { ConfigurationRegistry } from './configuration-registry.js';
+import { ContainerProviderRegistry } from './container-registry.js';
 import type { Directories } from './directories.js';
 import { Emitter } from './events/emitter.js';
+import { ExtensionLoader } from './extension-loader.js';
 import { PluginSystem } from './index.js';
 import type { MessageBox } from './message-box.js';
 import { Deferred } from './util/deferred.js';
+import { HttpServer } from './webview/webview-registry.js';
 
 let pluginSystem: TestPluginSystem;
 
@@ -67,9 +71,18 @@ beforeAll(() => {
       },
       app: {
         on: vi.fn(),
+        getVersion: vi.fn(),
       },
       clipboard: {
         writeText: vi.fn(),
+      },
+      ipcMain: {
+        handle: vi.fn(),
+        emit: vi.fn().mockReturnValue(true),
+        on: vi.fn(),
+      },
+      BrowserWindow: {
+        getAllWindows: vi.fn(),
       },
     };
   });
@@ -77,8 +90,25 @@ beforeAll(() => {
   pluginSystem = new TestPluginSystem(trayMenuMock, mainWindowDeferred);
 });
 
+const handlers = new Map<string, any>();
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.mocked(ipcMain.handle).mockImplementation((channel: string, listener: any) => {
+    handlers.set(channel, listener);
+  });
+  vi.mocked(BrowserWindow.getAllWindows).mockImplementation(() => {
+    return [
+      {
+        isDestroyed: () => false,
+        webContents,
+      } as unknown as BrowserWindow,
+    ];
+  });
+  vi.mocked(app.getVersion).mockReturnValue('100.0.0');
+  vi.spyOn(Updater.prototype, 'init').mockReturnValue({ dispose: vi.fn() } as any);
+  vi.spyOn(ExtensionLoader.prototype, 'readDevelopmentFolders').mockResolvedValue([]);
+  // to avoid port conflict when tests are running on windows host
+  vi.spyOn(HttpServer.prototype, 'start').mockImplementation(vi.fn());
 });
 
 test('Should queue events until we are ready', async () => {
@@ -283,4 +313,41 @@ test('configurationRegistry propagated', async () => {
   expect(receivedConfig).toBeDefined();
   expect(receivedConfig).toBe(configurationRegistry);
   expect(notifications.length).toBe(0);
+});
+
+const pushImageHandlerId = 'container-provider-registry:pushImage';
+const pushImageHandlerOnDataEvent = `${pushImageHandlerId}-onData`;
+
+test('push image command sends onData message with callbackId, event name and event data ', async () => {
+  await pluginSystem.initExtensions(new Emitter<ConfigurationRegistry>());
+  const handle = handlers.get(pushImageHandlerId);
+  expect(handle).not.equal(undefined);
+  const defaultCallback = vi.fn();
+  let registeredCallback: (name: string, data: string) => void = defaultCallback;
+  vi.spyOn(ContainerProviderRegistry.prototype, 'pushImage').mockImplementation(
+    (_engine, _imageId, callback: (name: string, data: string) => void) => {
+      registeredCallback = callback;
+      return Promise.resolve();
+    },
+  );
+  await handle(undefined, 'podman', 'registry.com/repo/image:latest', 1);
+  expect(registeredCallback).not.equal(defaultCallback);
+  registeredCallback('data', 'push image output');
+  expect(webContents.send).toBeCalledWith(pushImageHandlerOnDataEvent, 1, 'data', 'push image output');
+});
+
+test('push image sends data event with error and end event when fails', async () => {
+  const pushError = new Error('push error');
+  await pluginSystem.initExtensions(new Emitter<ConfigurationRegistry>());
+  const handle = handlers.get('container-provider-registry:pushImage');
+  expect(handle).not.equal(undefined);
+  vi.spyOn(ContainerProviderRegistry.prototype, 'pushImage').mockImplementation(
+    (_engine, _imageId, _callback: (name: string, data: string) => void) => {
+      return Promise.reject(pushError);
+    },
+  );
+  vi.mocked(webContents.send).mockReset();
+  await handle(undefined, 'podman', 'registry.com/repo/image:latest', 1);
+  expect(webContents.send).toBeCalledWith(pushImageHandlerOnDataEvent, 1, 'error', String(pushError));
+  expect(webContents.send).toBeCalledWith(pushImageHandlerOnDataEvent, 1, 'end');
 });

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1101,9 +1101,15 @@ export class PluginSystem {
     this.ipcHandle(
       'container-provider-registry:pushImage',
       async (_listener, engine: string, imageId: string, callbackId: number): Promise<void> => {
-        return containerProviderRegistry.pushImage(engine, imageId, (name: string, data: string) => {
-          this.getWebContentsSender().send('container-provider-registry:pushImage-onData', callbackId, name, data);
-        });
+        const msgName = 'container-provider-registry:pushImage-onData';
+        return containerProviderRegistry
+          .pushImage(engine, imageId, (name: string, data: string) => {
+            this.getWebContentsSender().send(msgName, callbackId, name, data);
+          })
+          .catch((error: unknown) => {
+            this.getWebContentsSender().send(msgName, callbackId, 'error', String(error));
+            this.getWebContentsSender().send(msgName, callbackId, 'end');
+          });
       },
     );
     this.ipcHandle(

--- a/packages/renderer/src/lib/image/PushImageModal.spec.ts
+++ b/packages/renderer/src/lib/image/PushImageModal.spec.ts
@@ -18,10 +18,10 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { fireEvent } from '@testing-library/dom';
-import { render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { Terminal } from '@xterm/xterm';
 import { tick } from 'svelte';
-import { beforeAll, expect, type Mock, test, vi } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { ImageInspectInfo } from '/@api/image-inspect-info';
 
@@ -29,16 +29,16 @@ import type { ImageInfoUI } from './ImageInfoUI';
 import PushImageModal from './PushImageModal.svelte';
 
 vi.mock('@xterm/xterm', () => {
-  return {
-    Terminal: vi.fn().mockReturnValue({
-      loadAddon: vi.fn(),
-      open: vi.fn(),
-      write: vi.fn(),
-      clear: vi.fn(),
-      reset: vi.fn(),
-      dispose: vi.fn(),
-    }),
+  const Terminal = vi.fn();
+  Terminal.prototype = {
+    loadAddon: vi.fn(),
+    open: vi.fn(),
+    write: vi.fn(),
+    clear: vi.fn(),
+    reset: vi.fn(),
+    dispose: vi.fn(),
   };
+  return { Terminal };
 });
 
 const getConfigurationValueMock = vi.fn();
@@ -150,38 +150,150 @@ async function waitRender(customProperties: object): Promise<void> {
   await tick();
 }
 
-test('Expect "Push Image" button to be disabled if window.hasAuthconfigForImage returns false', async () => {
-  hasAuthMock.mockImplementation(() => {
-    return new Promise(() => false);
+type CallbackType = (name: string, data?: string) => void;
+
+describe('Expect Push Image dialog', () => {
+  let callback: CallbackType | undefined;
+  const closeCallback = vi.fn();
+
+  function button(name: 'Cancel' | 'Push image' | 'Done') {
+    return screen.queryByRole('button', { name });
+  }
+
+  function terminal() {
+    return screen.queryByRole('term');
+  }
+
+  async function runTo(
+    step:
+      | 'DialogOpened'
+      | 'PushPressed'
+      | 'FirstMessage'
+      | 'DataMessage'
+      | 'DataErrorMessage'
+      | 'EndAfterError'
+      | 'End',
+    authConfig = true,
+  ) {
+    hasAuthMock.mockResolvedValue(authConfig);
+    vi.mocked(window.getImageInspect).mockResolvedValue(fakedImageInspect);
+    pushImageMock.mockImplementation((_imageId, _imageTag, cb) => {
+      callback = cb;
+    });
+
+    await waitRender({
+      imageInfoToPush: fakedImage,
+      closeCallback,
+    });
+
+    if (step === 'DialogOpened') return;
+
+    const pushButton = screen.getByRole('button', { name: 'Push image' });
+    await fireEvent.click(pushButton);
+
+    if (step === 'PushPressed') return;
+
+    callback?.('first-message');
+
+    if (step === 'FirstMessage') return;
+
+    callback?.('data', '{ "status": "DataMessage" }');
+    await tick();
+
+    if (step === 'DataMessage') return;
+
+    if (step === 'EndAfterError' || step === 'DataErrorMessage') {
+      callback?.('error', 'DataErrorMessage');
+    }
+
+    if (step === 'DataErrorMessage') return;
+
+    callback?.('end');
+  }
+
+  beforeEach(() => {
+    vi.resetAllMocks();
   });
-  (window.getImageInspect as Mock).mockResolvedValue(fakedImageInspect);
 
-  await waitRender({
-    imageInfoToPush: fakedImage,
-    closeCallback: vi.fn(),
+  test('have "Cancel" and "Push Image" buttons disabled after open when auth configuration is missing', async () => {
+    await runTo('DialogOpened', false);
+    expect(button('Push image')).toBeDisabled();
+    expect(button('Cancel')).toBeEnabled();
+    expect(terminal()).toBeNull();
   });
 
-  // Get the push button
-  const pushButton = screen.getByRole('button', { name: 'Push image' });
-  expect(pushButton).toBeInTheDocument();
-  expect(pushButton).toBeDisabled();
-});
-
-test('Expect "Push Image" button to actually be clickable if window.hasAuthconfigForImage is true', async () => {
-  hasAuthMock.mockImplementation(() => {
-    return new Promise(() => true);
-  });
-  (window.getImageInspect as Mock).mockResolvedValue(fakedImageInspect);
-
-  await waitRender({
-    imageInfoToPush: fakedImage,
-    closeCallback: vi.fn(),
+  test('have "Cancel" and "Push Image" buttons enable after open when auth configuration is present', async () => {
+    await runTo('DialogOpened');
+    expect(button('Push image')).toBeEnabled();
+    expect(button('Cancel')).toBeEnabled();
+    expect(terminal()).toBeNull();
   });
 
-  // Get the push button
-  const pushButton = screen.getByRole('button', { name: 'Push image' });
-  expect(pushButton).toBeInTheDocument();
+  test('to close when "Cancel" button pressed', async () => {
+    await runTo('DialogOpened');
+    const cancelButton = button('Cancel');
+    expect(cancelButton).toBeEnabled();
+    if (cancelButton) {
+      await fireEvent.click(cancelButton);
+    }
+    expect(closeCallback).toHaveBeenCalledOnce();
+  });
 
-  // Actually able to click it
-  fireEvent.click(pushButton);
+  test('to have no "Cancel" button and "Push Image" button disabled after "Push Image" button pressed', async () => {
+    await runTo('PushPressed');
+    // the click on 'Push Image' button should set callback
+    expect(callback).not.toBe(undefined);
+    // window.pushImage() called, `Cancel` and `Push Image` buttons are
+    // disabled and waiting for callback being called with first-message/data/end events
+    expect(button('Push image')).toBeDisabled();
+    expect(button('Cancel')).toBe(null);
+    expect(screen.queryByRole('term')).toBeVisible();
+  });
+
+  test('to clean terminal when "first-message" event received', async () => {
+    const terminalClearSpy = vi.spyOn(Terminal.prototype, 'clear');
+    await runTo('FirstMessage');
+    expect(terminalClearSpy).toHaveBeenCalledOnce();
+  });
+
+  test('to write "status" property to terminal received in "data" even', async () => {
+    const terminalWriteSpy = vi.spyOn(Terminal.prototype, 'write');
+    await runTo('DataMessage');
+    expect(terminalWriteSpy).toBeCalledWith('DataMessage\n\r');
+    expect(button('Push image')).toBeDisabled();
+    expect(button('Cancel')).toBe(null);
+  });
+
+  test('to write error message to terminal from "data" event and reset buttons to initial state', async () => {
+    const terminalWriteSpy = vi.spyOn(Terminal.prototype, 'write');
+    await runTo('DataErrorMessage');
+    expect(terminalWriteSpy).toBeCalledWith('DataErrorMessage\n\r');
+    expect(button('Push image')).toBeDisabled();
+    expect(button('Cancel')).toBe(null);
+  });
+
+  test('to show "Cancel" and "Push image" buttons after push call finished with error', async () => {
+    await runTo('EndAfterError');
+    expect(button('Push image')).toBeEnabled();
+    expect(button('Cancel')).toBeEnabled();
+    expect(terminal()).toBeVisible();
+  });
+
+  test('to show "Done" button after successful push', async () => {
+    await runTo('End');
+    expect(button('Push image')).toBe(null);
+    expect(button('Cancel')).toBe(null);
+    expect(button('Done')).toBeEnabled();
+    expect(terminal()).toBeVisible();
+  });
+
+  test('to close when "Done" button pressed', async () => {
+    await runTo('End');
+    const doneButton = button('Done');
+    expect(doneButton).toBeEnabled();
+    if (doneButton) {
+      await fireEvent.click(doneButton);
+    }
+    expect(closeCallback).toHaveBeenCalledOnce();
+  });
 });

--- a/packages/renderer/src/lib/image/PushImageModal.svelte
+++ b/packages/renderer/src/lib/image/PushImageModal.svelte
@@ -55,11 +55,11 @@ function callback(name: string, data: string) {
     // parse JSON message
     const jsonObject = JSON.parse(data);
     if (jsonObject.status) {
-      logsPush.write(jsonObject.status + '\n\r');
-    } else if (jsonObject.error) {
-      gotErrorDuringPush = true;
-      logsPush.write(jsonObject.error.replaceAll('\n', '\n\r') + '\n\r');
+      logsPush?.write(jsonObject.status + '\n\r');
     }
+  } else if (name === 'error') {
+    gotErrorDuringPush = true;
+    logsPush?.write(data + '\n\r');
   } else if (name === 'end') {
     if (!gotErrorDuringPush) {
       pushFinished = true;

--- a/packages/renderer/src/lib/ui/TerminalWindow.svelte
+++ b/packages/renderer/src/lib/ui/TerminalWindow.svelte
@@ -69,4 +69,4 @@ onDestroy(() => {
 });
 </script>
 
-<div class="{$$props.class} p-[5px] pr-0 bg-[var(--pd-terminal-background)]" bind:this={logsXtermDiv}></div>
+<div class="{$$props.class} p-[5px] pr-0 bg-[var(--pd-terminal-background)]" role="term" bind:this={logsXtermDiv}></div>


### PR DESCRIPTION
### What does this PR do?

This PR fixes error processing for imagePush call on main package side and generated required messages that push dialog on renderer side is expecting in case of error.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Fixes #6893 to allow work on #8482, so task would not stay forever in progrees task manager in case of error

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
