### PR TITLE
refactor(podman-extension): uses api env.isLinux

### DIFF
--- a/extensions/podman/packages/extension/src/podman-configuration.ts
+++ b/extensions/podman/packages/extension/src/podman-configuration.ts
@@ -24,7 +24,7 @@ import type { ProxySettings } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
 import * as toml from 'smol-toml';
 
-import { isLinux, isMac } from './util';
+import { isMac } from './util';
 
 const configurationRosetta = 'setting.rosetta';
 
@@ -321,7 +321,7 @@ export class PodmanConfiguration {
       podmanConfigContainersPath = path.resolve(os.homedir(), '.config', 'containers');
     } else if (extensionApi.env.isWindows) {
       podmanConfigContainersPath = path.resolve(os.homedir(), 'AppData', 'Roaming', 'containers');
-    } else if (isLinux()) {
+    } else if (extensionApi.env.isLinux) {
       const xdgRuntimeDirectory = process.env['XDG_RUNTIME_DIR'] ?? '';
       podmanConfigContainersPath = path.resolve(xdgRuntimeDirectory, 'containers');
     }

--- a/extensions/podman/packages/extension/src/registry-setup.ts
+++ b/extensions/podman/packages/extension/src/registry-setup.ts
@@ -22,7 +22,7 @@ import * as path from 'node:path';
 
 import * as extensionApi from '@podman-desktop/api';
 
-import { isLinux, isMac } from './util';
+import { isMac } from './util';
 
 export type ContainerAuthConfigEntry = {
   [key: string]: {
@@ -43,7 +43,7 @@ export class RegistrySetup {
 
     if (isMac() || extensionApi.env.isWindows) {
       podmanConfigContainersPath = path.resolve(os.homedir(), '.config/containers');
-    } else if (isLinux()) {
+    } else if (extensionApi.env.isLinux) {
       const xdgRuntimeDirectory = process.env['XDG_RUNTIME_DIR'] ?? '';
       podmanConfigContainersPath = path.resolve(xdgRuntimeDirectory, 'containers');
     }

--- a/extensions/podman/packages/extension/src/util.ts
+++ b/extensions/podman/packages/extension/src/util.ts
@@ -27,10 +27,6 @@ const mac = os.platform() === 'darwin';
 export function isMac(): boolean {
   return mac;
 }
-const linux = os.platform() === 'linux';
-export function isLinux(): boolean {
-  return linux;
-}
 const xdgDataDirectory = '.local/share/containers';
 export function appHomeDir(): string {
   return xdgDataDirectory + '/podman';


### PR DESCRIPTION
### What does this PR do?

Following step 1 (https://github.com/podman-desktop/podman-desktop/pull/10044) this is the second step of https://github.com/podman-desktop/podman-desktop/issues/9617, replacing `isLinux` by `env.isLinux` inside the Podman extension.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Related to https://github.com/podman-desktop/podman-desktop/issues/9617

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
