### PR TITLE
test(ui): adding unit tests for TerminalWindows

### DIFF
--- a/packages/renderer/src/lib/ui/TerminalWindows.spec.ts
+++ b/packages/renderer/src/lib/ui/TerminalWindows.spec.ts
@@ -22,7 +22,7 @@ import { render } from '@testing-library/svelte';
 import { FitAddon } from '@xterm/addon-fit';
 import { Terminal } from '@xterm/xterm';
 import { writable } from 'svelte/store';
-import { beforeEach, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
 import TerminalWindow from '/@/lib/ui/TerminalWindow.svelte';
 
@@ -54,10 +54,10 @@ beforeEach(() => {
 
   vi.mocked(Terminal).mockReturnValue(TerminalMock);
   vi.mocked(FitAddon).mockReturnValue(FitAddonMock);
+});
 
-  Object.defineProperty(window, 'addEventListener', {
-    value: vi.fn(),
-  });
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 test('expect terminal constructor to have been called on mount', async () => {
@@ -139,6 +139,9 @@ test('addon fit should be loaded on mount', async () => {
 });
 
 test('matchMedia resize listener should trigger fit addon', async () => {
+  // spy the event listener
+  vi.spyOn(window, 'addEventListener');
+
   render(TerminalWindow, {
     terminal: writable() as unknown as Terminal,
   });

--- a/packages/renderer/src/lib/ui/TerminalWindows.spec.ts
+++ b/packages/renderer/src/lib/ui/TerminalWindows.spec.ts
@@ -28,32 +28,12 @@ import TerminalWindow from '/@/lib/ui/TerminalWindow.svelte';
 
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
 
-vi.mock('@xterm/xterm', () => ({
-  Terminal: vi.fn(),
-}));
+vi.mock('@xterm/xterm');
 
-vi.mock('@xterm/addon-fit', () => ({
-  FitAddon: vi.fn(),
-}));
-
-const TerminalMock: Terminal = {
-  onWriteParsed: vi.fn(),
-  onResize: vi.fn(),
-  dispose: vi.fn(),
-  loadAddon: vi.fn(),
-  open: vi.fn(),
-  write: vi.fn(),
-} as unknown as Terminal;
-
-const FitAddonMock: FitAddon = {
-  fit: vi.fn(),
-} as unknown as FitAddon;
+vi.mock('@xterm/addon-fit');
 
 beforeEach(() => {
   vi.resetAllMocks();
-
-  vi.mocked(Terminal).mockReturnValue(TerminalMock);
-  vi.mocked(FitAddon).mockReturnValue(FitAddonMock);
 });
 
 afterEach(() => {
@@ -98,7 +78,7 @@ test('showCursor false or undefined should write specific instruction to termina
   await vi.waitFor(() => {
     expect(Terminal).toHaveBeenCalledOnce();
   });
-  expect(TerminalMock.write).toHaveBeenCalledWith('\x1b[?25l');
+  expect(Terminal.prototype.write).toHaveBeenCalledWith('\x1b[?25l');
 });
 
 test('terminal constructor should contains fontSize and lineHeight from configuration', async () => {
@@ -126,6 +106,12 @@ test('terminal constructor should contains fontSize and lineHeight from configur
 });
 
 test('addon fit should be loaded on mount', async () => {
+  const fitAddonMock = {
+    fit: vi.fn(),
+  } as unknown as FitAddon;
+
+  vi.mocked(FitAddon).mockReturnValue(fitAddonMock);
+
   render(TerminalWindow, {
     terminal: writable() as unknown as Terminal,
   });
@@ -135,7 +121,7 @@ test('addon fit should be loaded on mount', async () => {
   });
 
   expect(FitAddon).toHaveBeenCalled();
-  expect(TerminalMock.loadAddon).toHaveBeenCalledWith(FitAddonMock);
+  expect(Terminal.prototype.loadAddon).toHaveBeenCalledWith(fitAddonMock);
 });
 
 test('matchMedia resize listener should trigger fit addon', async () => {
@@ -156,10 +142,10 @@ test('matchMedia resize listener should trigger fit addon', async () => {
   });
 
   // reset fit calls count
-  vi.mocked(FitAddonMock.fit).mockReset();
-  expect(FitAddonMock.fit).not.toHaveBeenCalled();
+  vi.mocked(FitAddon.prototype.fit).mockReset();
+  expect(FitAddon.prototype.fit).not.toHaveBeenCalled();
 
   listener();
 
-  expect(FitAddonMock.fit).toHaveBeenCalled();
+  expect(FitAddon.prototype.fit).toHaveBeenCalled();
 });

--- a/packages/renderer/src/lib/ui/TerminalWindows.spec.ts
+++ b/packages/renderer/src/lib/ui/TerminalWindows.spec.ts
@@ -1,0 +1,162 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render } from '@testing-library/svelte';
+import { FitAddon } from '@xterm/addon-fit';
+import { Terminal } from '@xterm/xterm';
+import { writable } from 'svelte/store';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import TerminalWindow from '/@/lib/ui/TerminalWindow.svelte';
+
+import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: vi.fn(),
+}));
+
+vi.mock('@xterm/addon-fit', () => ({
+  FitAddon: vi.fn(),
+}));
+
+const TerminalMock: Terminal = {
+  onWriteParsed: vi.fn(),
+  onResize: vi.fn(),
+  dispose: vi.fn(),
+  loadAddon: vi.fn(),
+  open: vi.fn(),
+  write: vi.fn(),
+} as unknown as Terminal;
+
+const FitAddonMock: FitAddon = {
+  fit: vi.fn(),
+} as unknown as FitAddon;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  vi.mocked(Terminal).mockReturnValue(TerminalMock);
+  vi.mocked(FitAddon).mockReturnValue(FitAddonMock);
+
+  Object.defineProperty(window, 'addEventListener', {
+    value: vi.fn(),
+  });
+});
+
+test('expect terminal constructor to have been called on mount', async () => {
+  render(TerminalWindow, {
+    terminal: writable() as unknown as Terminal,
+  });
+
+  await vi.waitFor(() => {
+    expect(Terminal).toHaveBeenCalledOnce();
+  });
+});
+
+test('expect terminal constructor to reflect props', async () => {
+  render(TerminalWindow, {
+    terminal: writable() as unknown as Terminal,
+    disableStdin: true,
+    convertEol: true,
+    screenReaderMode: true,
+  });
+
+  await vi.waitFor(() => {
+    expect(Terminal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        disableStdin: true,
+        convertEol: true,
+        screenReaderMode: true,
+      }),
+    );
+  });
+});
+
+test('showCursor false or undefined should write specific instruction to terminal', async () => {
+  render(TerminalWindow, {
+    terminal: writable() as unknown as Terminal,
+    showCursor: false,
+  });
+
+  await vi.waitFor(() => {
+    expect(Terminal).toHaveBeenCalledOnce();
+  });
+  expect(TerminalMock.write).toHaveBeenCalledWith('\x1b[?25l');
+});
+
+test('terminal constructor should contains fontSize and lineHeight from configuration', async () => {
+  vi.mocked(window.getConfigurationValue).mockResolvedValue(10);
+
+  render(TerminalWindow, {
+    terminal: writable() as unknown as Terminal,
+  });
+
+  await vi.waitFor(() => {
+    expect(Terminal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fontSize: 10,
+        lineHeight: 10,
+      }),
+    );
+  });
+
+  expect(window.getConfigurationValue).toHaveBeenCalledWith(
+    TerminalSettings.SectionName + '.' + TerminalSettings.FontSize,
+  );
+  expect(window.getConfigurationValue).toHaveBeenCalledWith(
+    TerminalSettings.SectionName + '.' + TerminalSettings.LineHeight,
+  );
+});
+
+test('addon fit should be loaded on mount', async () => {
+  render(TerminalWindow, {
+    terminal: writable() as unknown as Terminal,
+  });
+
+  await vi.waitFor(() => {
+    expect(Terminal).toHaveBeenCalled();
+  });
+
+  expect(FitAddon).toHaveBeenCalled();
+  expect(TerminalMock.loadAddon).toHaveBeenCalledWith(FitAddonMock);
+});
+
+test('matchMedia resize listener should trigger fit addon', async () => {
+  render(TerminalWindow, {
+    terminal: writable() as unknown as Terminal,
+  });
+
+  const listener: () => void = await vi.waitFor(() => {
+    expect(window.addEventListener).toHaveBeenCalled();
+    const call = vi.mocked(window.addEventListener).mock.calls;
+    expect(call).toHaveLength(1);
+    expect(call[0][0]).toBe('resize');
+    expect(call[0][1]).toBeInstanceOf(Function);
+    return call[0][1] as unknown as () => void;
+  });
+
+  // reset fit calls count
+  vi.mocked(FitAddonMock.fit).mockReset();
+  expect(FitAddonMock.fit).not.toHaveBeenCalled();
+
+  listener();
+
+  expect(FitAddonMock.fit).toHaveBeenCalled();
+});


### PR DESCRIPTION
### What does this PR do?

While working on https://github.com/podman-desktop/podman-desktop/pull/10527 I noticed we do not have much tests for the `TerminalWindows` component.

Since we are using it in a lot of places, adding unit tests. 

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Required for https://github.com/podman-desktop/podman-desktop/issues/9726

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
