### PR TITLE
chore: fix the method signature for pruneAllImages of Podman

### DIFF
--- a/packages/main/src/plugin/dockerode/libpod-dockerode.spec.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.spec.ts
@@ -383,3 +383,31 @@ test('check correct header is provided for playKube', async () => {
   // Cleanup the file
   await rm(tmpFile);
 });
+
+test('Check prune all images', async () => {
+  server = setupServer(
+    http.post('http://localhost/v4.2.0/libpod/images/prune', async info => {
+      const url = new URL(info.request.url);
+      expect(url.searchParams.get('all')).toEqual('true');
+      return HttpResponse.json({}, { status: 200 });
+    }),
+  );
+  server.listen({ onUnhandledRequest: 'error' });
+
+  const api = new Dockerode({ protocol: 'http', host: 'localhost' });
+  await (api as unknown as LibPod).pruneAllImages(true);
+});
+
+test('Check prune default images (not all)', async () => {
+  server = setupServer(
+    http.post('http://localhost/v4.2.0/libpod/images/prune', async info => {
+      const url = new URL(info.request.url);
+      expect(url.searchParams.get('all')).toBeNull();
+      return HttpResponse.json({}, { status: 200 });
+    }),
+  );
+  server.listen({ onUnhandledRequest: 'error' });
+
+  const api = new Dockerode({ protocol: 'http', host: 'localhost' });
+  await (api as unknown as LibPod).pruneAllImages(false);
+});

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.ts
@@ -530,11 +530,9 @@ export class LibpodDockerode {
     };
 
     // add pruneAllImages
-    prototypeOfDockerode.pruneAllImages = function (): Promise<unknown> {
+    prototypeOfDockerode.pruneAllImages = function (all: boolean): Promise<unknown> {
       const optsf = {
-        path: '/v4.2.0/libpod/images/prune?all=true&', // this works
-        // For some reason the below doesn't work
-        // options: {all: 'true'}, // this doesn't work
+        path: '/v4.2.0/libpod/images/prune?',
         method: 'POST',
         statusCodes: {
           200: true,
@@ -542,6 +540,12 @@ export class LibpodDockerode {
           500: 'server error',
         },
       };
+      if (all) {
+        optsf.path += 'all=true&';
+        // For some reason the below doesn't work
+        // options: {all: 'true'}, // this doesn't work
+      }
+
       return new Promise((resolve, reject) => {
         this.modem.dial(optsf, (err: unknown, data: unknown) => {
           if (err) {

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.ts
@@ -532,7 +532,7 @@ export class LibpodDockerode {
     // add pruneAllImages
     prototypeOfDockerode.pruneAllImages = function (all: boolean): Promise<unknown> {
       const optsf = {
-        path: '/v4.2.0/libpod/images/prune?',
+        path: '/v4.2.0/libpod/images/prune',
         method: 'POST',
         statusCodes: {
           200: true,
@@ -541,7 +541,7 @@ export class LibpodDockerode {
         },
       };
       if (all) {
-        optsf.path += 'all=true&';
+        optsf.path += '?all=true&';
         // For some reason the below doesn't work
         // options: {all: 'true'}, // this doesn't work
       }


### PR DESCRIPTION
### What does this PR do?

the method accepts a boolean for dangling

https://github.com/podman-desktop/podman-desktop/blob/7da6e4a48972e27a0eab4ae06580a7a57f492cb7/packages/main/src/plugin/dockerode/libpod-dockerode.ts#L379

 but the implementation is ignoring the parameter value
make it handling the value

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/issues/7043

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
