### PR TITLE
feat: experimental health frontend

### DIFF
--- a/packages/api/src/kubernetes-contexts-healths.ts
+++ b/packages/api/src/kubernetes-contexts-healths.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export interface ContextHealth {
+  contextName: string;
+  checking: boolean;
+  reachable: boolean;
+}

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -87,6 +87,7 @@ import type { ImageInfo } from '/@api/image-info.js';
 import type { ImageInspectInfo } from '/@api/image-inspect-info.js';
 import type { ImageSearchOptions, ImageSearchResult, ImageTagsListOptions } from '/@api/image-registry.js';
 import type { KubeContext } from '/@api/kubernetes-context.js';
+import type { ContextHealth } from '/@api/kubernetes-contexts-healths.js';
 import type { ContextGeneralState, ResourceName } from '/@api/kubernetes-contexts-states.js';
 import type { ForwardConfig, ForwardOptions } from '/@api/kubernetes-port-forward-model.js';
 import type { ManifestCreateOptions, ManifestInspectInfo, ManifestPushOptions } from '/@api/manifest-info.js';
@@ -2583,6 +2584,10 @@ export class PluginSystem {
         return kubernetesClient.unregisterGetCurrentContextResources(resourceName);
       },
     );
+
+    this.ipcHandle('kubernetes:getContextsHealths', async (_listener): Promise<ContextHealth[]> => {
+      return kubernetesClient.getContextsHealths();
+    });
 
     const kubernetesExecCallbackMap = new Map<
       number,

