### PR TITLE
fix(push-manifest): terminal overflow

### DIFF
--- a/packages/renderer/src/lib/image/PushManifestModal.spec.ts
+++ b/packages/renderer/src/lib/image/PushManifestModal.spec.ts
@@ -40,13 +40,9 @@ vi.mock('@xterm/xterm', () => {
 });
 
 beforeAll(() => {
-  (window.events as unknown) = {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    receive: (_channel: string, func: any) => {
-      func();
-    },
-  };
-  (window.dispatchEvent as unknown) = vi.fn();
+  Object.defineProperty(window, 'dispatchEvent', {
+    value: vi.fn(),
+  });
 });
 
 const fakedManifest: ImageInfoUI = {

--- a/packages/renderer/src/lib/image/PushManifestModal.spec.ts
+++ b/packages/renderer/src/lib/image/PushManifestModal.spec.ts
@@ -39,9 +39,6 @@ vi.mock('@xterm/xterm', () => {
   };
 });
 
-const getConfigurationValueMock = vi.fn();
-const pushManifestMock = vi.fn();
-
 beforeAll(() => {
   (window.events as unknown) = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -49,13 +46,7 @@ beforeAll(() => {
       func();
     },
   };
-  (window as any).ResizeObserver = vi.fn().mockReturnValue({ observe: vi.fn(), unobserve: vi.fn() });
-  (window as any).getImageInspect = vi.fn().mockImplementation(() => Promise.resolve({}));
-  (window as any).logsContainer = vi.fn().mockResolvedValue(undefined);
-  (window as any).refreshTerminal = vi.fn();
-  (window as any).getConfigurationValue = getConfigurationValueMock;
-  (window as any).showMessageBox = vi.fn();
-  (window as any).pushManifest = pushManifestMock;
+  (window.dispatchEvent as unknown) = vi.fn();
 });
 
 const fakedManifest: ImageInfoUI = {
@@ -95,4 +86,14 @@ test('Expect to render PushManifestModal correctly with Push manifest button', a
 
   // Be able to click it
   fireEvent.click(pushButton);
+
+  // expect resize event to be dispatched
+  const event: Event = await vi.waitFor(() => {
+    expect(window.dispatchEvent).toHaveBeenCalled();
+    const calls = vi.mocked(window.dispatchEvent).mock.calls;
+    expect(calls).toHaveLength(1);
+    expect(calls[0][0]).toBeInstanceOf(Event);
+    return calls[0][0];
+  });
+  expect(event.type).toBe('resize');
 });

--- a/packages/renderer/src/lib/image/PushManifestModal.svelte
+++ b/packages/renderer/src/lib/image/PushManifestModal.svelte
@@ -20,6 +20,7 @@ let logsPush: Terminal;
 async function pushManifest() {
   initTerminal = true;
   await tick();
+  window.dispatchEvent(new Event('resize'));
   logsPush?.reset();
 
   pushInProgress = true;
@@ -58,8 +59,8 @@ async function pushManifestFinished() {
         {/if}
       </p>
     {/if}
-    <div hidden={initTerminal === false}>
-      <TerminalWindow bind:terminal={logsPush} disableStdIn />
+    <div class="h-[185px] max-w-full w-full" hidden={initTerminal === false}>
+      <TerminalWindow class="h-full" bind:terminal={logsPush} disableStdIn />
     </div>
   </div>
 

--- a/packages/renderer/src/lib/image/PushManifestModal.svelte
+++ b/packages/renderer/src/lib/image/PushManifestModal.svelte
@@ -59,7 +59,7 @@ async function pushManifestFinished() {
         {/if}
       </p>
     {/if}
-    <div class="h-[185px] max-w-full w-full" hidden={initTerminal === false}>
+    <div class="h-[185px]" hidden={initTerminal === false}>
       <TerminalWindow class="h-full" bind:terminal={logsPush} disableStdIn />
     </div>
   </div>


### PR DESCRIPTION
### What does this PR do?

The `PushManifestModal.svelte` is heavily inspired from `PushImageModal`. In the PushImageModal the following line ensure the terminal properly fit the area

https://github.com/podman-desktop/podman-desktop/blob/40c3807845576a8e31bb649e208d10fd1e60bc9f/packages/renderer/src/lib/image/PushImageModal.svelte#L36

so this PR simply add this missing line to the PushManifestModal. Moreover, the PushImageTerminal had some classes to define the sizes and height, this PR copy the values that were missing to ensure consistency 

https://github.com/podman-desktop/podman-desktop/blob/40c3807845576a8e31bb649e208d10fd1e60bc9f/packages/renderer/src/lib/image/PushImageModal.svelte#L111-L113

### Screenshot / video of UI

**Before**
![image](https://github.com/user-attachments/assets/da8c2946-4e5a-4bc2-9038-6f31b1a38ccd)

**After**
![image](https://github.com/user-attachments/assets/dbb375af-a3dd-414b-b3fa-02f6d75ea691)

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/10306

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
