### PR TITLE
chore(ci): add Mac Update E2E job into PR check and e2e-main workflows

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -403,7 +403,7 @@ jobs:
             echo "PNPM_LOCK_CHANGED=false" >> $GITHUB_OUTPUT
           fi
 
-  run-update-e2e-test:
+  win-update-e2e-test:
     name: win update e2e tests
     needs: detect_pnpm_changes
     if: contains(github.event.pull_request.labels.*.name, 'area/update') || needs.detect_pnpm_changes.outputs.pnpm_lock_changed == 'true'
@@ -467,19 +467,99 @@ jobs:
             ./tests/**/output/
             !./tests/**/traces/raw
 
+
+  mac-update-e2e-test:
+    name: mac update e2e tests
+    needs: detect_pnpm_changes
+    if: contains(github.event.pull_request.labels.*.name, 'area/update') || needs.detect_pnpm_changes.outputs.pnpm_lock_changed == 'true'
+    runs-on: macos-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Execute pnpm
+        run: pnpm install
+
+      - name: Execute PNPM
+        run: pnpm install --frozen-lockfile
+
+      - name: Adjust/Downgrade local podman desktop version
+        run: |
+          version="1.13.0"
+          jq --arg version "$version" '.version = $version' package.json > package.json_tmp
+          mv package.json_tmp package.json
+
+      - name: Build Podman Desktop locally with electron updater included
+        env:
+          ELECTRON_ENABLE_INSPECT: true
+        run: |
+          pnpm compile:current --mac dmg
+          dmgPath=$(realpath $(find ./dist -name "*.dmg"))
+          echo "DMG Path: $dmgPath"
+          # extract the dmg
+          hdiutil attach $dmgPath
+          pdVolumePath=$(find /Volumes -name *1.13.0*)
+          echo "PD Volume path: $pdVolumePath"
+          sudo cp -R "$pdVolumePath/Podman Desktop.app" /Applications
+          # codesign the extracted app
+          appPath="/Applications/Podman Desktop.app"
+          sudo codesign --force --deep --sign - "$appPath"
+          codesign --verify --deep --verbose=2 "$appPath"
+          binaryPath="$appPath/Contents/MacOS/Podman Desktop"
+          echo "PODMAN_DESKTOP_BINARY=$binaryPath" >> $GITHUB_ENV
+
+      - name: Run E2E Update test
+        env:
+          UPDATE_PODMAN_DESKTOP: true
+        run: |
+          echo "${{ env.PODMAN_DESKTOP_BINARY }}"
+          pnpm test:e2e:update:run
+
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v5
+        if: always() # always run even if the previous step fails
+        with:
+          fail_on_failure: true
+          include_passed: true
+          detailed_summary: true
+          annotate_only: true
+          require_tests:  true
+          report_paths: '**/*results.xml'
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: mac-update-e2e-test
+          path: |
+            ./tests/**/output/
+            !./tests/**/traces/raw
+          
   update-e2e-test:
     name: update E2E test
     runs-on: ubuntu-24.04
-    needs: run-update-e2e-test
+    needs: [win-update-e2e-test, mac-update-e2e-test]
     if: |
       always()
     steps:
-      - name: Evaluate the Windows Update test results
+      - name: Evaluate the Windows and Mac E2E Update test results
         run: |
-          echo "Windows updater result: ${{ needs.run-update-e2e-test.result }}"
-          if [ "${{ needs.run-update-e2e-test.result }}" = "failure" ]; then
-            echo "Windows udpater test failed..."
+          echo "Windows updater result: ${{ needs.win-update-e2e-test.result }}"
+          echo "Mac updater result: ${{ needs.mac-update-e2e-test.result }}"
+          if [[ "${{ needs.win-update-e2e-test.result }}" = "failure" || "${{ needs.mac-update-e2e-test.result }}" = "failure" ]]; then
+            echo "Windows or Mac udpater test failed..."
             exit 1
           else
-            echo "Windows updater test succeeded or was skipped..."
+            echo "Windows and Mac updater test succeeded or was skipped..."
           fi


### PR DESCRIPTION
### What does this PR do?
Brings new job in PR check and E2E-Main test workflows, the job runs update e2e tests on Mac OS to verify the possibility to update the podman-desktop via electron-builder updater. It does not actually perform the restart after downloading the target version, but it verifies PD can download the next version and does not crash.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#9214 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
Look at PR checks. Now there is mac update e2e test present when updater tests are run. One can add `area/update` label  to trigger a jobs.

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
