### PR TITLE
chore: making icon and title on windows bigger

### DIFF
--- a/packages/renderer/src/lib/ui/TitleBar.svelte
+++ b/packages/renderer/src/lib/ui/TitleBar.svelte
@@ -32,9 +32,9 @@ onMount(async () => {
     {:else if platform === 'win32'}
       <div class="flex flex-row pt-[10px] pb-[10px] items-center">
         <div class="absolute left-[7px] top-[7px]">
-          <DesktopIcon size="18" />
+          <DesktopIcon size="20" />
         </div>
-        <div class="ml-[35px] text-left text-xs leading-3 text-[color:var(--pd-titlebar-text)]">{title}</div>
+        <div class="ml-[35px] text-left text-base leading-3 text-[color:var(--pd-titlebar-text)]">{title}</div>
         <WindowControlButtons platform={platform} />
       </div>
     {/if}


### PR DESCRIPTION
### What does this PR do?
Makes icon and title on Windows bigger

### Screenshot / video of UI
Prev: 
![Screenshot 2024-12-18 194905](https://github.com/user-attachments/assets/49c10f8c-e346-469b-ba84-1538e01d0de8)

Now:
![Screenshot 2024-12-18 195235](https://github.com/user-attachments/assets/3208787a-bce3-42ab-af3a-9e93bb5a2658)


### What issues does this PR fix or reference?
Closes #10427 

### How to test this PR?
Run PD on Windows

- [x] Tests are covering the bug fix or the new feature
