### PR TITLE
feat: dispatch resources count

### DIFF
--- a/packages/api/src/kubernetes-resource-count.ts
+++ b/packages/api/src/kubernetes-resource-count.ts
@@ -16,27 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { expect, test } from 'vitest';
-
-import { ContextResourceRegistry } from './context-resource-registry.js';
-
-test('ContextResourceRegistry', () => {
-  const registry = new ContextResourceRegistry<string>();
-
-  registry.set('context1', 'resource1', 'value1');
-  expect(registry.get('context1', 'resource1')).toEqual('value1');
-
-  registry.set('context1', 'resource2', 'value2');
-  expect(registry.getAll()).toEqual([
-    {
-      contextName: 'context1',
-      resourceName: 'resource1',
-      value: 'value1',
-    },
-    {
-      contextName: 'context1',
-      resourceName: 'resource2',
-      value: 'value2',
-    },
-  ]);
-});
+export interface ResourceCount {
+  contextName: string;
+  resourceName: string;
+  count: number;
+}

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -93,6 +93,7 @@ import type { ContextHealth } from '/@api/kubernetes-contexts-healths.js';
 import type { ContextPermission } from '/@api/kubernetes-contexts-permissions.js';
 import type { ContextGeneralState, ResourceName } from '/@api/kubernetes-contexts-states.js';
 import type { ForwardConfig, ForwardOptions } from '/@api/kubernetes-port-forward-model.js';
+import type { ResourceCount } from '/@api/kubernetes-resource-count.js';
 import type { ManifestCreateOptions, ManifestInspectInfo, ManifestPushOptions } from '/@api/manifest-info.js';
 import type { NetworkInspectInfo } from '/@api/network-info.js';
 import type { NotificationCard, NotificationCardOptions } from '/@api/notification.js';
@@ -2600,6 +2601,10 @@ export class PluginSystem {
 
     this.ipcHandle('kubernetes:getContextsPermissions', async (_listener): Promise<ContextPermission[]> => {
       return kubernetesClient.getContextsPermissions();
+    });
+
+    this.ipcHandle('kubernetes:getResourcesCount', async (_listener): Promise<ResourceCount[]> => {
+      return kubernetesClient.getResourcesCount();
     });
 
     const kubernetesExecCallbackMap = new Map<

--- a/packages/main/src/plugin/kubernetes/context-resource-registry.ts
+++ b/packages/main/src/plugin/kubernetes/context-resource-registry.ts
@@ -16,6 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+export interface Details<T> {
+  contextName: string;
+  resourceName: string;
+  value: T;
+}
+
 // ContextResourceRegistry stores objects of type T for contexts and resources
 export class ContextResourceRegistry<T> {
   #registry: Map<string, Map<string, T>> = new Map();
@@ -31,11 +37,13 @@ export class ContextResourceRegistry<T> {
     return this.#registry.get(context)?.get(resource);
   }
 
-  getAll(): T[] {
-    const result: T[] = [];
-    for (const contexts of this.#registry.values()) {
-      result.push(...contexts.values());
-    }
-    return result;
+  getAll(): Details<T>[] {
+    return Array.from(this.#registry.entries()).flatMap(([contextName, resources]) => {
+      return Array.from(resources.entries()).map(([resourceName, value]) => ({
+        contextName,
+        resourceName,
+        value,
+      }));
+    });
   }
 }

--- a/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.spec.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.spec.ts
@@ -34,6 +34,7 @@ test('ContextsStatesDispatcher should call updateHealthStates when onContextHeal
     onContextDelete: vi.fn(),
     getHealthCheckersStates: vi.fn(),
     getPermissions: vi.fn(),
+    onResourceCountUpdated: vi.fn(),
   } as unknown as ContextsManagerExperimental;
   const apiSender: ApiSenderType = {
     send: vi.fn(),
@@ -61,6 +62,7 @@ test('ContextsStatesDispatcher should call updatePermissions when onContextPermi
     onContextDelete: vi.fn(),
     getHealthCheckersStates: vi.fn(),
     getPermissions: vi.fn(),
+    onResourceCountUpdated: vi.fn(),
   } as unknown as ContextsManagerExperimental;
   const apiSender: ApiSenderType = {
     send: vi.fn(),
@@ -87,6 +89,7 @@ test('ContextsStatesDispatcher should call updateHealthStates and updatePermissi
     onContextDelete: onContextDeleteMock,
     getHealthCheckersStates: vi.fn(),
     getPermissions: vi.fn(),
+    onResourceCountUpdated: vi.fn(),
   } as unknown as ContextsManagerExperimental;
   const apiSender: ApiSenderType = {
     send: vi.fn(),
@@ -239,18 +242,21 @@ test('getContextsPermissions should return the values as an array', () => {
 });
 
 test('updatePermissions should call apiSender.send with kubernetes-contexts-permissions', () => {
-  const manager: ContextsManagerExperimental = {
-    onContextHealthStateChange: vi.fn(),
-    onContextPermissionResult: vi.fn(),
-    onContextDelete: vi.fn(),
-    getHealthCheckersStates: vi.fn(),
-    getPermissions: vi.fn(),
-  } as unknown as ContextsManagerExperimental;
+  const manager: ContextsManagerExperimental = {} as ContextsManagerExperimental;
   const apiSender: ApiSenderType = {
     send: vi.fn(),
   } as unknown as ApiSenderType;
   const dispatcher = new ContextsStatesDispatcher(manager, apiSender);
-  vi.spyOn(dispatcher, 'getContextsPermissions').mockReturnValue([]);
   dispatcher.updatePermissions();
   expect(vi.mocked(apiSender.send)).toHaveBeenCalledWith('kubernetes-contexts-permissions');
+});
+
+test('updateResourcesCount should call apiSender.send with kubernetes-resources-count', () => {
+  const manager: ContextsManagerExperimental = {} as ContextsManagerExperimental;
+  const apiSender: ApiSenderType = {
+    send: vi.fn(),
+  } as unknown as ApiSenderType;
+  const dispatcher = new ContextsStatesDispatcher(manager, apiSender);
+  dispatcher.updateResourcesCount();
+  expect(vi.mocked(apiSender.send)).toHaveBeenCalledWith('kubernetes-resources-count');
 });

--- a/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.ts
@@ -18,6 +18,7 @@
 
 import type { ContextHealth } from '/@api/kubernetes-contexts-healths.js';
 import type { ContextPermission } from '/@api/kubernetes-contexts-permissions.js';
+import type { ResourceCount } from '/@api/kubernetes-resource-count.js';
 
 import type { ApiSenderType } from '../api.js';
 import type { ContextHealthState } from './context-health-checker.js';
@@ -38,6 +39,7 @@ export class ContextsStatesDispatcher {
       this.updateHealthStates();
       this.updatePermissions();
     });
+    this.manager.onResourceCountUpdated(() => this.updateResourcesCount());
   }
 
   updateHealthStates(): void {
@@ -69,5 +71,13 @@ export class ContextsStatesDispatcher {
         reason: contextResourcePermission.reason,
       }));
     });
