### PR TITLE
feat: dispatch kube resources to frontend

### DIFF
--- a/packages/api/src/kubernetes-resources.ts
+++ b/packages/api/src/kubernetes-resources.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/api/src/kubernetes-resources.ts
+++ b/packages/api/src/kubernetes-resources.ts
@@ -1,0 +1,24 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject } from '@kubernetes/client-node';
+
+export interface KubernetesContextResources {
+  contextName: string;
+  items: readonly KubernetesObject[];
+}

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -95,6 +95,7 @@ import type { ContextPermission } from '/@api/kubernetes-contexts-permissions.js
 import type { ContextGeneralState, ResourceName } from '/@api/kubernetes-contexts-states.js';
 import type { ForwardConfig, ForwardOptions } from '/@api/kubernetes-port-forward-model.js';
 import type { ResourceCount } from '/@api/kubernetes-resource-count.js';
+import type { KubernetesContextResources } from '/@api/kubernetes-resources.js';
 import type { ManifestCreateOptions, ManifestInspectInfo, ManifestPushOptions } from '/@api/manifest-info.js';
 import type { NetworkInspectInfo } from '/@api/network-info.js';
 import type { NotificationCard, NotificationCardOptions } from '/@api/notification.js';
@@ -2612,6 +2613,13 @@ export class PluginSystem {
     this.ipcHandle('kubernetes:getResourcesCount', async (_listener): Promise<ResourceCount[]> => {
       return kubernetesClient.getResourcesCount();
     });
+
+    this.ipcHandle(
+      'kubernetes:getResources',
+      async (_listener, resourceName: string): Promise<KubernetesContextResources[]> => {
+        return kubernetesClient.getResources(resourceName);
+      },
+    );
 
     const kubernetesExecCallbackMap = new Map<
       number,

--- a/packages/main/src/plugin/kubernetes/context-resource-registry.spec.ts
+++ b/packages/main/src/plugin/kubernetes/context-resource-registry.spec.ts
@@ -53,12 +53,14 @@ test('getForResource', () => {
   const result = registry.getForResource('resource1');
   expect(result).toEqual([
     {
-      context: 'context1',
-      item: 'value1',
+      contextName: 'context1',
+      resourceName: 'resource1',
+      value: 'value1',
     },
     {
-      context: 'context2',
-      item: 'value3',
+      contextName: 'context2',
+      resourceName: 'resource1',
+      value: 'value3',
     },
   ]);
 });

--- a/packages/main/src/plugin/kubernetes/context-resource-registry.spec.ts
+++ b/packages/main/src/plugin/kubernetes/context-resource-registry.spec.ts
@@ -16,13 +16,17 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { expect, test } from 'vitest';
+import { beforeEach, expect, test } from 'vitest';
 
 import { ContextResourceRegistry } from './context-resource-registry.js';
 
-test('ContextResourceRegistry', () => {
-  const registry = new ContextResourceRegistry<string>();
+let registry: ContextResourceRegistry<string>;
 
+beforeEach(() => {
+  registry = new ContextResourceRegistry<string>();
+});
+
+test('ContextResourceRegistry', () => {
   registry.set('context1', 'resource1', 'value1');
   expect(registry.get('context1', 'resource1')).toEqual('value1');
 
@@ -37,6 +41,24 @@ test('ContextResourceRegistry', () => {
       contextName: 'context1',
       resourceName: 'resource2',
       value: 'value2',
+    },
+  ]);
+});
+
+test('getForResource', () => {
+  registry.set('context1', 'resource1', 'value1');
+  registry.set('context1', 'resource2', 'value2');
+  registry.set('context2', 'resource1', 'value3');
+
+  const result = registry.getForResource('resource1');
+  expect(result).toEqual([
+    {
+      context: 'context1',
+      item: 'value1',
+    },
+    {
+      context: 'context2',
+      item: 'value3',
     },
   ]);
 });

--- a/packages/main/src/plugin/kubernetes/context-resource-registry.ts
+++ b/packages/main/src/plugin/kubernetes/context-resource-registry.ts
@@ -47,12 +47,12 @@ export class ContextResourceRegistry<T> {
     });
   }
 
