### PR TITLE
feat: add server type for Lima instances

### DIFF
--- a/packages/api/src/docker-compatibility-info.ts
+++ b/packages/api/src/docker-compatibility-info.ts
@@ -35,6 +35,7 @@ export interface DockerSocketMappingStatusInfo {
     displayName: string;
   };
   serverInfo?: {
+    name: string;
     type: DockerSocketServerInfoType;
     serverVersion: string;
     operatingSystem: string;

--- a/packages/main/src/plugin/docker/docker-compatibility.spec.ts
+++ b/packages/main/src/plugin/docker/docker-compatibility.spec.ts
@@ -43,8 +43,14 @@ const providerRegistry: ProviderRegistry = {
 } as unknown as ProviderRegistry;
 
 export class TestDockerCompatibility extends DockerCompatibility {
+  public override getNameFromServerInfo(
+    info: { Name?: string; OperatingSystem?: string },
+    podmanInfo?: unknown,
+  ): string {
+    return super.getNameFromServerInfo(info, podmanInfo);
+  }
   public override getTypeFromServerInfo(
-    info: { OperatingSystem?: string },
+    info: { Name?: string; OperatingSystem?: string },
     podmanInfo?: unknown,
   ): DockerSocketServerInfoType {
     return super.getTypeFromServerInfo(info, podmanInfo);
@@ -111,6 +117,7 @@ describe('getTypeFromServerInfo', async () => {
     const serverInfo = {
       OperatingSystem: 'Docker Desktop',
     };
+    expect(dockerCompatibility.getNameFromServerInfo(serverInfo)).toBe('docker');
     expect(dockerCompatibility.getTypeFromServerInfo(serverInfo)).toBe('docker');
   });
 
@@ -135,9 +142,19 @@ describe('getTypeFromServerInfo', async () => {
       ServerVersion: '1.0.0',
     };
 
+    expect(dockerCompatibility.getNameFromServerInfo(serverInfo, podmanInfo)).toBe('podman');
     expect(dockerCompatibility.getTypeFromServerInfo(serverInfo, podmanInfo)).toBe('podman');
   });
 
+  test('check lima', async () => {
+    const dockerCompatibility = new TestDockerCompatibility(configurationRegistry, providerRegistry);
+    const serverInfo = {
+      Name: 'lima-default',
+      OperatingSystem: 'Linux',
+    };
+    expect(dockerCompatibility.getNameFromServerInfo(serverInfo)).toBe('lima');
+    expect(dockerCompatibility.getTypeFromServerInfo(serverInfo)).toBe('docker');
+  });
   test('check unknown', async () => {
     const dockerCompatibility = new TestDockerCompatibility(configurationRegistry, providerRegistry);
     const serverInfo = {
@@ -220,6 +237,7 @@ describe('getSystemDockerSocketMappingStatus', async () => {
         osType: 'foo',
         serverVersion: '1.0.0',
         type: 'docker',
+        name: 'podman',
       },
       status: 'running',
     });
@@ -294,6 +312,7 @@ describe('getSystemDockerSocketMappingStatus', async () => {
         osType: 'foo',
         serverVersion: '1.0.0',
         type: 'docker',
+        name: 'podman',
       },
       status: 'running',
     });

--- a/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilitySocketMappingStatus.spec.ts
+++ b/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilitySocketMappingStatus.spec.ts
@@ -27,6 +27,7 @@ import type { DockerSocketMappingStatusInfo, DockerSocketServerInfoType } from '
 import PreferencesDockerCompatibilitySocketMappingStatus from './PreferencesDockerCompatibilitySocketMappingStatus.svelte';
 
 const podmanServerInfo = {
+  name: 'podman',
   type: 'podman' as DockerSocketServerInfoType,
   serverVersion: '1.0.0',
   operatingSystem: 'Linux',
@@ -35,6 +36,7 @@ const podmanServerInfo = {
 };
 
 const dockerServerInfo = {
+  name: 'docker',
   type: 'docker' as DockerSocketServerInfoType,
   serverVersion: '1.0.0',
   operatingSystem: 'Linux',

--- a/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilitySocketMappingStatus.svelte
+++ b/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilitySocketMappingStatus.svelte
@@ -53,7 +53,7 @@ onMount(async () => {
           <RefreshButton label="Refresh the status" onclick={refreshSocketMappingStatus} />
         </div>
         {#if dockerSocketMappingStatusInfo?.status === 'running' && dockerSocketMappingStatusInfo?.serverInfo}
-          <Label name="{dockerSocketMappingStatusInfo.serverInfo.type} is listening">
+          <Label name="{dockerSocketMappingStatusInfo.serverInfo.name} is listening">
             <ProviderInfoCircle type={engineType} />
           </Label>
         {:else if dockerSocketMappingStatusInfo?.status === 'unreachable'}
@@ -100,7 +100,7 @@ onMount(async () => {
       aria-label="Server information">
       <div class="grid grid-cols-2 gap-x-8 gap-y-2">
         <div>Server:</div>
-        <div>{dockerSocketMappingStatusInfo.serverInfo.type}</div>
+        <div>{dockerSocketMappingStatusInfo.serverInfo.name}</div>
 
         <div>Version:</div>
         <div>{dockerSocketMappingStatusInfo.serverInfo.serverVersion}</div>


### PR DESCRIPTION
### What does this PR do?

Adds detection of "server type" for lima docker socket

Previously it was listed as "Server: unknown", if linked

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

![pd-lima](https://github.com/user-attachments/assets/49ce09b8-525f-4a32-8b23-7223a8e1d07b)
![pd-light](https://github.com/user-attachments/assets/af7d61bb-85c6-4bca-8888-88ba10c9603d)

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

https://github.com/podman-desktop/podman-desktop/issues/9351#issuecomment-2488721180

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

You need to create the `/var/run/docker.sock`  symlink.

- [x] Tests are covering the bug fix or the new feature

---

The "provider info" is **only** used for the server type, the connection type is still the actual engine type...

So the server type is "lima", but the connection type is "docker" or "podman" or "kubernetes" (containerd)

It is shown in the right color for the containers, but it is still broken for the images (showing as "lima")

* https://github.com/podman-desktop/podman-desktop/issues/5609#issuecomment-1900956942

![pd-container](https://github.com/user-attachments/assets/7909111b-51e3-4559-9889-80581ba7a6bb)

![pd-image](https://github.com/user-attachments/assets/e06497f2-227c-45f8-9428-45bbe8eda2f0)

They are both supposed to show the engine type (connection type), and not the provider type

So the wrong type is being used, but since it is all string and they're all the same for the others...