### PR TITLE
fix(frontend): hide release note image on error

### DIFF
--- a/packages/renderer/src/lib/dashboard/ReleaseNotesBox.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ReleaseNotesBox.spec.ts
@@ -18,7 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { render, screen, waitFor } from '@testing-library/svelte';
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { tick } from 'svelte';
 import { beforeEach, expect, test, vi } from 'vitest';
@@ -67,6 +67,28 @@ test('expect banner to be visible', async () => {
   expect(screen.getAllByText(responseJSON.summary)[0]).toBeInTheDocument();
   expect(screen.getByRole('img')).toBeInTheDocument();
   expect(screen.getByRole('img')).toHaveAttribute('src', responseJSON.image);
+});
+
+test('expect image to be hidden if there is a loading error', async () => {
+  const { getByRole, queryByRole } = render(ReleaseNotesBox);
+
+  const image: HTMLImageElement = await vi.waitFor(() => {
+    const img = getByRole('img', {
+      name: 'Podman Desktop 1.1.0 release image',
+    });
+    expect(img).toBeInTheDocument();
+    expect(img).instanceof(HTMLImageElement);
+    return img as HTMLImageElement;
+  });
+
+  // svelte never render the image, so we need
+  // to manually send an error event
+  await fireEvent.error(image);
+
+  await vi.waitFor(() => {
+    const img = queryByRole('img');
+    expect(img).toBeNull();
+  });
 });
 
 test('expect no release notes available', async () => {

--- a/packages/renderer/src/lib/dashboard/ReleaseNotesBox.svelte
+++ b/packages/renderer/src/lib/dashboard/ReleaseNotesBox.svelte
@@ -8,16 +8,19 @@ import type { ReleaseNotes } from '/@api/release-notes-info';
 
 import Markdown from '../markdown/Markdown.svelte';
 
-let showBanner = false;
-let notesAvailable = false;
-let notesURL: string;
-let currentVersion: string;
-let notesInfo: ReleaseNotes | undefined;
+let showBanner = $state(false);
+let notesAvailable = $state(false);
+let notesURL: string | undefined = $state();
+let currentVersion: string | undefined = $state();
+let notesInfo: ReleaseNotes | undefined = $state();
+let imageError: boolean = $state(false);
+
 const receiveShowReleaseNotes = window.events?.receive('show-release-notes', () => {
   showBanner = true;
 });
 
 async function openReleaseNotes() {
+  if (!notesURL) return;
   await window.openExternal(notesURL);
 }
 
@@ -43,6 +46,10 @@ onMount(async () => {
   await getInfoFromNotes();
 });
 
+function onImageError(): void {
+  imageError = true;
+}
+
 onDestroy(async () => {
   receiveShowReleaseNotes.dispose();
 });
@@ -51,9 +58,10 @@ onDestroy(async () => {
 {#if showBanner}
   {#if notesAvailable}
     <div class="flex bg-[var(--pd-content-card-bg)] rounded-md p-5 gap-3 flex-row flex-nowrap h-[200px] items-center">
-      {#if notesInfo?.image}
+      {#if notesInfo?.image && !imageError}
         <img
           src={notesInfo.image}
+          onerror={onImageError}
           class="max-h-[100%] w-auto max-w-[20%] object-contain rounded-md self-start"
           alt={`Podman Desktop ${currentVersion} release image`} />
       {/if}


### PR DESCRIPTION
### What does this PR do?

Hide the release note image if the image raise an error (including loading error)

> ℹ️ this was not easy to test, as the jest never render the image, so we can't just provide an invalid image (see https://github.com/jsdom/jsdom/issues/2154#issuecomment-366536401), the solution was found in https://stackoverflow.com/a/66976133)

### Screenshot / video of UI

![image](https://github.com/user-attachments/assets/5cd40e0b-088b-416b-a2eb-fa7cd4700f6e)

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/9663

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature

**Manually**

1. Open the inspect tab, 
2. Change the `src` property of the image of the release note to something invalid
3. Assert image has been hidden