+  }
+
+  updateResourcesCount(): void {
+    this.apiSender.send(`kubernetes-resources-count`);
+  }
+
+  getResourcesCount(): ResourceCount[] {
+    return this.manager.getResourcesCount();
   }
 }

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.ts
@@ -75,6 +75,7 @@ import type { ContextHealth } from '/@api/kubernetes-contexts-healths.js';
 import type { ContextPermission } from '/@api/kubernetes-contexts-permissions.js';
 import type { ContextGeneralState, ResourceName } from '/@api/kubernetes-contexts-states.js';
 import type { ForwardConfig, ForwardOptions } from '/@api/kubernetes-port-forward-model.js';
+import type { ResourceCount } from '/@api/kubernetes-resource-count.js';
 import type { V1Route } from '/@api/openshift-types.js';
 
 import type { ApiSenderType } from '../api.js';
@@ -1690,5 +1691,12 @@ export class KubernetesClient {
       throw new Error('contextsStatesDispatcher is undefined. This should not happen in Kubernetes experimental');
     }
     return this.contextsStatesDispatcher.getContextsPermissions();
+  }
+
+  public getResourcesCount(): ResourceCount[] {
+    if (!this.contextsStatesDispatcher) {
+      throw new Error('contextsStatesDispatcher is undefined. This should not happen in Kubernetes experimental');
+    }
+    return this.contextsStatesDispatcher.getResourcesCount();
   }
 }

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -71,6 +71,7 @@ import type { ContextHealth } from '/@api/kubernetes-contexts-healths';
 import type { ContextPermission } from '/@api/kubernetes-contexts-permissions';
 import type { ContextGeneralState, ResourceName } from '/@api/kubernetes-contexts-states';
 import type { ForwardConfig, ForwardOptions } from '/@api/kubernetes-port-forward-model';
