### PR TITLE
chore: add link to /extensions page on /extend

### DIFF
--- a/website/src/pages/extend/index.tsx
+++ b/website/src/pages/extend/index.tsx
@@ -1,6 +1,6 @@
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
-import { faCertificate, faCloudArrowDown, faGears, faRocket } from '@fortawesome/free-solid-svg-icons';
+import { faBook, faCertificate, faCloudArrowDown, faGears, faRocket } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import TailWindThemeSelector from '@site/src/components/TailWindThemeSelector';
 import Layout from '@theme/Layout';
@@ -23,6 +23,10 @@ export default function Home(): JSX.Element {
             <p>Explore our comprehensive guides on extending Podman Desktop:</p>
             <div className="text-center">
               <ul className="list-none pl-0 mt-2">
+                <li>
+                  <FontAwesomeIcon icon={faBook} className="mr-2" />
+                  <a href={useBaseUrl('/extensions')}>View our Extensions Catalog</a>
+                </li>
                 <li>
                   <FontAwesomeIcon icon={faRocket} className="mr-2" />
                   <a href={useBaseUrl('/docs/extensions/developing')}>Developing an Extension</a>


### PR DESCRIPTION
chore: add link to /extensions page on /extend

### What does this PR do?

Adds a link to /extensions on our /extend page that links to our iframe
/ catalog list.

Will be improving showing extensions better in the future.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->
![Screenshot 2024-12-16 at 9 07 01 AM](https://github.com/user-attachments/assets/5f4d4baa-9c13-40fd-a15c-2dec7e2b08a2)




### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/podman-desktop/issues/10114

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

N/A, view site

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
