### PR TITLE
refactor(ui): preferences navigation component

### DIFF
--- a/packages/renderer/src/PreferencesNavigation.svelte
+++ b/packages/renderer/src/PreferencesNavigation.svelte
@@ -40,7 +40,7 @@ function updateDockerCompatibility(): void {
 }
 
 function sortItems(items: NavItem[]): NavItem[] {
-  return items.toSorted((a: { title: string }, b: { title: string }) => a.title.localeCompare(b.title));
+  return items.toSorted((a, b) => a.title.localeCompare(b.title));
 }
 
 onMount(() => {


### PR DESCRIPTION
### What does this PR do?

While working on https://github.com/podman-desktop/podman-desktop/issues/10226 I studied the preferences component because I need to create a new one, but found some serious issues.

This is a refactor / cleaning / fixing the `PreferencesNavigation.svelte` file. Here is a break down of the problem with it

**big problem with the Map value type**

Here it is declared as `Map<string, { id: string; title: string }>` as shown bellow

https://github.com/podman-desktop/podman-desktop/blob/e9eb09390bed6c7f96fef2eebfdf66a416839b62/packages/renderer/src/PreferencesNavigation.svelte#L13

but later, it is cast to any, to be able to push an array inside

https://github.com/podman-desktop/podman-desktop/blob/e9eb09390bed6c7f96fef2eebfdf66a416839b62/packages/renderer/src/PreferencesNavigation.svelte#L39

**Object.entries(Map) lose the type**

The following lose the type, and prevent typescript to do the job, as both `configSection` and `configItems` are cast to any

https://github.com/podman-desktop/podman-desktop/blob/e9eb09390bed6c7f96fef2eebfdf66a416839b62/packages/renderer/src/PreferencesNavigation.svelte#L80

Moreover we don't need to use `Object.entries` on a map, as there is `Map#entries` function available, which keep the types.

Moreover we access the map item using `[]` when we should be using `Map#get` and `Map#set`.

**unnecessary any everywhere**

https://github.com/podman-desktop/podman-desktop/blob/e9eb09390bed6c7f96fef2eebfdf66a416839b62/packages/renderer/src/PreferencesNavigation.svelte#L19-L21

https://github.com/podman-desktop/podman-desktop/blob/e9eb09390bed6c7f96fef2eebfdf66a416839b62/packages/renderer/src/PreferencesNavigation.svelte#L30

https://github.com/podman-desktop/podman-desktop/blob/e9eb09390bed6c7f96fef2eebfdf66a416839b62/packages/renderer/src/PreferencesNavigation.svelte#L37

Migrate to svelte 5 because it ease the refactor.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Preamble to https://github.com/podman-desktop/podman-desktop/issues/10226

### How to test this PR?

There are a tons of tests in `PreferencesNavigation.spec.ts` which ensure the behaviour is the same.

- [x] Tests are covering the bug fix or the new feature
