### PR TITLE
feat: added option to show svg files in addition to fa icons

### DIFF
--- a/packages/ui/src/lib/settingsNavItem/IconTest.svelte
+++ b/packages/ui/src/lib/settingsNavItem/IconTest.svelte
@@ -1,0 +1,5 @@
+<div role="img">
+    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+        <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z" />
+    </svg>
+</div>

--- a/packages/ui/src/lib/settingsNavItem/SettingsNavItem.spec.ts
+++ b/packages/ui/src/lib/settingsNavItem/SettingsNavItem.spec.ts
@@ -24,6 +24,7 @@ import { faBookOpen } from '@fortawesome/free-solid-svg-icons';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { beforeAll, expect, test, vi } from 'vitest';
 
+import MyIcon from './IconTest.svelte';
 import SettingsNavItem from './SettingsNavItem.svelte';
 
 function renderIt(title: string, href: string, selected?: boolean, section?: boolean, child?: boolean): void {
@@ -113,12 +114,23 @@ test('Expect sections expand', async () => {
   expect(element.firstChild?.childNodes[2]).toContainHTML('fa-angle-down');
 });
 
-test('icon should be visible', () => {
+test('fa icon should be visible', () => {
   render(SettingsNavItem, {
     title: 'DummyTitle',
     href: '/dummy/path',
     selected: false,
     icon: faBookOpen,
+  });
+  const svg = screen.getByRole('img', { hidden: true });
+  expect(svg).toBeInTheDocument();
+});
+
+test('svg icon should be visible', () => {
+  render(SettingsNavItem, {
+    title: 'DummyTitle',
+    href: '/dummy/path',
+    selected: false,
+    icon: MyIcon,
   });
   const svg = screen.getByRole('img', { hidden: true });
   expect(svg).toBeInTheDocument();

--- a/packages/ui/src/lib/settingsNavItem/SettingsNavItem.svelte
+++ b/packages/ui/src/lib/settingsNavItem/SettingsNavItem.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
 import type { IconDefinition } from '@fortawesome/free-regular-svg-icons';
+import type { Component } from 'svelte';
 import Fa from 'svelte-fa';
+
+import { isFontAwesomeIcon } from '../utils/icon-utils';
 
 interface Props {
   title: string;
@@ -9,7 +12,7 @@ interface Props {
   expanded?: boolean;
   child?: boolean;
   selected?: boolean;
-  icon?: IconDefinition;
+  icon?: IconDefinition | Component;
   onClick?: () => void;
 }
 
@@ -66,7 +69,12 @@ function click(): void {
     class:hover:border-[var(--pd-secondary-nav-text-hover-bg)]={!selected}>
     <span class="group-hover:block flex flex-row items-center" class:capitalize={!child}>
       {#if icon}
-        <Fa class="mr-4" icon={icon} />
+        {#if isFontAwesomeIcon(icon)}
+          <Fa class="mr-4" {icon} />
+        {:else}
+          {@const Icon = icon}
+          <Icon size="14" class="mr-4"/>
+        {/if}
       {/if}
       {title}
     </span>


### PR DESCRIPTION
### What does this PR do?
Adds option to show svg icon 

### Screenshot / video of UI


### What issues does this PR fix or reference?
Required for https://github.com/containers/podman-desktop-extension-ai-lab/pull/2246

### How to test this PR?
- [x] Tests are covering the bug fix or the new feature
