### PR TITLE
chore(test): Automation of Kubernetes e2e tests

### DIFF
--- a/.github/workflows/e2e-kubernetes-main.yaml
+++ b/.github/workflows/e2e-kubernetes-main.yaml
@@ -15,7 +15,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-name: e2e-tests-main
+name: e2e-kubernetes-tests-main
 
 on:
   push:
@@ -31,11 +31,6 @@ on:
       repositoryName:
         default: 'podman-desktop'
         description: 'Podman Desktop repository name'
-        type: string
-        required: true
-      npm_target:
-        default: 'test:e2e'
-        description: 'npm target to run tests'
         type: string
         required: true
       branch:
@@ -57,12 +52,6 @@ jobs:
 
       - uses: actions/checkout@v4
         if: github.event_name == 'push'
-
-      - name: Set the default npm target variable
-        env:
-          DEFAULT_NPM_TARGET: 'test:e2e'
-        run: |
-          echo "NPM_TARGET=${{ github.event.inputs.npm_target || env.DEFAULT_NPM_TARGET }}" >> $GITHUB_ENV
 
       - name: Update podman
         run: |
@@ -114,11 +103,10 @@ jobs:
 
       - name: Create Kind Cluster
         uses: helm/kind-action@v1.10.0
-        if: ${{ env.NPM_TARGET == 'test:e2e:all' }}
         with: 
           cluster_name: 'kind-cluster'
-        
-      - name: Run E2E tests in Production Mode
+            
+      - name: Run E2E kubernetes tests in Production Mode
         env:
           PODMANDESKTOP_CI_BOT_TOKEN: ${{ secrets.PODMANDESKTOP_CI_BOT_TOKEN }}
           TEST_PODMAN_MACHINE: 'true'
@@ -130,7 +118,7 @@ jobs:
           path=$(realpath ./dist/linux-unpacked/podman-desktop)
           echo "Podman Desktop built binary: $path"
           export PODMAN_DESKTOP_BINARY_PATH=$path
-          pnpm ${{ env.NPM_TARGET }}
+          pnpm test:e2e:k8s
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v5
@@ -141,83 +129,12 @@ jobs:
           detailed_summary: true
           annotate_only: true
           require_tests:  true
-          report_paths: '**/*results.xml'
+          report_paths: '**/*results.xml'      
 
       - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: e2e-tests
-          path: |
-            ./tests/**/output/
-            !./tests/**/traces/raw
-
-  win-update-e2e-test:
-    name: win update e2e tests
-    runs-on: windows-2022
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          repository: ${{ github.event.inputs.organization }}/${{ github.event.inputs.repositoryName }}
-          ref: ${{ github.event.inputs.branch }}
-        if: github.event_name == 'workflow_dispatch'
-
-      - uses: actions/checkout@v4
-        if: github.event_name == 'push'
-
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        with:
-          run_install: false
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'pnpm'
-
-      - name: Execute pnpm
-        run: pnpm install
-
-      - name: Execute PNPM
-        run: pnpm install --frozen-lockfile
-
-      - name: Adjust/Downgrade local podman desktop version Windows
-        run: |
-          $version="1.0.0"
-          jq --arg version "$version" '.version = $version' package.json | Out-File -FilePath package.json_tmp
-          Move-Item -Path package.json_tmp -Destination package.json -Force
-
-      - name: Build Podman Desktop locally with electron updater included
-        env:
-          ELECTRON_ENABLE_INSPECT: true
-        run: |
-          pnpm compile:current --win nsis
-          $path=('./dist/win-unpacked/Podman Desktop.exe' | resolve-path).ProviderPath
-          echo $path
-          echo ("PODMAN_DESKTOP_BINARY=" + $path) >> $env:GITHUB_ENV
-
-      - name: Run E2E Update test
-        run: |
-          echo "${{ env.PODMAN_DESKTOP_BINARY }}"
-          pnpm test:e2e:update:run
-
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v5
-        if: always() # always run even if the previous step fails
-        with:
-          fail_on_failure: true
-          include_passed: true
-          detailed_summary: true
-          annotate_only: true
-          require_tests:  true
-          report_paths: '**/*results.xml'
-
-      - uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: update-e2e-test
           path: |
             ./tests/**/output/
             !./tests/**/traces/raw

