### PR TITLE
feat(backend): adding experimental property to configuration schema

### DIFF
--- a/packages/api/src/configuration/models.ts
+++ b/packages/api/src/configuration/models.ts
@@ -1,0 +1,22 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export interface IExperimentalConfiguration {
+  // href to the discussion
+  discussion: string;
+}

--- a/packages/api/src/configuration/models.ts
+++ b/packages/api/src/configuration/models.ts
@@ -18,5 +18,5 @@
 
 export interface IExperimentalConfiguration {
   // href to the discussion
-  discussion: string;
+  githubDiscussionLink?: string;
 }

--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -22,6 +22,7 @@ import * as path from 'node:path';
 import type * as containerDesktopAPI from '@podman-desktop/api';
 
 import { CONFIGURATION_DEFAULT_SCOPE } from '/@api/configuration/constants.js';
+import type { IExperimentalConfiguration } from '/@api/configuration/models.js';
 import type { NotificationCardOptions } from '/@api/notification.js';
 
 import type { ApiSenderType } from './api.js';
@@ -73,6 +74,7 @@ export interface IConfigurationPropertySchema {
   hidden?: boolean;
   enum?: string[];
   when?: string;
+  experimental?: IExperimentalConfiguration;
 }
 
 export type ConfigurationScope =


### PR DESCRIPTION
### What does this PR do?

First step of the experimental list, adding the experimental property on the configuration schema.

> :question: I am wondering I should be moving the `IConfigurationPropertySchema`, `IConfigurationPropertyRecordedSchema`, `IConfigurationChangeEvent` and `IConfigurationPropertySchemaType` to the `packages/api` :thinking: 

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Related to https://github.com/podman-desktop/podman-desktop/issues/10226

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
