### PR TITLE
chore: update styling kubernetes empty page

### DIFF
--- a/packages/renderer/src/lib/kube/KubernetesEmptyPage.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesEmptyPage.svelte
@@ -1,12 +1,18 @@
 <script lang="ts">
-import { Link } from '@podman-desktop/ui-svelte';
+import { faPlusCircle } from '@fortawesome/free-solid-svg-icons';
+import { Button, Link } from '@podman-desktop/ui-svelte';
+import Fa from 'svelte-fa';
 import { router } from 'tinro';
 
 import type { ProviderInfo } from '/@api/provider-info';
 
 import { providerInfos } from '../../stores/providers';
+import IconImage from '../appearance/IconImage.svelte';
 import EmbeddableCatalogExtensionList from '../extensions/EmbeddableCatalogExtensionList.svelte';
 import KubeIcon from '../images/KubeIcon.svelte';
+import Markdown from '../markdown/Markdown.svelte';
+
+const kubernetesExternalDocs = 'https://podman-desktop.io/docs/kubernetes';
 
 async function createNew(provider: ProviderInfo) {
   await window.telemetryTrack('kubernetes.nocontext.createNew', {
@@ -31,36 +37,61 @@ async function ondetails(extensionId: string) {
 <div class="mt-8 flex justify-center overflow-auto">
   <div class="max-w-[800px] flex flex-col text-center space-y-3">
     <div class="flex justify-center text-[var(--pd-details-empty-icon)] py-2">
-      <KubeIcon />
+      <KubeIcon size="80" />
     </div>
     <h1 class="text-xl text-[var(--pd-details-empty-header)]">No Kubernetes cluster</h1>
     <div class="text-[var(--pd-details-empty-sub-header)] text-pretty">
-      Deploy a Kubernetes cluster or connect to a remote one
+      A Kubernetes cluster is a group of nodes (virtual or physical) that run Kubernetes, a system for automating the deployment and management of containerized applications.
     </div>
+    <!-- Only show the text if there are providers with p.kubernetesProviderConnectionCreation -->
+      {#if $providerInfos.some(p => p.kubernetesProviderConnectionCreation)}
+    <div class="text-[var(--pd-details-empty-sub-header)] text-pretty">
+      Deploy a Kubernetes cluster of your choice below:
+    </div>
+      {/if}
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 p-2 justify-center">
 
-    <div class="w-full justify-center flex flex-row space-x-3">
       {#each $providerInfos.filter(p => p.kubernetesProviderConnectionCreation) as provider}
-        {@const label = `${provider.kubernetesProviderConnectionCreationButtonTitle ?? 'Create new'} ${provider.kubernetesProviderConnectionCreationDisplayName ?? provider.name}...`}
-        <Link onclick={() => createNew(provider)} aria-label={label}>
+        {@const label = `${provider.kubernetesProviderConnectionCreationButtonTitle ?? 'Create new'}`}
+      <div class="rounded-xl p-5 text-left bg-[var(--pd-content-card-bg)] ">
+
+        <div class="flex justify-left text-[var(--pd-details-empty-icon)] py-2 mb-2">
+        <IconImage image={provider?.images?.icon} class="mx-0 max-h-10" alt={provider.name}></IconImage>
+        </div>
+        <h1 class="text-lg font-semibold mb-4">
+          {provider.kubernetesProviderConnectionCreationDisplayName ?? provider.name}
+        </h1>
+    
+        <p class="text-sm text-gray-300 mb-6">
+        <Markdown markdown={provider.emptyConnectionMarkdownDescription} />
+        </p>
+    
+        <div class="flex justify-center">
+        <Button
+          type="primary"
+          on:click={() => createNew(provider)}
+          class="flex items-center"
+          aria-label={label}
+        >
+          <Fa icon="{faPlusCircle}" size="1.2x" class="mr-1"/>
           {label}
-        </Link>
+        </Button>
+        </div>
+      </div>
       {/each}
     </div>
+    
     <EmbeddableCatalogExtensionList
       oninstall={oninstall}
       ondetails={ondetails}
       showEmptyScreen={false}
-      title="Extensions to help you deploy Kubernetes clusters on your machine"
+      title="Extensions to help you deploy Kubernetes clusters on your machine or connect remotely to:"
       category="Kubernetes"
-      keywords={['provider', 'local']}
+      keywords={['provider']}
       showInstalled={false} />
-    <EmbeddableCatalogExtensionList
-      oninstall={oninstall}
-      ondetails={ondetails}
-      showEmptyScreen={false}
-      title="Extensions to help you connect to remote Kubernetes clusters"
-      category="Kubernetes"
-      keywords={['provider', 'remote']}
-      showInstalled={false} />
+
+    <div class="text-[var(--pd-details-empty-sub-header)] text-pretty">
+     Want to learn more about Kubernetes on Podman Desktop? <Link on:click={() => window.openExternal(kubernetesExternalDocs)}>Check out our documentation.</Link>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
chore: update styling kubernetes empty page

### What does this PR do?

* Updates the styling for what providers are available with "Create new"
  for Kubernetes
* Combines 2 row extension download section to 1 section with both
  remote and regular Kubernetes providers

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->


https://github.com/user-attachments/assets/d5db75f3-340e-426e-a8fa-18281e764434



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/podman-desktop/issues/10204

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

1. Click on Kubernetes section (with a blank / non existant config)
2. See new UI

N/A with regards to tests, minor UI changes

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
