### PR TITLE
feat: introducing experimental section

### DIFF
--- a/packages/api/src/configuration/constants.ts
+++ b/packages/api/src/configuration/constants.ts
@@ -18,3 +18,8 @@
 
 export const CONFIGURATION_DEFAULT_SCOPE = 'DEFAULT';
 export const CONFIGURATION_ONBOARDING_SCOPE = 'Onboarding';
+
+export enum CONFIGURATION_SECTION {
+  PREFERENCES = 'preferences',
+  EXPERIMENTAL = 'experimental',
+}

--- a/packages/main/src/plugin/docker/docker-compatibility.spec.ts
+++ b/packages/main/src/plugin/docker/docker-compatibility.spec.ts
@@ -25,6 +25,7 @@ import type { ProviderContainerConnection } from '@podman-desktop/api';
 import type { Mock } from 'vitest';
 import { beforeAll, describe, expect, test, vi } from 'vitest';
 
+import { CONFIGURATION_SECTION } from '/@api/configuration/constants.js';
 import type { DockerSocketServerInfoType } from '/@api/docker-compatibility-info.js';
 import type { ProviderInfo } from '/@api/provider-info.js';
 
@@ -92,8 +93,8 @@ test('should register a configuration', async () => {
 
   expect(configurationRegistry.registerConfigurations).toBeCalled();
   const configurationNode = vi.mocked(configurationRegistry.registerConfigurations).mock.calls[0]?.[0][0];
-  expect(configurationNode?.id).toBe('preferences.experimental.dockerCompatibility');
-  expect(configurationNode?.title).toBe('Experimental (Docker Compatibility)');
+  expect(configurationNode?.id).toBe(`${CONFIGURATION_SECTION.EXPERIMENTAL}.dockerCompatibility`);
+  expect(configurationNode?.title).toBe('Docker Compatibility');
   expect(configurationNode?.properties).toBeDefined();
   expect(Object.keys(configurationNode?.properties ?? {}).length).toBe(1);
   expect(configurationNode?.properties?.[TestDockerCompatibility.ENABLED_FULL_KEY]).toBeDefined();

--- a/packages/main/src/plugin/docker/docker-compatibility.ts
+++ b/packages/main/src/plugin/docker/docker-compatibility.ts
@@ -21,6 +21,7 @@ import { promises } from 'node:fs';
 import Dockerode from 'dockerode';
 
 import { isMac, isWindows } from '/@/util.js';
+import { CONFIGURATION_SECTION } from '/@api/configuration/constants.js';
 import type {
   DockerContextInfo,
   DockerSocketMappingStatusInfo,
@@ -53,8 +54,8 @@ export class DockerCompatibility {
 
   init(): void {
     const dockerCompatibilityConfiguration: IConfigurationNode = {
-      id: 'preferences.experimental.dockerCompatibility',
-      title: 'Experimental (Docker Compatibility)',
+      id: `${CONFIGURATION_SECTION.EXPERIMENTAL}.dockerCompatibility`,
+      title: 'Docker Compatibility',
       type: 'object',
       properties: {
         [DockerCompatibility.ENABLED_FULL_KEY]: {

--- a/packages/main/src/plugin/tasks/task-manager.spec.ts
+++ b/packages/main/src/plugin/tasks/task-manager.spec.ts
@@ -21,6 +21,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import type { CommandRegistry } from '/@/plugin/command-registry.js';
 import type { ConfigurationRegistry } from '/@/plugin/configuration-registry.js';
 import type { StatusBarRegistry } from '/@/plugin/statusbar/statusbar-registry.js';
+import { CONFIGURATION_SECTION } from '/@api/configuration/constants.js';
 
 import type { ApiSenderType } from '../api.js';
 import { TaskManager } from './task-manager.js';
@@ -57,7 +58,7 @@ test('task manager init should register a configuration option', async () => {
   taskManager.init();
   expect(configurationRegistry.registerConfigurations).toHaveBeenCalledOnce();
   expect(configurationRegistry.registerConfigurations).toHaveBeenCalledWith(
-    expect.arrayContaining([expect.objectContaining({ id: 'preferences.experimental.tasks' })]),
+    expect.arrayContaining([expect.objectContaining({ id: `${CONFIGURATION_SECTION.EXPERIMENTAL}.tasks` })]),
   );
   expect(configurationRegistry.registerConfigurations).toHaveBeenCalledWith(
     expect.arrayContaining([

--- a/packages/main/src/plugin/tasks/task-manager.ts
+++ b/packages/main/src/plugin/tasks/task-manager.ts
@@ -23,6 +23,7 @@ import { NotificationImpl } from '/@/plugin/tasks/notification-impl.js';
 import type { NotificationTask } from '/@/plugin/tasks/notifications.js';
 import { TaskImpl } from '/@/plugin/tasks/task-impl.js';
 import type { Task, TaskAction, TaskUpdateEvent } from '/@/plugin/tasks/tasks.js';
+import { CONFIGURATION_SECTION } from '/@api/configuration/constants.js';
 import type { NotificationTaskInfo, TaskInfo } from '/@api/taskInfo.js';
 import { ExperimentalTasksSettings } from '/@api/tasks-preferences.js';
 
@@ -60,7 +61,7 @@ export class TaskManager {
 
     this.configurationRegistry.registerConfigurations([
       {
-        id: 'preferences.experimental.tasks',
+        id: `${CONFIGURATION_SECTION.EXPERIMENTAL}.tasks`,
         title: 'Tasks',
         type: 'object',
         properties: {

--- a/packages/renderer/src/PreferencesNavigation.spec.ts
+++ b/packages/renderer/src/PreferencesNavigation.spec.ts
@@ -18,10 +18,12 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { render, screen } from '@testing-library/svelte';
+import { render, screen, within } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import type { TinroRouteMeta } from 'tinro';
 import { beforeEach, expect, test, vi } from 'vitest';
+
+import { CONFIGURATION_SECTION } from '/@api/configuration/constants';
 
 import PreferencesNavigation from './PreferencesNavigation.svelte';
 import { configurationProperties } from './stores/configurationProperties';
@@ -191,4 +193,60 @@ test('Test rendering of the compatibility docker page does change if config chan
     const dockerCompatLink = screen.queryByRole('link', { name: 'Docker Compatibility' });
     expect(dockerCompatLink).not.toBeNull();
   });
+});
+
+test('expect preference section not to have an icon', async () => {
+  const { getByLabelText } = render(PreferencesNavigation, {
+    meta: {
+      url: '/',
+    } as unknown as TinroRouteMeta,
+  });
+
+  configurationProperties.set([
+    {
+      id: `bar`,
+      scope: 'DEFAULT',
+      type: 'boolean',
+      title: 'Hello world',
+      parentId: `${CONFIGURATION_SECTION.PREFERENCES}.foo`,
+    },
+  ]);
+
+  // get the experimental section
+  const section: HTMLElement = await vi.waitFor<HTMLElement>(() => {
+    const div = getByLabelText('preferences');
+    expect(div).toBeDefined();
+    return div;
+  });
+
+  const icon = within(section).queryByRole('img', { hidden: true });
+  expect(icon).toBeNull();
+});
+
+test('expect experimental section to have an icon', async () => {
+  const { getByLabelText } = render(PreferencesNavigation, {
+    meta: {
+      url: '/',
+    } as unknown as TinroRouteMeta,
+  });
+
+  configurationProperties.set([
+    {
+      id: `bar`,
+      scope: 'DEFAULT',
+      type: 'boolean',
+      title: 'Hello world',
+      parentId: `${CONFIGURATION_SECTION.EXPERIMENTAL}.foo`,
+    },
+  ]);
+
+  // get the experimental section
+  const section: HTMLElement = await vi.waitFor<HTMLElement>(() => {
+    const div = getByLabelText('experimental');
+    expect(div).toBeDefined();
+    return div;
+  });
+
+  const icon = within(section).getByRole('img', { hidden: true });
+  expect(icon).toBeDefined();
 });

--- a/packages/renderer/src/PreferencesNavigation.svelte
+++ b/packages/renderer/src/PreferencesNavigation.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
+import { faFlask } from '@fortawesome/free-solid-svg-icons';
 import { SettingsNavItem } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 import type { TinroRouteMeta } from 'tinro';
 
-import { CONFIGURATION_DEFAULT_SCOPE } from '/@api/configuration/constants.js';
+import { CONFIGURATION_DEFAULT_SCOPE, CONFIGURATION_SECTION } from '/@api/configuration/constants.js';
 import { ExperimentalSettings } from '/@api/docker-compatibility-info';
 
 import { configurationProperties } from './stores/configurationProperties';
@@ -91,6 +92,7 @@ onMount(() => {
     {#each configProperties as [configSection, configItems] (configSection)}
       <SettingsNavItem
         title={configSection}
+        icon={configSection === CONFIGURATION_SECTION.EXPERIMENTAL?faFlask:undefined}
         href="/preferences/default/{configSection}"
         section={configItems.length > 0}
         selected={meta.url === `/preferences/default/${configSection}`}


### PR DESCRIPTION
### What does this PR do?

First step of https://github.com/podman-desktop/podman-desktop/issues/10226.

This PR add a new `Experimental` section in the settings. I moved the docker compatibility and tasks to the experimental (as they are?).

❓ I hardcoded the the flask icon on the frontend, not sure if we want to add the full logic of adding an icon to the configuration.. 

### Screenshot / video of UI

![image](https://github.com/user-attachments/assets/506ad47d-0276-4c11-9d2e-5e80a5260dd4)

![image](https://github.com/user-attachments/assets/bb73d034-3382-4ed8-b80f-8eb8e2b7bcc0)

### What issues does this PR fix or reference?

Related to https://github.com/podman-desktop/podman-desktop/issues/10226

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
