### PR TITLE
refactor: container details terminal tests

### DIFF
--- a/packages/renderer/src/lib/container/ContainerDetailsTerminal.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerDetailsTerminal.spec.ts
@@ -18,39 +18,49 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { render, screen, waitFor } from '@testing-library/svelte';
+import { render, waitFor } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import { get } from 'svelte/store';
-import { beforeEach, expect, test, vi } from 'vitest';
+import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
 import { containerTerminals } from '/@/stores/container-terminal-store';
 
 import ContainerDetailsTerminal from './ContainerDetailsTerminal.svelte';
 import type { ContainerInfoUI } from './ContainerInfoUI';
 
-const getConfigurationValueMock = vi.fn();
-const shellInContainerMock = vi.fn();
-const shellInContainerResizeMock = vi.fn();
 vi.mock('xterm', () => {
   return {
-    Terminal: vi
-      .fn()
-      .mockReturnValue({ loadAddon: vi.fn(), open: vi.fn(), write: vi.fn(), dispose: vi.fn(), onData: vi.fn() }),
+    Terminal: vi.fn(),
   };
+});
+
+beforeAll(() => {
+  // we cannot define on global because terminal is doing some magic with the window value
+  Object.defineProperties(window, {
+    getConfigurationValue: {
+      value: vi.fn(),
+    },
+    shellInContainer: {
+      value: vi.fn(),
+    },
+    shellInContainerResize: {
+      value: vi.fn(),
+    },
+    matchMedia: {
+      value: vi.fn(),
+    },
+  });
 });
 
 beforeEach(() => {
   vi.resetAllMocks();
-  (window as any).getConfigurationValue = getConfigurationValueMock;
-  (window as any).shellInContainer = shellInContainerMock;
-  (window as any).shellInContainerResize = shellInContainerResizeMock;
 
-  (window as any).matchMedia = vi.fn().mockReturnValue({
+  vi.mocked(window.matchMedia).mockReturnValue({
     addListener: vi.fn(),
     removeListener: vi.fn(),
-  });
+  } as unknown as MediaQueryList);
 
-  // reset terminals
+  // reset
   containerTerminals.set([]);
 });
 
