### PR TITLE
chore: remove error body from connection error message

### DIFF
--- a/packages/main/src/plugin/kubernetes/contexts-manager.spec.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager.spec.ts
@@ -515,7 +515,7 @@ describe('update', async () => {
     await client.update(kubeConfig);
     expect(consoleDebugMock).toHaveBeenCalledWith(
       expect.stringMatching(
-        /Trying to watch pods on the kubernetes context named "context1" but got a connection refused, retrying the connection in \d*s. Error: connection error/,
+        /Trying to watch pods on the kubernetes context named "context1" but got a connection refused, retrying the connection in \d*s./,
       ),
     );
   });

--- a/packages/main/src/plugin/kubernetes/contexts-manager.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager.ts
@@ -817,7 +817,7 @@ export class ContextsManager {
       const nextTimeout = options.backoff.get();
       if (err !== undefined) {
         console.debug(
-          `Trying to watch ${options.resource} on the kubernetes context named "${context.name}" but got a connection refused, retrying the connection in ${Math.round(nextTimeout / 1000)}s. ${String(err)})`,
+          `Trying to watch ${options.resource} on the kubernetes context named "${context.name}" but got a connection refused, retrying the connection in ${Math.round(nextTimeout / 1000)}s.`,
         );
         options.onConnectionError?.(String(err));
       }
@@ -916,7 +916,7 @@ export class ContextsManager {
       const nextTimeout = options.backoff.get();
       if (err !== undefined) {
         console.debug(
-          `Trying to watch ${options.resource} on the kubernetes context named "${context.name}" but got a connection refused, retrying the connection in ${Math.round(nextTimeout / 1000)}s. ${String(err)})`,
+          `Trying to watch ${options.resource} on the kubernetes context named "${context.name}" but got a connection refused, retrying the connection in ${Math.round(nextTimeout / 1000)}s.`,
         );
         options.onConnectionError?.(String(err));
       }


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR remove the error body from the connection failed message 

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Fixes https://github.com/podman-desktop/podman-desktop/issues/9942

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
