### PR TITLE
refactor(podman): replace isMac with extension api

### DIFF
--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -2156,7 +2156,6 @@ describe('registerOnboardingRemoveUnsupportedMachinesCommand', () => {
 
   test('check with previous podman v4 config files on Windows', async () => {
     vi.mocked(extensionApi.env).isWindows = true;
-    vi.mocked(extensionApi.env).isMac = false;
 
     // mock confirmation window message to true
     vi.mocked(extensionApi.window.showWarningMessage).mockResolvedValue('Yes');
@@ -2323,7 +2322,6 @@ describe('checkRosettaMacArm', async () => {
   } as unknown as PodmanConfiguration;
 
   test('check do nothing on non-macOS', async () => {
-    vi.mocked(extensionApi.env).isMac = false;
     await extension.checkRosettaMacArm(podmanConfiguration);
     // not called as not on macOS
     expect(vi.mocked(podmanConfiguration.isRosettaEnabled)).not.toBeCalled();

--- a/extensions/podman/packages/extension/src/podman-cli.ts
+++ b/extensions/podman/packages/extension/src/podman-cli.ts
@@ -17,15 +17,13 @@
  ***********************************************************************/
 import * as extensionApi from '@podman-desktop/api';
 
-import { isMac } from './util';
-
 const macosExtraPath = '/opt/podman/bin:/usr/local/bin:/opt/homebrew/bin:/opt/local/bin';
 
 export function getInstallationPath(): string | undefined {
   const env = process.env;
   if (extensionApi.env.isWindows) {
     return `c:\\Program Files\\RedHat\\Podman;${env.PATH}`;
-  } else if (isMac()) {
+  } else if (extensionApi.env.isMac) {
     if (!env.PATH) {
       return macosExtraPath;
     } else {

--- a/extensions/podman/packages/extension/src/podman-configuration.ts
+++ b/extensions/podman/packages/extension/src/podman-configuration.ts
@@ -24,8 +24,6 @@ import type { ProxySettings } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
 import * as toml from 'smol-toml';
 
-import { isMac } from './util';
-
 const configurationRosetta = 'setting.rosetta';
 
 /**
@@ -98,7 +96,7 @@ export class PodmanConfiguration {
     }
 
     // If we are on Mac, we need to monitor the configuration file to handle Rosetta changes
-    if (isMac()) {
+    if (extensionApi.env.isMac) {
       extensionApi.configuration.onDidChangeConfiguration(async e => {
         if (e.affectsConfiguration(`podman.${configurationRosetta}`)) {
           await this.handleRosettaSetting();
@@ -317,7 +315,7 @@ export class PodmanConfiguration {
   getContainersFileLocation(): string {
     let podmanConfigContainersPath = '';
 
-    if (isMac()) {
+    if (extensionApi.env.isMac) {
       podmanConfigContainersPath = path.resolve(os.homedir(), '.config', 'containers');
     } else if (extensionApi.env.isWindows) {
       podmanConfigContainersPath = path.resolve(os.homedir(), 'AppData', 'Roaming', 'containers');

--- a/extensions/podman/packages/extension/src/registry-setup.ts
+++ b/extensions/podman/packages/extension/src/registry-setup.ts
@@ -22,8 +22,6 @@ import * as path from 'node:path';
 
 import * as extensionApi from '@podman-desktop/api';
 
-import { isMac } from './util';
-
 export type ContainerAuthConfigEntry = {
   [key: string]: {
     auth: string;
@@ -41,7 +39,7 @@ export class RegistrySetup {
   protected getAuthFileLocation(): string {
     let podmanConfigContainersPath = '';
 
-    if (isMac() || extensionApi.env.isWindows) {
+    if (extensionApi.env.isMac || extensionApi.env.isWindows) {
       podmanConfigContainersPath = path.resolve(os.homedir(), '.config/containers');
     } else if (extensionApi.env.isLinux) {
       const xdgRuntimeDirectory = process.env['XDG_RUNTIME_DIR'] ?? '';

--- a/extensions/podman/packages/extension/src/util.ts
+++ b/extensions/podman/packages/extension/src/util.ts
@@ -16,17 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import * as os from 'node:os';
 import * as path from 'node:path';
 
 import * as extensionApi from '@podman-desktop/api';
 
 import { getPodmanCli } from './podman-cli';
 
-const mac = os.platform() === 'darwin';
-export function isMac(): boolean {
-  return mac;
-}
 const xdgDataDirectory = '.local/share/containers';
 export function appHomeDir(): string {
   return xdgDataDirectory + '/podman';


### PR DESCRIPTION
### What does this PR do?

Following https://github.com/podman-desktop/podman-desktop/pull/10044 and https://github.com/podman-desktop/podman-desktop/pull/10403 this PR is the last part, replacing all isMac call with the api env.isMac.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/9617

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