@@ -64,8 +74,8 @@ test('expect being able to reconnect ', async () => {
   let onDataCallback: (data: Buffer) => void = () => {};
 
   const sendCallbackId = 12345;
-  shellInContainerMock.mockImplementation(
-    (
+  vi.mocked(window.shellInContainer).mockImplementation(
+    async (
       _engineId: string,
       _containerId: string,
       onData: (data: Buffer) => void,
@@ -82,19 +92,16 @@ test('expect being able to reconnect ', async () => {
   let renderObject = render(ContainerDetailsTerminal, { container, screenReaderMode: true });
 
   // wait shellInContainerMock is called
-  await waitFor(() => expect(shellInContainerMock).toHaveBeenCalled());
+  await waitFor(() => expect(window.shellInContainer).toHaveBeenCalled());
 
   // write some data on the terminal
   onDataCallback(Buffer.from('hello\nworld'));
 
-  // wait 1s
-  await new Promise(resolve => setTimeout(resolve, 1000));
-
-  // search a div having aria-live="assertive" attribute
-  const terminalLinesLiveRegion = renderObject.container.querySelector('div[aria-live="assertive"]');
-
-  // check the content
-  expect(terminalLinesLiveRegion).toHaveTextContent('hello world');
+  // ensure the terminal has render our text
+  await waitFor(() => {
+    const div = renderObject.getByText('hello world');
+    expect(div).toBeDefined();
+  });
 
   // should be no terminal being stored
   const terminals = get(containerTerminals);
@@ -111,18 +118,16 @@ test('expect being able to reconnect ', async () => {
   renderObject = render(ContainerDetailsTerminal, { container, screenReaderMode: true });
 
   // wait shellInContainerMock is called
-  await waitFor(() => expect(shellInContainerMock).toHaveBeenCalledTimes(2));
+  await waitFor(() => expect(window.shellInContainer).toHaveBeenCalledTimes(2));
 
-  // wait 1s that everything is done
-  await new Promise(resolve => setTimeout(resolve, 1000));
-
-  const terminalLinesLiveRegion2 = renderObject.container.querySelector('div[aria-live="assertive"]');
-
-  // check the content
-  expect(terminalLinesLiveRegion2).toHaveTextContent('hello world');
+  // ensure the terminal has render our text
+  await waitFor(() => {
+    const div = renderObject.getByText('hello world');
+    expect(div).toBeDefined();
+  });
 
   // creating a new terminal requires new shellInContainer call
-  expect(shellInContainerMock).toHaveBeenCalledTimes(2);
+  expect(window.shellInContainer).toHaveBeenCalledTimes(2);
 });
 
 test('terminal active/ restarts connection after stopping and starting a container', async () => {
@@ -135,7 +140,7 @@ test('terminal active/ restarts connection after stopping and starting a contain
   let onDataCallback: (data: Buffer) => void = () => {};
 
   const sendCallbackId = 12345;
-  shellInContainerMock.mockImplementation(
+  vi.mocked(window.shellInContainer).mockImplementation(
     async (
       _engineId: string,
       _containerId: string,
@@ -156,19 +161,16 @@ test('terminal active/ restarts connection after stopping and starting a contain
   const renderObject = render(ContainerDetailsTerminal, { container, screenReaderMode: true });
 
   // wait shellInContainerMock is called
-  await waitFor(() => expect(shellInContainerMock).toHaveBeenCalled());
+  await waitFor(() => expect(window.shellInContainer).toHaveBeenCalled());
 
   // write some data on the terminal
   onDataCallback(Buffer.from('hello\nworld'));
 
-  // wait 1s
-  await waitFor(() => renderObject.container.querySelector('div[aria-live="assertive"]'));
-
-  // search a div having aria-live="assertive" attribute
-  const terminalLinesLiveRegion = renderObject.container.querySelector('div[aria-live="assertive"]');
-
-  // check the content
-  await waitFor(() => expect(terminalLinesLiveRegion).toHaveTextContent('hello world'));
+  // ensure the terminal has render our text
+  await waitFor(() => {
+    const div = renderObject.getByText('hello world');
+    expect(div).toBeDefined();
+  });
 
   container.state = 'EXITED';
 
@@ -176,7 +178,7 @@ test('terminal active/ restarts connection after stopping and starting a contain
 
   await tick();
 
-  await waitFor(() => expect(screen.queryByText('Container is not running')).toBeInTheDocument());
+  await waitFor(() => expect(renderObject.queryByText('Container is not running')).toBeInTheDocument());
 
   container.state = 'STARTING';
 
@@ -190,7 +192,7 @@ test('terminal active/ restarts connection after stopping and starting a contain
 
   await tick();
 
-  await waitFor(() => expect(shellInContainerMock).toHaveBeenCalledTimes(10), { timeout: 2000 });
+  await waitFor(() => expect(window.shellInContainer).toHaveBeenCalledTimes(10), { timeout: 2000 });
 });
 
 test('terminal active/ restarts connection after restarting a container', async () => {
@@ -203,7 +205,7 @@ test('terminal active/ restarts connection after restarting a container', async 
   let onDataCallback: (data: Buffer) => void = () => {};
 
   const sendCallbackId = 12345;
-  shellInContainerMock.mockImplementation(
+  vi.mocked(window.shellInContainer).mockImplementation(
     async (
       _engineId: string,
       _containerId: string,
@@ -224,19 +226,16 @@ test('terminal active/ restarts connection after restarting a container', async 
   const renderObject = render(ContainerDetailsTerminal, { container, screenReaderMode: true });
 
   // wait shellInContainerMock is called
-  await waitFor(() => expect(shellInContainerMock).toHaveBeenCalled());
+  await waitFor(() => expect(window.shellInContainer).toHaveBeenCalled());
 
   // write some data on the terminal
   onDataCallback(Buffer.from('hello\nworld'));
 
-  // wait 1s
-  await waitFor(() => renderObject.container.querySelector('div[aria-live="assertive"]'));
-
-  // search a div having aria-live="assertive" attribute
-  const terminalLinesLiveRegion = renderObject.container.querySelector('div[aria-live="assertive"]');
-
-  // check the content
-  await waitFor(() => expect(terminalLinesLiveRegion).toHaveTextContent('hello world'));
+  // ensure the terminal has render our text
+  await waitFor(() => {
+    const div = renderObject.getByText('hello world');
+    expect(div).toBeDefined();
+  });
 
   container.state = 'RESTARTING';
 
@@ -250,5 +249,5 @@ test('terminal active/ restarts connection after restarting a container', async 
 
   await tick();
 
-  expect(shellInContainerMock).toHaveBeenCalledTimes(2);
+  expect(window.shellInContainer).toHaveBeenCalledTimes(2);
 });


### PR DESCRIPTION
### What does this PR do?

While working on https://github.com/podman-desktop/podman-desktop/issues/10405 I updated the `ContainerDetailsTerminal.spec.ts` to try to find out the origin of the bug.

Here are a list of changes

1. Uses the vi.mocked(windows.<function>) instead of having global mock 
2. Simplify how we check for content in the Terminal
Before this PR, we were querying some specific div with the following code

```ts
  // wait 1s
  await waitFor(() => renderObject.container.querySelector('div[aria-live="assertive"]'));

  // search a div having aria-live="assertive" attribute
  const terminalLinesLiveRegion = renderObject.container.querySelector('div[aria-live="assertive"]');

  // check the content
  await waitFor(() => expect(terminalLinesLiveRegion).toHaveTextContent('hello world'));
```

we do not need to do that as we can use the renderObject and use the `renderObject.getByText` function to do the same.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
