### PR TITLE
chore(test): extract cluster-related operations to a dedicated utility file

### DIFF
--- a/tests/playwright/src/index.ts
+++ b/tests/playwright/src/index.ts
@@ -81,3 +81,4 @@ export * from './model/pages/settings-page';
 export * from './model/pages/welcome-page';
 export * from './model/workbench/navigation';
 export * from './model/workbench/status-bar';
+export * from './utility/cluster-operations';

--- a/tests/playwright/src/model/pages/cli-tools-page.ts
+++ b/tests/playwright/src/model/pages/cli-tools-page.ts
@@ -19,8 +19,7 @@
 import test, { expect as playExpect } from '@playwright/test';
 import type { Locator, Page } from 'playwright';
 
-import { handleConfirmationDialog } from '/@/utility/operations';
-
+import { handleConfirmationDialog } from '../../utility/operations';
 import { SettingsPage } from './settings-page';
 
 export class CLIToolsPage extends SettingsPage {

--- a/tests/playwright/src/specs/deploy-to-kubernetes.spec.ts
+++ b/tests/playwright/src/specs/deploy-to-kubernetes.spec.ts
@@ -26,13 +26,14 @@ import { waitForPodmanMachineStartup } from '../utility/wait';
 
 const CLUSTER_NAME: string = 'kind-cluster';
 const CLUSTER_CREATION_TIMEOUT: number = 300_000;
-const KIND_CONTAINER_NAME: string = `${CLUSTER_NAME}-control-plane`;
+const KIND_NODE: string = `${CLUSTER_NAME}-control-plane`;
 const KUBERNETES_CONTEXT: string = `kind-${CLUSTER_NAME}`;
+const RESOURCE_NAME: string = 'kind';
 const IMAGE_TO_PULL: string = 'ghcr.io/linuxcontainers/alpine';
 const IMAGE_TAG: string = 'latest';
 const CONTAINER_NAME: string = 'alpine-container';
 const NAMESPACE: string = 'default';
-const DEPLOYED_POD_NAME: string = `${CONTAINER_NAME} ${KIND_CONTAINER_NAME} ${NAMESPACE}`;
+const DEPLOYED_POD_NAME: string = `${CONTAINER_NAME} ${KIND_NODE} ${NAMESPACE}`;
 const CONTAINER_START_PARAMS: ContainerInteractiveParams = {
   attachTerminal: false,
 };
@@ -64,7 +65,7 @@ test.afterAll(async ({ runner, page }) => {
   try {
     await deleteContainer(page, CONTAINER_NAME);
     await deleteImage(page, IMAGE_TO_PULL);
-    await deleteCluster(page, KIND_CONTAINER_NAME, CLUSTER_NAME);
+    await deleteCluster(page, RESOURCE_NAME, KIND_NODE, CLUSTER_NAME);
   } finally {
     await runner.close();
     console.log('Runner closed');

--- a/tests/playwright/src/specs/deploy-to-kubernetes.spec.ts
+++ b/tests/playwright/src/specs/deploy-to-kubernetes.spec.ts
@@ -19,14 +19,9 @@
 import { ContainerState } from '../model/core/states';
 import type { ContainerInteractiveParams } from '../model/core/types';
 import { ContainerDetailsPage } from '../model/pages/container-details-page';
+import { createKindCluster, deleteCluster } from '../utility/cluster-operations';
 import { expect as playExpect, test } from '../utility/fixtures';
-import {
-  createKindCluster,
-  deleteContainer,
-  deleteImage,
-  deleteKindCluster,
-  ensureCliInstalled,
-} from '../utility/operations';
+import { deleteContainer, deleteImage, ensureCliInstalled } from '../utility/operations';
 import { waitForPodmanMachineStartup } from '../utility/wait';
 
 const CLUSTER_NAME: string = 'kind-cluster';
@@ -69,7 +64,7 @@ test.afterAll(async ({ runner, page }) => {
   try {
     await deleteContainer(page, CONTAINER_NAME);
     await deleteImage(page, IMAGE_TO_PULL);
-    await deleteKindCluster(page, KIND_CONTAINER_NAME, CLUSTER_NAME);
+    await deleteCluster(page, KIND_CONTAINER_NAME, CLUSTER_NAME);
   } finally {
     await runner.close();
     console.log('Runner closed');

--- a/tests/playwright/src/specs/kind.spec.ts
+++ b/tests/playwright/src/specs/kind.spec.ts
@@ -16,13 +16,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { ResourceElementActions } from '../model/core/operations';
+import { ResourceElementState } from '../model/core/states';
 import { ResourceConnectionCardPage } from '../model/pages/resource-connection-card-page';
 import { ResourcesPage } from '../model/pages/resources-page';
 import {
   checkClusterResources,
-  clusterOperations,
   createKindCluster,
   deleteCluster,
+  resourceConnectionAction,
 } from '../utility/cluster-operations';
 import { expect as playExpect, test } from '../utility/fixtures';
 import { ensureCliInstalled } from '../utility/operations';
@@ -31,7 +33,7 @@ import { waitForPodmanMachineStartup } from '../utility/wait';
 const RESOURCE_NAME: string = 'kind';
 const EXTENSION_LABEL: string = 'podman-desktop.kind';
 const CLUSTER_NAME: string = 'kind-cluster';
-const KIND_CONTAINER_NAME: string = `${CLUSTER_NAME}-control-plane`;
+const KIND_NODE: string = `${CLUSTER_NAME}-control-plane`;
 const CLUSTER_CREATION_TIMEOUT: number = 300_000;
 let resourcesPage: ResourcesPage;
 
@@ -49,7 +51,7 @@ test.beforeAll(async ({ runner, page, welcomePage }) => {
 
 test.afterAll(async ({ runner, page }) => {
   try {
-    await deleteCluster(page, KIND_CONTAINER_NAME, CLUSTER_NAME);
+    await deleteCluster(page, RESOURCE_NAME, KIND_NODE, CLUSTER_NAME);
   } finally {
     await runner.close();
   }
@@ -97,11 +99,33 @@ test.describe.serial('Kind End-to-End Tests', { tag: '@k8s_e2e' }, () => {
     });
 
     test('Check resources added with the Kind cluster', async ({ page }) => {
-      await checkClusterResources(page, KIND_CONTAINER_NAME);
+      await checkClusterResources(page, KIND_NODE);
     });
 
-    test('Kind cluster operations', async ({ page }) => {
-      await clusterOperations(page, kindResourceCard, KIND_CONTAINER_NAME, CLUSTER_NAME);
+    test('Kind cluster operations - STOP', async ({ page }) => {
+      await resourceConnectionAction(page, kindResourceCard, ResourceElementActions.Stop, ResourceElementState.Off);
+    });
+
+    test('Kind cluster operations - START', async ({ page }) => {
+      await resourceConnectionAction(
+        page,
+        kindResourceCard,
+        ResourceElementActions.Start,
+        ResourceElementState.Running,
+      );
+    });
+
+    test('Kind cluster operatioms - RESTART', async ({ page }) => {
+      await resourceConnectionAction(
+        page,
+        kindResourceCard,
+        ResourceElementActions.Restart,
+        ResourceElementState.Running,
+      );
+    });
+
+    test('Kind cluster operations - DELETE', async ({ page }) => {
+      await deleteCluster(page, RESOURCE_NAME, KIND_NODE, CLUSTER_NAME);
     });
   });
 });

--- a/tests/playwright/src/specs/kind.spec.ts
+++ b/tests/playwright/src/specs/kind.spec.ts
@@ -16,18 +16,16 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { ResourceElementActions } from '../model/core/operations';
-import { ContainerState, ResourceElementState } from '../model/core/states';
 import { ResourceConnectionCardPage } from '../model/pages/resource-connection-card-page';
 import { ResourcesPage } from '../model/pages/resources-page';
-import { VolumesPage } from '../model/pages/volumes-page';
-import { expect as playExpect, test } from '../utility/fixtures';
 import {
+  checkClusterResources,
+  clusterOperations,
   createKindCluster,
-  deleteKindCluster,
-  ensureCliInstalled,
-  getVolumeNameForContainer,
-} from '../utility/operations';
+  deleteCluster,
+} from '../utility/cluster-operations';
+import { expect as playExpect, test } from '../utility/fixtures';
+import { ensureCliInstalled } from '../utility/operations';
 import { waitForPodmanMachineStartup } from '../utility/wait';
 
 const RESOURCE_NAME: string = 'kind';
@@ -51,9 +49,7 @@ test.beforeAll(async ({ runner, page, welcomePage }) => {
 
 test.afterAll(async ({ runner, page }) => {
   try {
-    if (!(process.env.GITHUB_ACTIONS && process.env.RUNNER_OS === 'Linux')) {
-      await deleteKindCluster(page, KIND_CONTAINER_NAME, CLUSTER_NAME);
-    }
+    await deleteCluster(page, KIND_CONTAINER_NAME, CLUSTER_NAME);
   } finally {
     await runner.close();
   }
@@ -86,7 +82,11 @@ test.describe.serial('Kind End-to-End Tests', { tag: '@k8s_e2e' }, () => {
         await playExpect.poll(async () => resourcesPage.resourceCardIsVisible(RESOURCE_NAME)).toBeTruthy();
       });
     });
-  test.describe('Kind cluster operations', () => {
+  test.describe('Kind cluster validation tests', () => {
+    test.skip(
+      !!process.env.GITHUB_ACTIONS && process.env.RUNNER_OS === 'Linux',
+      'Tests suite should not run on Linux platform',
+    );
     test('Create a Kind cluster', async ({ page }) => {
       test.setTimeout(CLUSTER_CREATION_TIMEOUT);
       if (process.env.GITHUB_ACTIONS && process.env.RUNNER_OS === 'Linux') {
@@ -96,51 +96,12 @@ test.describe.serial('Kind End-to-End Tests', { tag: '@k8s_e2e' }, () => {
       }
     });
 
-    test('Check resources added with the Kind cluster', async ({ page, navigationBar }) => {
-      const containersPage = await navigationBar.openContainers();
-      await playExpect.poll(async () => containersPage.containerExists(KIND_CONTAINER_NAME)).toBeTruthy();
-      const containerDetailsPage = await containersPage.openContainersDetails(KIND_CONTAINER_NAME);
-      await playExpect.poll(async () => await containerDetailsPage.getState()).toEqual(ContainerState.Running);
-
-      const volumesPage = new VolumesPage(page);
-      const volumeName = await getVolumeNameForContainer(page, KIND_CONTAINER_NAME);
-      if (!volumeName) {
-        throw new Error(`Volume name for container "${KIND_CONTAINER_NAME}" is not defined.`);
-      }
-      const volumeDetailsPage = await volumesPage.openVolumeDetails(volumeName);
-      await playExpect.poll(async () => await volumeDetailsPage.isUsed()).toBeTruthy();
+    test('Check resources added with the Kind cluster', async ({ page }) => {
+      await checkClusterResources(page, KIND_CONTAINER_NAME);
     });
 
-    test('Kind cluster operations - STOP', async ({ navigationBar }) => {
-      await navigationBar.openSettings();
-      await playExpect(kindResourceCard.resourceElementConnectionStatus).toHaveText(ResourceElementState.Running);
-      await kindResourceCard.performConnectionAction(ResourceElementActions.Stop);
-      await playExpect(kindResourceCard.resourceElementConnectionStatus).toHaveText(ResourceElementState.Off, {
-        timeout: 50000,
-      });
-    });
-
-    test('Kind cluster operations - START', async () => {
-      await kindResourceCard.performConnectionAction(ResourceElementActions.Start);
-      await playExpect(kindResourceCard.resourceElementConnectionStatus).toHaveText(ResourceElementState.Running, {
-        timeout: 50000,
-      });
-    });
-
-    test('Kind cluster operatioms - RESTART', async () => {
-      await kindResourceCard.performConnectionAction(ResourceElementActions.Restart);
-      const stopButton = kindResourceCard.resourceElementConnectionActions.getByRole('button', {
-        name: ResourceElementActions.Stop,
-        exact: true,
-      });
-      await playExpect(stopButton).toBeEnabled({ timeout: 25_000 });
-      await playExpect(kindResourceCard.resourceElementConnectionStatus).toHaveText(ResourceElementState.Running, {
-        timeout: 50000,
-      });
-    });
-
-    test('Kind cluster operations - DELETE', async ({ page }) => {
-      await deleteKindCluster(page, KIND_CONTAINER_NAME, CLUSTER_NAME);
+    test('Kind cluster operations', async ({ page }) => {
+      await clusterOperations(page, kindResourceCard, KIND_CONTAINER_NAME, CLUSTER_NAME);
     });
   });
 });

--- a/tests/playwright/src/specs/kubernetes-edit-yaml.spec.ts
+++ b/tests/playwright/src/specs/kubernetes-edit-yaml.spec.ts
@@ -23,13 +23,9 @@ import { PlayYamlRuntime } from '../model/core/operations';
 import { KubernetesResourceState } from '../model/core/states';
 import { KubernetesResources } from '../model/core/types';
 import { KubernetesResourceDetailsPage } from '../model/pages/kubernetes-resource-details-page';
+import { createKindCluster, deleteCluster } from '../utility/cluster-operations';
 import { expect as playExpect, test } from '../utility/fixtures';
-import {
-  createKindCluster,
-  deleteKindCluster,
-  ensureCliInstalled,
-  handleConfirmationDialog,
-} from '../utility/operations';
+import { ensureCliInstalled, handleConfirmationDialog } from '../utility/operations';
 import { waitForPodmanMachineStartup } from '../utility/wait';
 
 const CLUSTER_NAME: string = 'kind-cluster';
@@ -73,7 +69,7 @@ test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
 test.afterAll(async ({ runner, page }) => {
   test.setTimeout(90000);
   try {
-    await deleteKindCluster(page, KIND_NODE, CLUSTER_NAME);
+    await deleteCluster(page, KIND_NODE, CLUSTER_NAME);
   } finally {
     await runner.close();
   }

--- a/tests/playwright/src/specs/kubernetes-edit-yaml.spec.ts
+++ b/tests/playwright/src/specs/kubernetes-edit-yaml.spec.ts
@@ -31,6 +31,7 @@ import { waitForPodmanMachineStartup } from '../utility/wait';
 const CLUSTER_NAME: string = 'kind-cluster';
 const CLUSTER_CREATION_TIMEOUT: number = 300_000;
 const KIND_NODE: string = `${CLUSTER_NAME}-control-plane`;
+const RESOURCE_NAME: string = 'kind';
 const KUBERNETES_CONTEXT = `kind-${CLUSTER_NAME}`;
 const KUBERNETES_NAMESPACE = 'default';
 const DEPLOYMENT_NAME = 'test-deployment-resource';
@@ -69,7 +70,7 @@ test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
 test.afterAll(async ({ runner, page }) => {
   test.setTimeout(90000);
   try {
-    await deleteCluster(page, KIND_NODE, CLUSTER_NAME);
+    await deleteCluster(page, RESOURCE_NAME, KIND_NODE, CLUSTER_NAME);
   } finally {
     await runner.close();
   }

--- a/tests/playwright/src/specs/kubernetes.spec.ts
+++ b/tests/playwright/src/specs/kubernetes.spec.ts
@@ -30,6 +30,7 @@ import { waitForPodmanMachineStartup } from '../utility/wait';
 const CLUSTER_NAME: string = 'kind-cluster';
 const CLUSTER_CREATION_TIMEOUT: number = 300_000;
 const KIND_NODE: string = `${CLUSTER_NAME}-control-plane`;
+const RESOURCE_NAME: string = 'kind';
 const KUBERNETES_CONTEXT = `kind-${CLUSTER_NAME}`;
 const KUBERNETES_NAMESPACE = 'default';
 const PVC_NAME = 'test-pvc-resource';
@@ -76,7 +77,7 @@ test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
 test.afterAll(async ({ runner, page }) => {
   test.setTimeout(90000);
   try {
-    await deleteCluster(page, KIND_NODE, CLUSTER_NAME);
+    await deleteCluster(page, RESOURCE_NAME, KIND_NODE, CLUSTER_NAME);
   } finally {
     await runner.close();
   }

--- a/tests/playwright/src/specs/kubernetes.spec.ts
+++ b/tests/playwright/src/specs/kubernetes.spec.ts
@@ -22,14 +22,9 @@ import { fileURLToPath } from 'node:url';
 import { PlayYamlRuntime } from '../model/core/operations';
 import { KubernetesResourceState, PodState } from '../model/core/states';
 import { KubernetesResources } from '../model/core/types';
+import { createKindCluster, deleteCluster } from '../utility/cluster-operations';
 import { expect as playExpect, test } from '../utility/fixtures';
-import {
-  createKindCluster,
-  deleteKindCluster,
-  deletePod,
-  ensureCliInstalled,
-  handleConfirmationDialog,
-} from '../utility/operations';
+import { deletePod, ensureCliInstalled, handleConfirmationDialog } from '../utility/operations';
 import { waitForPodmanMachineStartup } from '../utility/wait';
 
 const CLUSTER_NAME: string = 'kind-cluster';
@@ -81,7 +76,7 @@ test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
 test.afterAll(async ({ runner, page }) => {
   test.setTimeout(90000);
   try {
-    await deleteKindCluster(page, KIND_NODE, CLUSTER_NAME);
+    await deleteCluster(page, KIND_NODE, CLUSTER_NAME);
   } finally {
     await runner.close();
   }

--- a/tests/playwright/src/utility/cluster-operations.ts
+++ b/tests/playwright/src/utility/cluster-operations.ts
@@ -147,7 +147,7 @@ export async function resourceConnectionAction(
   resourceConnectionAction: ResourceElementActions,
   expectedResourceState: ResourceElementState,
 ): Promise<void> {
-  return test.step('Perform resource connection action', async () => {
+  return test.step(`Performs "${resourceConnectionAction}" action, expects "${expectedResourceState}" state.`, async () => {
     const navigationBar = new NavigationBar(page);
     await navigationBar.openSettings();
     await resourceCard.performConnectionAction(resourceConnectionAction);

--- a/tests/playwright/src/utility/cluster-operations.ts
+++ b/tests/playwright/src/utility/cluster-operations.ts
@@ -151,6 +151,13 @@ export async function resourceConnectionAction(
     const navigationBar = new NavigationBar(page);
     await navigationBar.openSettings();
     await resourceCard.performConnectionAction(resourceConnectionAction);
+    if (resourceConnectionAction === ResourceElementActions.Restart) {
+      const stopButton = resourceCard.resourceElementConnectionActions.getByRole('button', {
+        name: ResourceElementActions.Stop,
+        exact: true,
+      });
+      await playExpect(stopButton).toBeEnabled({ timeout: 25_000 });
+    }
     await playExpect(resourceCard.resourceElementConnectionStatus).toHaveText(expectedResourceState, {
       timeout: 50_000,
     });

--- a/tests/playwright/src/utility/cluster-operations.ts
+++ b/tests/playwright/src/utility/cluster-operations.ts
@@ -84,7 +84,7 @@ export async function deleteCluster(
   containerName: string = 'kind-cluster-control-plane',
   clusterName: string = 'kind-cluster',
 ): Promise<void> {
-  return test.step('Delete Kind cluster', async () => {
+  return test.step(`Delete ${resourceName} cluster`, async () => {
     const navigationBar = new NavigationBar(page);
     const resourceCard = new ResourceConnectionCardPage(page, resourceName, clusterName);
     const volumeName = await getVolumeNameForContainer(page, containerName);
@@ -124,7 +124,7 @@ export async function deleteCluster(
 }
 
 export async function checkClusterResources(page: Page, containerName: string): Promise<void> {
-  return test.step('Check resources added with cluster', async () => {
+  return test.step(`Check container '${containerName}' and volume cluster resources.`, async () => {
     const navigationBar = new NavigationBar(page);
     const containersPage = await navigationBar.openContainers();
     await playExpect.poll(async () => containersPage.containerExists(containerName)).toBeTruthy();
@@ -141,31 +141,18 @@ export async function checkClusterResources(page: Page, containerName: string): 
   });
 }
 
-export async function clusterOperations(
+export async function resourceConnectionAction(
   page: Page,
   resourceCard: ResourceConnectionCardPage,
-  containerName: string,
-  clusterName: string,
+  resourceConnectionAction: ResourceElementActions,
+  expectedResourceState: ResourceElementState,
 ): Promise<void> {
-  return test.step('Basic cluster operations', async () => {
+  return test.step('Perform resource connection action', async () => {
     const navigationBar = new NavigationBar(page);
     await navigationBar.openSettings();
-    await playExpect(resourceCard.resourceElementConnectionStatus).toHaveText(ResourceElementState.Running);
-    await resourceCard.performConnectionAction(ResourceElementActions.Stop);
-    await playExpect(resourceCard.resourceElementConnectionStatus).toHaveText(ResourceElementState.Off, {
-      timeout: 50000,
+    await resourceCard.performConnectionAction(resourceConnectionAction);
+    await playExpect(resourceCard.resourceElementConnectionStatus).toHaveText(expectedResourceState, {
+      timeout: 50_000,
     });
-
-    await resourceCard.performConnectionAction(ResourceElementActions.Start);
-    await playExpect(resourceCard.resourceElementConnectionStatus).toHaveText(ResourceElementState.Running, {
-      timeout: 50000,
-    });
-
-    await resourceCard.performConnectionAction(ResourceElementActions.Restart);
-    await playExpect(resourceCard.resourceElementConnectionStatus).toHaveText(ResourceElementState.Running, {
-      timeout: 50000,
-    });
-
-    await deleteCluster(page, containerName, clusterName);
   });
 }

--- a/tests/playwright/src/utility/cluster-operations.ts
+++ b/tests/playwright/src/utility/cluster-operations.ts
@@ -1,0 +1,171 @@
+/**********************************************************************
+ * Copyright (C) 2023-2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Page } from '@playwright/test';
+import test, { expect as playExpect } from '@playwright/test';
+
+import { ResourceElementActions } from '../model/core/operations';
+import { ContainerState, ResourceElementState } from '../model/core/states';
+import type { KindClusterOptions } from '../model/core/types';
+import { CreateKindClusterPage } from '../model/pages/create-kind-cluster-page';
+import { ResourceConnectionCardPage } from '../model/pages/resource-connection-card-page';
+import { ResourcesPage } from '../model/pages/resources-page';
+import { VolumesPage } from '../model/pages/volumes-page';
+import { NavigationBar } from '../model/workbench/navigation';
+import { StatusBar } from '../model/workbench/status-bar';
+import { getVolumeNameForContainer } from './operations';
+
+export async function createKindCluster(
+  page: Page,
+  clusterName: string,
+  usedefaultOptions: boolean,
+  timeout: number = 300_000,
+  { providerType, httpPort, httpsPort, useIngressController, containerImage }: KindClusterOptions = {},
+): Promise<void> {
+  return test.step('Create Kind cluster', async () => {
+    const navigationBar = new NavigationBar(page);
+    const statusBar = new StatusBar(page);
+    const kindResourceCard = new ResourceConnectionCardPage(page, 'kind', clusterName);
+    const createKindClusterPage = new CreateKindClusterPage(page);
+
+    const settingsPage = await navigationBar.openSettings();
+    const resourcesPage = await settingsPage.openTabPage(ResourcesPage);
+    await playExpect(resourcesPage.heading).toBeVisible({ timeout: 10_000 });
+    await playExpect.poll(async () => resourcesPage.resourceCardIsVisible('kind')).toBeTruthy();
+    await playExpect(kindResourceCard.createButton).toBeVisible();
+
+    if (await kindResourceCard.doesResourceElementExist()) {
+      console.log(`Kind cluster [${clusterName}] already present, skipping creation.`);
+      return;
+    }
+
+    await kindResourceCard.createButton.click();
+    if (usedefaultOptions) {
+      await createKindClusterPage.createClusterDefault(clusterName, timeout);
+    } else {
+      await createKindClusterPage.createClusterParametrized(
+        clusterName,
+        {
+          providerType: providerType,
+          httpPort: httpPort,
+          httpsPort: httpsPort,
+          useIngressController: useIngressController,
+          containerImage: containerImage,
+        },
+        timeout,
+      );
+    }
+    await playExpect(kindResourceCard.resourceElement).toBeVisible();
+    await playExpect(kindResourceCard.resourceElementConnectionStatus).toHaveText(ResourceElementState.Running, {
+      timeout: 15_000,
+    });
+    await statusBar.validateKubernetesContext(`kind-${clusterName}`);
+  });
+}
+
+export async function deleteCluster(
+  page: Page,
+  resourceName: string = 'kind',
+  containerName: string = 'kind-cluster-control-plane',
+  clusterName: string = 'kind-cluster',
+): Promise<void> {
+  return test.step('Delete Kind cluster', async () => {
+    const navigationBar = new NavigationBar(page);
+    const resourceCard = new ResourceConnectionCardPage(page, resourceName, clusterName);
+    const volumeName = await getVolumeNameForContainer(page, containerName);
+
+    await navigationBar.openSettings();
+    const resourcesPage = new ResourcesPage(page);
+    await playExpect(resourcesPage.heading).toBeVisible({ timeout: 10_000 });
+    if (!(await resourceCard.doesResourceElementExist())) {
+      console.log(`Kind cluster [${clusterName}] not present, skipping deletion.`);
+      return;
+    }
+
+    await resourceCard.performConnectionAction(ResourceElementActions.Stop);
+    await playExpect(resourceCard.resourceElementConnectionStatus).toHaveText(ResourceElementState.Off, {
+      timeout: 50_000,
+    });
+    await resourceCard.performConnectionAction(ResourceElementActions.Delete);
+    await playExpect(resourceCard.markdownContent).toBeVisible({
+      timeout: 50_000,
+    });
+    const containersPage = await navigationBar.openContainers();
+    await playExpect(containersPage.heading).toBeVisible();
+    await playExpect
+      .poll(async () => containersPage.containerExists(containerName), {
+        timeout: 10_000,
+      })
+      .toBeFalsy();
+
+    const volumePage = await navigationBar.openVolumes();
+    await playExpect(volumePage.heading).toBeVisible();
+    await playExpect
+      .poll(async () => await volumePage.waitForVolumeDelete(volumeName), {
+        timeout: 20_000,
+      })
+      .toBeTruthy();
+  });
+}
+
+export async function checkClusterResources(page: Page, containerName: string): Promise<void> {
+  return test.step('Check resources added with cluster', async () => {
+    const navigationBar = new NavigationBar(page);
+    const containersPage = await navigationBar.openContainers();
+    await playExpect.poll(async () => containersPage.containerExists(containerName)).toBeTruthy();
+    const containerDetailsPage = await containersPage.openContainersDetails(containerName);
+    await playExpect.poll(async () => await containerDetailsPage.getState()).toEqual(ContainerState.Running);
+
+    const volumesPage = new VolumesPage(page);
+    const volumeName = await getVolumeNameForContainer(page, containerName);
+    if (!volumeName) {
+      throw new Error(`Volume name for container "${containerName}" is not defined.`);
+    }
+    const volumeDetailsPage = await volumesPage.openVolumeDetails(volumeName);
+    await playExpect.poll(async () => await volumeDetailsPage.isUsed()).toBeTruthy();
+  });
+}
+
+export async function clusterOperations(
+  page: Page,
+  resourceCard: ResourceConnectionCardPage,
+  containerName: string,
+  clusterName: string,
+): Promise<void> {
+  return test.step('Basic cluster operations', async () => {
+    const navigationBar = new NavigationBar(page);
+    await navigationBar.openSettings();
+    await playExpect(resourceCard.resourceElementConnectionStatus).toHaveText(ResourceElementState.Running);
+    await resourceCard.performConnectionAction(ResourceElementActions.Stop);
+    await playExpect(resourceCard.resourceElementConnectionStatus).toHaveText(ResourceElementState.Off, {
+      timeout: 50000,
+    });
+
+    await resourceCard.performConnectionAction(ResourceElementActions.Start);
+    await playExpect(resourceCard.resourceElementConnectionStatus).toHaveText(ResourceElementState.Running, {
+      timeout: 50000,
+    });
+
+    await resourceCard.performConnectionAction(ResourceElementActions.Restart);
+    await playExpect(resourceCard.resourceElementConnectionStatus).toHaveText(ResourceElementState.Running, {
+      timeout: 50000,
+    });
+
+    await deleteCluster(page, containerName, clusterName);
+  });
+}

--- a/tests/playwright/src/utility/operations.ts
+++ b/tests/playwright/src/utility/operations.ts
@@ -23,15 +23,12 @@ import test, { expect as playExpect } from '@playwright/test';
 
 import { ResourceElementActions } from '../model/core/operations';
 import { ResourceElementState } from '../model/core/states';
-import type { KindClusterOptions } from '../model/core/types';
 import { CLIToolsPage } from '../model/pages/cli-tools-page';
-import { CreateKindClusterPage } from '../model/pages/create-kind-cluster-page';
 import { RegistriesPage } from '../model/pages/registries-page';
 import { ResourceConnectionCardPage } from '../model/pages/resource-connection-card-page';
 import { ResourcesPage } from '../model/pages/resources-page';
 import { VolumeDetailsPage } from '../model/pages/volume-details-page';
 import { NavigationBar } from '../model/workbench/navigation';
-import { StatusBar } from '../model/workbench/status-bar';
 import { waitUntil, waitWhile } from './wait';
 
 /**
@@ -310,98 +307,6 @@ export async function ensureCliInstalled(page: Page, resourceName: string, timeo
     await playExpect
       .poll(async () => await cliToolsPage.getCurrentToolVersion(resourceName), {
         timeout: timeout,
-      })
-      .toBeTruthy();
-  });
-}
-
-export async function createKindCluster(
-  page: Page,
-  clusterName: string,
-  usedefaultOptions: boolean,
-  timeout: number = 300_000,
-  { providerType, httpPort, httpsPort, useIngressController, containerImage }: KindClusterOptions = {},
-): Promise<void> {
-  return test.step('Create Kind cluster', async () => {
-    const navigationBar = new NavigationBar(page);
-    const statusBar = new StatusBar(page);
-    const kindResourceCard = new ResourceConnectionCardPage(page, 'kind', clusterName);
-    const createKindClusterPage = new CreateKindClusterPage(page);
-
-    const settingsPage = await navigationBar.openSettings();
-    const resourcesPage = await settingsPage.openTabPage(ResourcesPage);
-    await playExpect(resourcesPage.heading).toBeVisible({ timeout: 10_000 });
-    await playExpect.poll(async () => resourcesPage.resourceCardIsVisible('kind')).toBeTruthy();
-    await playExpect(kindResourceCard.createButton).toBeVisible();
-
-    if (await kindResourceCard.doesResourceElementExist()) {
-      console.log(`Kind cluster [${clusterName}] already present, skipping creation.`);
-      return;
-    }
-
-    await kindResourceCard.createButton.click();
-    if (usedefaultOptions) {
-      await createKindClusterPage.createClusterDefault(clusterName, timeout);
-    } else {
-      await createKindClusterPage.createClusterParametrized(
-        clusterName,
-        {
-          providerType: providerType,
-          httpPort: httpPort,
-          httpsPort: httpsPort,
-          useIngressController: useIngressController,
-          containerImage: containerImage,
-        },
-        timeout,
-      );
-    }
-    await playExpect(kindResourceCard.resourceElement).toBeVisible();
-    await playExpect(kindResourceCard.resourceElementConnectionStatus).toHaveText(ResourceElementState.Running, {
-      timeout: 15_000,
-    });
-    await statusBar.validateKubernetesContext(`kind-${clusterName}`);
-  });
-}
-
-export async function deleteKindCluster(
-  page: Page,
-  containerName: string = 'kind-cluster-control-plane',
-  clusterName: string = 'kind-cluster',
-): Promise<void> {
-  return test.step('Delete Kind cluster', async () => {
-    const navigationBar = new NavigationBar(page);
-    const kindResourceCard = new ResourceConnectionCardPage(page, 'kind', clusterName);
-    const volumeName = await getVolumeNameForContainer(page, containerName);
-
-    await navigationBar.openSettings();
-    const resourcesPage = new ResourcesPage(page);
-    await playExpect(resourcesPage.heading).toBeVisible({ timeout: 10_000 });
-    if (!(await kindResourceCard.doesResourceElementExist())) {
-      console.log(`Kind cluster [${clusterName}] not present, skipping deletion.`);
-      return;
-    }
-
-    await kindResourceCard.performConnectionAction(ResourceElementActions.Stop);
-    await playExpect(kindResourceCard.resourceElementConnectionStatus).toHaveText(ResourceElementState.Off, {
-      timeout: 50_000,
-    });
-    await kindResourceCard.performConnectionAction(ResourceElementActions.Delete);
-    await playExpect(kindResourceCard.markdownContent).toBeVisible({
-      timeout: 50_000,
-    });
-    const containersPage = await navigationBar.openContainers();
-    await playExpect(containersPage.heading).toBeVisible();
-    await playExpect
-      .poll(async () => containersPage.containerExists(containerName), {
-        timeout: 10_000,
-      })
-      .toBeFalsy();
-
-    const volumePage = await navigationBar.openVolumes();
-    await playExpect(volumePage.heading).toBeVisible();
-    await playExpect
-      .poll(async () => await volumePage.waitForVolumeDelete(volumeName), {
-        timeout: 20_000,
       })
       .toBeTruthy();
   });


### PR DESCRIPTION

Signed-off-by: Anton Misskii <amisskii@redhat.com>

### What does this PR do?

extracts cluster-related operations to a dedicated utility file

### What issues does this PR fix or reference?

https://github.com/podman-desktop/podman-desktop/issues/10389
### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
