### PR TITLE
feat(feedback): add enabled extensions in additional-context

### DIFF
--- a/packages/main/src/plugin/feedback-handler.spec.ts
+++ b/packages/main/src/plugin/feedback-handler.spec.ts
@@ -170,4 +170,43 @@ describe('openGitHubIssue', () => {
       'additional-context': '**Enabled Extensions**\n- dummy-started-extension',
     });
   });
+
+  test('expect extensions to be sorted', async () => {
+    const extensions: ExtensionInfo[] = [
+      {
+        id: 'b',
+        name: 'b',
+        state: 'started',
+      },
+      {
+        id: 'a',
+        name: 'a',
+        state: 'started',
+      },
+      {
+        id: 'c',
+        name: 'c',
+        state: 'started',
+      },
+    ] as ExtensionInfo[];
+
+    vi.mocked(extensionLoaderMock.listExtensions).mockResolvedValue(extensions);
+
+    const issueProperties: GitHubIssue = {
+      category: 'bug',
+      title: 'PD is not working',
+      description: 'bug description',
+      includeSystemInfo: false,
+      includeExtensionInfo: true,
+    };
+
+    const feedbackHandler = new FeedbackHandler(extensionLoaderMock);
+    await feedbackHandler.openGitHubIssue(issueProperties);
+
+    // extract the first argument of the shell.openExternal call
+    const url: string | undefined = vi.mocked(shell.openExternal).mock.calls[0]?.[0];
+    containSearchParams(url, {
+      'additional-context': '**Enabled Extensions**\n- a\n- b\n- c',
+    });
+  });
 });

--- a/packages/main/src/plugin/feedback-handler.spec.ts
+++ b/packages/main/src/plugin/feedback-handler.spec.ts
@@ -21,7 +21,9 @@ import { release } from 'node:os';
 import { shell } from 'electron';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
+import type { ExtensionLoader } from '/@/plugin/extension-loader.js';
 import { isLinux, isMac, isWindows } from '/@/util.js';
+import type { ExtensionInfo } from '/@api/extension-info.js';
 import type { GitHubIssue } from '/@api/feedback.js';
 
 import { FeedbackHandler } from './feedback-handler.js';
@@ -42,6 +44,20 @@ vi.mock('node:os', () => ({
   release: vi.fn(),
 }));
 
