### PR TITLE
chore: change GitHub podman desktop links in website to podman-desktop org

### DIFF
--- a/website/blog/2024-11-08-bootc-microshift.md
+++ b/website/blog/2024-11-08-bootc-microshift.md
@@ -28,7 +28,7 @@ Before starting the tutorial, ensure you have:
 - An active [Red Hat account](https://developers.redhat.com/articles/2024/05/07/podman-desktop-red-hat-developer-subscription) in order to access RHEL-based images
 - Access to an [OpenShift Hybrid Cloud pull secret](https://console.redhat.com/openshift/install/pull-secret)
 - [Podman Desktop installed](https://podman-desktop.io/downloads)
-- [Podman Desktop BootC Extension](https://github.com/containers/podman-desktop-extension-bootc)
+- [Podman Desktop BootC Extension](https://github.com/podman-desktop/podman-desktop-extension-bootc)
 - Your preferred VM-running software (e.g., [using libvirt](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/configuring_and_managing_virtualization/introducing-virtualization-in-rhel_configuring-and-managing-virtualization#what-is-virtualization_introducing-virtualization-in-rhel))
 
 ## Building the BootC container image

--- a/website/docs/extensions/developing/index.md
+++ b/website/docs/extensions/developing/index.md
@@ -12,13 +12,13 @@ Podman Desktop is organized so that you can modularly add new functionality in t
 
 It is recommended that an extension is written in **TypeScript** for typechecking, but extensions CAN be written in **JavaScript**.
 
-Most extensions are externally loaded, however, we also dog-food our own API by loading them as [internal extensions](https://github.com/containers/podman-desktop/tree/main/extensions) that use the same API. These internal maintained extensions can be used as an example and basis of how to build an externally-loaded extension.
+Most extensions are externally loaded, however, we also dog-food our own API by loading them as [internal extensions](https://github.com/podman-desktop/podman-desktop/tree/main/extensions) that use the same API. These internal maintained extensions can be used as an example and basis of how to build an externally-loaded extension.
 
 ## Overview of creating a new extension
 
 We try to simplify extension creation as much as possible by utilizing `package.json` as well as keeping activations simplistic within the extension by only providing two entrypoints: `activate()` and `deactivate()` from within the extension.
 
-All functionality with Podman Desktop is also communicated entirely through the `extension-api` which is loaded as `import * as extensionApi from '@podman-desktop/api';`. The API code is located [here](https://github.com/containers/podman-desktop/blob/main/packages/extension-api/src/extension-api.d.ts) while the website representation of the code is located [here](https://podman-desktop.io/api).
+All functionality with Podman Desktop is also communicated entirely through the `extension-api` which is loaded as `import * as extensionApi from '@podman-desktop/api';`. The API code is located [here](https://github.com/podman-desktop/podman-desktop/blob/main/packages/extension-api/src/extension-api.d.ts) while the website representation of the code is located [here](https://podman-desktop.io/api).
 
 ### Activating
 
@@ -32,7 +32,7 @@ When activating an extension, Podman Desktop will:
 When deactivating an extension, Podman Desktop will:
 
 1. Run the (optional) exported `deactivate` function.
-2. Dispose of any resources that have been added to `extensionContext.subscriptions`, see `deactivateExtension` in [extension-loader.ts](https://github.com/containers/podman-desktop/blob/main/packages/main/src/plugin/extension-loader.ts).
+2. Dispose of any resources that have been added to `extensionContext.subscriptions`, see `deactivateExtension` in [extension-loader.ts](https://github.com/podman-desktop/podman-desktop/blob/main/packages/main/src/plugin/extension-loader.ts).
 
 ### Example boilerplate code
 
@@ -376,7 +376,7 @@ export default config;
 #### Prerequisites
 
 - JavaScript or TypeScript
-- A clone of the [Podman Desktop](https://github.com/containers/podman-desktop) repository
+- A clone of the [Podman Desktop](https://github.com/podman-desktop/podman-desktop) repository
 
 #### Procedure
 
@@ -397,7 +397,7 @@ Below is documentation and/or "boiler-plate" code that can help expand your exte
 
 ### Using `ProviderStatus`
 
-Podman Desktop runs each provider via series of statuses from [extension-api](https://github.com/containers/podman-desktop/blob/main/packages/extension-api/src/extension-api.d.ts).
+Podman Desktop runs each provider via series of statuses from [extension-api](https://github.com/podman-desktop/podman-desktop/blob/main/packages/extension-api/src/extension-api.d.ts).
 
 ```ts
 export type ProviderStatus =
@@ -431,7 +431,7 @@ export type ProviderConnectionStatus = 'started' | 'stopped' | 'starting' | 'sto
 
 Upon a successful start up via the `activate` function within your extension, `ProviderConnectionStatus` will be reflected as 'started'.
 
-`ProviderConnectionStatus` statuses are used in two areas, [extension-loader.ts](https://github.com/containers/podman-desktop/blob/main/packages/main/src/plugin/extension-loader.ts) and [tray-menu.ts](https://github.com/containers/podman-desktop/blob/main/packages/main/src/tray-menu.ts):
+`ProviderConnectionStatus` statuses are used in two areas, [extension-loader.ts](https://github.com/podman-desktop/podman-desktop/blob/main/packages/main/src/plugin/extension-loader.ts) and [tray-menu.ts](https://github.com/podman-desktop/podman-desktop/blob/main/packages/main/src/tray-menu.ts):
 
 - `extension-loader.ts`: Attempts to load the extension and sets the status accordingly (either `started`, `stopped`, `starting` or `stopping`). If an unknown error has occurred, the status is set to `unknown`. `extension-loader.ts` also sends an API call to Podman Desktop to update the UI of the extension.
 - `tray-menu.ts`: If `extensionApi.tray.registerMenuItem(item);` API call has been used, a tray menu of the extension will be created. When created, Podman Desktop will use the `ProviderConnectionStatus` to indicate the status within the tray menu.

--- a/website/docs/extensions/templates/index.md
+++ b/website/docs/extensions/templates/index.md
@@ -14,7 +14,7 @@ Below are a list of officially maintained templates to be used for Podman Deskto
 
 ![minimal](../img/minimal.png)
 
-**Link:** https://github.com/containers/podman-desktop-extension-minimal-template
+**Link:** https://github.com/podman-desktop/podman-desktop-extension-minimal-template
 
 This template provides a minimal template on how to build a Podman Desktop extension. More information can be found on our official extension documentation on how to further expand your extension.
 
@@ -24,7 +24,7 @@ With this template, on activating a "Hello World!" dialog will appear.
 
 ![webview](../img/webview.png)
 
-**Link:** https://github.com/containers/podman-desktop-extension-webview-template
+**Link:** https://github.com/podman-desktop/podman-desktop-extension-webview-template
 
 This template provides a webview template on how to build a Podman Desktop extension showcasing a frontend.
 
@@ -36,7 +36,7 @@ With this template, you will see a new button on the navbar that says "Hello Wor
 
 ![full](../img/full.png)
 
-**Link:** https://github.com/containers/podman-desktop-extension-full-template
+**Link:** https://github.com/podman-desktop/podman-desktop-extension-full-template
 
 This template provides a "full" example of creating an extension with a webview that utilizes multiple packages. Within this template, we use three separate packages to distinguish between the frontend, backend, and shared code that connects the frontend and backend.
 

--- a/website/docs/installation/linux-install/installing-podman-desktop-from-a-flatpak-bundle.md
+++ b/website/docs/installation/linux-install/installing-podman-desktop-from-a-flatpak-bundle.md
@@ -24,7 +24,7 @@ Consider installing a Flatpak bundle rather than [from Flathub](/docs/installati
 
    - [Downloads page](/downloads/linux)
 
-   - [Git repository release assets](https://github.com/containers/podman-desktop/releases)
+   - [Git repository release assets](https://github.com/podman-desktop/podman-desktop/releases)
 
 2. Install Podman Desktop from the downloaded Flatpak bundle:
 

--- a/website/docs/troubleshooting/index.md
+++ b/website/docs/troubleshooting/index.md
@@ -6,7 +6,7 @@ description: How to investigate when Podman Desktop does not work as expected.
 
 # Troubleshooting
 
-If you cannot find your issue here or in the documentation, please fill an issue on our [repository](https://github.com/containers/podman-desktop/issues). You can also explore the [discussions](https://github.com/containers/podman-desktop/discussions) and do a search on similar issues on the [repository](https://github.com/containers/podman-desktop/issues).
+If you cannot find your issue here or in the documentation, please fill an issue on our [repository](https://github.com/podman-desktop/podman-desktop/issues). You can also explore the [discussions](https://github.com/podman-desktop/podman-desktop/discussions) and do a search on similar issues on the [repository](https://github.com/podman-desktop/podman-desktop/issues).
 
 Access the following pages to troubleshoot your issues:
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -361,7 +361,7 @@ const config = {
         docs: {
           sidebarCollapsed: false,
           sidebarPath: require.resolve('./sidebars.js'),
-          editUrl: 'https://github.com/containers/podman-desktop/tree/main/website',
+          editUrl: 'https://github.com/podman-desktop/podman-desktop/tree/main/website',
         },
         blog: {
           blogTitle: 'Podman Desktop blog!',
@@ -414,7 +414,7 @@ const config = {
           { to: '/blog', label: 'Blog', position: 'left' },
           { to: '/tutorial', label: 'Tutorials', position: 'left' },
           {
-            href: 'https://github.com/containers/podman-desktop',
+            href: 'https://github.com/podman-desktop/podman-desktop',
             className: 'header-github-link',
             position: 'right',
           },
@@ -448,7 +448,7 @@ const config = {
             items: [
               {
                 label: 'GitHub',
-                href: 'https://github.com/containers/podman-desktop',
+                href: 'https://github.com/podman-desktop/podman-desktop',
               },
               {
                 label: 'Chat (bridged): #podman-desktop on Discord',
@@ -456,7 +456,7 @@ const config = {
               },
               {
                 label: 'Other ways to Communicate',
-                href: 'https://github.com/containers/podman-desktop#communication',
+                href: 'https://github.com/podman-desktop/podman-desktop#communication',
               },
               {
                 label: 'Current Sprint',


### PR DESCRIPTION
### What does this PR do?
This PR updates some of the Podman Desktop repo GitHub references in the website to use the new Podman-Desktop org https://github.com/podman-desktop/podman-desktop

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Fixes https://github.com/podman-desktop/podman-desktop/issues/9979

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
