### PR TITLE
fix: building image without name should have a correct task title

### DIFF
--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -2538,7 +2538,7 @@ export class ContainerProviderRegistry {
         eventCollect('error', errorMessage);
         throw error;
       }
-      eventCollect('stream', `Building ${options?.tag}...\r\n`);
+      eventCollect('stream', `Building image ${options?.tag ?? ''}...\r\n`);
       // eslint-disable-next-line @typescript-eslint/no-empty-object-type
       let resolve: (output: {}) => void;
       let reject: (err: Error) => void;

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1280,7 +1280,7 @@ export class PluginSystem {
         _listener,
         containerBuildContextDirectory: string,
         relativeContainerfilePath: string,
-        imageName: string,
+        imageName: string | undefined,
         platform: string,
         selectedProvider: ProviderContainerConnectionInfo,
         onDataCallbacksBuildImageId: number,
@@ -1289,7 +1289,7 @@ export class PluginSystem {
       ): Promise<unknown> => {
         // create task
         const task = taskManager.createTask({
-          title: `Building ${imageName}`,
+          title: `Building ${imageName ?? 'unnamed image'}`,
           action: {
             name: 'Go to task >',
             execute: () => {

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1289,7 +1289,7 @@ export class PluginSystem {
       ): Promise<unknown> => {
         // create task
         const task = taskManager.createTask({
-          title: `Building ${imageName ?? 'unnamed image'}`,
+          title: `Building image ${imageName ?? ''}`,
           action: {
             name: 'Go to task >',
             execute: () => {

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1204,7 +1204,7 @@ export function initExposure(): void {
     async (
       containerBuildContextDirectory: string,
       relativeContainerfilePath: string,
-      imageName: string,
+      imageName: string | undefined,
       platform: string,
       selectedProvider: ProviderContainerConnectionInfo,
       key: symbol,

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
@@ -218,7 +218,7 @@ test('Select multiple platforms and expect pressing Build will do two buildImage
   expect(window.buildImage).toHaveBeenCalledWith(
     '/somepath',
     'containerfile',
-    '',
+    undefined,
     'linux/amd64',
     expect.anything(),
     expect.anything(),
@@ -230,7 +230,7 @@ test('Select multiple platforms and expect pressing Build will do two buildImage
   expect(window.buildImage).toHaveBeenCalledWith(
     '/somepath',
     'containerfile',
-    '',
+    undefined,
     'linux/arm64',
     expect.anything(),
     expect.anything(),
@@ -238,6 +238,37 @@ test('Select multiple platforms and expect pressing Build will do two buildImage
     expect.anything(),
     expect.anything(),
   );
+});
+
+test('Select multiple platforms without image name should disable Build button', async () => {
+  // Auto select amd64
+  vi.mocked(window.getOsArch).mockResolvedValue('amd64');
+  setup();
+  await waitRender();
+
+  const containerFilePath = screen.getByRole('textbox', { name: 'Containerfile path' });
+  expect(containerFilePath).toBeInTheDocument();
+  await userEvent.type(containerFilePath, '/somepath/containerfile');
+
+  // Wait until 'linux/arm64' checkboxes exist and are enabled
+  await waitFor(() => {
+    const platform1 = screen.getByRole('checkbox', { name: 'Intel and AMD x86_64 systems' });
+    expect(platform1).toBeInTheDocument();
+    expect(platform1).toBeChecked();
+  });
+
+  // Click on the 'linux/arm64' button
+  const platform2button = screen.getByRole('button', { name: 'linux/arm64' });
+  expect(platform2button).toBeInTheDocument();
+  await userEvent.click(platform2button);
+
+  const platform2 = screen.getByRole('checkbox', { name: 'ARM® aarch64 systems' });
+  expect(platform2).toBeInTheDocument();
+  expect(platform2).toBeChecked();
+
+  const buildButton = screen.getByRole('button', { name: 'Build' });
+  expect(buildButton).toBeInTheDocument();
+  expect(buildButton).toBeDisabled();
 });
 
 test('Selecting one platform only calls buildImage once with the selected platform, make sure that it has a name', async () => {

--- a/packages/renderer/src/lib/image/build-image-task.spec.ts
+++ b/packages/renderer/src/lib/image/build-image-task.spec.ts
@@ -32,7 +32,7 @@ test('check start build', async () => {
     onEnd: vi.fn(),
   };
 
-  const key = startBuild('foo', dummyCallback);
+  const key = startBuild(dummyCallback);
   expect(key).toBeDefined();
 });
 
@@ -49,7 +49,7 @@ test('check reconnect', async () => {
     onEnd: vi.fn(),
   };
 
-  const firstKey = startBuild('foo', dummyCallback);
+  const firstKey = startBuild(dummyCallback);
 
   // stream some stuff
   eventCollect(firstKey.buildImageKey, 'stream', 'hello');
@@ -76,7 +76,7 @@ test('check error', async () => {
     onEnd: vi.fn(),
   };
 
-  const key = startBuild('foo', dummyCallback);
+  const key = startBuild(dummyCallback);
 
   eventCollect(key.buildImageKey, 'stream', 'hello');
   eventCollect(key.buildImageKey, 'error', 'world');

--- a/packages/renderer/src/lib/image/build-image-task.ts
+++ b/packages/renderer/src/lib/image/build-image-task.ts
@@ -54,7 +54,7 @@ const buildOnHolds = new Map<symbol, BuildHold>();
 const buildReplays = new Map<symbol, BuildReplay>();
 
 // new build is occuring, needs to compute a new key and prepare replay data
-export function startBuild(imageName: string, buildImageCallback: BuildImageCallback): BuildImageInfo {
+export function startBuild(buildImageCallback: BuildImageCallback): BuildImageInfo {
   const key = getKey();
   buildCallbacks.set(key, buildImageCallback);
 


### PR DESCRIPTION
Fixes #10078

### What does this PR do?

Ensure the task title is correct if no image name is given

### Screenshot / video of UI

![unamed](https://github.com/user-attachments/assets/6ddf67cd-6769-4806-86dc-d9e6abb85258)

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

1. Build an image without the image name
2. Check the task title

- [x] Tests are covering the bug fix or the new feature
