### PR TITLE
chore: convert PreferencesRenderingItemFormat to svelte 5 runes

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -14,25 +14,42 @@ import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/
 import Markdown from '../markdown/Markdown.svelte';
 import { getInitialValue, getNormalizedDefaultNumberValue } from './Util';
 
-let invalidText: string | undefined = undefined;
-export let invalidRecord = (_error: string) => {};
-export let validRecord = () => {};
-export let updateResetButtonVisibility = (_recordValue: any) => {};
-export let resetToDefault = false;
-export let enableAutoSave = false;
+let invalidText: string | undefined = $state(undefined);
 
-export let setRecordValue = (_id: string, _value: string | boolean | number) => {};
-export let enableSlider = false;
-export let record: IConfigurationPropertyRecordedSchema;
-export let initialValue: Promise<any>;
-export let givenValue: unknown = undefined;
+interface Props {
+  record: IConfigurationPropertyRecordedSchema;
+  initialValue: Promise<any>;
+  givenValue?: unknown;
+  setRecordValue?: (id: string, value: string | boolean | number) => void;
+  invalidRecord?: (error: string) => void;
+  validRecord?: () => void;
+  updateResetButtonVisibility?: (recordValue: any) => void;
+  resetToDefault?: boolean;
+  enableAutoSave?: boolean;
+  enableSlider?: boolean;
+}
+
+let {
+  record,
+  initialValue,
+  givenValue,
+  setRecordValue = () => {},
+  invalidRecord = () => {},
+  validRecord = () => {},
+  updateResetButtonVisibility = () => {},
+  resetToDefault = false,
+  enableAutoSave = false,
+  enableSlider = false,
+}: Props = $props();
 
 let currentRecord: IConfigurationPropertyRecordedSchema;
 let recordUpdateTimeout: NodeJS.Timeout;
 
-let recordValue: string | boolean | number | undefined;
-$: recordValue;
-$: updateResetButtonVisibility?.(recordValue);
+let recordValue: string | boolean | number | undefined = $state(undefined);
+
+$effect(() => {
+  updateResetButtonVisibility?.(recordValue);
+});
 
 let callBack: EventListenerOrEventListenerObject | undefined = undefined;
 let callbackId: string | undefined = undefined;
@@ -58,28 +75,32 @@ onDestroy(() => {
   }
 });
 
-$: if (resetToDefault) {
-  recordValue = record.type === 'number' ? getNormalizedDefaultNumberValue(record) : record.default;
-  if (ensureType(recordValue)) {
-    update(record).catch((err: unknown) => console.log(`Error updating ${record.id}`, err));
+$effect(() => {
+  if (resetToDefault) {
+    recordValue = record.type === 'number' ? getNormalizedDefaultNumberValue(record) : record.default;
+    if (ensureType(recordValue)) {
+      update(record).catch((err: unknown) => console.log(`Error updating ${record.id}`, err));
+    }
+
+    resetToDefault = false;
   }
+});
 
-  resetToDefault = false;
-}
+$effect(() => {
+  if (!isEqual(currentRecord, record)) {
+    initialValue
+      .then(value => {
+        recordValue = value;
+        if (record.type === 'boolean') {
+          recordValue = !!value;
+        }
+      })
+      .catch((err: unknown) => console.error('Error getting initial value', err));
 
-$: if (!isEqual(currentRecord, record)) {
-  initialValue
-    .then(value => {
-      recordValue = value;
-      if (record.type === 'boolean') {
-        recordValue = !!value;
-      }
-    })
-    .catch((err: unknown) => console.error('Error getting initial value', err));
-
-  invalidText = undefined;
-  currentRecord = record;
-}
+    invalidText = undefined;
+    currentRecord = record;
+  }
+});
 
 async function update(record: IConfigurationPropertyRecordedSchema) {
   // save the value

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -14,8 +14,6 @@ import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/
 import Markdown from '../markdown/Markdown.svelte';
 import { getInitialValue, getNormalizedDefaultNumberValue } from './Util';
 
-let invalidText: string | undefined = $state(undefined);
-
 interface Props {
   record: IConfigurationPropertyRecordedSchema;
   initialValue: Promise<any>;
@@ -45,6 +43,7 @@ let {
 let currentRecord: IConfigurationPropertyRecordedSchema;
 let recordUpdateTimeout: NodeJS.Timeout;
 
+let invalidText: string | undefined = $state(undefined);
 let recordValue: string | boolean | number | undefined = $state(undefined);
 
 $effect(() => {


### PR DESCRIPTION
### What does this PR do?
convert PreferencesRenderingItemFormat to svelte 5 runes

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

part of https://github.com/podman-desktop/podman-desktop/issues/10240

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
