### PR TITLE
refactor: adding a check for the KUBECONFIG variable

### DIFF
--- a/packages/main/src/plugin/kubernetes/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.ts
@@ -222,6 +222,14 @@ export class KubernetesClient {
   ) {
     this.kubeConfig = new KubeConfig();
     this.contextsState = new ContextsManager(this.apiSender);
+    // Check if KUBECONFIG environment variable is set
+    const kubeconfigEnv = process.env.KUBECONFIG;
+    if (kubeconfigEnv && kubeconfigEnv !== KubernetesClient.DEFAULT_KUBECONFIG_PATH) {
+      console.warn(
+        `Warning: The KUBECONFIG environment variable is set to '${kubeconfigEnv}', which differs from the
+	 default path '${KubernetesClient.DEFAULT_KUBECONFIG_PATH}'. This may lead to unexpected behavior.`
+      );
+    }
   }
 
   async init(): Promise<void> {


### PR DESCRIPTION
Signed-off-by: Alexon Oliveira <alexon@redhat.com>

### What does this PR do?

This validation of the existence of the KUBECONFIG variable set in the operating system aims to inform the use through the console that this could lead to an unexpected behavior in some scenarios, like trying to install a Kubernetes cluster and failing because Podman Desktop cannot use or update the default ~/.kube/config file.  Although this not correct the variable value, at least informs the user of its value, allowing the user to take the proper action to fix it.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

The issue #9983 describes this better with an example of such situation. Closes #9983.

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
