### PR TITLE
fix: add hidden input component in Dropdown for form submissions

### DIFF
--- a/packages/ui/src/lib/dropdown/Dropdown.spec.ts
+++ b/packages/ui/src/lib/dropdown/Dropdown.spec.ts
@@ -145,3 +145,35 @@ test('should be able to navigate with keys', async () => {
   expect(item).toBeNull();
   expect(input).toHaveTextContent('C');
 });
+
+test('value of hidden select component is updated based on Dropdown value', async () => {
+  render(Dropdown, {
+    value: 'b',
+    options: [
+      { label: 'A', value: 'a' },
+      { label: 'B', value: 'b' },
+      { label: 'C', value: 'c' },
+    ],
+    name: 'testDropdown',
+  });
+
+  const input = screen.getByRole('button');
+  expect(input).toBeInTheDocument();
+  input.focus();
+
+  let selectItem = screen.getByRole('combobox');
+  expect(selectItem).toBeInTheDocument();
+  expect(selectItem).toHaveValue('b');
+
+  // open dropdown (selects A)
+  await userEvent.keyboard('[ArrowDown]');
+  const item = screen.queryByRole('button', { name: 'A' });
+  expect(item).not.toBeNull();
+
+  // select A, closes dropdown and updates selection
+  await userEvent.keyboard('[Enter]');
+
+  selectItem = screen.getByRole('combobox');
+  expect(selectItem).toBeInTheDocument();
+  expect(selectItem).toHaveValue('a');
+});

--- a/packages/ui/src/lib/dropdown/Dropdown.spec.ts
+++ b/packages/ui/src/lib/dropdown/Dropdown.spec.ts
@@ -161,9 +161,9 @@ test('value of hidden select component is updated based on Dropdown value', asyn
   expect(input).toBeInTheDocument();
   input.focus();
 
-  let selectItem = screen.getByRole('combobox');
-  expect(selectItem).toBeInTheDocument();
-  expect(selectItem).toHaveValue('b');
+  let hiddenInput = screen.getByLabelText('hidden input');
+  expect(hiddenInput).toBeInTheDocument();
+  expect(hiddenInput).toHaveValue('b');
 
   // open dropdown (selects A)
   await userEvent.keyboard('[ArrowDown]');
@@ -173,7 +173,7 @@ test('value of hidden select component is updated based on Dropdown value', asyn
   // select A, closes dropdown and updates selection
   await userEvent.keyboard('[Enter]');
 
-  selectItem = screen.getByRole('combobox');
-  expect(selectItem).toBeInTheDocument();
-  expect(selectItem).toHaveValue('a');
+  hiddenInput = screen.getByLabelText('hidden input');
+  expect(hiddenInput).toBeInTheDocument();
+  expect(hiddenInput).toHaveValue('a');
 });

--- a/packages/ui/src/lib/dropdown/Dropdown.svelte
+++ b/packages/ui/src/lib/dropdown/Dropdown.svelte
@@ -231,6 +231,12 @@ function onWindowClick(e: Event): void {
   {/if}
 
   <select use:buildOptions class="hidden" name={name} bind:value={value}>
-    {@render children?.()}
+    {#if !children || children.length === 0}
+      {#each options as option}
+        <option value={option.value}></option>
+      {/each}
+    {:else}
+      {@render children?.()}
+    {/if}
   </select>
 </div>

--- a/packages/ui/src/lib/dropdown/Dropdown.svelte
+++ b/packages/ui/src/lib/dropdown/Dropdown.svelte
@@ -230,13 +230,9 @@ function onWindowClick(e: Event): void {
     </div>
   {/if}
 
-  <select use:buildOptions class="hidden" name={name} bind:value={value}>
-    {#if !children || children.length === 0}
-      {#each options as option}
-        <option value={option.value}></option>
-      {/each}
-    {:else}
-      {@render children?.()}
-    {/if}
+  <input name={name} value={value} type="hidden" aria-label="hidden input"/>
+
+  <select use:buildOptions class="hidden" bind:value={value}>
+    {@render children?.()}
   </select>
 </div>


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR adds a hidden input component to ensure that the value of the Dropdown is always passed in form submissions, regardless if children elements or property are used.

From a quick check, it looks like the only place that uses the value of the hidden `select` in `Dropdown` is `new FormData()` in `PreferencesConnectionCreationOrEditRendering.svelte` as it relies on basic input components to gather the form data. It also seems like the value of `select` cannot be set to a value it doesn't contain, so if there are no children to render in the hidden `select`, its value cannot be updated to the value of the `Dropdown`. 

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Fixes https://github.com/podman-desktop/podman-desktop/issues/10435

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
