### PR TITLE
chore: add option for given value in NumberItem

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
@@ -153,6 +153,7 @@ test('Expect a text input when record is type number and enableSlider is false',
     type: 'number',
     minimum: 1,
     maximum: 34,
+    default: 20,
   };
   await awaitRender(record, {});
   const input = screen.getByLabelText('record-description');
@@ -160,6 +161,26 @@ test('Expect a text input when record is type number and enableSlider is false',
   expect(input instanceof HTMLInputElement).toBe(true);
   expect((input as HTMLInputElement).type).toBe('text');
   expect((input as HTMLInputElement).name).toBe('record');
+  expect((input as HTMLInputElement).value).toBe('20');
+});
+
+test('Expect record with type number and enableSlider false to use given value if available', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'number',
+    minimum: 1,
+    maximum: 34,
+  };
+  await awaitRender(record, { givenValue: 5 });
+  const input = screen.getByLabelText('record-description');
+  expect(input).toBeInTheDocument();
+  expect(input instanceof HTMLInputElement).toBe(true);
+  expect((input as HTMLInputElement).type).toBe('text');
+  expect((input as HTMLInputElement).name).toBe('record');
+  expect((input as HTMLInputElement).value).toBe('5');
 });
 
 test('Expect a fileinput when record is type string and format file', async () => {

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -147,6 +147,15 @@ async function onChange(recordId: string, value: boolean | string | number): Pro
   // auto save
   return await autoSave();
 }
+
+function numberItemValue(): number {
+  if (givenValue && typeof givenValue === 'number') {
+    return givenValue;
+  } else if (recordValue && typeof recordValue === 'number') {
+    return recordValue;
+  }
+  return getNormalizedDefaultNumberValue(record);
+}
 </script>
 
 <div class="flex flex-row mb-1 pt-2 text-start items-center justify-start">
@@ -167,7 +176,7 @@ async function onChange(recordId: string, value: boolean | string | number): Pro
     {:else}
       <NumberItem
         record={record}
-        value={typeof givenValue === 'number' ? givenValue : (typeof recordValue === 'number' ? recordValue : getNormalizedDefaultNumberValue(record))}
+        value={numberItemValue()}
         onChange={onChange}
         invalidRecord={invalidRecord} />
     {/if}

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -167,7 +167,7 @@ async function onChange(recordId: string, value: boolean | string | number): Pro
     {:else}
       <NumberItem
         record={record}
-        value={typeof recordValue === 'number' ? recordValue : getNormalizedDefaultNumberValue(record)}
+        value={typeof givenValue === 'number' ? givenValue : (typeof recordValue === 'number' ? recordValue : getNormalizedDefaultNumberValue(record))}
         onChange={onChange}
         invalidRecord={invalidRecord} />
     {/if}


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR adds the support of providing a given value to `NumberItem` in `PreferencesRenderingItemFormat`.
Needed for https://github.com/podman-desktop/podman-desktop/pull/10354.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/6062
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
