### PR TITLE
fix: toggle of help menu

### DIFF
--- a/packages/renderer/src/lib/help/HelpActions.spec.ts
+++ b/packages/renderer/src/lib/help/HelpActions.spec.ts
@@ -26,19 +26,15 @@ import { Items } from './HelpItems';
 
 let toggleMenuCallback: () => void;
 
+const receiveEventMock = vi.fn();
+
 suite('HelpActions component', () => {
   beforeEach(() => {
     vi.resetAllMocks();
     (window as any).events = {
-      receive: vi.fn(),
+      receive: receiveEventMock,
     };
     (window as any).ResizeObserver = vi.fn().mockReturnValue({ observe: vi.fn(), unobserve: vi.fn() });
-    vi.mocked(window.events.receive).mockImplementation((channel: string, callback: () => void) => {
-      toggleMenuCallback = callback;
-      return {
-        dispose: () => {},
-      };
-    });
   });
 
   test('by default is not visible', () => {
@@ -47,22 +43,60 @@ suite('HelpActions component', () => {
     expect(items).toHaveLength(0);
   });
 
-  test('is visible after toggling', async () => {
-    const ha = render(HelpActions);
-    toggleMenuCallback();
-    await vi.waitFor(() => {
-      const items = ha.queryAllByTitle(Items[0].title);
-      expect(items).toHaveLength(1);
+  test('simulate clicking outside the menu closes it', async () => {
+    vi.mocked(receiveEventMock).mockImplementation((channel: string, callback: () => void) => {
+      toggleMenuCallback = callback;
+      return {
+        dispose: () => {},
+      };
     });
-    // Toggle again and expect it to be hidden
+    const ha = render(HelpActions);
+
     toggleMenuCallback();
+
     await vi.waitFor(() => {
-      const items = ha.queryAllByTitle(Items[0].title);
-      expect(items).toHaveLength(0);
+      const helpMenu = ha.getByTestId('help-menu');
+      expect(helpMenu).toBeVisible();
+    });
+
+    // Click "outside" the menu (body)
+    const event = new MouseEvent('click', { bubbles: true });
+    document.body.dispatchEvent(event);
+
+    await vi.waitFor(() => {
+      const helpMenu = ha.queryByTestId('help-menu');
+      expect(helpMenu).toBeNull();
     });
   });
 
+  test('create a span that has data-task-button=Help attribute, spy on and make sure that it is only called once each click', async () => {
+    render(HelpActions);
+
+    // Create data-task-button=Help to simulate the status bar icon / button
+    const span = document.createElement('span');
+    span.setAttribute('data-task-button', 'Help');
+    document.body.appendChild(span);
+
+    // Click
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+    span.dispatchEvent(event);
+
+    // Expect receiveEventMock to have been called
+    // why we do this is because we are mocking receiveEvent already, so we're not "toggling" it
+    // this test ensures that the event is only called once / we are toggling correctly.
+    expect(receiveEventMock).toHaveBeenCalledTimes(1);
+
+    // Remove the span after (unsure if needed, but dont want to break other tests)
+    span.remove();
+  });
+
   test.each(Items)('contains item with $title', async ({ title, tooltip }) => {
+    vi.mocked(receiveEventMock).mockImplementation((channel: string, callback: () => void) => {
+      toggleMenuCallback = callback;
+      return {
+        dispose: () => {},
+      };
+    });
     const ha = render(HelpActions);
     toggleMenuCallback();
     await vi.waitFor(async () => {

--- a/packages/renderer/src/lib/help/HelpActions.spec.ts
+++ b/packages/renderer/src/lib/help/HelpActions.spec.ts
@@ -47,6 +47,21 @@ suite('HelpActions component', () => {
     expect(items).toHaveLength(0);
   });
 
+  test('is visible after toggling', async () => {
+    const ha = render(HelpActions);
+    toggleMenuCallback();
+    await vi.waitFor(() => {
+      const items = ha.queryAllByTitle(Items[0].title);
+      expect(items).toHaveLength(1);
+    });
+    // Toggle again and expect it to be hidden
+    toggleMenuCallback();
+    await vi.waitFor(() => {
+      const items = ha.queryAllByTitle(Items[0].title);
+      expect(items).toHaveLength(0);
+    });
+  });
+
   test.each(Items)('contains item with $title', async ({ title, tooltip }) => {
     const ha = render(HelpActions);
     toggleMenuCallback();

--- a/packages/renderer/src/lib/help/HelpActions.svelte
+++ b/packages/renderer/src/lib/help/HelpActions.svelte
@@ -19,9 +19,9 @@ function handleEscape({ key }: KeyboardEvent): void {
 }
 
 function onWindowClick(e: any): void {
-  // We listen to the click event on anything BUT the question circle icon which is
-  // where the help menu is. This is to ensure the menu is closed if the user clicks the circle again.
-  if (!e.srcElement.classList.contains('fa-question-circle')) {
+  const target = e.target as HTMLElement;
+  // Listen to anything **but** the button that has "data-task-button" attribute with a value of "Help"
+  if (target && target.getAttribute('data-task-button') !== 'Help') {
     showMenu = outsideWindow.contains(e.target);
   }
 }

--- a/packages/renderer/src/lib/help/HelpActions.svelte
+++ b/packages/renderer/src/lib/help/HelpActions.svelte
@@ -19,7 +19,11 @@ function handleEscape({ key }: KeyboardEvent): void {
 }
 
 function onWindowClick(e: any): void {
-  showMenu = outsideWindow.contains(e.target);
+  // We listen to the click event on anything BUT the question circle icon which is
+  // where the help menu is. This is to ensure the menu is closed if the user clicks the circle again.
+  if (!e.srcElement.classList.contains('fa-question-circle')) {
+    showMenu = outsideWindow.contains(e.target);
+  }
 }
 
 async function onClick(action?: ItemAction): Promise<void> {

--- a/packages/renderer/src/lib/help/HelpMenu.svelte
+++ b/packages/renderer/src/lib/help/HelpMenu.svelte
@@ -24,7 +24,8 @@ onDestroy(() => window.removeEventListener('resize', updateMenuLocation));
   bind:offsetHeight={dropDownHeight}
   bind:offsetWidth={dropDownWidth}
   bind:this={dropDownElement}
-  class="absolute">
+  class="absolute"
+  data-testid="help-menu">
   <div
     title="Help Menu Items"
     class="z-10 m-1 rounded-md shadow-lg bg-[var(--pd-dropdown-bg)] ring-2 ring-[var(--pd-dropdown-ring)] hover:ring-[var(--pd-dropdown-hover-ring)] divide-y divide-[var(--pd-dropdown-divider)] focus:outline-none">

--- a/packages/renderer/src/lib/statusbar/StatusBarItem.svelte
+++ b/packages/renderer/src/lib/statusbar/StatusBarItem.svelte
@@ -42,7 +42,7 @@ async function executeCommand(entry: StatusBarEntry) {
   )} relative inline-block"
   title={tooltipText(entry)}>
   {#if iconClass(entry)}
-    <span class={iconClass(entry)} aria-hidden="true"></span>
+    <span class={iconClass(entry)} aria-hidden="true" data-task-button="{tooltipText(entry)}"></span>
   {/if}
   {#if entry.text}
     <span class="ml-1">{entry.text}</span>


### PR DESCRIPTION
fix: toggle of help menu

### What does this PR do?

Fixes toggling the help menu

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

https://github.com/user-attachments/assets/87babb2c-ffa5-44ac-9c2a-ccbdd258f4a4




### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/podman-desktop/issues/10154

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Toggle the help menu button, it should close now

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
