### PR TITLE
chore: generate all the mocks of exposed methods during the setup of vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "test:extensions:podman": "vitest run -r extensions/podman/packages/extension --passWithNoTests --coverage ",
     "test:extensions:registries": "vitest run -r extensions/registries --passWithNoTests --coverage ",
     "test:extensions:kubectl-cli": "vitest run -r extensions/kubectl-cli --passWithNoTests --coverage ",
-    "test:renderer": "npm run build:ui && vitest -c packages/renderer/vite.config.js run packages/renderer --passWithNoTests --coverage",
+    "test:renderer": "npm run build:preload:types && npm run build:ui && vitest -c packages/renderer/vite.config.js run packages/renderer --passWithNoTests --coverage",
     "test:ui": "vitest --config packages/ui/vite.config.js run --passWithNoTests --coverage",
     "test:tools": "vitest run tools --passWithNoTests --coverage",
     "test:scripts:stylesheet": "vitest run ./scripts/generate-stylesheet.spec.ts --passWithNoTests",

--- a/packages/renderer/vite.tests.setup.js
+++ b/packages/renderer/vite.tests.setup.js
@@ -16,6 +16,61 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import path from 'node:path';
+import { readFileSync } from 'node:fs';
 import 'vitest-canvas-mock';
+import typescript from 'typescript';
+import { expect } from 'vitest';
 
 global.window.matchMedia = () => {};
+
+// read the given path and extract the method names from the Window interface
+function extractWindowMethods(filePath) {
+  // Read the content of the .d.ts file
+  const fileContent = readFileSync(filePath, 'utf-8');
+
+  // Create a TypeScript SourceFile
+  const sourceFile = typescript.createSourceFile(filePath, fileContent, typescript.ScriptTarget.Latest, true);
+
+  const methodNames = [];
+
+  // Visit each node in the AST
+  const visit = node => {
+    // Look for the Window interface
+    if (
+      typescript.isInterfaceDeclaration(node) &&
+      node.name.text === 'Window' // Target the "Window" interface
+    ) {
+      for (const member of node.members) {
+        if (typescript.isPropertySignature(member) && member.type && typescript.isFunctionTypeNode(member.type)) {
+          const name = member.name.text;
+          methodNames.push(name);
+        }
+      }
+    }
+
+    typescript.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+
+  return methodNames;
+}
+
+// methods being exposed
+const declarationsPath = path.resolve(__dirname, '../preload/exposedInMainWorld.d.ts');
+
+// Extract method names from the Window interface
+const methodNames = extractWindowMethods(declarationsPath);
+
+// assert that we have more than 50 methods
+expect(methodNames.length).toBeGreaterThan(50);
+
+// Dynamically create vi mocks for all the given methods
+for (const methodName of methodNames) {
+  Object.defineProperty(window, methodName, {
+    value: vi.fn(),
+    configurable: true,
+    writable: true,
+  });
+}


### PR DESCRIPTION

### What does this PR do?
avoid to have to think about it in all unit tests. Still need to provide the returned value if needed but no need to initialize all vi.fn()


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/podman-desktop/podman-desktop/issues/10420


### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
