### PR TITLE
chore: allow to set values for dropdown in DockerCompatibility

### DIFF
--- a/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityContributions.spec.ts
+++ b/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityContributions.spec.ts
@@ -19,6 +19,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { ContextUI } from '/@/lib/context/context';
@@ -31,18 +32,6 @@ import PreferencesDockerCompatibilityContributions from './PreferencesDockerComp
 
 beforeEach(() => {
   vi.resetAllMocks();
-
-  Object.defineProperty(global, 'window', {
-    value: {
-      getConfigurationValue: vi.fn(),
-      navigator: {
-        clipboard: {
-          writeText: vi.fn(),
-        },
-      },
-    },
-    writable: true,
-  });
 });
 
 test('display group', async () => {
@@ -144,4 +133,88 @@ test('no group if empty', async () => {
   // no list item
   const listItems = screen.queryAllByRole('list');
   expect(listItems.length).toBe(0);
+});
+
+test('display enum', async () => {
+  // one extension
+  extensionInfos.set([
+    {
+      id: 'my.extensionId',
+      name: 'My Extension',
+      description: 'My Extension description',
+      version: '1.0.0',
+      publisher: 'My Publisher',
+      icon: 'my-icon',
+      state: 'started',
+    } as ExtensionInfo,
+  ]);
+
+  // set the context value
+  const contextUi = new ContextUI();
+  context.set(contextUi);
+  const enumValues = [
+    { label: 'Value 1', value: 'value1', selected: false },
+    { label: 'Value 2', value: 'value2', selected: true },
+  ];
+  contextUi.setValue('my.extensionId.DockerCompatibility.my.property', enumValues);
+
+  configurationProperties.set([
+    {
+      id: 'my.property',
+      title: 'Property title',
+      markdownDescription: 'Property Description',
+      parentId: '',
+      type: 'string',
+      enum: [],
+      scope: 'DockerCompatibility',
+      group: 'my.extensionId',
+      extension: {
+        id: 'my.extensionId',
+      },
+    },
+  ]);
+
+  // mock the configuration
+  vi.mocked(window.updateConfigurationValue).mockResolvedValue();
+
+  render(PreferencesDockerCompatibilityContributions);
+
+  // check that the group is being displayed
+  const groupName = screen.getByRole('list', { name: 'my.extensionId' });
+  expect(groupName).toBeInTheDocument();
+
+  // search for text "My: Property"
+  const propertyTitle = screen.getByRole('status', { name: 'My: Property' });
+  expect(propertyTitle).toBeInTheDocument();
+
+  // check markdown description
+  const propertyDescription = screen.getByRole('document', { name: 'my.property' });
+  expect(propertyDescription).toBeInTheDocument();
+
+  // search for a combobox element
+  const dropdownElement = screen.getByRole('combobox');
+  expect(dropdownElement).toBeInTheDocument();
+
+  // check that the selected value is being displayed
+  const selectedValue = screen.getByRole('button', { name: 'Value 2' });
+  expect(selectedValue).toBeInTheDocument();
+
+  // click on the first child of the dropdown
+  await userEvent.click(selectedValue);
+
+  // check that the value 1 is also displayed
+  const value1 = screen.getByRole('button', { name: 'Value 1' });
+  expect(value1).toBeInTheDocument();
+
+  // click on the value 1
+  await userEvent.click(value1);
+
+  // check that the value 1 is now selected
+  const selectedValue1 = screen.getByRole('button', { name: 'Value 1' });
+  expect(selectedValue1).toBeInTheDocument();
+
+  // now expect that there is a call to update the configuration
+  await vi.waitFor(() =>
+    expect(window.updateConfigurationValue).toHaveBeenCalledWith('my.property', 'value1', 'DockerCompatibility'),
+  );
 });

--- a/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityContributions.spec.ts
+++ b/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityContributions.spec.ts
@@ -218,3 +218,106 @@ test('display enum', async () => {
     expect(window.updateConfigurationValue).toHaveBeenCalledWith('my.property', 'value1', 'DockerCompatibility'),
   );
 });
+
+test('check invalid enum (not array) makes no renderim as enum', async () => {
+  // one extension
+  extensionInfos.set([
+    {
+      id: 'my.extensionId',
+      name: 'My Extension',
+      description: 'My Extension description',
+      version: '1.0.0',
+      publisher: 'My Publisher',
+      icon: 'my-icon',
+      state: 'started',
+    } as ExtensionInfo,
+  ]);
+
+  // set the context value
+  const contextUi = new ContextUI();
+  context.set(contextUi);
+  contextUi.setValue(
+    'my.extensionId.DockerCompatibility.my.property',
+    'pure string, should be an array with expected fields',
+  );
+
+  configurationProperties.set([
+    {
+      id: 'my.property',
+      title: 'Property title',
+      markdownDescription: 'Property Description',
+      parentId: '',
+      type: 'string',
+      enum: [],
+      scope: 'DockerCompatibility',
+      group: 'my.extensionId',
+      extension: {
+        id: 'my.extensionId',
+      },
+    },
+  ]);
+
+  // mock the configuration
+  vi.mocked(window.updateConfigurationValue).mockResolvedValue();
+
+  render(PreferencesDockerCompatibilityContributions);
+
+  // check that the group is being displayed
+  const groupName = screen.getByRole('list', { name: 'my.extensionId' });
+  expect(groupName).toBeInTheDocument();
+
+  // search for a combobox element
+  const dropdownElement = screen.queryByRole('combobox');
+  expect(dropdownElement).not.toBeInTheDocument();
+});
+
+test('check invalid enum (missing fields) makes no renderim as enum', async () => {
+  // one extension
+  extensionInfos.set([
+    {
+      id: 'my.extensionId',
+      name: 'My Extension',
+      description: 'My Extension description',
+      version: '1.0.0',
+      publisher: 'My Publisher',
+      icon: 'my-icon',
+      state: 'started',
+    } as ExtensionInfo,
+  ]);
+
+  // set the context value
+  const contextUi = new ContextUI();
+  context.set(contextUi);
+  contextUi.setValue('my.extensionId.DockerCompatibility.my.property', [
+    { label: 'Value 1', value: 'value1' /*missing the selected field*/ },
+  ]);
+
+  configurationProperties.set([
+    {
+      id: 'my.property',
+      title: 'Property title',
+      markdownDescription: 'Property Description',
+      parentId: '',
+      type: 'string',
+      enum: [],
+      scope: 'DockerCompatibility',
+      group: 'my.extensionId',
+      extension: {
+        id: 'my.extensionId',
+      },
+    },
+  ]);
+
+  // mock the configuration
+  vi.mocked(window.updateConfigurationValue).mockResolvedValue();
+
+  render(PreferencesDockerCompatibilityContributions);
+
+  // check that the group is being displayed
+  const groupName = screen.getByRole('list', { name: 'my.extensionId' });
+  expect(groupName).toBeInTheDocument();
+
+  // search for a combobox element
+  const dropdownElement = screen.queryByRole('combobox');
+  expect(dropdownElement).not.toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityContributions.svelte
+++ b/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityContributions.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 /* eslint-disable import/no-duplicates */
+import { Dropdown } from '@podman-desktop/ui-svelte';
 import { onDestroy, onMount } from 'svelte';
 import { get, type Unsubscriber, type Writable } from 'svelte/store';
 
@@ -50,8 +51,17 @@ onDestroy(() => {
   }
 });
 
+interface EnumItem {
+  label: string;
+  value: string;
+  selected: boolean;
+}
+
 interface PropertyWithDisplayName extends IConfigurationPropertyRecordedSchema {
+  id: string;
   displayName: string;
+  selectedValue?: string;
+  enumItems?: EnumItem[];
 }
 
 interface GroupItem {
@@ -115,11 +125,34 @@ function extractGroupItems(): void {
 
       const displayName = `${leftPart}: ${rightPart}`;
 
-      // add the property to the group
-      groupItem.properties.push({ ...property, displayName });
+      if (property.id) {
+        const newItem: PropertyWithDisplayName = { ...property, id: property.id, displayName };
+
+        // do we have a dynamic enum ?
+        if (property.enum) {
+          // get the enum from the context using the following key
+          // ${groupName}.DockerCompatibility.${property.id}
+
+          // get the enum from the context
+          const enumKey = `${name}.DockerCompatibility.${property.id}`;
+          const enumItems = globalContext.getValue<EnumItem[]>(enumKey);
+          if (enumItems) {
+            newItem.enumItems = enumItems;
+            newItem.selectedValue = enumItems.find(item => item.selected)?.value;
+          }
+        }
+
+        // add the property to the group
+        groupItem.properties.push(newItem);
+      }
     }
   }
   groupItems.items = updatedGroupItems;
+}
+
+async function onChangeProperty(property: PropertyWithDisplayName, value: unknown): Promise<void> {
+  // notify a configuration change using the DockerCompatibility scope
+  await window.updateConfigurationValue(property.id, value, 'DockerCompatibility');
 }
 </script>
 
@@ -156,6 +189,16 @@ function extractGroupItems(): void {
                   <Markdown markdown={property.markdownDescription} />
                 </div>
               </div>
+              {#if property.enumItems && property.enumItems.length > 0}
+                <Dropdown
+                  name="select-property-{property.id}"
+                  ariaLabel="dropdown for property {property.id}"
+                  disabled={property.enumItems.length === 0}
+                  bind:value={property.selectedValue}
+                  onChange={(val: unknown) => onChangeProperty(property, val)}
+                  options={property.enumItems}>
+                </Dropdown>
+              {/if}
             </div>
           </div>
         </div>

--- a/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityContributions.svelte
+++ b/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityContributions.svelte
@@ -135,7 +135,20 @@ function extractGroupItems(): void {
 
           // get the enum from the context
           const enumKey = `${name}.DockerCompatibility.${property.id}`;
-          const enumItems = globalContext.getValue<EnumItem[]>(enumKey);
+          const enumItemsRaw = globalContext.getValue<unknown>(enumKey);
+
+          // check if the raw value is an array and contains the expected fields of EnumItem type
+          if (!Array.isArray(enumItemsRaw)) {
+            continue;
+          }
+          if (
+            !enumItemsRaw.every(
+              item => typeof item === 'object' && 'label' in item && 'value' in item && 'selected' in item,
+            )
+          ) {
+            continue;
+          }
+          const enumItems = enumItemsRaw as EnumItem[];
           if (enumItems) {
             newItem.enumItems = enumItems;
             newItem.selectedValue = enumItems.find(item => item.selected)?.value;


### PR DESCRIPTION
### What does this PR do?
extensions can register enum values for a DockerCompatibility property using the `context.setValue` and scope 'DockerCompatibility'
It'll register the dropdown. Each time the user select a value in the dropdown, a configuration change event is thrown that extensions can intercept


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/podman-desktop/podman-desktop/issues/10514

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
