### PR TITLE
chore: add esnext so can use private # variables

### DIFF
--- a/extensions/docker/tsconfig.json
+++ b/extensions/docker/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "Node",
     "strict": true,
     "lib": ["ES2017", "webworker"],
     "sourceMap": true,


### PR DESCRIPTION
### What does this PR do?
I want to be able to use private variables in the docker extension using `#`
need to change the source content

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

https://github.com/podman-desktop/podman-desktop/pull/10526

### How to test this PR?

should work as before

- [ ] Tests are covering the bug fix or the new feature
