### PR TITLE
docs: fix release notes 1.15

### DIFF
--- a/website/blog/2024-12-12-release-1.15.md
+++ b/website/blog/2024-12-12-release-1.15.md
@@ -12,7 +12,7 @@ import ReactPlayer from 'react-player'
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import ThemedImage from '@theme/ThemedImage';
 
-# Podman Desktop 1.15 Release! 🎉
+Podman Desktop 1.15 Release! 🎉
 
 ![podman-desktop-hero-1.15](/img/blog/podman-desktop-release-1.15/banner.png)
 


### PR DESCRIPTION
### What does this PR do?
Removes the `#` from `Podman Desktop 1.15 Release! 🎉` since this sentence doesn't show up on the website and the `#` is seen in the release notes banner

![Screenshot from 2024-12-17 11-55-46](https://github.com/user-attachments/assets/60f48eb2-b94a-4c1f-87af-83627c5515be)


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
