### PR TITLE
chore: remember provider creation form data for go back to task

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
@@ -23,6 +23,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
 import { get } from 'svelte/store';
 import { router } from 'tinro';
 import { beforeAll, beforeEach, describe, expect, type Mock, test, vi } from 'vitest';
@@ -225,6 +226,7 @@ describe.each([
       expect(currentConnectionInfoAfter?.operationInProgress).toBeFalsy();
       expect(currentConnectionInfoAfter?.operationStarted).toBeTruthy();
       expect(currentConnectionInfoAfter?.operationSuccessful).toBeTruthy();
+      expect(currentConnectionInfoAfter?.formData).toBeDefined();
       const closeButton = screen.getByRole('button', { name: 'Close panel' });
       expect(closeButton).toBeInTheDocument();
     }
@@ -569,6 +571,115 @@ test(`Expect create with unchecked and checked checkboxes having multiple scopes
   expect(callback).toBeCalledWith(
     'test',
     { 'test.factoryProperty': '0', 'test.checked': true, 'test.unchecked': false },
+    expect.anything(),
+    eventCollect,
+    undefined,
+    taskId,
+  );
+});
+
+test('Expect form data saved in store when submitting the form and when the task ends', async () => {
+  let providedKeyLogger: ((key: symbol, eventName: LoggerEventName, args: string[]) => void) | undefined;
+
+  const callback = mockCallback(async keyLogger => {
+    providedKeyLogger = keyLogger;
+  });
+
+  const taskId = 1;
+  const label = 'Create';
+
+  render(PreferencesConnectionCreationOrEditRendering, {
+    properties,
+    providerInfo,
+    propertyScope,
+    callback,
+    pageIsLoading: false,
+    taskId,
+  });
+  await vi.waitUntil(() => screen.queryByRole('textbox', { name: 'test.factoryProperty' }));
+  const factoryProperty = screen.getByRole('textbox', { name: 'test.factoryProperty' });
+  await userEvent.type(factoryProperty, '2');
+
+  const createButton = screen.getByRole('button', { name: `${label}` });
+  expect(createButton).toBeInTheDocument();
+  // click on the button
+  await fireEvent.click(createButton);
+
+  // do we have a task
+  const currentConnectionInfoMap = get(operationConnectionsInfo);
+  expect(currentConnectionInfoMap).toBeDefined();
+  const currentConnectionInfo = currentConnectionInfoMap.get(taskId);
+  expect(currentConnectionInfo).toBeDefined();
+  if (currentConnectionInfo) {
+    expect(currentConnectionInfo.formData).toBeDefined();
+    expect(currentConnectionInfo.formData).toStrictEqual({ 'test.factoryProperty': '2' });
+    expect(providedKeyLogger).toBeDefined();
+
+    // simulate end of the create operation
+    if (providedKeyLogger) {
+      providedKeyLogger(currentConnectionInfo.operationKey, 'finish', []);
+    }
+
+    // expect it is successful
+    const currentConnectionInfoAfterMap = get(operationConnectionsInfo);
+    expect(currentConnectionInfoAfterMap).toBeDefined();
+    const currentConnectionInfoAfter = currentConnectionInfoAfterMap.get(taskId);
+
+    expect(currentConnectionInfoAfter?.formData).toBeDefined();
+    expect(currentConnectionInfoAfter?.formData).toStrictEqual({ 'test.factoryProperty': '2' });
+  }
+});
+
+test('Expect form data saved in store to be repopulated when reopening a task', async () => {
+  let providedKeyLogger: ((key: symbol, eventName: LoggerEventName, args: string[]) => void) | undefined;
+  const callback = mockCallback(async keyLogger => {
+    providedKeyLogger = keyLogger;
+  });
+
+  const taskId = 1;
+
+  const formProperties: IConfigurationPropertyRecordedSchema[] = [
+    {
+      title: 'FactoryProperty',
+      parentId: '',
+      scope: 'ContainerProviderConnectionFactory',
+      id: 'test.factoryProperty',
+      type: 'string',
+      description: 'test.factoryProperty',
+    },
+  ];
+
+  const operationConnectionsInfoMock = {
+    operationKey: Symbol(),
+    providerInfo,
+    connectionInfo: undefined,
+    properties: formProperties,
+    propertyScope: 'DEFAULT',
+    operationInProgress: false,
+    operationSuccessful: false,
+    operationStarted: false,
+    errorMessage: '',
+    formData: { 'test.factoryProperty': '5' },
+  };
+  operationConnectionsInfo.update(map => map.set(taskId, operationConnectionsInfoMock));
+
+  render(PreferencesConnectionCreationOrEditRendering, {
+    properties: formProperties,
+    providerInfo,
+    propertyScope,
+    callback,
+    pageIsLoading: false,
+    taskId,
+  });
+  await vi.waitUntil(() => screen.queryByRole('textbox', { name: 'test.factoryProperty' }));
+
+  const createButton = screen.getByRole('button', { name: 'Create' });
+  expect(createButton).toBeInTheDocument();
+  // click on the button
+  await fireEvent.click(createButton);
+  expect(callback).toBeCalledWith(
+    'test',
+    { 'test.factoryProperty': '5' },
     expect.anything(),
     eventCollect,
     undefined,

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
@@ -638,22 +638,11 @@ test('Expect form data saved in store to be repopulated when reopening a task', 
 
   const taskId = 1;
 
-  const formProperties: IConfigurationPropertyRecordedSchema[] = [
-    {
-      title: 'FactoryProperty',
-      parentId: '',
-      scope: 'ContainerProviderConnectionFactory',
-      id: 'test.factoryProperty',
-      type: 'string',
-      description: 'test.factoryProperty',
-    },
-  ];
-
   const operationConnectionsInfoMock = {
     operationKey: Symbol(),
     providerInfo,
     connectionInfo: undefined,
-    properties: formProperties,
+    properties,
     propertyScope: 'DEFAULT',
     operationInProgress: false,
     operationSuccessful: false,
@@ -664,7 +653,7 @@ test('Expect form data saved in store to be repopulated when reopening a task', 
   operationConnectionsInfo.update(map => map.set(taskId, operationConnectionsInfoMock));
 
   render(PreferencesConnectionCreationOrEditRendering, {
-    properties: formProperties,
+    properties,
     providerInfo,
     propertyScope,
     callback,

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
@@ -317,9 +317,6 @@ function restoreConfigurationValues(): void {
   }
 }
 
-let logsTerminal: Terminal;
-let loggerHandlerKey: symbol | undefined = undefined;
-
 function getLoggerHandler(): ConnectionCallback {
   return {
     log: (args): void => {

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
@@ -134,7 +134,7 @@ onMount(async () => {
       tokenId = value.tokenId;
       existingFormData = value.formData;
     }
-    dataToConfigurationValues();
+    restoreConfigurationValues();
   }
 
   if (taskId === undefined) {
@@ -294,7 +294,7 @@ async function getConfigurationValue(configurationKey: IConfigurationPropertyRec
   }
 }
 
-function dataToConfigurationValues(): void {
+function restoreConfigurationValues(): void {
   if (!existingFormData) {
     return;
   }

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
@@ -287,11 +287,6 @@ async function getConfigurationValue(configurationKey: IConfigurationPropertyRec
       );
       internalSetConfigurationValue(configurationKey.id, false, value as string);
       return value;
-      // } else if (existingFormData && existingFormData[configurationKey.id]) {
-      //   const value = existingFormData[configurationKey.id];
-      //   // internalSetConfigurationValue(configurationKey.id, true, value as string);
-      //   console.log(`getconfigvalue ${configurationKey.id}: ${value}`)
-      //   return value;
     }
     const initialValue = await getInitialValue(configurationKey);
     internalSetConfigurationValue(configurationKey.id, false, initialValue as string);
@@ -496,12 +491,7 @@ function getConnectionResourceConfigurationNumberValue(
   configurationKey: IConfigurationPropertyRecordedSchema,
   configurationValues: Map<string, { modified: boolean; value: string | boolean | number }>,
 ): number | undefined {
-  let value;
-  if (existingFormData && configurationKey.id && existingFormData[configurationKey.id]) {
-    value = existingFormData[configurationKey.id];
-  } else {
-    value = getConnectionResourceConfigurationValue(configurationKey, configurationValues);
-  }
+  const value = getConnectionResourceConfigurationValue(configurationKey, configurationValues);
   if (typeof value === 'number') {
     return value;
   }

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
@@ -312,7 +312,6 @@ function dataToConfigurationValues(): void {
       typeof existingFormData[dataItem] === 'string' ||
       typeof existingFormData[dataItem] === 'boolean'
     ) {
-      console.log(`${existingFormData[dataItem]}`);
       configurationValues.set(dataItem, { modified: true, value: existingFormData[dataItem] });
     }
   }

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
@@ -134,6 +134,7 @@ onMount(async () => {
       tokenId = value.tokenId;
       existingFormData = value.formData;
     }
+    dataToConfigurationValues();
   }
 
   if (taskId === undefined) {
@@ -154,7 +155,6 @@ onMount(async () => {
       console.warn(e && typeof e === 'object' && 'message' in e ? e.message : e);
     }
   }
-  dataToConfigurationValues();
   pageIsLoading = false;
 });
 
@@ -299,12 +299,22 @@ function dataToConfigurationValues(): void {
     return;
   }
   for (let dataItem in existingFormData) {
+    const configurationKey = configurationKeys.find(configKey => configKey.id === dataItem);
+    if (
+      configurationKey?.type === 'number' &&
+      typeof existingFormData[dataItem] === 'string' &&
+      !isNaN(parseFloat(existingFormData[dataItem]))
+    ) {
+      existingFormData[dataItem] = parseFloat(existingFormData[dataItem]);
+    }
     if (
       typeof existingFormData[dataItem] === 'number' ||
       typeof existingFormData[dataItem] === 'string' ||
       typeof existingFormData[dataItem] === 'boolean'
-    )
+    ) {
+      console.log(`${existingFormData[dataItem]}`);
       configurationValues.set(dataItem, { modified: true, value: existingFormData[dataItem] });
+    }
   }
 }
 

--- a/packages/renderer/src/stores/operation-connections.ts
+++ b/packages/renderer/src/stores/operation-connections.ts
@@ -38,6 +38,7 @@ interface OperationConnectionInfo {
   operationStarted: boolean;
   errorMessage: string;
   tokenId?: number;
+  formData?: { [key: string]: unknown };
 }
 
 // current create key


### PR DESCRIPTION
### What does this PR do?
This PR adds the functionality to remember form data based on taskId so that when coming back to a task of creating a new provider connection, the form is populated with the provided values from the initial submission

Right now this fix doesn't save dropdown values due to unrelated bug https://github.com/podman-desktop/podman-desktop/issues/10435

### Screenshot / video of UI

https://github.com/user-attachments/assets/cec26f97-cbed-4709-974a-0f295c141ef1


https://github.com/user-attachments/assets/b71cfe90-c513-4a1c-99df-5830f40855be



<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Fixes https://github.com/podman-desktop/podman-desktop/issues/6062

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
