### PR TITLE
fix: cleanup log files before starting the app

### DIFF
--- a/packages/main/src/system/macos-startup.spec.ts
+++ b/packages/main/src/system/macos-startup.spec.ts
@@ -1,0 +1,247 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { existsSync } from 'node:fs';
+import { unlink, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import type { Configuration } from '@podman-desktop/api';
+import { app } from 'electron';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { ConfigurationRegistry } from '/@/plugin/configuration-registry.js';
+
+import { MacosStartup } from './macos-startup.js';
+
+vi.mock('electron', async () => {
+  return {
+    app: {
+      getPath: vi.fn(),
+    },
+  };
+});
+
+vi.mock('node:fs', async () => {
+  return {
+    existsSync: vi.fn(),
+  };
+});
+vi.mock('node:fs/promises');
+vi.mock('node:path');
+
+const configurationRegistry = {
+  getConfiguration: vi.fn(),
+} as unknown as ConfigurationRegistry;
+
+let macosStartup: MacosStartup;
+
+const fakeAppExe = 'fakeAppExe';
+const fakeAppHome = 'fakeAppHome';
+
+const originalConsoleInfo = console.info;
+const originalConsoleWarn = console.warn;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  console.info = vi.fn();
+  console.warn = vi.fn();
+
+  // fake path.resolve by just adding /
+  vi.mocked(resolve).mockImplementation((...args: string[]) => args.join('/'));
+
+  vi.mocked(app.getPath).mockImplementation(
+    (
+      name:
+        | 'home'
+        | 'appData'
+        | 'userData'
+        | 'sessionData'
+        | 'temp'
+        | 'exe'
+        | 'module'
+        | 'desktop'
+        | 'documents'
+        | 'downloads'
+        | 'music'
+        | 'pictures'
+        | 'videos'
+        | 'recent'
+        | 'logs'
+        | 'crashDumps',
+    ) => {
+      if (name === 'exe') {
+        return fakeAppExe;
+      }
+      if (name === 'home') {
+        return fakeAppHome;
+      }
+      throw new Error('Unsupported path');
+    },
+  );
+  macosStartup = new MacosStartup(configurationRegistry);
+});
+
+afterEach(() => {
+  console.info = originalConsoleInfo;
+  console.warn = originalConsoleWarn;
+});
+
+describe('enable', () => {
+  test('check writing the plist file with the correct instruction', async () => {
+    vi.mocked(configurationRegistry.getConfiguration).mockReturnValue({
+      get: vi.fn().mockReturnValue(true),
+    } as unknown as Configuration);
+
+    await macosStartup.enable();
+
+    // check content being written
+    expect(writeFile).toHaveBeenCalledWith(
+      expect.stringContaining('fakeAppHome/Library/LaunchAgents/io.podman_desktop.PodmanDesktop.plist'),
+      expect.stringContaining(
+        `truncate -s 0 'fakeAppHome/Library/Logs/Podman Desktop/launchd-stdout.log'; truncate -s 0 'fakeAppHome/Library/Logs/Podman Desktop/launchd-stderr.log'; 'fakeAppExe'`,
+      ),
+      'utf-8',
+    );
+
+    // check console
+    expect(console.info).toHaveBeenCalledWith(expect.stringContaining('Installing Podman Desktop startup file at'));
+  });
+
+  test('check unable to write the plist file if app is in /Volumes', async () => {
+    // change the app home to be in /Volumes
+    vi.mocked(app.getPath).mockImplementation(
+      (
+        name:
+          | 'home'
+          | 'appData'
+          | 'userData'
+          | 'sessionData'
+          | 'temp'
+          | 'exe'
+          | 'module'
+          | 'desktop'
+          | 'documents'
+          | 'downloads'
+          | 'music'
+          | 'pictures'
+          | 'videos'
+          | 'recent'
+          | 'logs'
+          | 'crashDumps',
+      ) => {
+        if (name === 'exe') {
+          return `/Volumes/${fakeAppExe}`;
+        }
+        if (name === 'home') {
+          return fakeAppHome;
+        }
+        throw new Error('Unsupported path');
+      },
+    );
+    // recreate the object to get correct resolve method
+    macosStartup = new MacosStartup(configurationRegistry);
+
+    vi.mocked(configurationRegistry.getConfiguration).mockReturnValue({
+      get: vi.fn().mockReturnValue(true),
+    } as unknown as Configuration);
+
+    await macosStartup.enable();
+
+    // check no content has being written
+    expect(writeFile).not.toHaveBeenCalled();
+
+    // check console
+    expect(console.info).not.toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalled();
+  });
+});
+
+describe('disable', () => {
+  test('check remove if exists', async () => {
+    // mock as file exists
+    vi.mocked(existsSync).mockReturnValue(true);
+
+    await macosStartup.disable();
+
+    // check calls on fs
+    expect(existsSync).toHaveBeenCalled();
+    expect(unlink).toHaveBeenCalled();
+  });
+
+  test('check do not remove if not exists', async () => {
+    // mock as file not existing
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    await macosStartup.disable();
+
+    // check calls on fs
+    expect(existsSync).toHaveBeenCalled();
+    expect(unlink).not.toHaveBeenCalled();
+  });
+});
+
+describe('shouldEnable', () => {
+  test('check shouldEnable being true', async () => {
+    // change the app folder to be in /Applications
+    vi.mocked(app.getPath).mockImplementation(
+      (
+        name:
+          | 'home'
+          | 'appData'
+          | 'userData'
+          | 'sessionData'
+          | 'temp'
+          | 'exe'
+          | 'module'
+          | 'desktop'
+          | 'documents'
+          | 'downloads'
+          | 'music'
+          | 'pictures'
+          | 'videos'
+          | 'recent'
+          | 'logs'
+          | 'crashDumps',
+      ) => {
+        if (name === 'exe') {
+          return `/Applications/${fakeAppExe}`;
+        }
+        if (name === 'home') {
+          return fakeAppHome;
+        }
+        throw new Error('Unsupported path');
+      },
+    );
+
+    // recreate the object to get correct resolve method
+    macosStartup = new MacosStartup(configurationRegistry);
+
+    const result = macosStartup.shouldEnable();
+    expect(result).toBeTruthy();
+  });
+
+  test('check shouldEnable being false', async () => {
+    const result = macosStartup.shouldEnable();
+
+    expect(console.warn).toHaveBeenCalledWith(
+      'Skipping Start on Login option as the app is not starting from an Applications folder',
+    );
+
+    expect(result).toBeFalsy();
+  });
+});