--- a/.github/workflows/e2e-kubernetes-main.yaml
+++ b/.github/workflows/e2e-kubernetes-main.yaml
@@ -100,11 +100,6 @@ jobs:
 
       - name: Execute pnpm
         run: pnpm install
-
-      - name: Create Kind Cluster
-        uses: helm/kind-action@v1.10.0
-        with: 
-          cluster_name: 'kind-cluster'
             
       - name: Run E2E kubernetes tests in Production Mode
         env:
@@ -134,7 +129,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: e2e-tests
+          name: k8s-e2e-tests
           path: |
             ./tests/**/output/
             !./tests/**/traces/raw

--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -35,7 +35,7 @@ on:
         required: true
       npm_target:
         default: 'test:e2e'
-        description: 'npm target to run tests'
+        description: 'The npm target to run tests. Use "test:e2e:all" to run all test suites, including Kubernetes tests.'
         type: string
         required: true
       branch:

--- a/tests/playwright/src/specs/deploy-to-kubernetes.spec.ts
+++ b/tests/playwright/src/specs/deploy-to-kubernetes.spec.ts
@@ -67,11 +67,9 @@ test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
 test.afterAll(async ({ runner, page }) => {
   test.setTimeout(90000);
   try {
-    if (!(process.env.GITHUB_ACTIONS && process.env.RUNNER_OS === 'Linux')) {
-      await deleteContainer(page, CONTAINER_NAME);
-      await deleteImage(page, IMAGE_TO_PULL);
-      await deleteKindCluster(page, KIND_CONTAINER_NAME, CLUSTER_NAME);
-    }
+    await deleteContainer(page, CONTAINER_NAME);
+    await deleteImage(page, IMAGE_TO_PULL);
+    await deleteKindCluster(page, KIND_CONTAINER_NAME, CLUSTER_NAME);
   } finally {
     await runner.close();
     console.log('Runner closed');

--- a/tests/playwright/src/specs/deploy-to-kubernetes.spec.ts
+++ b/tests/playwright/src/specs/deploy-to-kubernetes.spec.ts
@@ -19,7 +19,6 @@
 import { ContainerState } from '../model/core/states';
 import type { ContainerInteractiveParams } from '../model/core/types';
 import { ContainerDetailsPage } from '../model/pages/container-details-page';
-import { KubeContextPage } from '../model/pages/kubernetes-context-page';
 import { expect as playExpect, test } from '../utility/fixtures';
 import {
   createKindCluster,
@@ -56,14 +55,12 @@ test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
     await settingsBar.cliToolsTab.click();
 
     await ensureCliInstalled(page, 'Kind');
-    await createKindCluster(page, CLUSTER_NAME, true, CLUSTER_CREATION_TIMEOUT);
   }
-  if (process.env.GITHUB_ACTIONS && process.env.RUNNER_OS === 'Linux') {
-    const settingsBar = await navigationBar.openSettings();
-    const kubePage = await settingsBar.openTabPage(KubeContextPage);
-    await playExpect(kubePage.heading).toBeVisible();
 
-    playExpect(await kubePage.isContextDefault('kind-kind-cluster')).toBeTruthy();
+  if (process.env.GITHUB_ACTIONS && process.env.RUNNER_OS === 'Linux') {
+    await createKindCluster(page, CLUSTER_NAME, false, CLUSTER_CREATION_TIMEOUT, { useIngressController: false });
+  } else {
+    await createKindCluster(page, CLUSTER_NAME, true, CLUSTER_CREATION_TIMEOUT);
   }
 });
 

--- a/tests/playwright/src/specs/kind.spec.ts
+++ b/tests/playwright/src/specs/kind.spec.ts
@@ -18,7 +18,6 @@
 
 import { ResourceElementActions } from '../model/core/operations';
 import { ContainerState, ResourceElementState } from '../model/core/states';
-import { KubeContextPage } from '../model/pages/kubernetes-context-page';
 import { ResourceConnectionCardPage } from '../model/pages/resource-connection-card-page';
 import { ResourcesPage } from '../model/pages/resources-page';
 import { VolumesPage } from '../model/pages/volumes-page';
@@ -42,19 +41,12 @@ let kindResourceCard: ResourceConnectionCardPage;
 
 const skipKindInstallation = process.env.SKIP_KIND_INSTALL === 'true';
 
-test.beforeAll(async ({ runner, page, welcomePage, navigationBar }) => {
+test.beforeAll(async ({ runner, page, welcomePage }) => {
   runner.setVideoAndTraceName('kind-e2e');
   await welcomePage.handleWelcomePage(true);
   await waitForPodmanMachineStartup(page);
   resourcesPage = new ResourcesPage(page);
   kindResourceCard = new ResourceConnectionCardPage(page, RESOURCE_NAME);
-  if (process.env.GITHUB_ACTIONS && process.env.RUNNER_OS === 'Linux') {
-    const settingsBar = await navigationBar.openSettings();
-    const kubePage = await settingsBar.openTabPage(KubeContextPage);
-    await playExpect(kubePage.heading).toBeVisible();
-
-    playExpect(await kubePage.isContextDefault('kind-kind-cluster')).toBeTruthy();
-  }
 });
 
 test.afterAll(async ({ runner, page }) => {

--- a/tests/playwright/src/specs/kind.spec.ts
+++ b/tests/playwright/src/specs/kind.spec.ts
@@ -95,13 +95,13 @@ test.describe.serial('Kind End-to-End Tests', { tag: '@k8s_e2e' }, () => {
       });
     });
   test.describe('Kind cluster operations', () => {
-    test.skip(
-      !!process.env.GITHUB_ACTIONS && process.env.RUNNER_OS === 'Linux',
-      'Tests should not run on the Linux platform in GitHub Actions',
-    );
     test('Create a Kind cluster', async ({ page }) => {
       test.setTimeout(CLUSTER_CREATION_TIMEOUT);
-      await createKindCluster(page, CLUSTER_NAME, true, CLUSTER_CREATION_TIMEOUT);
+      if (process.env.GITHUB_ACTIONS && process.env.RUNNER_OS === 'Linux') {
+        await createKindCluster(page, CLUSTER_NAME, false, CLUSTER_CREATION_TIMEOUT, { useIngressController: false });
+      } else {
+        await createKindCluster(page, CLUSTER_NAME, true, CLUSTER_CREATION_TIMEOUT);
+      }
     });
 
     test('Check resources added with the Kind cluster', async ({ page, navigationBar }) => {

--- a/tests/playwright/src/specs/kubernetes-edit-yaml.spec.ts
+++ b/tests/playwright/src/specs/kubernetes-edit-yaml.spec.ts
@@ -22,7 +22,6 @@ import { fileURLToPath } from 'node:url';
 import { PlayYamlRuntime } from '../model/core/operations';
 import { KubernetesResourceState } from '../model/core/states';
 import { KubernetesResources } from '../model/core/types';
-import { KubeContextPage } from '../model/pages/kubernetes-context-page';
 import { KubernetesResourceDetailsPage } from '../model/pages/kubernetes-resource-details-page';
 import { expect as playExpect, test } from '../utility/fixtures';
 import {
@@ -62,14 +61,12 @@ test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
     await settingsBar.cliToolsTab.click();
 
     await ensureCliInstalled(page, 'Kind');
-    await createKindCluster(page, CLUSTER_NAME, true, CLUSTER_CREATION_TIMEOUT);
   }
-  if (process.env.GITHUB_ACTIONS && process.env.RUNNER_OS === 'Linux') {
-    const settingsBar = await navigationBar.openSettings();
-    const kubePage = await settingsBar.openTabPage(KubeContextPage);
-    await playExpect(kubePage.heading).toBeVisible();
 
-    playExpect(await kubePage.isContextDefault('kind-kind-cluster')).toBeTruthy();
+  if (process.env.GITHUB_ACTIONS && process.env.RUNNER_OS === 'Linux') {
+    await createKindCluster(page, CLUSTER_NAME, false, CLUSTER_CREATION_TIMEOUT, { useIngressController: false });
+  } else {
+    await createKindCluster(page, CLUSTER_NAME, true, CLUSTER_CREATION_TIMEOUT);
   }
 });
 

--- a/tests/playwright/src/specs/kubernetes-edit-yaml.spec.ts
+++ b/tests/playwright/src/specs/kubernetes-edit-yaml.spec.ts
@@ -73,9 +73,7 @@ test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
 test.afterAll(async ({ runner, page }) => {
   test.setTimeout(90000);
   try {
-    if (!(process.env.GITHUB_ACTIONS && process.env.RUNNER_OS === 'Linux')) {
-      await deleteKindCluster(page, KIND_NODE, CLUSTER_NAME);
-    }
+    await deleteKindCluster(page, KIND_NODE, CLUSTER_NAME);
   } finally {
     await runner.close();
   }

--- a/tests/playwright/src/specs/kubernetes.spec.ts
+++ b/tests/playwright/src/specs/kubernetes.spec.ts
@@ -22,7 +22,6 @@ import { fileURLToPath } from 'node:url';
 import { PlayYamlRuntime } from '../model/core/operations';
 import { KubernetesResourceState, PodState } from '../model/core/states';
 import { KubernetesResources } from '../model/core/types';
-import { KubeContextPage } from '../model/pages/kubernetes-context-page';
 import { expect as playExpect, test } from '../utility/fixtures';
 import {
   createKindCluster,
@@ -70,14 +69,12 @@ test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
     await settingsBar.cliToolsTab.click();
 
     await ensureCliInstalled(page, 'Kind');
-    await createKindCluster(page, CLUSTER_NAME, true, CLUSTER_CREATION_TIMEOUT);
   }
-  if (process.env.GITHUB_ACTIONS && process.env.RUNNER_OS === 'Linux') {
-    const settingsBar = await navigationBar.openSettings();
-    const kubePage = await settingsBar.openTabPage(KubeContextPage);
-    await playExpect(kubePage.heading).toBeVisible();
 
-    playExpect(await kubePage.isContextDefault('kind-kind-cluster')).toBeTruthy();
+  if (process.env.GITHUB_ACTIONS && process.env.RUNNER_OS === 'Linux') {
+    await createKindCluster(page, CLUSTER_NAME, false, CLUSTER_CREATION_TIMEOUT, { useIngressController: false });
+  } else {
+    await createKindCluster(page, CLUSTER_NAME, true, CLUSTER_CREATION_TIMEOUT);
   }
 });
 

--- a/tests/playwright/src/specs/kubernetes.spec.ts
+++ b/tests/playwright/src/specs/kubernetes.spec.ts
@@ -81,9 +81,7 @@ test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
 test.afterAll(async ({ runner, page }) => {
   test.setTimeout(90000);
   try {
-    if (!(process.env.GITHUB_ACTIONS && process.env.RUNNER_OS === 'Linux')) {
-      await deleteKindCluster(page, KIND_NODE, CLUSTER_NAME);
-    }
+    await deleteKindCluster(page, KIND_NODE, CLUSTER_NAME);
   } finally {
     await runner.close();
   }


### PR DESCRIPTION
Signed-off-by: Anton Misskii <amisskii@redhat.com>

### What does this PR do?

Modifies Kubernetes tests to run on the Linux platform in GitHub Actions, introduces a workflow to run only Kubernetes tests, and configures the e2e-main workflow to run all test suites using the test:e2e:all npm target.

### What issues does this PR fix or reference?

https://github.com/podman-desktop/podman-desktop/issues/10001

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
