### PR TITLE
chore: make getProxySettingsFromSystem() work on FreeBSD

### DIFF
--- a/packages/main/src/plugin/proxy-system.spec.ts
+++ b/packages/main/src/plugin/proxy-system.spec.ts
@@ -47,6 +47,7 @@ function setupPlatform(platform: Platform): void {
   vi.spyOn(util, 'isWindows').mockReturnValue(platform === Platform.WINDOWS);
   vi.spyOn(util, 'isMac').mockReturnValue(platform === Platform.MACOS);
   vi.spyOn(util, 'isLinux').mockReturnValue(platform === Platform.LINUX);
+  vi.spyOn(util, 'isUnixLike').mockReturnValue(platform === Platform.LINUX);
 }
 
 describe('Windows platform tests', () => {

--- a/packages/main/src/plugin/proxy-system.ts
+++ b/packages/main/src/plugin/proxy-system.ts
@@ -20,7 +20,7 @@ import { promisify } from 'node:util';
 import { type ProxySettings } from '@podman-desktop/api';
 import WinReg from 'winreg';
 
-import { isLinux, isMac, isWindows } from '../util.js';
+import { isMac, isUnixLike, isWindows } from '../util.js';
 import type { Proxy } from './proxy.js';
 import { Exec } from './util/exec.js';
 
@@ -29,7 +29,7 @@ export async function getProxySettingsFromSystem(proxy: Proxy): Promise<ProxySet
     return getWindowsProxySettings();
   } else if (isMac()) {
     return getMacOSProxySettings(new Exec(proxy));
-  } else if (isLinux()) {
+  } else if (isUnixLike()) {
     const httpProxy = process.env['HTTP_PROXY'];
     const httpsProxy = process.env['HTTPS_PROXY'];
     const noProxy = process.env['NO_PROXY'];

--- a/packages/main/src/util.ts
+++ b/packages/main/src/util.ts
@@ -32,6 +32,13 @@ const linux = os.platform() === 'linux';
 export function isLinux(): boolean {
   return linux;
 }
+const freebsd = os.platform() === 'freebsd';
+export function isFreeBSD(): boolean {
+  return freebsd;
+}
+export function isUnixLike(): boolean {
+  return linux || freebsd;
+}
 
 export const stoppedExtensions = { val: false };
 


### PR DESCRIPTION
### What does this PR do?

This change adds the `isUnixLike()` function which returns true for Linux and FreeBSD OSes. It then used to fix `getProxySettingsFromSystem()` for the FreeBSD case.

### How to test this PR?

- [X] Tests are covering the bug fix or the new feature
