### PR TITLE
chore: add telemetry events to GitHubIssue feedback forms

### DIFF
--- a/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.spec.ts
@@ -298,7 +298,8 @@ describe('includeExtensionInfo', () => {
       }),
     );
   });
-  
+});
+
 test.each(['bug', 'feature'])('Expect %s to have specific telemetry track events', async category => {
   const { title, description, preview } = renderGitHubIssueFeedback({
     category: category,

--- a/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.spec.ts
@@ -307,14 +307,14 @@ test.each(['bug', 'feature'])('Expect %s to have specific telemetry track events
     contentChange: vi.fn(),
   });
 
-  expect(window.telemetryTrack).toHaveBeenNthCalledWith(1, `feedback.${category}FormOpened`);
+  expect(window.telemetryTrack).toHaveBeenNthCalledWith(1, `feedback.FormOpened`, { feedbackCategory: category });
 
   await userEvent.type(title, 'Bug title');
   await userEvent.type(description, 'Bug description');
   await userEvent.click(preview);
 
   await vi.waitFor(() =>
-    expect(window.telemetryTrack).toHaveBeenNthCalledWith(2, `feedback.${category}FormSubmitteds`),
+    expect(window.telemetryTrack).toHaveBeenNthCalledWith(2, `feedback.FormSubmitted`, { feedbackCategory: category }),
   );
 });
 

--- a/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.spec.ts
@@ -35,6 +35,7 @@ beforeAll(() => {
     value: {
       openExternal: openExternalMock,
       previewOnGitHub: previewOnGitHubMock,
+      telemetryTrack: vi.fn(),
       navigator: {
         clipboard: {
           writeText: vi.fn(),
@@ -297,6 +298,23 @@ describe('includeExtensionInfo', () => {
       }),
     );
   });
+  
+test.each(['bug', 'feature'])('Expect %s to have specific telemetry track events', async category => {
+  const { title, description, preview } = renderGitHubIssueFeedback({
+    category: category,
+    onCloseForm: vi.fn(),
+    contentChange: vi.fn(),
+  });
+
+  expect(window.telemetryTrack).toHaveBeenNthCalledWith(1, `feedback.${category}FormOpened`);
+
+  await userEvent.type(title, 'Bug title');
+  await userEvent.type(description, 'Bug description');
+  await userEvent.click(preview);
+
+  await vi.waitFor(() =>
+    expect(window.telemetryTrack).toHaveBeenNthCalledWith(2, `feedback.${category}FormSubmitteds`),
+  );
 });
 
 test('Expect close confirmation to be true if cancel clicked', async () => {

--- a/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.spec.ts
@@ -48,6 +48,7 @@ beforeAll(() => {
 
 beforeEach(() => {
   vi.resetAllMocks();
+  vi.mocked(window.previewOnGitHub).mockResolvedValue(undefined);
 });
 
 /**
@@ -309,14 +310,39 @@ test.each(['bug', 'feature'])('Expect %s to have specific telemetry track events
 
   expect(window.telemetryTrack).toHaveBeenNthCalledWith(1, `feedback.FormOpened`, { feedbackCategory: category });
 
-  await userEvent.type(title, 'Bug title');
-  await userEvent.type(description, 'Bug description');
+  await userEvent.type(title, `${category} title`);
+  await userEvent.type(description, `${category} description`);
   await userEvent.click(preview);
 
   await vi.waitFor(() =>
     expect(window.telemetryTrack).toHaveBeenNthCalledWith(2, `feedback.FormSubmitted`, { feedbackCategory: category }),
   );
 });
+
+test.each(['bug', 'feature'])(
+  'Expect %s to have specific telemetry track events with error if the preview on GitHub fails',
+  async category => {
+    vi.mocked(window.previewOnGitHub).mockRejectedValue('error: unable to preview on GitHub');
+    const { title, description, preview } = renderGitHubIssueFeedback({
+      category: category,
+      onCloseForm: vi.fn(),
+      contentChange: vi.fn(),
+    });
+
+    expect(window.telemetryTrack).toHaveBeenNthCalledWith(1, `feedback.FormOpened`, { feedbackCategory: category });
+
+    await userEvent.type(title, `${category} title`);
+    await userEvent.type(description, `${category} description`);
+    await userEvent.click(preview);
+
+    await vi.waitFor(() =>
+      expect(window.telemetryTrack).toHaveBeenNthCalledWith(2, `feedback.FormSubmitted`, {
+        feedbackCategory: category,
+        error: 'error: unable to preview on GitHub',
+      }),
+    );
+  },
+);
 
 test('Expect close confirmation to be true if cancel clicked', async () => {
   const closeMock = vi.fn();

--- a/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.spec.ts
@@ -49,6 +49,7 @@ beforeAll(() => {
 beforeEach(() => {
   vi.resetAllMocks();
   vi.mocked(window.previewOnGitHub).mockResolvedValue(undefined);
+  vi.mocked(window.telemetryTrack).mockResolvedValue(undefined);
 });
 
 /**

--- a/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { Button, Checkbox, ErrorMessage, Link } from '@podman-desktop/ui-svelte';
+import { onMount } from 'svelte';
 
 import FeedbackForm from '/@/lib/feedback/FeedbackForm.svelte';
 import type { FeedbackCategory, GitHubIssue } from '/@api/feedback';
@@ -42,6 +43,10 @@ let existingIssuesLink = $state(
 
 $effect(() => contentChange(Boolean(issueTitle || issueDescription)));
 
+onMount(async () => {
+  await window.telemetryTrack(`feedback.${category}FormOpened`);
+});
+
 async function openGitHubIssues(): Promise<void> {
   onCloseForm(false);
   await window.openExternal(existingIssuesLink);
@@ -58,6 +63,7 @@ async function previewOnGitHub(): Promise<void> {
   try {
     await window.previewOnGitHub(issueProperties);
     onCloseForm(false);
+    await window.telemetryTrack(`feedback.${category}FormSubmitted`);
   } catch (error: unknown) {
     console.error('There was a problem with preview on GitHub', error);
   }

--- a/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.svelte
@@ -44,7 +44,7 @@ let existingIssuesLink = $state(
 $effect(() => contentChange(Boolean(issueTitle || issueDescription)));
 
 onMount(async () => {
-  await window.telemetryTrack(`feedback.${category}FormOpened`);
+  await window.telemetryTrack(`feedback.FormOpened`, { feedbackCategory: category });
 });
 
 async function openGitHubIssues(): Promise<void> {
@@ -63,7 +63,7 @@ async function previewOnGitHub(): Promise<void> {
   try {
     await window.previewOnGitHub(issueProperties);
     onCloseForm(false);
-    await window.telemetryTrack(`feedback.${category}FormSubmitted`);
+    await window.telemetryTrack(`feedback.FormSubmitted`, { feedbackCategory: category });
   } catch (error: unknown) {
     console.error('There was a problem with preview on GitHub', error);
   }


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR adds telemetry events to track when a user opens a bug or a feature feedback form, and when they click on the `Preview on GitHub` button. (as request in https://github.com/podman-desktop/podman-desktop/issues/9584#issuecomment-2466104205)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
related to https://github.com/podman-desktop/podman-desktop/issues/9584
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
