### PR TITLE
feat(ui): add close button to hide banners

### DIFF
--- a/packages/renderer/src/lib/recommendation/ExtensionBanner.spec.ts
+++ b/packages/renderer/src/lib/recommendation/ExtensionBanner.spec.ts
@@ -18,7 +18,7 @@
 
 import { render, screen } from '@testing-library/svelte';
 import { tick } from 'svelte';
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import ExtensionBanner from '/@/lib/recommendation/ExtensionBanner.svelte';
 
@@ -59,6 +59,14 @@ const imageBackground: IExtensionBanner = {
     dark: 'data:image/png;base64-image-dark',
   },
 };
+
+const showMessageBoxMock = vi.fn();
+
+beforeAll(() => {
+  Object.defineProperty(window, 'showMessageBox', {
+    value: showMessageBoxMock,
+  });
+});
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -137,5 +145,26 @@ describe('backgrounds', () => {
     expect(card.attributes.getNamedItem('style')?.value).toBe(
       'background-image: url("data:image/png;base64-image-light");',
     );
+  });
+});
+
+test('opening messageBox', async () => {
+  render(ExtensionBanner, {
+    banner: gradientBackground,
+    isDark: true,
+  });
+  await tick();
+
+  const card = screen.getByLabelText('Recommended extension');
+  expect(card).toBeDefined();
+
+  const closeButton = screen.getByLabelText('Close');
+  closeButton.click();
+
+  expect(showMessageBoxMock).toBeCalledWith({
+    title: 'Hide extension recommendation banners',
+    message: `Do you want to hide extension recommendation banners?`,
+    type: 'warning',
+    buttons: [`Don't hide`, 'Hide'],
   });
 });

--- a/packages/renderer/src/lib/recommendation/ExtensionBanner.svelte
+++ b/packages/renderer/src/lib/recommendation/ExtensionBanner.svelte
@@ -27,23 +27,21 @@ $effect(() => {
 });
 
 async function onClose(): Promise<void> {
-  let result: MessageBoxReturnValue;
+  let result: MessageBoxReturnValue = { response: -1 };
   try {
     result = await window.showMessageBox({
       title: 'Hide extension recommendation banners',
       message: `Do you want to hide extension recommendation banners?`,
       type: 'warning',
-      buttons: [`Don't hide`, 'Hide'],
+      buttons: [`No, keep them`, 'Yes, hide'],
     });
 
     if (result && result.response === 1) {
       await window.updateConfigurationValue(`extensions.ignoreBannerRecommendations`, true, 'DEFAULT');
     }
-    await window.telemetryTrack('hideRecommendationExtensionBanner', {
-      result: result.response,
-    });
-  } catch (err) {
-    console.error('Error when hiding recommended extension banners');
+  } finally {
+    let choice: 'hide' | 'keep' = result && result.response === 1 ? 'hide' : 'keep';
+    await window.telemetryTrack('hideRecommendationExtensionBanner', { choice });
   }
 }
 </script>


### PR DESCRIPTION
### What does this PR do?
Adds UI Close button to hide promoted extensions banners
PR 2/2 - first PR https://github.com/podman-desktop/podman-desktop/pull/10322 (Needs to be merged first)
Frontend changes

### Screenshot / video of UI



https://github.com/user-attachments/assets/4b0a3b3d-673b-40ac-97f9-dd35fa950be4




### What issues does this PR fix or reference?
Closes #9415 

### How to test this PR?
Try to show/ hide banners on Dashboard/ in the preferences

- [x] Tests are covering the bug fix or the new feature
