### PR TITLE
fix: add server type for default Docker Engine

### DIFF
--- a/packages/main/src/plugin/docker/docker-compatibility.spec.ts
+++ b/packages/main/src/plugin/docker/docker-compatibility.spec.ts
@@ -44,7 +44,7 @@ const providerRegistry: ProviderRegistry = {
 
 export class TestDockerCompatibility extends DockerCompatibility {
   public override getTypeFromServerInfo(
-    info: { OperatingSystem?: string },
+    info: { Name?: string; OperatingSystem?: string },
     podmanInfo?: unknown,
   ): DockerSocketServerInfoType {
     return super.getTypeFromServerInfo(info, podmanInfo);
@@ -75,6 +75,7 @@ vi.mock('../../util', () => {
     isWindows: vi.fn(),
     isMac: vi.fn(),
     isLinux: vi.fn(),
+    getHostname: vi.fn(),
     exec: vi.fn(),
   };
 });
@@ -110,6 +111,17 @@ describe('getTypeFromServerInfo', async () => {
     const dockerCompatibility = new TestDockerCompatibility(configurationRegistry, providerRegistry);
     const serverInfo = {
       OperatingSystem: 'Docker Desktop',
+    };
+    expect(dockerCompatibility.getTypeFromServerInfo(serverInfo)).toBe('docker');
+  });
+
+  test('Docker Engine', async () => {
+    const dockerCompatibility = new TestDockerCompatibility(configurationRegistry, providerRegistry);
+    vi.spyOn(util, 'isLinux').mockImplementation(() => true);
+    vi.spyOn(util, 'getHostname').mockImplementation(() => 'localhost');
+    const serverInfo = {
+      Name: 'localhost',
+      OperatingSystem: 'Ubuntu',
     };
     expect(dockerCompatibility.getTypeFromServerInfo(serverInfo)).toBe('docker');
   });

--- a/packages/main/src/plugin/docker/docker-compatibility.ts
+++ b/packages/main/src/plugin/docker/docker-compatibility.ts
@@ -20,7 +20,7 @@ import { promises } from 'node:fs';
 
 import Dockerode from 'dockerode';
 
-import { isMac, isWindows } from '/@/util.js';
+import { getHostname, isLinux, isMac, isWindows } from '/@/util.js';
 import type { DockerSocketMappingStatusInfo, DockerSocketServerInfoType } from '/@api/docker-compatibility-info.js';
 import { ExperimentalSettings } from '/@api/docker-compatibility-info.js';
 
@@ -64,7 +64,7 @@ export class DockerCompatibility {
   }
 
   protected getTypeFromServerInfo(
-    info: { OperatingSystem?: string },
+    info: { Name?: string; OperatingSystem?: string },
     podmanInfo?: unknown,
   ): DockerSocketServerInfoType {
     if (info.OperatingSystem === 'Docker Desktop') {
@@ -72,6 +72,9 @@ export class DockerCompatibility {
     } else if (info.OperatingSystem === 'podman' || podmanInfo) {
       // if podman info is available, then it is podman
       return 'podman';
+    } else if (isLinux() && info.Name === getHostname()) {
+      // Docker Engine
+      return 'docker';
     }
     return 'unknown';
   }

--- a/packages/main/src/util.ts
+++ b/packages/main/src/util.ts
@@ -32,6 +32,10 @@ const linux = os.platform() === 'linux';
 export function isLinux(): boolean {
   return linux;
 }
+const hostname = os.hostname();
+export function getHostname(): string {
+  return hostname;
+}
 
 export const stoppedExtensions = { val: false };
 


### PR DESCRIPTION
### What does this PR do?

Show Docker as "docker" instead of "unknown"

### Screenshot / video of UI

Before
![Image](https://github.com/user-attachments/assets/63643e59-ffa6-4d52-b623-b957c223194b)

After
![pd-engine](https://github.com/user-attachments/assets/dd18241b-24c5-4f7c-9300-d3fa9fc340e9)

### What issues does this PR fix or reference?

https://github.com/podman-desktop/podman-desktop/issues/9351#issuecomment-2555794075

### How to test this PR?

Make sure that Docker Engine is running, on Linux

- [x] Tests are covering the bug fix or the new feature