--- a/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.spec.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.spec.ts
@@ -27,12 +27,11 @@ import type { KubeConfigSingleContext } from './kubeconfig-single-context.js';
 test('ContextsStatesDispatcher should call updateHealthStates when onContextHealthStateChange event is fired', () => {
   const onContextHealthStateChangeMock = vi.fn();
   const onContextPermissionResultMock = vi.fn();
-  const getHealthCheckersStatesMock = vi.fn();
   const manager: ContextsManagerExperimental = {
     onContextHealthStateChange: onContextHealthStateChangeMock,
     onContextPermissionResult: onContextPermissionResultMock,
     onContextDelete: vi.fn(),
-    getHealthCheckersStates: getHealthCheckersStatesMock,
+    getHealthCheckersStates: vi.fn(),
     getPermissions: vi.fn(),
   } as unknown as ContextsManagerExperimental;
   const apiSender: ApiSenderType = {
@@ -46,7 +45,7 @@ test('ContextsStatesDispatcher should call updateHealthStates when onContextHeal
   expect(updatePermissionsSpy).not.toHaveBeenCalled();
 
   onContextHealthStateChangeMock.mockImplementation(f => f());
-  getHealthCheckersStatesMock.mockReturnValue(new Map<string, ContextHealthState>());
+  vi.mocked(manager.getHealthCheckersStates).mockReturnValue(new Map<string, ContextHealthState>());
   dispatcher.init();
   expect(updateHealthStatesSpy).toHaveBeenCalled();
   expect(updatePermissionsSpy).not.toHaveBeenCalled();
@@ -78,12 +77,11 @@ test('ContextsStatesDispatcher should call updatePermissions when onContextPermi
 
 test('ContextsStatesDispatcher should call updateHealthStates and updatePermissions when onContextDelete event is fired', () => {
   const onContextDeleteMock = vi.fn();
-  const getHealthCheckersStatesMock = vi.fn();
   const manager: ContextsManagerExperimental = {
     onContextHealthStateChange: vi.fn(),
     onContextPermissionResult: vi.fn(),
     onContextDelete: onContextDeleteMock,
-    getHealthCheckersStates: getHealthCheckersStatesMock,
+    getHealthCheckersStates: vi.fn(),
     getPermissions: vi.fn(),
   } as unknown as ContextsManagerExperimental;
   const apiSender: ApiSenderType = {
@@ -92,7 +90,7 @@ test('ContextsStatesDispatcher should call updateHealthStates and updatePermissi
   const dispatcher = new ContextsStatesDispatcher(manager, apiSender);
   const updateHealthStatesSpy = vi.spyOn(dispatcher, 'updateHealthStates');
   const updatePermissionsSpy = vi.spyOn(dispatcher, 'updatePermissions');
-  getHealthCheckersStatesMock.mockReturnValue(new Map<string, ContextHealthState>());
+  vi.mocked(manager.getHealthCheckersStates).mockReturnValue(new Map<string, ContextHealthState>());
   dispatcher.init();
   expect(updateHealthStatesSpy).not.toHaveBeenCalled();
   expect(updatePermissionsSpy).not.toHaveBeenCalled();
@@ -104,13 +102,11 @@ test('ContextsStatesDispatcher should call updateHealthStates and updatePermissi
 });
 
 test('getContextsHealths should return the values of the map returned by manager.getHealthCheckersStates without kubeConfig', () => {
-  const onContextDeleteMock = vi.fn();
-  const getHealthCheckersStatesMock = vi.fn();
   const manager: ContextsManagerExperimental = {
     onContextHealthStateChange: vi.fn(),
     onContextPermissionResult: vi.fn(),
-    onContextDelete: onContextDeleteMock,
-    getHealthCheckersStates: getHealthCheckersStatesMock,
+    onContextDelete: vi.fn(),
+    getHealthCheckersStates: vi.fn(),
     getPermissions: vi.fn(),
   } as unknown as ContextsManagerExperimental;
   const sendMock = vi.fn();
@@ -132,19 +128,17 @@ test('getContextsHealths should return the values of the map returned by manager
     ['context1', { ...context1State, kubeConfig: {} as unknown as KubeConfigSingleContext }],
     ['context2', { ...context2State, kubeConfig: {} as unknown as KubeConfigSingleContext }],
   ]);
-  getHealthCheckersStatesMock.mockReturnValue(value);
+  vi.mocked(manager.getHealthCheckersStates).mockReturnValue(value);
   const result = dispatcher.getContextsHealths();
   expect(result).toEqual([context1State, context2State]);
 });
 
 test('updateHealthStates should call apiSender.send with the result of getContextsHealths', () => {
-  const onContextDeleteMock = vi.fn();
-  const getHealthCheckersStatesMock = vi.fn();
   const manager: ContextsManagerExperimental = {
     onContextHealthStateChange: vi.fn(),
     onContextPermissionResult: vi.fn(),
-    onContextDelete: onContextDeleteMock,
-    getHealthCheckersStates: getHealthCheckersStatesMock,
+    onContextDelete: vi.fn(),
+    getHealthCheckersStates: vi.fn(),
     getPermissions: vi.fn(),
   } as unknown as ContextsManagerExperimental;
   const sendMock = vi.fn();

--- a/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.spec.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.spec.ts
@@ -133,7 +133,7 @@ test('getContextsHealths should return the values of the map returned by manager
   expect(result).toEqual([context1State, context2State]);
 });
 
-test('updateHealthStates should call apiSender.send with the result of getContextsHealths', () => {
+test('updateHealthStates should call apiSender.send with kubernetes-contexts-healths', () => {
   const manager: ContextsManagerExperimental = {
     onContextHealthStateChange: vi.fn(),
     onContextPermissionResult: vi.fn(),
@@ -146,17 +146,7 @@ test('updateHealthStates should call apiSender.send with the result of getContex
     send: sendMock,
   } as unknown as ApiSenderType;
   const dispatcher = new ContextsStatesDispatcher(manager, apiSender);
-  const context1State = {
-    contextName: 'context1',
-    checking: true,
-    reachable: false,
-  };
-  const context2State = {
-    contextName: 'context2',
-    checking: false,
-    reachable: true,
-  };
-  vi.spyOn(dispatcher, 'getContextsHealths').mockReturnValue([context1State, context2State]);
+  vi.spyOn(dispatcher, 'getContextsHealths').mockReturnValue([]);
   dispatcher.updateHealthStates();
-  expect(sendMock).toHaveBeenCalledWith('kubernetes-contexts-healths', [context1State, context2State]);
+  expect(sendMock).toHaveBeenCalledWith('kubernetes-contexts-healths');
 });

--- a/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.ts
@@ -40,7 +40,7 @@ export class ContextsStatesDispatcher {
   }
 
   updateHealthStates(): void {
-    this.apiSender.send('kubernetes-contexts-healths', this.getContextsHealths());
+    this.apiSender.send('kubernetes-contexts-healths');
   }
 
   getContextsHealths(): ContextHealth[] {

--- a/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.ts
@@ -16,13 +16,19 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ContextHealth } from '/@api/kubernetes-contexts-healths.js';
+
+import type { ApiSenderType } from '../api.js';
 import type { ContextHealthState } from './context-health-checker.js';
 import type { ContextPermissionResult } from './context-permissions-checker.js';
 import type { DispatcherEvent } from './contexts-dispatcher.js';
 import type { ContextsManagerExperimental } from './contexts-manager-experimental.js';
 
 export class ContextsStatesDispatcher {
-  constructor(private manager: ContextsManagerExperimental) {}
+  constructor(
+    private manager: ContextsManagerExperimental,
+    private apiSender: ApiSenderType,
+  ) {}
 
   init(): void {
     this.manager.onContextHealthStateChange((_state: ContextHealthState) => this.updateHealthStates());
@@ -34,7 +40,19 @@ export class ContextsStatesDispatcher {
   }
 
   updateHealthStates(): void {
-    console.log('current health check states', this.manager.getHealthCheckersStates());
+    this.apiSender.send('kubernetes-contexts-healths', this.getContextsHealths());
+  }
+
+  getContextsHealths(): ContextHealth[] {
+    const value: ContextHealth[] = [];
+    for (const [contextName, health] of this.manager.getHealthCheckersStates()) {
+      value.push({
+        contextName,
+        checking: health.checking,
+        reachable: health.reachable,
+      });
+    }
+    return value;
   }
 
   updatePermissions(): void {

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.ts
@@ -71,6 +71,7 @@ import { parseAllDocuments } from 'yaml';
 import type { KubernetesPortForwardService } from '/@/plugin/kubernetes/kubernetes-port-forward-service.js';
 import { KubernetesPortForwardServiceProvider } from '/@/plugin/kubernetes/kubernetes-port-forward-service.js';
 import type { KubeContext } from '/@api/kubernetes-context.js';
+import type { ContextHealth } from '/@api/kubernetes-contexts-healths.js';
 import type { ContextGeneralState, ResourceName } from '/@api/kubernetes-contexts-states.js';
 import type { ForwardConfig, ForwardOptions } from '/@api/kubernetes-port-forward-model.js';
 import type { V1Route } from '/@api/openshift-types.js';
@@ -270,7 +271,7 @@ export class KubernetesClient {
     if (statesExperimental) {
       const manager = new ContextsManagerExperimental();
       this.contextsState = manager;
-      this.contextsStatesDispatcher = new ContextsStatesDispatcher(manager);
+      this.contextsStatesDispatcher = new ContextsStatesDispatcher(manager, this.apiSender);
       this.contextsStatesDispatcher.init();
     }
 
@@ -1843,5 +1844,12 @@ export class KubernetesClient {
 
   public async deletePortForward(config: ForwardConfig): Promise<void> {
     return this.ensurePortForwardService().deleteForward(config);
+  }
+
+  public getContextsHealths(): ContextHealth[] {
+    if (!this.contextsStatesDispatcher) {
+      throw new Error('contextsStatesDispatcher is undefined. This should not happen in Kubernetes experimental');
+    }
+    return this.contextsStatesDispatcher?.getContextsHealths();
   }
 }

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -67,6 +67,7 @@ import type { ImageInfo } from '/@api/image-info';
 import type { ImageInspectInfo } from '/@api/image-inspect-info';
 import type { ImageSearchOptions, ImageSearchResult, ImageTagsListOptions } from '/@api/image-registry';
 import type { KubeContext } from '/@api/kubernetes-context';
+import type { ContextHealth } from '/@api/kubernetes-contexts-healths';
 import type { ContextGeneralState, ResourceName } from '/@api/kubernetes-contexts-states';
 import type { ForwardConfig, ForwardOptions } from '/@api/kubernetes-port-forward-model';
 import type { ManifestCreateOptions, ManifestInspectInfo, ManifestPushOptions } from '/@api/manifest-info';
@@ -1870,6 +1871,10 @@ export function initExposure(): void {
       return ipcInvoke('kubernetes-client:unregisterGetCurrentContextResources', resourceName);
     },
   );
+
+  contextBridge.exposeInMainWorld('kubernetesGetContextsHealths', async (): Promise<ContextHealth[]> => {
+    return ipcInvoke('kubernetes:getContextsHealths');
+  });
 
   contextBridge.exposeInMainWorld('kubernetesGetClusters', async (): Promise<Cluster[]> => {
     return ipcInvoke('kubernetes-client:getClusters');

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
@@ -171,8 +171,14 @@ describe.each([
       vi.mocked(kubernetesContextsState).kubernetesContextsCheckingStateDelayed = readable<Map<string, boolean>>(
         new Map(),
       );
-      (window as any).getConfigurationValue = vi.fn().mockResolvedValue(true);
-      (window as any).kubernetesGetContextsHealths = vi.fn().mockResolvedValue([
+      Object.defineProperty(global, 'window', {
+        value: {
+          getConfigurationValue: vi.fn(),
+          kubernetesGetContextsHealths: vi.fn(),
+        },
+      });
+      vi.mocked(window.getConfigurationValue<boolean>).mockResolvedValue(true);
+      vi.mocked(window.kubernetesGetContextsHealths).mockResolvedValue([
         {
           contextName: 'context-name',
           reachable: true,

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
@@ -20,7 +20,7 @@ import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen, within } from '@testing-library/svelte';
 import { readable } from 'svelte/store';
-import { beforeEach, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { kubernetesContexts } from '/@/stores/kubernetes-contexts';
 import * as kubernetesContextsState from '/@/stores/kubernetes-contexts-state';
@@ -157,45 +157,96 @@ test('when deleting the non current context, no popup should ask confirmation', 
   expect(showMessageBoxMock).not.toHaveBeenCalled();
 });
 
-test('state and resources counts are displayed in contexts', () => {
-  const state: Map<string, ContextGeneralState> = new Map();
-  state.set('context-name', {
-    reachable: true,
-    resources: {
-      pods: 1,
-      deployments: 2,
+describe.each([
+  {
+    name: 'experimental states',
+    implemented: {
+      health: true,
+      resourcesCount: false,
     },
-  });
-  state.set('context-name2', {
-    reachable: false,
-    resources: {
-      pods: 0,
-      deployments: 0,
+    initMocks: () => {
+      vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextGeneralState>>(
+        new Map<string, ContextGeneralState>(),
+      );
+      vi.mocked(kubernetesContextsState).kubernetesContextsCheckingStateDelayed = readable<Map<string, boolean>>(
+        new Map(),
+      );
+      (window as any).getConfigurationValue = vi.fn().mockResolvedValue(true);
+      (window as any).kubernetesGetContextsHealths = vi.fn().mockResolvedValue([
+        {
+          contextName: 'context-name',
+          reachable: true,
+          checking: false,
+        },
+        {
+          contextName: 'context-name2',
+          reachable: false,
+          checking: false,
+        },
+      ]);
     },
+  },
+  {
+    name: 'non-experimental states',
+    implemented: {
+      health: true,
+      resourcesCount: true,
+    },
+    initMocks: () => {
+      const state: Map<string, ContextGeneralState> = new Map();
+      state.set('context-name', {
+        reachable: true,
+        resources: {
+          pods: 1,
+          deployments: 2,
+        },
+      });
+      state.set('context-name2', {
+        reachable: false,
+        resources: {
+          pods: 0,
+          deployments: 0,
+        },
+      });
+      vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextGeneralState>>(state);
+      vi.mocked(kubernetesContextsState).kubernetesContextsCheckingStateDelayed = readable<Map<string, boolean>>(
+        new Map(),
+      );
+    },
+  },
+])('$name', ({ implemented, initMocks }) => {
+  test('state and resources counts are displayed in contexts', async () => {
+    initMocks();
+    render(PreferencesKubernetesContextsRendering, {});
+    const context1 = screen.getAllByRole('row')[0];
+    const context2 = screen.getAllByRole('row')[1];
+    if (implemented.health) {
+      await vi.waitFor(() => {
+        expect(within(context1).queryByText('REACHABLE')).toBeInTheDocument();
+      });
+    }
+    expect(within(context1).queryByText('PODS')).toBeInTheDocument();
+    expect(within(context1).queryByText('DEPLOYMENTS')).toBeInTheDocument();
+
+    if (implemented.resourcesCount) {
+      const checkCount = (el: HTMLElement, label: string, count: number) => {
+        const countEl = within(el).getByLabelText(label);
+        expect(countEl).toBeInTheDocument();
+        expect(within(countEl).queryByText(count)).toBeTruthy();
+      };
+      checkCount(context1, 'Context Pods Count', 1);
+      checkCount(context1, 'Context Deployments Count', 2);
+    }
+
+    if (implemented.health) {
+      expect(within(context2).queryByText('UNREACHABLE')).toBeInTheDocument();
+    }
+    expect(within(context2).queryByText('PODS')).not.toBeInTheDocument();
+    expect(within(context2).queryByText('DEPLOYMENTS')).not.toBeInTheDocument();
+
+    const podsCountContext2 = within(context2).queryByLabelText('Context Pods Count');
+    expect(podsCountContext2).not.toBeInTheDocument();
+    const deploymentsCountContext2 = within(context2).queryByLabelText('Context Deployments Count');
+    expect(deploymentsCountContext2).not.toBeInTheDocument();
   });
-  vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextGeneralState>>(state);
-  vi.mocked(kubernetesContextsState).kubernetesContextsCheckingStateDelayed = readable<Map<string, boolean>>(new Map());
-  render(PreferencesKubernetesContextsRendering, {});
-  const context1 = screen.getAllByRole('row')[0];
-  const context2 = screen.getAllByRole('row')[1];
-  expect(within(context1).queryByText('REACHABLE')).toBeInTheDocument();
-  expect(within(context1).queryByText('PODS')).toBeInTheDocument();
-  expect(within(context1).queryByText('DEPLOYMENTS')).toBeInTheDocument();
-
-  const checkCount = (el: HTMLElement, label: string, count: number) => {
-    const countEl = within(el).getByLabelText(label);
-    expect(countEl).toBeInTheDocument();
-    expect(within(countEl).queryByText(count)).toBeTruthy();
-  };
-  checkCount(context1, 'Context Pods Count', 1);
-  checkCount(context1, 'Context Deployments Count', 2);
-
-  expect(within(context2).queryByText('UNREACHABLE')).toBeInTheDocument();
-  expect(within(context2).queryByText('PODS')).not.toBeInTheDocument();
-  expect(within(context2).queryByText('DEPLOYMENTS')).not.toBeInTheDocument();
-
-  const podsCountContext2 = within(context2).queryByLabelText('Context Pods Count');
-  expect(podsCountContext2).not.toBeInTheDocument();
-  const deploymentsCountContext2 = within(context2).queryByLabelText('Context Deployments Count');
-  expect(deploymentsCountContext2).not.toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
@@ -22,6 +22,7 @@ import { fireEvent, render, screen, within } from '@testing-library/svelte';
 import { readable } from 'svelte/store';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
+import { kubernetesContextsHealths } from '/@/stores/kubernetes-context-health';
 import { kubernetesContexts } from '/@/stores/kubernetes-contexts';
 import * as kubernetesContextsState from '/@/stores/kubernetes-contexts-state';
 import type { KubeContext } from '/@api/kubernetes-context';
@@ -165,20 +166,13 @@ describe.each([
       resourcesCount: false,
     },
     initMocks: () => {
-      vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextGeneralState>>(
-        new Map<string, ContextGeneralState>(),
-      );
-      vi.mocked(kubernetesContextsState).kubernetesContextsCheckingStateDelayed = readable<Map<string, boolean>>(
-        new Map(),
-      );
       Object.defineProperty(global, 'window', {
         value: {
           getConfigurationValue: vi.fn(),
-          kubernetesGetContextsHealths: vi.fn(),
         },
       });
       vi.mocked(window.getConfigurationValue<boolean>).mockResolvedValue(true);
-      vi.mocked(window.kubernetesGetContextsHealths).mockResolvedValue([
+      kubernetesContextsHealths.set([
         {
           contextName: 'context-name',
           reachable: true,

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -4,6 +4,7 @@ import { Button, EmptyScreen, ErrorMessage, Spinner } from '@podman-desktop/ui-s
 import { onMount } from 'svelte';
 import { router } from 'tinro';
 
+import { kubernetesContextsHealths } from '/@/stores/kubernetes-context-health';
 import { kubernetesContextsCheckingStateDelayed, kubernetesContextsState } from '/@/stores/kubernetes-contexts-state';
 
 import { kubernetesContexts } from '../../stores/kubernetes-contexts';
@@ -125,7 +126,7 @@ async function handleDeleteContext(contextName: string) {
         <div class="grow flex-column divide-gray-900 text-[var(--pd-invert-content-card-text)]">
           <div class="flex flex-row">
             <div class="flex-none w-36">
-              {#if $kubernetesContextsState.get(context.name)?.reachable}
+              {#if $kubernetesContextsState.get(context.name)?.reachable ?? $kubernetesContextsHealths.some(contextHealth => contextHealth.contextName === context.name && contextHealth.reachable)}
                 <div class="flex flex-row pt-2">
                   <div class="w-3 h-3 rounded-full bg-[var(--pd-status-connected)]"></div>
                   <div
@@ -154,13 +155,13 @@ async function handleDeleteContext(contextName: string) {
                 <div class="flex flex-row pt-2">
                   <div class="w-3 h-3 rounded-full bg-[var(--pd-status-disconnected)]"></div>
                   <div class="ml-1 text-xs text-[var(--pd-status-disconnected)]" aria-label="Context Unreachable">
-                    {#if $kubernetesContextsState.get(context.name)}
+                    {#if $kubernetesContextsState.get(context.name) ?? $kubernetesContextsHealths.some(contextHealth => contextHealth.contextName === context.name && !contextHealth.reachable)}
                       UNREACHABLE
                     {:else}
                       UNKNOWN
                     {/if}
                   </div>
-                  {#if $kubernetesContextsCheckingStateDelayed?.get(context.name)}
+                  {#if $kubernetesContextsCheckingStateDelayed?.get(context.name) ?? $kubernetesContextsHealths.some(contextHealth => contextHealth.contextName === context.name && contextHealth.checking)}
                     <div class="ml-1"><Spinner size="12px"></Spinner></div>
                   {/if}
                 </div>

--- a/packages/renderer/src/stores/kubernetes-context-health.spec.ts
+++ b/packages/renderer/src/stores/kubernetes-context-health.spec.ts
@@ -1,0 +1,99 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Unsubscriber } from 'svelte/store';
+import { afterEach, expect, test, vi } from 'vitest';
+
+import type { ContextHealth } from '/@api/kubernetes-contexts-healths';
+
+import { kubernetesContextsHealths } from './kubernetes-context-health';
+
+const callbacks = new Map<string, any>();
+const eventEmitter = {
+  receive: (message: string, callback: any) => {
+    callbacks.set(message, callback);
+  },
+};
+
+Object.defineProperty(global, 'window', {
+  value: {
+    kubernetesGetContextsHealths: vi.fn(),
+    addEventListener: eventEmitter.receive,
+    events: {
+      receive: eventEmitter.receive,
+    },
+  },
+  writable: true,
+});
+
+let unsubscribe: Unsubscriber;
+
+afterEach(() => {
+  unsubscribe?.();
+});
+
+test('kubernetesContextsHealths', async () => {
+  let states: ContextHealth[] = [];
+
+  const initialValues = [
+    {
+      contextName: 'context1',
+      checking: true,
+      reachable: false,
+    },
+    {
+      contextName: 'context2',
+      checking: false,
+      reachable: true,
+    },
+  ];
+
+  const nextValues = [
+    {
+      contextName: 'context1',
+      checking: false,
+      reachable: true,
+    },
+    {
+      contextName: 'context2',
+      checking: false,
+      reachable: true,
+    },
+  ];
+
+  vi.mocked(window.kubernetesGetContextsHealths).mockResolvedValue(initialValues);
+  unsubscribe = kubernetesContextsHealths.subscribe(value => {
+    states = value;
+  });
+
+  // check initial value
+  await vi.waitFor(() => {
+    expect(states).toEqual(initialValues);
+  });
+
+  // update object via an event
+  const event = 'kubernetes-contexts-healths';
+  const callback = callbacks.get(event);
+  expect(callback).toBeDefined();
+  await callback(nextValues);
+
+  // check data is updated with event's data
+  await vi.waitFor(() => {
+    expect(states).toEqual(nextValues);
+  });
+});

--- a/packages/renderer/src/stores/kubernetes-context-health.ts
+++ b/packages/renderer/src/stores/kubernetes-context-health.ts
@@ -1,0 +1,31 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { readable } from 'svelte/store';
+
+import type { ContextHealth } from '/@api/kubernetes-contexts-healths';
+
+export const kubernetesContextsHealths = readable<ContextHealth[]>([], set => {
+  window.events?.receive('kubernetes-contexts-healths', (value: unknown) => {
+    set(value as ContextHealth[]);
+  });
+  window
+    .kubernetesGetContextsHealths()
+    .then(value => set(value))
+    .catch((err: unknown) => console.log('Error getting contexts healths', err));
+});


### PR DESCRIPTION
### What does this PR do?

Display the health of kubernetes contexts in Settings > Kubernetes

### Screenshot / video of UI


### What issues does this PR fix or reference?

Fixes #9938 

### How to test this PR?

Activate the experimental mode in `~/.local/share/containers/podman-desktop/configuration/settings.json`:

```
"kubernetes.statesExperimental": true
```
- [x] Tests are covering the bug fix or the new feature
