### PR TITLE
chore: migrate ProviderResultPage (and ImageDetailsCheck) components to svelte 5

### DIFF
--- a/packages/renderer/src/lib/image/ImageDetailsCheck.svelte
+++ b/packages/renderer/src/lib/image/ImageDetailsCheck.svelte
@@ -15,14 +15,18 @@ import ProviderResultPage from '../ui/ProviderResultPage.svelte';
 const orderStatus = ['failed', 'success'];
 const orderSeverity = ['critical', 'high', 'medium', 'low', undefined];
 
-export let imageInfo: ImageInfo | undefined;
+interface Props {
+  imageInfo?: ImageInfo;
+}
 
-let providers: ProviderUI[];
-let results: CheckUI[] = [];
-let cancellableTokenId: number = 0;
+const { imageInfo }: Props = $props();
 
-let remainingProviders: number;
-let aborted = false;
+let providers: ProviderUI[] = $state([]);
+let results: CheckUI[] = $state([]);
+let cancellableTokenId: number = $state(0);
+
+let remainingProviders: number = $state(0);
+let aborted = $state(false);
 
 let providersUnsubscribe: Unsubscriber;
 

--- a/packages/renderer/src/lib/image/ImageDetailsCheck.svelte
+++ b/packages/renderer/src/lib/image/ImageDetailsCheck.svelte
@@ -9,7 +9,7 @@ import Fa from 'svelte-fa';
 import { imageCheckerProviders } from '/@/stores/image-checker-providers';
 import type { ImageCheckerInfo } from '/@api/image-checker-info';
 
-import { type CheckUI, type ProviderUI } from '../ui/ProviderResultPage';
+import type { CheckUI, ProviderUI } from '../ui/ProviderResultPage';
 import ProviderResultPage from '../ui/ProviderResultPage.svelte';
 
 const orderStatus = ['failed', 'success'];