+const extensionLoaderMock: ExtensionLoader = {
+  listExtensions: vi.fn(),
+} as unknown as ExtensionLoader;
+
+const STARTED_EXTENSION: ExtensionInfo = {
+  state: 'started',
+  id: 'dummy-started-extension',
+} as ExtensionInfo;
+
+const STOPPED_EXTENSION: ExtensionInfo = {
+  state: 'stopped',
+  id: 'dummy-stopped-extension',
+} as ExtensionInfo;
+
 beforeEach(() => {
   vi.resetAllMocks();
 
@@ -49,6 +65,8 @@ beforeEach(() => {
   vi.mocked(isLinux).mockReturnValue(true);
   vi.mocked(isMac).mockReturnValue(false);
   vi.mocked(isWindows).mockReturnValue(false);
+
+  vi.mocked(extensionLoaderMock.listExtensions).mockResolvedValue([STARTED_EXTENSION, STOPPED_EXTENSION]);
 });
 
 /**
@@ -62,8 +80,8 @@ function containSearchParams(url: string | undefined, params: Record<string, str
 
   const search = new URLSearchParams(new URL(url).search);
   Object.entries(params).forEach(([key, value]) => {
-    expect(search.has(key)).toBeTruthy();
-    expect(search.get(key)).toBe(value);
+    expect(search.has(key), `expected url to have ${key} as query parameter`).toBeTruthy();
+    expect(search.get(key), `expected ${search.get(key)} to be ${value}`).toBe(value);
   });
 }
 
@@ -75,7 +93,7 @@ describe('openGitHubIssue', () => {
       description: 'bug description',
     };
 
-    const feedbackHandler = new FeedbackHandler();
+    const feedbackHandler = new FeedbackHandler(extensionLoaderMock);
     await feedbackHandler.openGitHubIssue(issueProperties);
 
     expect(shell.openExternal).toHaveBeenCalledOnce();
@@ -96,7 +114,7 @@ describe('openGitHubIssue', () => {
       description: 'feature description',
     };
 
-    const feedbackHandler = new FeedbackHandler();
+    const feedbackHandler = new FeedbackHandler(extensionLoaderMock);
     await feedbackHandler.openGitHubIssue(issueProperties);
 
     expect(shell.openExternal).toHaveBeenCalledOnce();
@@ -120,7 +138,7 @@ describe('openGitHubIssue', () => {
       includeSystemInfo: true,
     };
 
-    const feedbackHandler = new FeedbackHandler();
+    const feedbackHandler = new FeedbackHandler(extensionLoaderMock);
     await feedbackHandler.openGitHubIssue(issueProperties);
 
     expect(shell.openExternal).toHaveBeenCalledOnce();
@@ -129,6 +147,27 @@ describe('openGitHubIssue', () => {
     const url: string | undefined = vi.mocked(shell.openExternal).mock.calls[0]?.[0];
     containSearchParams(url, {
       os: 'Linux - dummy-release',
+    });
+  });
+
+  test('expect enabled extensions to be included if includeExtensionInfo is true', async () => {
+    const issueProperties: GitHubIssue = {
+      category: 'bug',
+      title: 'PD is not working',
+      description: 'bug description',
+      includeSystemInfo: false,
+      includeExtensionInfo: true,
+    };
+
+    const feedbackHandler = new FeedbackHandler(extensionLoaderMock);
+    await feedbackHandler.openGitHubIssue(issueProperties);
+
+    expect(shell.openExternal).toHaveBeenCalledOnce();
+
+    // extract the first argument of the shell.openExternal call
+    const url: string | undefined = vi.mocked(shell.openExternal).mock.calls[0]?.[0];
+    containSearchParams(url, {
+      'additional-context': '**Enabled Extensions**\n- dummy-started-extension',
     });
   });
 });

--- a/packages/main/src/plugin/feedback-handler.ts
+++ b/packages/main/src/plugin/feedback-handler.ts
@@ -46,6 +46,7 @@ export class FeedbackHandler {
     const extensions = await this.extensionLoader.listExtensions();
     return extensions
       .filter(extension => extension.state === 'started')
+      .sort((a, b) => a.name.localeCompare(b.name))
       .map(extension => `- ${extension.id}`)
       .join('\n');
   }
@@ -58,7 +59,7 @@ export class FeedbackHandler {
     return this.#systemInfo.getSystemName();
   }
 
-  protected toQueryParameters(issue: GitHubIssue, additional: string | undefined): Record<string, string> {
+  protected toQueryParameters(issue: GitHubIssue, additional?: string): Record<string, string> {
     const result: Record<string, string> = {};
     result['title'] = issue.title;
 

--- a/packages/main/src/plugin/feedback-handler.ts
+++ b/packages/main/src/plugin/feedback-handler.ts
@@ -18,6 +18,7 @@
 
 import { shell } from 'electron';
 
+import type { ExtensionLoader } from '/@/plugin/extension-loader.js';
 import type { SystemInfo } from '/@/plugin/util/sys-info.js';
 import { getSystemInfo } from '/@/plugin/util/sys-info.js';
 import type { GitHubIssue } from '/@api/feedback.js';
@@ -25,14 +26,28 @@ import type { GitHubIssue } from '/@api/feedback.js';
 export class FeedbackHandler {
   #systemInfo: SystemInfo;
 
-  constructor() {
+  constructor(protected extensionLoader: ExtensionLoader) {
     this.#systemInfo = getSystemInfo();
   }
 
   async openGitHubIssue(issueProperties: GitHubIssue): Promise<void> {
-    const urlSearchParams = new URLSearchParams(this.toQueryParameters(issueProperties)).toString();
+    let additionalContent: string | undefined;
+    if (issueProperties.includeExtensionInfo) {
+      const extensions = await this.getStartedExtensions();
+      additionalContent = `**Enabled Extensions**\n${extensions}`;
+    }
+
+    const urlSearchParams = new URLSearchParams(this.toQueryParameters(issueProperties, additionalContent)).toString();
     const link = `https://github.com/containers/podman-desktop/issues/new?${urlSearchParams}`;
     await shell.openExternal(link);
+  }
+
+  protected async getStartedExtensions(): Promise<string> {
+    const extensions = await this.extensionLoader.listExtensions();
+    return extensions
+      .filter(extension => extension.state === 'started')
+      .map(extension => `- ${extension.id}`)
+      .join('\n');
   }
 
   /**
@@ -43,7 +58,7 @@ export class FeedbackHandler {
     return this.#systemInfo.getSystemName();
   }
 
-  protected toQueryParameters(issue: GitHubIssue): Record<string, string> {
+  protected toQueryParameters(issue: GitHubIssue, additional: string | undefined): Record<string, string> {
     const result: Record<string, string> = {};
     result['title'] = issue.title;
 
@@ -60,6 +75,9 @@ export class FeedbackHandler {
         if (issue.includeSystemInfo) {
           result['os'] = this.getOsInfo();
         }
+
+        // happen additional context if provided
+        if (additional) result['additional-context'] = additional;
 
         return result;
       default:

--- a/packages/main/src/plugin/feedback-handler.ts
+++ b/packages/main/src/plugin/feedback-handler.ts
@@ -76,7 +76,7 @@ export class FeedbackHandler {
           result['os'] = this.getOsInfo();
         }
 
-        // happen additional context if provided
+        // append additional context if provided
         if (additional) result['additional-context'] = additional;
 
         return result;

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -472,9 +472,6 @@ export class PluginSystem {
 
     const telemetry = new Telemetry(configurationRegistry);
     await telemetry.init();
-
-    const feedback = new FeedbackHandler();
-
     const exec = new Exec(proxy);
 
     const commandRegistry = new CommandRegistry(apiSender, telemetry);
@@ -703,6 +700,8 @@ export class PluginSystem {
       certificates,
     );
     await this.extensionLoader.init();
+
+    const feedback = new FeedbackHandler(this.extensionLoader);
 
     const extensionsCatalog = new ExtensionsCatalog(certificates, proxy, configurationRegistry, apiSender);
     extensionsCatalog.init();

--- a/packages/renderer/src/lib/actions/ContributionActions.svelte
+++ b/packages/renderer/src/lib/actions/ContributionActions.svelte
@@ -24,7 +24,14 @@ export let contextUI: ContextUI | undefined = undefined;
 
 let filteredContributions: Menu[] = [];
 $: {
+  console.log('[ContributionActions] contextUI', contextUI?.collectAllValues());
+
   filteredContributions = contributions.reduce((previousValue, currentValue) => {
+    // Transform the unknown[] args objects as contexts
+    const argsContexts = args.map(arg => transformObjectToContext(arg, contextPrefix));
+
+    console.log('[ContributionActions] argsContexts', argsContexts);
+
     // If no when property is set, we keep all additional menus
     if (currentValue.when === undefined) return [...previousValue, currentValue];
 
@@ -35,9 +42,6 @@ $: {
     if (globalContext && whenDeserialized?.evaluate(globalContext)) {
       return [...previousValue, currentValue];
     }
-
-    // Transform the unknown[] args objects as contexts
-    const argsContexts = args.map(arg => transformObjectToContext(arg, contextPrefix));
 
     // Evaluate the arguments as context
     for (let argsContext of argsContexts) {

--- a/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.svelte
@@ -15,6 +15,7 @@ let { onCloseForm = () => {}, category = 'bug', contentChange }: Props = $props(
 let issueTitle = $state('');
 let issueDescription = $state('');
 let includeSystemInfo: boolean = $state(true); // default to true
+let includeExtensionInfo: boolean = $state(true); // default to true
 
 let issueValidationError = $derived.by(() => {
   if (!issueTitle) {
@@ -52,6 +53,7 @@ async function previewOnGitHub(): Promise<void> {
     title: $state.snapshot(issueTitle),
     description: $state.snapshot(issueDescription),
     includeSystemInfo: $state.snapshot(includeSystemInfo),
+    includeExtensionInfo: $state.snapshot(includeExtensionInfo),
   };
   try {
     await window.previewOnGitHub(issueProperties);
@@ -96,6 +98,12 @@ async function previewOnGitHub(): Promise<void> {
           title="Include system information"
           bind:checked={includeSystemInfo} />
         <div>Include system information (os, architecture etc.)</div>
+      </div>
+      <div class="flex flex-row align-items items-center mt-2">
+        <Checkbox
+          title="Include enabled extensions"
+          bind:checked={includeExtensionInfo} />
+        <div>Include enabled extensions</div>
       </div>
     {/if}
   </svelte:fragment>


### PR DESCRIPTION
### What does this PR do?

Add `Include enabled extensions` checkbox in the feedback bug form.

### Screenshot / video of UI

![image](https://github.com/user-attachments/assets/cc26c0dc-75e4-436d-9472-fd6f9e48218b)

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/pull/10276

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

**Manually**

1. checkout
2. Open feedback form 
3. Select `Bug` category
4. Open in GitHub
5. assert, all started extensions are listed in the Additional Context section
