### PR TITLE
fix: kube health store is inactive in non experimental mode

### DIFF
--- a/packages/renderer/src/stores/kubernetes-context-health-experimental.spec.ts
+++ b/packages/renderer/src/stores/kubernetes-context-health-experimental.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import { get } from 'svelte/store';
-import { expect, test, vi } from 'vitest';
+import { beforeAll, expect, test, vi } from 'vitest';
 
 import { kubernetesContextsHealths, kubernetesContextsHealthsStore } from './kubernetes-context-health';
 
@@ -28,15 +28,17 @@ const eventEmitter = {
   },
 };
 
-Object.defineProperty(global, 'window', {
-  value: {
-    kubernetesGetContextsHealths: vi.fn(),
-    getConfigurationValue: vi.fn(),
-    addEventListener: eventEmitter.receive,
-    events: {
-      receive: eventEmitter.receive,
+beforeAll(() => {
+  Object.defineProperty(global, 'window', {
+    value: {
+      kubernetesGetContextsHealths: vi.fn(),
+      getConfigurationValue: vi.fn(),
+      addEventListener: eventEmitter.receive,
+      events: {
+        receive: eventEmitter.receive,
+      },
     },
-  },
+  });
 });
 
 test('kubernetesContextsHealths in experimental states mode', async () => {

--- a/packages/renderer/src/stores/kubernetes-context-health-experimental.spec.ts
+++ b/packages/renderer/src/stores/kubernetes-context-health-experimental.spec.ts
@@ -21,9 +21,9 @@ import { expect, test, vi } from 'vitest';
 
 import { kubernetesContextsHealths, kubernetesContextsHealthsStore } from './kubernetes-context-health';
 
-const callbacks = new Map<string, any>();
+const callbacks = new Map<string, () => Promise<void>>();
 const eventEmitter = {
-  receive: (message: string, callback: any) => {
+  receive: (message: string, callback: () => Promise<void>) => {
     callbacks.set(message, callback);
   },
 };
@@ -75,7 +75,7 @@ test('kubernetesContextsHealths in experimental states mode', async () => {
   // send 'extensions-already-started' event
   const callbackExtensionsStarted = callbacks.get('extensions-already-started');
   expect(callbackExtensionsStarted).toBeDefined();
-  await callbackExtensionsStarted();
+  await callbackExtensionsStarted!();
 
   await vi.waitFor(() => {
     const currentValue = get(kubernetesContextsHealths);
@@ -89,7 +89,7 @@ test('kubernetesContextsHealths in experimental states mode', async () => {
   const event = 'kubernetes-contexts-healths';
   const callback = callbacks.get(event);
   expect(callback).toBeDefined();
-  await callback();
+  await callback!();
 
   // check received data is updated
   await vi.waitFor(() => {

--- a/packages/renderer/src/stores/kubernetes-context-health-experimental.spec.ts
+++ b/packages/renderer/src/stores/kubernetes-context-health-experimental.spec.ts
@@ -37,7 +37,6 @@ Object.defineProperty(global, 'window', {
       receive: eventEmitter.receive,
     },
   },
-  writable: true,
 });
 
 test('kubernetesContextsHealths in experimental states mode', async () => {

--- a/packages/renderer/src/stores/kubernetes-context-health-non-experimental.spec.ts
+++ b/packages/renderer/src/stores/kubernetes-context-health-non-experimental.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import { get } from 'svelte/store';
-import { expect, test, vi } from 'vitest';
+import { beforeAll, expect, test, vi } from 'vitest';
 
 import { kubernetesContextsHealths, kubernetesContextsHealthsStore } from './kubernetes-context-health';
 
@@ -32,15 +32,17 @@ const eventEmitter = {
   },
 };
 
-Object.defineProperty(global, 'window', {
-  value: {
-    kubernetesGetContextsHealths: vi.fn(),
-    getConfigurationValue: vi.fn(),
-    addEventListener: eventEmitter.receive,
-    events: {
-      receive: eventEmitter.receive,
+beforeAll(() => {
+  Object.defineProperty(global, 'window', {
+    value: {
+      kubernetesGetContextsHealths: vi.fn(),
+      getConfigurationValue: vi.fn(),
+      addEventListener: eventEmitter.receive,
+      events: {
+        receive: eventEmitter.receive,
+      },
     },
-  },
+  });
 });
 
 test('kubernetesContextsHealths not in experimental states mode', async () => {

--- a/packages/renderer/src/stores/kubernetes-context-health-non-experimental.spec.ts
+++ b/packages/renderer/src/stores/kubernetes-context-health-non-experimental.spec.ts
@@ -1,0 +1,76 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { get } from 'svelte/store';
+import { expect, test, vi } from 'vitest';
+
+import { kubernetesContextsHealths, kubernetesContextsHealthsStore } from './kubernetes-context-health';
+
+// We need to have separate tests files to run different tests, as there are global variables in the store file, which cannot be reset between tests
+
+// This file can be removed as soon as the experimental states mode is adopted as non experimental
+
+const callbacks = new Map<string, any>();
+const eventEmitter = {
+  receive: (message: string, callback: any) => {
+    callbacks.set(message, callback);
+  },
+};
+
+Object.defineProperty(global, 'window', {
+  value: {
+    kubernetesGetContextsHealths: vi.fn(),
+    getConfigurationValue: vi.fn(),
+    addEventListener: eventEmitter.receive,
+    events: {
+      receive: eventEmitter.receive,
+    },
+  },
+  writable: true,
+});
+
+test('kubernetesContextsHealths not in experimental states mode', async () => {
+  vi.mocked(window.getConfigurationValue).mockResolvedValue(false);
+  const initialValues = [
+    {
+      contextName: 'context1',
+      checking: true,
+      reachable: false,
+    },
+    {
+      contextName: 'context2',
+      checking: false,
+      reachable: true,
+    },
+  ];
+
+  vi.mocked(window.kubernetesGetContextsHealths).mockResolvedValue(initialValues);
+
+  kubernetesContextsHealthsStore.setup();
+
+  // send 'extensions-already-started' event
+  const callbackExtensionsStarted = callbacks.get('extensions-already-started');
+  expect(callbackExtensionsStarted).toBeDefined();
+  await callbackExtensionsStarted();
+
+  // values are never fetched
+  await new Promise(resolve => setTimeout(resolve, 500));
+  const currentValue = get(kubernetesContextsHealths);
+  expect(currentValue).toEqual([]);
+  expect(vi.mocked(window.kubernetesGetContextsHealths)).not.toHaveBeenCalled();
+});

--- a/packages/renderer/src/stores/kubernetes-context-health-non-experimental.spec.ts
+++ b/packages/renderer/src/stores/kubernetes-context-health-non-experimental.spec.ts
@@ -41,7 +41,6 @@ Object.defineProperty(global, 'window', {
       receive: eventEmitter.receive,
     },
   },
-  writable: true,
 });
 
 test('kubernetesContextsHealths not in experimental states mode', async () => {

--- a/packages/renderer/src/stores/kubernetes-context-health-non-experimental.spec.ts
+++ b/packages/renderer/src/stores/kubernetes-context-health-non-experimental.spec.ts
@@ -25,9 +25,9 @@ import { kubernetesContextsHealths, kubernetesContextsHealthsStore } from './kub
 
 // This file can be removed as soon as the experimental states mode is adopted as non experimental
 
-const callbacks = new Map<string, any>();
+const callbacks = new Map<string, () => Promise<void>>();
 const eventEmitter = {
-  receive: (message: string, callback: any) => {
+  receive: (message: string, callback: () => Promise<void>) => {
     callbacks.set(message, callback);
   },
 };
@@ -66,7 +66,7 @@ test('kubernetesContextsHealths not in experimental states mode', async () => {
   // send 'extensions-already-started' event
   const callbackExtensionsStarted = callbacks.get('extensions-already-started');
   expect(callbackExtensionsStarted).toBeDefined();
-  await callbackExtensionsStarted();
+  await callbackExtensionsStarted!();
 
   // values are never fetched
   await new Promise(resolve => setTimeout(resolve, 500));

--- a/packages/renderer/src/stores/kubernetes-context-health.ts
+++ b/packages/renderer/src/stores/kubernetes-context-health.ts
@@ -25,8 +25,18 @@ import { EventStore } from './event-store';
 const windowEvents = ['kubernetes-contexts-healths', 'extension-stopped', 'extensions-started'];
 const windowListeners = ['extensions-already-started'];
 
+let experimentalStates: boolean | undefined = undefined;
 let readyToUpdate = false;
+
 export async function checkForUpdate(eventName: string): Promise<boolean> {
+  // check for update only in experimental states mode
+  if (experimentalStates === undefined) {
+    experimentalStates = (await window.getConfigurationValue<boolean>('kubernetes.statesExperimental')) ?? false;
+  }
+  if (experimentalStates === false) {
+    return false;
+  }
+
   if ('extensions-already-started' === eventName) {
     readyToUpdate = true;
   }


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

The PR #10349 introduced a store to be used in Experimental states mode only, but the store was fetching the health values in all cases (experimental mode or not).

Because of this, a log 'Failed to update contexts healths Error: contextsStatesDispatcher is undefined. This should not happen in Kubernetes experimental' was displayed in the console.

This PR makes the Kubernetes health store inactive in non experimental mode, and the log is not displayed anymore.

### What issues does this PR fix or reference?

Fixes #9938 

### How to test this PR?

Define or not the experimental mode, and check that the health is coorectly displayed in experimental mode, and no logs are displayed when the experimental mode is not set:

````
"kubernetes.statesExperimental": true,
````

- [x] Tests are covering the bug fix or the new feature