@@ -127,7 +127,9 @@ async function handleAbort() {
 </script>
 
 <ProviderResultPage providers={providers} results={results}>
-  <div class="flex flex-row" slot="header-info">
+  <!-- eslint-disable-next-line sonarjs/no-unused-vars -->
+  {#snippet headerInfo()}
+  <div class="flex flex-row">
     <div class="w-full flex mb-4 space-x-4">
       <Fa size="1.5x" icon={faStethoscope} />
       {#if aborted}
@@ -144,4 +146,5 @@ async function handleAbort() {
       </div>
     {/if}
   </div>
+  {/snippet}
 </ProviderResultPage>

--- a/packages/renderer/src/lib/ui/ProviderResultPage.spec.ts
+++ b/packages/renderer/src/lib/ui/ProviderResultPage.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen, within } from '@testing-library/svelte';
+import { createRawSnippet, type Snippet } from 'svelte';
 import { describe, expect, test } from 'vitest';
 
 import type { CheckUI, ProviderUI } from './ProviderResultPage';
@@ -109,6 +110,16 @@ describe('test ProviderResultPage', async () => {
     },
   ];
 
+  const HEADER_INFO_SNIPPET_TEXT = 'Header Info Snippet';
+
+  const snippet: Snippet<[]> = createRawSnippet(() => {
+    return {
+      render: () => `
+			<h1>${HEADER_INFO_SNIPPET_TEXT}</h1>
+		`,
+    };
+  });
+
   test('all providers are displayed as running', async () => {
     const checkProviderRunning = (text: string) => {
       const providerEntry = screen.getByRole('row', { name: text });
@@ -123,10 +134,15 @@ describe('test ProviderResultPage', async () => {
     providers[1].state = 'running';
     render(ProviderResultPage, {
       providers: JSON.parse(JSON.stringify(providers)),
+      headerInfo: snippet,
     });
 
     checkProviderRunning('Provider 1');
     checkProviderRunning('Provider 2');
+
+    // expect to see the snippet
+    const snippetElement = screen.getByRole('heading', { name: HEADER_INFO_SNIPPET_TEXT });
+    expect(snippetElement).toBeInTheDocument();
   });
 
   test('all providers are displayed as successful', () => {
@@ -143,10 +159,15 @@ describe('test ProviderResultPage', async () => {
     providers[1].state = 'success';
     render(ProviderResultPage, {
       providers: JSON.parse(JSON.stringify(providers)),
+      headerInfo: snippet,
     });
 
     checkProviderSuccess('Provider 1');
     checkProviderSuccess('Provider 2');
+
+    // expect to see the snippet
+    const snippetElement = screen.getByRole('heading', { name: HEADER_INFO_SNIPPET_TEXT });
+    expect(snippetElement).toBeInTheDocument();
   });
 
   test('all results are displayed', () => {
@@ -155,6 +176,7 @@ describe('test ProviderResultPage', async () => {
     render(ProviderResultPage, {
       providers: JSON.parse(JSON.stringify(providers)),
       results: JSON.parse(JSON.stringify(results)),
+      headerInfo: snippet,
     });
     results.forEach(result => checkResultDisplayed(result));
   });
@@ -165,6 +187,7 @@ describe('test ProviderResultPage', async () => {
     render(ProviderResultPage, {
       providers: JSON.parse(JSON.stringify(providers)),
       results: JSON.parse(JSON.stringify(results)),
+      headerInfo: snippet,
     });
 
     const providerEntry = screen.getByRole('row', { name: 'Provider 1' });
@@ -172,6 +195,10 @@ describe('test ProviderResultPage', async () => {
     await fireEvent.click(cb);
     results.filter(r => r.provider.id === 'provider1').forEach(result => checkResultNotDisplayed(result));
     results.filter(r => r.provider.id === 'provider2').forEach(result => checkResultDisplayed(result));
+
+    // expect to see the snippet
+    const snippetElement = screen.getByRole('heading', { name: HEADER_INFO_SNIPPET_TEXT });
+    expect(snippetElement).toBeInTheDocument();
   });
 
   test('results from selected providers -1st- only are displayed', async () => {
@@ -180,11 +207,13 @@ describe('test ProviderResultPage', async () => {
     render(ProviderResultPage, {
       providers: JSON.parse(JSON.stringify(providers)),
       results: JSON.parse(JSON.stringify(results)),
+      headerInfo: snippet,
     });
 
     const providerEntry = screen.getByRole('row', { name: 'Provider 2' });
     const cb = within(providerEntry).getByRole('checkbox');
     await fireEvent.click(cb);
+
     results.filter(r => r.provider.id === 'provider1').forEach(result => checkResultDisplayed(result));
     results.filter(r => r.provider.id === 'provider2').forEach(result => checkResultNotDisplayed(result));
   });
@@ -195,6 +224,7 @@ describe('test ProviderResultPage', async () => {
     render(ProviderResultPage, {
       providers: JSON.parse(JSON.stringify(providers)),
       results: JSON.parse(JSON.stringify(results)),
+      headerInfo: snippet,
     });
 
     const criticalButton = screen.getByRole('button', { name: 'Critical (2)' });

--- a/packages/renderer/src/lib/ui/ProviderResultPage.svelte
+++ b/packages/renderer/src/lib/ui/ProviderResultPage.svelte
@@ -8,6 +8,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import type { ImageCheck } from '@podman-desktop/api';
 import { Spinner } from '@podman-desktop/ui-svelte';
+import type { Snippet } from 'svelte';
 import Fa from 'svelte-fa';
 
 import type { ImageCheckerInfo } from '/@api/image-checker-info';
@@ -21,24 +22,22 @@ interface CheckUI {
   provider: ImageCheckerInfo;
   check: ImageCheck;
 }
+interface Props {
+  providers?: ProviderUI[];
+  results?: CheckUI[];
+  headerInfo: Snippet;
+}
 
-export let providers: ProviderUI[] = [];
+const { headerInfo, providers = [], results = [] }: Props = $props();
 
-export let results: CheckUI[] = [];
-
-let selectedProviders = new Map<string, boolean>();
-
-const selectedSeverities = {
+let selectedProviders = $state(new Map<string, boolean>());
+const selectedSeverities = $state({
   critical: true,
   high: true,
   medium: true,
   low: true,
   success: true,
-};
-
-$: resultsFilteredByProvider = getFilteredResultsByProvider(results, selectedProviders);
-$: countBySeverity = getCountBySeverity(resultsFilteredByProvider);
-$: filtered = getFilteredResultsBySeverity(resultsFilteredByProvider, selectedSeverities);
+});
 
 function getIcon(check: ImageCheck): IconDefinition {
   if (check.status === 'success') {
@@ -55,14 +54,12 @@ function getIcon(check: ImageCheck): IconDefinition {
   }
 }
 
-function getCountBySeverity(results: CheckUI[]): {
-  critical: number;
-  high: number;
-  medium: number;
-  low: number;
-  success: number;
-} {
-  return results.reduce(
+const resultsByProviders = $derived(
+  results.filter(r => selectedProviders.get(r.provider.id) === undefined || selectedProviders.get(r.provider.id)),
+);
+
+const countBySeverity = $derived(
+  resultsByProviders.reduce(
     (acc, current) => {
       if (current.check.status === 'success') {
         acc['success']++;
@@ -81,20 +78,11 @@ function getCountBySeverity(results: CheckUI[]): {
       low: 0,
       success: 0,
     },
-  );
-}
+  ),
+);
 
-function onProviderChecked(id: string, checked: boolean): void {
-  selectedProviders.set(id, checked);
-  selectedProviders = selectedProviders;
-}
-
-function getFilteredResultsByProvider(results: CheckUI[], checkedProviders: Map<string, boolean>): CheckUI[] {
-  return results.filter(r => checkedProviders.get(r.provider.id) === undefined || checkedProviders.get(r.provider.id));
-}
-
-function getFilteredResultsBySeverity(results: CheckUI[], selectedSeverities: any): CheckUI[] {
-  return results.filter(r => {
+const filtered = $derived(
+  resultsByProviders.filter(r => {
     if (r.check.status === 'success') {
       return selectedSeverities['success'];
     }
@@ -102,7 +90,12 @@ function getFilteredResultsBySeverity(results: CheckUI[], selectedSeverities: an
       return selectedSeverities[r.check.severity];
     }
     return true;
-  });
+  }),
+);
+
+function onProviderChecked(id: string, checked: boolean): void {
+  selectedProviders.set(id, checked);
+  selectedProviders = new Map(selectedProviders);
 }
 
 function onSeverityClicked(severity: 'critical' | 'high' | 'medium' | 'low' | 'success', clicked: boolean): void {
@@ -112,7 +105,7 @@ function onSeverityClicked(severity: 'critical' | 'high' | 'medium' | 'low' | 's
 
 <div class="flex flex-col w-full h-full p-8 pr-0">
   <div class="pr-4">
-    <slot name="header-info" />
+    {@render headerInfo()}
   </div>
   <div class="mb-2 flex flex-row pr-12 pb-2">
     <span class="grow">Checkers</span>


### PR DESCRIPTION
### What does this PR do?

migrate component to svelte 5

- change header-info to headerInfo (as it's not possible to have header-info in a Snippet/slot....)
- move the content of the method to the $derived methods so it can check the values being used

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

install for example openshift checker extension

- [x] Tests are covering the bug fix or the new feature