-  getForResource(resourceName: string): { context: string; item: T }[] {
-    const result: { context: string; item: T }[] = [];
-    for (const [context, contextResources] of this.#registry.entries()) {
-      const item = contextResources.get(resourceName);
-      if (item) {
-        result.push({ context, item });
+  getForResource(resourceName: string): Details<T>[] {
+    const result: Details<T>[] = [];
+    for (const [contextName, contextResources] of this.#registry.entries()) {
+      const value = contextResources.get(resourceName);
+      if (value) {
+        result.push({ contextName, value, resourceName });
       }
     }
     return result;

--- a/packages/main/src/plugin/kubernetes/context-resource-registry.ts
+++ b/packages/main/src/plugin/kubernetes/context-resource-registry.ts
@@ -46,4 +46,15 @@ export class ContextResourceRegistry<T> {
       }));
     });
   }
+
+  getForResource(resourceName: string): { context: string; item: T }[] {
+    const result: { context: string; item: T }[] = [];
+    for (const [context, contextResources] of this.#registry.entries()) {
+      const item = contextResources.get(resourceName);
+      if (item) {
+        result.push({ context, item });
+      }
+    }
+    return result;
+  }
 }

--- a/packages/main/src/plugin/kubernetes/contexts-manager-experimental.spec.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager-experimental.spec.ts
@@ -376,6 +376,29 @@ describe('HealthChecker pass and PermissionsChecker resturns a value', async () 
         },
       ]);
     });
+
+    test('getResources', async () => {
+      const listMock = vi.fn();
+      startMock.mockReturnValue({
+        list: listMock,
+        get: vi.fn(),
+      } as ObjectCache<KubernetesObject>);
+      listMock.mockReturnValueOnce([{ metadata: { name: 'obj1' } }]);
+      listMock.mockReturnValueOnce([{ metadata: { name: 'obj2' } }, { metadata: { name: 'obj3' } }]);
+      await manager.update(kc);
+      const resources = manager.getResources('resource1');
+      console.log('==> ', resources);
+      expect(resources).toEqual([
+        {
+          contextName: 'context1',
+          items: [{ metadata: { name: 'obj1' } }],
+        },
+        {
+          contextName: 'context2',
+          items: [{ metadata: { name: 'obj2' } }, { metadata: { name: 'obj3' } }],
+        },
+      ]);
+    });
   });
 });
 

--- a/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
@@ -206,10 +206,10 @@ export class ContextsManagerExperimental {
   }
 
   getResources(resourceName: string): KubernetesContextResources[] {
-    return this.#objectCaches.getForResource(resourceName).map(({ context, item }) => {
+    return this.#objectCaches.getForResource(resourceName).map(({ contextName, value }) => {
       return {
-        contextName: context,
-        items: item.list(),
+        contextName,
+        items: value.list(),
       };
     });
   }

--- a/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
@@ -20,6 +20,7 @@ import type { KubeConfig, KubernetesObject, ObjectCache } from '@kubernetes/clie
 
 import type { ContextGeneralState, ResourceName } from '/@api/kubernetes-contexts-states.js';
 import type { ResourceCount } from '/@api/kubernetes-resource-count.js';
+import type { KubernetesContextResources } from '/@api/kubernetes-resources.js';
 
 import type { Event } from '../events/emitter.js';
 import { Emitter } from '../events/emitter.js';
@@ -202,6 +203,15 @@ export class ContextsManagerExperimental {
       resourceName: informer.resourceName,
       count: informer.value.list().length,
     }));
+  }
+
+  getResources(resourceName: string): KubernetesContextResources[] {
+    return this.#objectCaches.getForResource(resourceName).map(({ context, item }) => {
+      return {
+        contextName: context,
+        items: item.list(),
+      };
+    });
   }
 
   getContextsGeneralState(): Map<string, ContextGeneralState> {

--- a/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.spec.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.spec.ts
@@ -265,5 +265,5 @@ test('updateResource should call apiSender.send with kubernetes-`resource-name`'
   } as unknown as ApiSenderType;
   const dispatcher = new ContextsStatesDispatcher(manager, apiSender);
   dispatcher.updateResource('resource1');
-  expect(vi.mocked(apiSender.send)).toHaveBeenCalledWith('kubernetes-resource1');
+  expect(vi.mocked(apiSender.send)).toHaveBeenCalledWith('kubernetes-update-resource1');
 });