+import type { ResourceCount } from '/@api/kubernetes-resource-count';
 import type { ManifestCreateOptions, ManifestInspectInfo, ManifestPushOptions } from '/@api/manifest-info';
 import type { NetworkInspectInfo } from '/@api/network-info';
 import type { NotificationCard, NotificationCardOptions } from '/@api/notification';
@@ -1879,6 +1880,10 @@ export function initExposure(): void {
 
   contextBridge.exposeInMainWorld('kubernetesGetContextsPermissions', async (): Promise<ContextPermission[]> => {
     return ipcInvoke('kubernetes:getContextsPermissions');
+  });
+
+  contextBridge.exposeInMainWorld('kubernetesGetResourcesCount', async (): Promise<ResourceCount[]> => {
+    return ipcInvoke('kubernetes:getResourcesCount');
   });
 
   contextBridge.exposeInMainWorld('kubernetesGetClusters', async (): Promise<Cluster[]> => {

--- a/packages/renderer/src/stores/kubernetes-resources-count-experimental.spec.ts
+++ b/packages/renderer/src/stores/kubernetes-resources-count-experimental.spec.ts
@@ -1,0 +1,90 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { get } from 'svelte/store';
+import { beforeAll, expect, test, vi } from 'vitest';
+
+import type { ResourceCount } from '/@api/kubernetes-resource-count';
+
+import { kubernetesResourcesCount, kubernetesResourcesCountStore } from './kubernetes-resources-count';
+
+const callbacks = new Map<string, () => Promise<void>>();
+const eventEmitter = {
+  receive: (message: string, callback: () => Promise<void>) => {
+    callbacks.set(message, callback);
+  },
+};
+
+beforeAll(() => {
+  Object.defineProperty(global, 'window', {
+    value: {
+      kubernetesGetResourcesCount: vi.fn(),
+      getConfigurationValue: vi.fn(),
+      addEventListener: eventEmitter.receive,
+      events: {
+        receive: eventEmitter.receive,
+      },
+    },
+  });
+});
+
+test('kubernetesResourcesCount in experimental states mode', async () => {
+  vi.mocked(window.getConfigurationValue).mockResolvedValue(true);
+
+  const initialValues: ResourceCount[] = [];
+  const nextValues: ResourceCount[] = [
+    {
+      contextName: 'context1',
+      resourceName: 'pods',
+      count: 1,
+    },
+    {
+      contextName: 'context2',
+      resourceName: 'deployments',
+      count: 2,
+    },
+  ];
+  vi.mocked(window.kubernetesGetResourcesCount).mockResolvedValue(initialValues);
+
+  kubernetesResourcesCountStore.setup();
+
+  // send 'extensions-already-started' event
+  const callbackExtensionsStarted = callbacks.get('extensions-already-started');
+  expect(callbackExtensionsStarted).toBeDefined();
+  await callbackExtensionsStarted!();
+
+  await vi.waitFor(() => {
+    const currentValue = get(kubernetesResourcesCount);
+    expect(currentValue).toEqual(initialValues);
+  }, 500);
+
+  // data has been updated in the backend
+  vi.mocked(window.kubernetesGetResourcesCount).mockResolvedValue(nextValues);
+
+  // send an event indicating the data is updated
+  const event = 'kubernetes-resources-count';
+  const callback = callbacks.get(event);
+  expect(callback).toBeDefined();
+  await callback!();
+
+  await vi.waitFor(() => {
+    // check received data is updated
+    const currentValue = get(kubernetesResourcesCount);
+    expect(currentValue).toEqual(nextValues);
+  }, 500);
+});

--- a/packages/renderer/src/stores/kubernetes-resources-count-non-experimental.spec.ts
+++ b/packages/renderer/src/stores/kubernetes-resources-count-non-experimental.spec.ts
@@ -1,0 +1,75 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { get } from 'svelte/store';
+import { beforeAll, expect, test, vi } from 'vitest';
+
+import type { ResourceCount } from '/@api/kubernetes-resource-count';
+
+import { kubernetesResourcesCount, kubernetesResourcesCountStore } from './kubernetes-resources-count';
+
+const callbacks = new Map<string, () => Promise<void>>();
+const eventEmitter = {
+  receive: (message: string, callback: () => Promise<void>) => {
+    callbacks.set(message, callback);
+  },
+};
+
+beforeAll(() => {
+  Object.defineProperty(global, 'window', {
+    value: {
+      kubernetesGetResourcesCount: vi.fn(),
+      getConfigurationValue: vi.fn(),
+      addEventListener: eventEmitter.receive,
+      events: {
+        receive: eventEmitter.receive,
+      },
+    },
+  });
+});
+
+test('kubernetesResourcesCount in non experimental states mode', async () => {
+  vi.mocked(window.getConfigurationValue).mockResolvedValue(false);
+
+  const initialValues: ResourceCount[] = [
+    {
+      contextName: 'context1',
+      resourceName: 'pods',
+      count: 1,
+    },
+    {
+      contextName: 'context2',
+      resourceName: 'deployments',
+      count: 2,
+    },
+  ];
+  vi.mocked(window.kubernetesGetResourcesCount).mockResolvedValue(initialValues);
+
+  kubernetesResourcesCountStore.setup();
+
+  // send 'extensions-already-started' event
+  const callbackExtensionsStarted = callbacks.get('extensions-already-started');
+  expect(callbackExtensionsStarted).toBeDefined();
+  await callbackExtensionsStarted!();
+
+  // values are never fetched
+  await new Promise(resolve => setTimeout(resolve, 500));
+  const currentValue = get(kubernetesResourcesCount);
+  expect(currentValue).toEqual([]);
+  expect(vi.mocked(window.kubernetesGetResourcesCount)).not.toHaveBeenCalled();
+});

--- a/packages/renderer/src/stores/kubernetes-resources-count.ts
+++ b/packages/renderer/src/stores/kubernetes-resources-count.ts
@@ -1,0 +1,62 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { type Writable, writable } from 'svelte/store';
+
+import type { ResourceCount } from '/@api/kubernetes-resource-count';
+
+import { EventStore } from './event-store';
+
+const windowEvents = ['kubernetes-resources-count', 'extension-stopped', 'extensions-started'];
+const windowListeners = ['extensions-already-started'];
+
+let experimentalStates: boolean | undefined = undefined;
+let readyToUpdate = false;
+
+export async function checkForUpdate(eventName: string): Promise<boolean> {
+  // check for update only in experimental states mode
+  if (experimentalStates === undefined) {
+    experimentalStates = (await window.getConfigurationValue<boolean>('kubernetes.statesExperimental')) ?? false;
+  }
+  if (experimentalStates === false) {
+    return false;
+  }
+
+  if ('extensions-already-started' === eventName) {
+    readyToUpdate = true;
+  }
+  // do not fetch until extensions are all started
+  return readyToUpdate;
+}
+
+export const kubernetesResourcesCount: Writable<ResourceCount[]> = writable([]);
+
+// use helper here as window methods are initialized after the store in tests
+const listResourcesCount = (): Promise<ResourceCount[]> => {
+  return window.kubernetesGetResourcesCount();
+};
+
+export const kubernetesResourcesCountStore = new EventStore<ResourceCount[]>(
+  'kubernetes resources count',
+  kubernetesResourcesCount,
+  checkForUpdate,
+  windowEvents,
+  windowListeners,
+  listResourcesCount,
+);
+kubernetesResourcesCountStore.setup();


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Dispatch resources count to the frontend

### Screenshot / video of UI

No UI

### What issues does this PR fix or reference?

Fixes #10468

### How to test this PR?

Set this preference in ~/.local/share/containers/podman-desktop/configuration/settings.json:

```
  "kubernetes.statesExperimental": true
```

You can use this patch to see what is logged when on the Settings > Kubernetes page and create/delete pods and/or deployments

```
diff --git a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
index dfda79e0683..b98eb386181 100644
--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -6,6 +6,7 @@ import { router } from 'tinro';
 
 import { kubernetesContextsHealths } from '/@/stores/kubernetes-context-health';
 import { kubernetesContextsCheckingStateDelayed, kubernetesContextsState } from '/@/stores/kubernetes-contexts-state';
+import { kubernetesResourcesCount } from '../../stores/kubernetes-resources-count';
 import type { KubeContext } from '/@api/kubernetes-context';
 
 import { kubernetesContexts } from '../../stores/kubernetes-contexts';
@@ -34,6 +35,10 @@ const kubernetesContextsWithStates: KubeContextWithStates[] = $derived(
   })),
 );
 
+$effect(() => {
+  console.log('==> counts', $kubernetesResourcesCount);
+});
+
 onMount(async () => {
   try {
     const val: string | undefined = await window.getConfigurationValue('kubernetes.Kubeconfig');
```
- [x] Tests are covering the bug fix or the new feature
