### PR TITLE
fix: copy docker-compose over existing file fails during installation

### DIFF
--- a/extensions/compose/src/cli-run.spec.ts
+++ b/extensions/compose/src/cli-run.spec.ts
@@ -98,7 +98,7 @@ test('success: installBinaryToSystem on mac with /usr/local/bin already created'
   // check called with admin being true
   expect(extensionApi.process.exec).toBeCalledWith(
     'exec',
-    expect.arrayContaining(['cp', 'test', `${path.sep}usr${path.sep}local${path.sep}bin${path.sep}tmpBinary`]),
+    expect.arrayContaining(['cp', '-f', 'test', `${path.sep}usr${path.sep}local${path.sep}bin${path.sep}tmpBinary`]),
     expect.objectContaining({ isAdmin: true }),
   );
 });

--- a/extensions/compose/src/cli-run.ts
+++ b/extensions/compose/src/cli-run.ts
@@ -67,7 +67,7 @@ export async function installBinaryToSystem(binaryPath: string, binaryName: stri
     args = [`"${binaryPath}"`, `"${destinationPath}"`];
   } else if (system === 'darwin') {
     command = 'exec';
-    args = ['cp', binaryPath, destinationPath];
+    args = ['cp', '-f', binaryPath, destinationPath];
   } else if (system === 'linux') {
     command = '/bin/sh';
     args = ['-c', `cp ${binaryPath} ${destinationPath}`];


### PR DESCRIPTION
### What does this PR do?

Copy docker-compose on macos using cp command with -f option to overwrite existing file.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

https://github.com/user-attachments/assets/5ba6aabd-60b1-45e2-8ab8-501e13525a1e

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Fix #5334.

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
