### PR TITLE
fix: create task when running push image command

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1102,11 +1102,18 @@ export class PluginSystem {
       'container-provider-registry:pushImage',
       async (_listener, engine: string, imageId: string, callbackId: number): Promise<void> => {
         const msgName = 'container-provider-registry:pushImage-onData';
+        const task = taskManager.createTask({
+          title: `Push image '${imageId}'`,
+        });
         return containerProviderRegistry
           .pushImage(engine, imageId, (name: string, data: string) => {
             this.getWebContentsSender().send(msgName, callbackId, name, data);
           })
+          .then(() => {
+            task.status = 'success';
+          })
           .catch((error: unknown) => {
+            task.error = String(error);
             this.getWebContentsSender().send(msgName, callbackId, 'error', String(error));
             this.getWebContentsSender().send(msgName, callbackId, 'end');
           });

--- a/packages/renderer/src/lib/image/PushImageModal.spec.ts
+++ b/packages/renderer/src/lib/image/PushImageModal.spec.ts
@@ -155,7 +155,6 @@ type CallbackType = (name: string, data?: string) => void;
 describe('Expect Push Image dialog', () => {
   let callback: CallbackType | undefined;
   const closeCallback = vi.fn();
-
   function button(name: 'Cancel' | 'Push image' | 'Done') {
     return screen.queryByRole('button', { name });
   }


### PR DESCRIPTION
### What does this PR do?

Creates Task that appears in Task Manager UI. It does not show real progress but it finishes successfully or with error, so if you closed Push Image dialog you know how it ended.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

https://github.com/user-attachments/assets/4a41a59b-a12b-4b7b-ba98-9a014bdceaad

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Fixes #8482.

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
