### PR TITLE
docs: in code guidelines, use vi.mocked

### DIFF
--- a/CODE-GUIDELINES.md
+++ b/CODE-GUIDELINES.md
@@ -15,9 +15,8 @@ const windowMethodMock = vi.fn();
 
 Object.defineProperty(global, 'window', {
   value: {
-    windowMethod:windowMethodMock,
+    windowMethod: windowMethodMock,
   },
-  writable: true,
 });
 
 test('...', () => {
@@ -32,7 +31,6 @@ Object.defineProperty(global, 'window', {
   value: {
     windowMethod: vi.fn(),
   },
-  writable: true,
 });
 
 test('...', () => {

--- a/CODE-GUIDELINES.md
+++ b/CODE-GUIDELINES.md
@@ -1,0 +1,41 @@
+# Guidelines for Podman Desktop Code
+
+## Production code
+
+## Unit tests code
+
+### Use `vi.mocked`, not a generic `myFunctionMock`
+
+If you define a mock with `const myFunctionMock = vi.fn();` its type is `Mock<Procedure>`, which is a generic type.
+
+For example, do not write this, or Typescript won't be able to detect that you passed an object instead of a string to `mockResolvedValue`:
+
+```ts
+const windowMethodMock = vi.fn();
+
+Object.defineProperty(global, 'window', {
+  value: {
+    windowMethod:windowMethodMock,
+  },
+  writable: true,
+});
+
+test('...', () => {
+  windowMethodMock.mockResolvedValue({ msg: 'a string' }); // here, Typescript is not able to detect that the type is wrong
+});
+```
+
+Instead, you can write `vi.mocked(window.windowMethod).mock...`, and Typescript will check that you correctly pass a string to `mockResolvedValue`:
+
+```ts
+Object.defineProperty(global, 'window', {
+  value: {
+    windowMethod: vi.fn(),
+  },
+  writable: true,
+});
+
+test('...', () => {
+  vi.mocked(window.windowMethod).mockResolvedValue('a string');
+});
+```


### PR DESCRIPTION
### What does this PR do?

Create a `CODE-GUIDELINES.md` file, with a first guideline

I would like to visually differentiate the `DON'T` code to the `DO` code, but I have no idea how, I cannot find a simple way to modify code block rendering (reddish background, remove copy button, etc)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
