### PR TITLE
chore: create a command for pullImage and add a task to it

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -700,7 +700,7 @@ declare module '@podman-desktop/api' {
   /**
    * The commands module provides functions to register and execute commands
    * Existing command available for extensions to use:
-   * - `pullImage`: uses Podman Desktop's UI pull image behavior. This command will create a visible task to show the progress of the pulImage action.
+   * - `pullImage`: uses Podman Desktop's UI pull image behavior. This command will create a visible task to show the progress of the pulImage action with the option to include a task action.
    *
    * @example
    * ```typescript

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -146,16 +146,14 @@ declare module '@podman-desktop/api' {
    * }
    * ```
    */
-  export interface Event<T> {
-    /**
-     * @param listener The listener function will be called when the event happens.
-     * @param thisArgs The `this`-argument which will be used when calling the event listener.
-     * @param disposables An array to which the resulting {@link Disposable} will be added.
-     * @return A disposable which unsubscribes the event listener.
-     */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (listener: (e: T) => any, thisArgs?: any, disposables?: Disposable[]): Disposable;
-  }
+  /**
+   * @param listener The listener function will be called when the event happens.
+   * @param thisArgs The `this`-argument which will be used when calling the event listener.
+   * @param disposables An array to which the resulting {@link Disposable} will be added.
+   * @return A disposable which unsubscribes the event listener.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  export type Event<T> = (listener: (e: T) => any, thisArgs?: any, disposables?: Disposable[]) => Disposable;
 
   /**
    * A class to create and manage an {@link Event} for clients to subscribe to.
@@ -701,6 +699,8 @@ declare module '@podman-desktop/api' {
 
   /**
    * The commands module provides functions to register and execute commands
+   * Existing command available for extensions to use:
+   * - `pullImage`: uses Podman Desktop's UI pull image behavior. This command will create a visible task to show the progress of the pulImage action.
    *
    * @example
    * ```typescript

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -703,6 +703,7 @@ declare module '@podman-desktop/api' {
    * The commands module provides functions to register and execute commands
    * Existing command available for extensions to use:
    * - `pullImage`: uses Podman Desktop's UI pull image behavior. This command will create a visible task to show the progress of the pulImage action with the option to include a task action.
+   * It uses the same parameters as the original pullImage function, in addition to having `taskActionName: string` and `taskActionCallback: () => void` as parameters to create a task action (optional).
    *
    * @example
    * ```typescript

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -146,14 +146,16 @@ declare module '@podman-desktop/api' {
    * }
    * ```
    */
-  /**
-   * @param listener The listener function will be called when the event happens.
-   * @param thisArgs The `this`-argument which will be used when calling the event listener.
-   * @param disposables An array to which the resulting {@link Disposable} will be added.
-   * @return A disposable which unsubscribes the event listener.
-   */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  export type Event<T> = (listener: (e: T) => any, thisArgs?: any, disposables?: Disposable[]) => Disposable;
+  export interface Event<T> {
+    /**
+     * @param listener The listener function will be called when the event happens.
+     * @param thisArgs The `this`-argument which will be used when calling the event listener.
+     * @param disposables An array to which the resulting {@link Disposable} will be added.
+     * @return A disposable which unsubscribes the event listener.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (listener: (e: T) => any, thisArgs?: any, disposables?: Disposable[]): Disposable;
+  }
 
   /**
    * A class to create and manage an {@link Event} for clients to subscribe to.

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -701,8 +701,8 @@ declare module '@podman-desktop/api' {
 
   /**
    * The commands module provides functions to register and execute commands
-   * Existing command available for extensions to use:
-   * - `pullImage`: uses Podman Desktop's UI pull image behavior. This command will create a visible task to show the progress of the pulImage action with the option to include a task action.
+   * Existing commands available for extensions to use:
+   * - `pullImage`: uses Podman Desktop's UI pull image behavior. This command will create a visible task to show the progress of the pullImage action with the option to include a task action.
    * It uses the same parameters as the original pullImage function, in addition to having `taskActionName: string` and `taskActionCallback: () => void` as parameters to create a task action (optional).
    *
    * @example

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1107,12 +1107,12 @@ export class PluginSystem {
       async (
         providerContainerConnectionInfo: ProviderContainerConnectionInfo,
         imageName: string,
-        callbackId: number,
+        callback: (event: PullEvent) => void,
         platform?: string,
         taskActionName?: string,
         taskActionCallback?: () => void,
       ) => {
-        if (!providerContainerConnectionInfo || !imageName || !callbackId) {
+        if (!providerContainerConnectionInfo || !imageName || !callback || typeof callback !== 'function') {
           return;
         }
 
@@ -1136,14 +1136,7 @@ export class PluginSystem {
         });
 
         return containerProviderRegistry
-          .pullImage(
-            providerContainerConnectionInfo,
-            imageName,
-            (event: PullEvent) => {
-              this.getWebContentsSender().send('container-provider-registry:pullImage-onData', callbackId, event);
-            },
-            platform,
-          )
+          .pullImage(providerContainerConnectionInfo, imageName, callback, platform)
           .then(result => {
             task.status = 'success';
             return result;
@@ -1167,7 +1160,9 @@ export class PluginSystem {
           'pullImage',
           providerContainerConnectionInfo,
           imageName,
-          callbackId,
+          (event: PullEvent) => {
+            this.getWebContentsSender().send('container-provider-registry:pullImage-onData', callbackId, event);
+          },
           platform,
         );
       },

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -182,6 +182,7 @@ import type { StatusBarEntryDescriptor } from './statusbar/statusbar-registry.js
 import { StatusBarRegistry } from './statusbar/statusbar-registry.js';
 import { NotificationRegistry } from './tasks/notification-registry.js';
 import { ProgressImpl } from './tasks/progress-impl.js';
+import type { TaskAction } from './tasks/tasks.js';
 import { PAGE_EVENT_TYPE, Telemetry } from './telemetry/telemetry.js';
 import { TerminalInit } from './terminal-init.js';
 import { TrayIconColor } from './tray-icon-color.js';
@@ -1100,6 +1101,40 @@ export class PluginSystem {
         return containerProviderRegistry.resolveShortnameImage(providerContainerConnectionInfo, shortName);
       },
     );
+
+    commandRegistry.registerCommand(
+      'pullImage',
+      async (
+        providerContainerConnectionInfo: ProviderContainerConnectionInfo,
+        imageName: string,
+        callbackId: number,
+        platform?: string,
+        taskAction?: TaskAction,
+      ) => {
+        const task = taskManager.createTask({
+          title: `Pulling ${imageName}`,
+          action: taskAction,
+        });
+
+        return containerProviderRegistry
+          .pullImage(
+            providerContainerConnectionInfo,
+            imageName,
+            (event: PullEvent) => {
+              this.getWebContentsSender().send('container-provider-registry:pullImage-onData', callbackId, event);
+            },
+            platform,
+          )
+          .then(result => {
+            task.status = 'success';
+            return result;
+          })
+          .catch((error: unknown) => {
+            task.error = `Something went wrong while trying to pull ${imageName}: ${error};`;
+            throw error;
+          });
+      },
+    );
     this.ipcHandle(
       'container-provider-registry:pullImage',
       async (
@@ -1109,12 +1144,11 @@ export class PluginSystem {
         callbackId: number,
         platform?: string,
       ): Promise<void> => {
-        return containerProviderRegistry.pullImage(
+        return commandRegistry.executeCommand(
+          'pullImage',
           providerContainerConnectionInfo,
           imageName,
-          (event: PullEvent) => {
-            this.getWebContentsSender().send('container-provider-registry:pullImage-onData', callbackId, event);
-          },
+          callbackId,
           platform,
         );
       },

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1112,18 +1112,13 @@ export class PluginSystem {
         taskActionName?: string,
         taskActionCallback?: () => void,
       ) => {
-        if (!providerContainerConnectionInfo || !imageName || !callback || typeof callback !== 'function') {
+        if (!providerContainerConnectionInfo || !imageName || typeof callback !== 'function') {
           return;
         }
 
         let taskAction: TaskAction | undefined;
 
-        if (
-          taskActionName &&
-          typeof taskActionName === 'string' &&
-          taskActionCallback &&
-          typeof taskActionCallback === 'function'
-        ) {
+        if (taskActionName && typeof taskActionName === 'string' && typeof taskActionCallback === 'function') {
           taskAction = {
             name: taskActionName,
             execute: taskActionCallback,

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1109,8 +1109,27 @@ export class PluginSystem {
         imageName: string,
         callbackId: number,
         platform?: string,
-        taskAction?: TaskAction,
+        taskActionName?: string,
+        taskActionCallback?: () => void,
       ) => {
+        if (!providerContainerConnectionInfo || !imageName || !callbackId) {
+          return;
+        }
+
+        let taskAction: TaskAction | undefined;
+
+        if (
+          taskActionName &&
+          typeof taskActionName === 'string' &&
+          taskActionCallback &&
+          typeof taskActionCallback === 'function'
+        ) {
+          taskAction = {
+            name: taskActionName,
+            execute: taskActionCallback,
+          };
+        }
+
         const task = taskManager.createTask({
           title: `Pulling ${imageName}`,
           action: taskAction,


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR adds a `pullImage` command so that extensions could use it to have the same pullImage behavior as Podman Desktop UI, in addition to adding a task to track the pullImage status.

### Screenshot / video of UI
![Screenshot from 2024-12-10 22-02-21](https://github.com/user-attachments/assets/eefae9c0-7901-41b2-bc2c-ddd3156e8d64)


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
Closes https://github.com/podman-desktop/podman-desktop/issues/9989

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
