### PR TITLE
chore: migrate AuditMessageBox to svelte5 rune

### DIFF
--- a/packages/renderer/src/lib/ui/AuditMessageBox.svelte
+++ b/packages/renderer/src/lib/ui/AuditMessageBox.svelte
@@ -1,17 +1,17 @@
 <script lang="ts">
 import { faCircleInfo, faTriangleExclamation, faXmarkCircle } from '@fortawesome/free-solid-svg-icons';
-import type { AuditRecord, AuditResult } from '@podman-desktop/api';
+import type { AuditResult } from '@podman-desktop/api';
 import Fa from 'svelte-fa';
 
-export let auditResult: AuditResult;
+interface Props {
+  auditResult: AuditResult;
+}
 
-let infoRecords: AuditRecord[];
-let warningRecords: AuditRecord[];
-let errorRecords: AuditRecord[];
+const { auditResult }: Props = $props();
 
-$: infoRecords = auditResult?.records.filter(record => record.type === 'info');
-$: warningRecords = auditResult?.records.filter(record => record.type === 'warning');
-$: errorRecords = auditResult?.records.filter(record => record.type === 'error');
+const infoRecords = $derived(auditResult?.records.filter(record => record.type === 'info'));
+const warningRecords = $derived(auditResult?.records.filter(record => record.type === 'warning'));
+const errorRecords = $derived(auditResult?.records.filter(record => record.type === 'error'));
 </script>
 
 {#if errorRecords && errorRecords.length > 0}


### PR DESCRIPTION
### What does this PR do?
migrate AuditMessageBox to svelte5 rune

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

part of https://github.com/podman-desktop/podman-desktop/issues/10240

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
