### PR TITLE
chore: do not declare kubernetes-client module as external

### DIFF
--- a/packages/main/vite.config.js
+++ b/packages/main/vite.config.js
@@ -51,7 +51,6 @@ const config = {
       external: [
         'electron',
         'chokidar',
-        '@kubernetes/client-node',
         'tar-fs',
         'ssh2',
         '@segment/analytics-node',


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Do not declare kubernetes-client module as external

This will be necessary for updating to kubernetes-client v1.0.0, as it has been updated to ESM

### How to test this PR?

Build the app in different platforms and check it builds correctly