--- a/packages/main/src/system/macos-startup.spec.ts
+++ b/packages/main/src/system/macos-startup.spec.ts
@@ -113,7 +113,7 @@ describe('enable', () => {
     expect(writeFile).toHaveBeenCalledWith(
       expect.stringContaining('fakeAppHome/Library/LaunchAgents/io.podman_desktop.PodmanDesktop.plist'),
       expect.stringContaining(
-        `truncate -s 0 'fakeAppHome/Library/Logs/Podman Desktop/launchd-stdout.log'; truncate -s 0 'fakeAppHome/Library/Logs/Podman Desktop/launchd-stderr.log'; 'fakeAppExe'`,
+        `/usr/bin/truncate -s 0 'fakeAppHome/Library/Logs/Podman Desktop/launchd-stdout.log'; /usr/bin/truncate -s 0 'fakeAppHome/Library/Logs/Podman Desktop/launchd-stderr.log'; 'fakeAppExe'`,
       ),
       'utf-8',
     );

--- a/packages/main/src/system/macos-startup.ts
+++ b/packages/main/src/system/macos-startup.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022 Red Hat, Inc.
+ * Copyright (C) 2022-2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import fs from 'node:fs';
+import { existsSync } from 'node:fs';
+import { mkdir, unlink, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import { app } from 'electron';
@@ -71,6 +72,9 @@ export class MacosStartup {
       return;
     }
 
+    const stdoutPath = `${app.getPath('home')}/Library/Logs/Podman Desktop/launchd-stdout.log`;
+    const stderrPath = `${app.getPath('home')}/Library/Logs/Podman Desktop/launchd-stderr.log`;
+
     // write the file
     const plistContent =
       `<?xml version="1.0" encoding="UTF-8"?>
@@ -81,7 +85,9 @@ export class MacosStartup {
     <string>io.podman_desktop.PodmanDesktop</string>
     <key>ProgramArguments</key>
     <array>
-        <string>${this.podmanDesktopBinaryPath}</string>
+        <string>bash</string>
+        <string>-c</string>
+        <string>truncate -s 0 '${stdoutPath}'; truncate -s 0 '${stderrPath}'; '${this.podmanDesktopBinaryPath}'</string>
         ` +
       minimizeSettings +
       `
@@ -89,18 +95,18 @@ export class MacosStartup {
     <key>RunAtLoad</key>
     <true/>
     <key>StandardOutPath</key>
-    <string>${app.getPath('home')}/Library/Logs/Podman Desktop/launchd-stdout.log</string>
+    <string>${stdoutPath}</string>
     <key>StandardErrorPath</key>
-    <string>${app.getPath('home')}/Library/Logs/Podman Desktop/launchd-stderr.log</string>
+    <string>${stderrPath}</string>
 </dict>
 </plist>
 `;
 
     // ensure the parent directory of the plist file exists
-    await fs.promises.mkdir(path.dirname(this.plistFile), { recursive: true });
+    await mkdir(path.dirname(this.plistFile), { recursive: true });
 
     // write the file
-    await fs.promises.writeFile(this.plistFile, plistContent, 'utf-8');
+    await writeFile(this.plistFile, plistContent, 'utf-8');
     console.info(
       `Installing Podman Desktop startup file at ${this.plistFile} using ${this.podmanDesktopBinaryPath} location.`,
     );
@@ -108,8 +114,8 @@ export class MacosStartup {
 
   async disable(): Promise<void> {
     // remove the file at this.podmanDesktopBinaryPath only if it exists
-    if (fs.existsSync(this.plistFile)) {
-      await fs.promises.unlink(this.plistFile);
+    if (existsSync(this.plistFile)) {
+      await unlink(this.plistFile);
     }
   }
 }

--- a/packages/main/src/system/macos-startup.ts
+++ b/packages/main/src/system/macos-startup.ts
@@ -85,9 +85,9 @@ export class MacosStartup {
     <string>io.podman_desktop.PodmanDesktop</string>
     <key>ProgramArguments</key>
     <array>
-        <string>bash</string>
+        <string>/bin/bash</string>
         <string>-c</string>
-        <string>truncate -s 0 '${stdoutPath}'; truncate -s 0 '${stderrPath}'; '${this.podmanDesktopBinaryPath}'</string>
+        <string>/usr/bin/truncate -s 0 '${stdoutPath}'; /usr/bin/truncate -s 0 '${stderrPath}'; '${this.podmanDesktopBinaryPath}'</string>
         ` +
       minimizeSettings +
       `


### PR DESCRIPTION
### What does this PR do?
macOS pList files are appending data to previous log files. Ensure to clean (truncate) the log file before starting the application. It ensures the log files won't grow indefinitely 

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/podman-desktop/podman-desktop/issues/10120

### How to test this PR?

on macOS only:
using a production binary installed in /Applications folder, disable and enable again the startup on Login in preferences
logout from your current macOS session and login

check that the log files have been wiped truncated before the app is starting

- [x] Tests are covering the bug fix or the new feature

the file was not tested, added unit tests