--- a/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.spec.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.spec.ts
@@ -20,21 +20,21 @@ import { expect, test, vi } from 'vitest';
 
 import type { ApiSenderType } from '../api.js';
 import type { ContextHealthState } from './context-health-checker.js';
-import type { ContextResourcePermission } from './context-permissions-checker.js';
+import type { ContextPermissionResult, ContextResourcePermission } from './context-permissions-checker.js';
+import type { DispatcherEvent } from './contexts-dispatcher.js';
 import type { ContextsManagerExperimental } from './contexts-manager-experimental.js';
 import { ContextsStatesDispatcher } from './contexts-states-dispatcher.js';
 import type { KubeConfigSingleContext } from './kubeconfig-single-context.js';
 
 test('ContextsStatesDispatcher should call updateHealthStates when onContextHealthStateChange event is fired', () => {
-  const onContextHealthStateChangeMock = vi.fn();
-  const onContextPermissionResultMock = vi.fn();
   const manager: ContextsManagerExperimental = {
-    onContextHealthStateChange: onContextHealthStateChangeMock,
-    onContextPermissionResult: onContextPermissionResultMock,
+    onContextHealthStateChange: vi.fn(),
+    onContextPermissionResult: vi.fn(),
     onContextDelete: vi.fn(),
     getHealthCheckersStates: vi.fn(),
     getPermissions: vi.fn(),
     onResourceCountUpdated: vi.fn(),
+    onResourceUpdated: vi.fn(),
   } as unknown as ContextsManagerExperimental;
   const apiSender: ApiSenderType = {
     send: vi.fn(),
@@ -46,7 +46,7 @@ test('ContextsStatesDispatcher should call updateHealthStates when onContextHeal
   expect(updateHealthStatesSpy).not.toHaveBeenCalled();
   expect(updatePermissionsSpy).not.toHaveBeenCalled();
 
-  onContextHealthStateChangeMock.mockImplementation(f => f());
+  vi.mocked(manager.onContextHealthStateChange).mockImplementation(f => f({} as ContextHealthState));
   vi.mocked(manager.getHealthCheckersStates).mockReturnValue(new Map<string, ContextHealthState>());
   dispatcher.init();
   expect(updateHealthStatesSpy).toHaveBeenCalled();
@@ -54,15 +54,14 @@ test('ContextsStatesDispatcher should call updateHealthStates when onContextHeal
 });
 
 test('ContextsStatesDispatcher should call updatePermissions when onContextPermissionResult event is fired', () => {
-  const onContextHealthStateChangeMock = vi.fn();
-  const onContextPermissionResultMock = vi.fn();
   const manager: ContextsManagerExperimental = {
-    onContextHealthStateChange: onContextHealthStateChangeMock,
-    onContextPermissionResult: onContextPermissionResultMock,
+    onContextHealthStateChange: vi.fn(),
+    onContextPermissionResult: vi.fn(),
     onContextDelete: vi.fn(),
     getHealthCheckersStates: vi.fn(),
     getPermissions: vi.fn(),
     onResourceCountUpdated: vi.fn(),
+    onResourceUpdated: vi.fn(),
   } as unknown as ContextsManagerExperimental;
   const apiSender: ApiSenderType = {
     send: vi.fn(),
@@ -75,21 +74,21 @@ test('ContextsStatesDispatcher should call updatePermissions when onContextPermi
   expect(updateHealthStatesSpy).not.toHaveBeenCalled();
   expect(updatePermissionsSpy).not.toHaveBeenCalled();
 
-  onContextPermissionResultMock.mockImplementation(f => f());
+  vi.mocked(manager.onContextPermissionResult).mockImplementation(f => f({} as ContextPermissionResult));
   dispatcher.init();
   expect(updateHealthStatesSpy).not.toHaveBeenCalled();
   expect(updatePermissionsSpy).toHaveBeenCalled();
 });
 
 test('ContextsStatesDispatcher should call updateHealthStates and updatePermissions when onContextDelete event is fired', () => {
-  const onContextDeleteMock = vi.fn();
   const manager: ContextsManagerExperimental = {
     onContextHealthStateChange: vi.fn(),
     onContextPermissionResult: vi.fn(),
-    onContextDelete: onContextDeleteMock,
+    onContextDelete: vi.fn(),
     getHealthCheckersStates: vi.fn(),
     getPermissions: vi.fn(),
     onResourceCountUpdated: vi.fn(),
+    onResourceUpdated: vi.fn(),
   } as unknown as ContextsManagerExperimental;
   const apiSender: ApiSenderType = {
     send: vi.fn(),
@@ -103,7 +102,7 @@ test('ContextsStatesDispatcher should call updateHealthStates and updatePermissi
   expect(updateHealthStatesSpy).not.toHaveBeenCalled();
   expect(updatePermissionsSpy).not.toHaveBeenCalled();
 
-  onContextDeleteMock.mockImplementation(f => f());
+  vi.mocked(manager.onContextDelete).mockImplementation(f => f({} as DispatcherEvent));
   dispatcher.init();
   expect(updateHealthStatesSpy).toHaveBeenCalled();
   expect(updatePermissionsSpy).toHaveBeenCalled();
@@ -117,9 +116,8 @@ test('getContextsHealths should return the values of the map returned by manager
     getHealthCheckersStates: vi.fn(),
     getPermissions: vi.fn(),
   } as unknown as ContextsManagerExperimental;
-  const sendMock = vi.fn();
   const apiSender: ApiSenderType = {
-    send: sendMock,
+    send: vi.fn(),
   } as unknown as ApiSenderType;
   const dispatcher = new ContextsStatesDispatcher(manager, apiSender);
   const context1State = {
@@ -149,14 +147,13 @@ test('updateHealthStates should call apiSender.send with kubernetes-contexts-hea
     getHealthCheckersStates: vi.fn(),
     getPermissions: vi.fn(),
   } as unknown as ContextsManagerExperimental;
-  const sendMock = vi.fn();
   const apiSender: ApiSenderType = {
-    send: sendMock,
+    send: vi.fn(),
   } as unknown as ApiSenderType;
   const dispatcher = new ContextsStatesDispatcher(manager, apiSender);
   vi.spyOn(dispatcher, 'getContextsHealths').mockReturnValue([]);
   dispatcher.updateHealthStates();
-  expect(sendMock).toHaveBeenCalledWith('kubernetes-contexts-healths');
+  expect(apiSender.send).toHaveBeenCalledWith('kubernetes-contexts-healths');
 });
 
 test('getContextsPermissions should return the values as an array', () => {
@@ -259,4 +256,14 @@ test('updateResourcesCount should call apiSender.send with kubernetes-resources-
   const dispatcher = new ContextsStatesDispatcher(manager, apiSender);
   dispatcher.updateResourcesCount();
   expect(vi.mocked(apiSender.send)).toHaveBeenCalledWith('kubernetes-resources-count');
+});
+
+test('updateResource should call apiSender.send with kubernetes-`resource-name`', () => {
+  const manager: ContextsManagerExperimental = {} as ContextsManagerExperimental;
+  const apiSender: ApiSenderType = {
+    send: vi.fn(),
+  } as unknown as ApiSenderType;
+  const dispatcher = new ContextsStatesDispatcher(manager, apiSender);
+  dispatcher.updateResource('resource1');
+  expect(vi.mocked(apiSender.send)).toHaveBeenCalledWith('kubernetes-resource1');
 });

--- a/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.ts
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { KubernetesObject } from '@kubernetes/client-node';
+
 import type { ContextHealth } from '/@api/kubernetes-contexts-healths.js';
 import type { ContextPermission } from '/@api/kubernetes-contexts-permissions.js';
 import type { ResourceCount } from '/@api/kubernetes-resource-count.js';
@@ -40,6 +42,7 @@ export class ContextsStatesDispatcher {
       this.updatePermissions();
     });
     this.manager.onResourceCountUpdated(() => this.updateResourcesCount());
+    this.manager.onResourceUpdated(event => this.updateResource(event.resourceName));
   }
 
   updateHealthStates(): void {
@@ -79,5 +82,13 @@ export class ContextsStatesDispatcher {
 
   getResourcesCount(): ResourceCount[] {
     return this.manager.getResourcesCount();
+  }
+
+  updateResource(resourceName: string): void {
+    this.apiSender.send(`kubernetes-${resourceName}`);
+  }
+
+  getResources(resourceName: string): { contextName: string; items: readonly KubernetesObject[] }[] {
+    return this.manager.getResources(resourceName);
   }
 }

--- a/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.ts
@@ -16,11 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { KubernetesObject } from '@kubernetes/client-node';
-
 import type { ContextHealth } from '/@api/kubernetes-contexts-healths.js';
 import type { ContextPermission } from '/@api/kubernetes-contexts-permissions.js';
 import type { ResourceCount } from '/@api/kubernetes-resource-count.js';
+import type { KubernetesContextResources } from '/@api/kubernetes-resources.js';
 
 import type { ApiSenderType } from '../api.js';
 import type { ContextHealthState } from './context-health-checker.js';
@@ -85,10 +84,10 @@ export class ContextsStatesDispatcher {
   }
 
   updateResource(resourceName: string): void {
-    this.apiSender.send(`kubernetes-${resourceName}`);
+    this.apiSender.send(`kubernetes-update-${resourceName}`);
   }
 
-  getResources(resourceName: string): { contextName: string; items: readonly KubernetesObject[] }[] {
+  getResources(resourceName: string): KubernetesContextResources[] {
     return this.manager.getResources(resourceName);
   }
 }

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.ts
@@ -76,6 +76,7 @@ import type { ContextPermission } from '/@api/kubernetes-contexts-permissions.js
 import type { ContextGeneralState, ResourceName } from '/@api/kubernetes-contexts-states.js';
 import type { ForwardConfig, ForwardOptions } from '/@api/kubernetes-port-forward-model.js';
 import type { ResourceCount } from '/@api/kubernetes-resource-count.js';
+import type { KubernetesContextResources } from '/@api/kubernetes-resources.js';
 import type { V1Route } from '/@api/openshift-types.js';
 
 import type { ApiSenderType } from '../api.js';
@@ -1698,5 +1699,12 @@ export class KubernetesClient {
       throw new Error('contextsStatesDispatcher is undefined. This should not happen in Kubernetes experimental');
     }
     return this.contextsStatesDispatcher.getResourcesCount();
+  }
+
+  public getResources(resourceName: string): KubernetesContextResources[] {
+    if (!this.contextsStatesDispatcher) {
+      throw new Error('contextsStatesDispatcher is undefined. This should not happen in Kubernetes experimental');
+    }
+    return this.contextsStatesDispatcher.getResources(resourceName);
   }
 }

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.ts
@@ -1703,7 +1703,9 @@ export class KubernetesClient {
 
   public getResources(resourceName: string): KubernetesContextResources[] {
     if (!this.contextsStatesDispatcher) {
-      throw new Error('contextsStatesDispatcher is undefined. This should not happen in Kubernetes experimental');
+      throw new Error(
+        `contextsStatesDispatcher is undefined when getting ${resourceName}. This should not happen in Kubernetes experimental`,
+      );
     }
     return this.contextsStatesDispatcher.getResources(resourceName);
   }

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -73,6 +73,7 @@ import type { ContextPermission } from '/@api/kubernetes-contexts-permissions';
 import type { ContextGeneralState, ResourceName } from '/@api/kubernetes-contexts-states';
 import type { ForwardConfig, ForwardOptions } from '/@api/kubernetes-port-forward-model';
 import type { ResourceCount } from '/@api/kubernetes-resource-count';
+import type { KubernetesContextResources } from '/@api/kubernetes-resources';
 import type { ManifestCreateOptions, ManifestInspectInfo, ManifestPushOptions } from '/@api/manifest-info';
 import type { NetworkInspectInfo } from '/@api/network-info';
 import type { NotificationCard, NotificationCardOptions } from '/@api/notification';
@@ -1886,6 +1887,13 @@ export function initExposure(): void {
   contextBridge.exposeInMainWorld('kubernetesGetResourcesCount', async (): Promise<ResourceCount[]> => {
     return ipcInvoke('kubernetes:getResourcesCount');
   });
+
+  contextBridge.exposeInMainWorld(
+    'kubernetesGetResources',
+    async (resourceName: string): Promise<KubernetesContextResources[]> => {
+      return ipcInvoke('kubernetes:getResources', resourceName);
+    },
+  );
 
   contextBridge.exposeInMainWorld('kubernetesGetClusters', async (): Promise<Cluster[]> => {
     return ipcInvoke('kubernetes-client:getClusters');


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Dispatch resources to the frontend

Stores for Kubernetes resources are not created at startup, but only when the frontend needs to display resources.

### Screenshot / video of UI

No UI

### What issues does this PR fix or reference?

Fixes #10632 

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
