### PR TITLE
feat: init experimental for preferences items

### DIFF
--- a/packages/main/src/plugin/tasks/task-manager.spec.ts
+++ b/packages/main/src/plugin/tasks/task-manager.spec.ts
@@ -81,6 +81,9 @@ test('task manager init should register a configuration option', async () => {
             type: 'boolean',
             description: 'Replace the current task manager widget by the new one',
             default: false,
+            experimental: {
+              githubDiscussionLink: expect.any(String),
+            },
           },
         }),
       }),

--- a/packages/main/src/plugin/tasks/task-manager.spec.ts
+++ b/packages/main/src/plugin/tasks/task-manager.spec.ts
@@ -82,7 +82,7 @@ test('task manager init should register a configuration option', async () => {
             description: 'Replace the current task manager widget by the new one',
             default: false,
             experimental: {
-              githubDiscussionLink: expect.any(String),
+              githubDiscussionLink: expect.stringContaining('github.com/podman-desktop/podman-desktop/discussions'),
             },
           },
         }),

--- a/packages/main/src/plugin/tasks/task-manager.ts
+++ b/packages/main/src/plugin/tasks/task-manager.ts
@@ -78,6 +78,9 @@ export class TaskManager {
             description: 'Replace the current task manager widget by the new one',
             type: 'boolean',
             default: false,
+            experimental: {
+              githubDiscussionLink: 'https://github.com/podman-desktop/podman-desktop/discussions/10533',
+            },
           },
         },
       },

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.spec.ts
@@ -49,7 +49,7 @@ test('experimental record should have clickable GitHub link', async () => {
   });
 
   const link: HTMLElement = await vi.waitFor(() => {
-    const element = getByRole('link', { name: 'GitHub discussion link' });
+    const element = getByRole('button', { name: 'Share feedback' });
     expect(element).toBeInTheDocument();
     return element;
   });

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.spec.ts
@@ -1,0 +1,74 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import PreferencesRenderingItem from '/@/lib/preferences/PreferencesRenderingItem.svelte';
+
+import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
+
+const EXPERIMENTAL_RECORD: IConfigurationPropertyRecordedSchema = {
+  id: 'record',
+  title: 'Hello',
+  parentId: 'parent.record',
+  description: 'record-description',
+  type: 'integer',
+  minimum: 1,
+  maximum: 15,
+  experimental: {
+    githubDiscussionLink: 'https://github.com/podman-desktop',
+  },
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(window.openExternal).mockResolvedValue(undefined);
+});
+
+test('experimental record should have clickable GitHub link', async () => {
+  const { getByRole } = render(PreferencesRenderingItem, {
+    record: EXPERIMENTAL_RECORD,
+  });
+
+  const link: HTMLElement = await vi.waitFor(() => {
+    const element = getByRole('link', { name: 'GitHub discussion link' });
+    expect(element).toBeInTheDocument();
+    return element;
+  });
+
+  await fireEvent.click(link);
+
+  await vi.waitFor(() => {
+    expect(window.openExternal).toHaveBeenCalledWith(EXPERIMENTAL_RECORD.experimental?.githubDiscussionLink);
+  });
+});
+
+test('experimental record should have flask icon', async () => {
+  const { queryAllByRole } = render(PreferencesRenderingItem, {
+    record: EXPERIMENTAL_RECORD,
+  });
+
+  await vi.waitFor(() => {
+    const elements = queryAllByRole('img', { hidden: true });
+    expect(elements.length).toBeGreaterThan(0);
+    expect(elements.find(element => element.textContent === 'experimental')).toBeDefined();
+  });
+});

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 import { faArrowUpRightFromSquare, faFlask } from '@fortawesome/free-solid-svg-icons';
-import { Link } from '@podman-desktop/ui-svelte';
+import { Button } from '@podman-desktop/ui-svelte';
 import Fa from 'svelte-fa';
 
 import { getInitialValue } from '/@/lib/preferences/Util';
+import Badge from '/@/lib/ui/Badge.svelte';
 import RefreshButton from '/@/lib/ui/RefreshButton.svelte';
 
 import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
@@ -69,7 +70,7 @@ function openGitHubDiscussion(): void {
 }
 </script>
 
-<div class="flex flex-col px-2 py-2 w-full text-[color:var(--pd-invert-content-card-text)] space-y-2">
+<div class="flex flex-col px-2 py-2 w-full text-[color:var(--pd-invert-content-card-text)] space-y-4">
   <div class="flex flex-row justify-between">
     <div
       class="flex flex-col {recordUI.original.type === 'string' &&
@@ -77,10 +78,13 @@ function openGitHubDiscussion(): void {
       ? 'w-full'
       : ''}">
       <div class="flex flex-row text-[color:var(--pd-invert-content-card-text)]">
-        <div class="flex flex-row space-x-1 items-center">
-          <span>{recordUI.title}</span>
-          {#if record.experimental?.githubDiscussionLink !== undefined}
-            <Fa title="experimental" size="xs" icon={faFlask}/>
+        <div class="flex flex-row space-x-2 items-center">
+          <span class="font-semibold">{recordUI.title}</span>
+          {#if record.experimental !== undefined}
+            <Badge class="text-[8px] flex flex-row space-x-1 items-center" label="Experimental" >
+              <Fa title="experimental" size="xs" icon={faFlask}/>
+              <span>Experimental</span>
+            </Badge>
           {/if}
         </div>
         {#if showResetButton}
@@ -115,11 +119,12 @@ function openGitHubDiscussion(): void {
     {/if}
   </div>
   {#if record.experimental?.githubDiscussionLink !== undefined}
-    <Link aria-label="GitHub discussion link" on:click={openGitHubDiscussion} class="flex flex-row space-x-1 w-min items-center">
-      <span class="text-nowrap text-sm">
-        Join discussion on GitHub
-      </span>
-      <Fa icon={faArrowUpRightFromSquare}/>
-    </Link>
+    <Button
+      padding="px-3 py-1"
+      class="w-min"
+      title="Share feedback on GitHub discussion"
+      icon={faArrowUpRightFromSquare}
+      on:click={openGitHubDiscussion}
+    >Share feedback</Button>
   {/if}
 </div>

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
@@ -63,10 +63,10 @@ function doResetToDefault() {
   resetToDefault = true;
 }
 
-function openGitHubDiscussion(): void {
+async function openGitHubDiscussion(): Promise<void> {
   if (!recordUI.experimental?.githubDiscussionLink) return;
 
-  window.openExternal(recordUI.experimental.githubDiscussionLink).catch(console.error);
+  return window.openExternal(recordUI.experimental.githubDiscussionLink);
 }
 </script>
 
@@ -120,7 +120,7 @@ function openGitHubDiscussion(): void {
         initialValue={getInitialValue(recordUI.original)} />
     {/if}
   </div>
-  {#if record.experimental?.githubDiscussionLink !== undefined}
+  {#if record.experimental?.githubDiscussionLink}
     <Button
       padding="px-3 py-1"
       class="w-min"

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
@@ -4,7 +4,7 @@ import { Button } from '@podman-desktop/ui-svelte';
 import Fa from 'svelte-fa';
 
 import { getInitialValue } from '/@/lib/preferences/Util';
-import Badge from '/@/lib/ui/Badge.svelte';
+import Label from '/@/lib/ui/Label.svelte';
 import RefreshButton from '/@/lib/ui/RefreshButton.svelte';
 
 import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
@@ -81,10 +81,12 @@ function openGitHubDiscussion(): void {
         <div class="flex flex-row space-x-2 items-center">
           <span class="font-semibold">{recordUI.title}</span>
           {#if record.experimental !== undefined}
-            <Badge class="text-[8px] flex flex-row space-x-1 items-center" label="Experimental" >
-              <Fa title="experimental" size="xs" icon={faFlask}/>
-              <span>Experimental</span>
-            </Badge>
+            <Label>
+              <div class="flex flex-row space-x-1 items-center">
+                <Fa title="experimental" size="xs" icon={faFlask}/>
+                <span>Experimental</span>
+              </div>
+            </Label>
           {/if}
         </div>
         {#if showResetButton}

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
@@ -1,4 +1,8 @@
 <script lang="ts">
+import { faArrowUpRightFromSquare, faFlask } from '@fortawesome/free-solid-svg-icons';
+import { Link } from '@podman-desktop/ui-svelte';
+import Fa from 'svelte-fa';
+
 import { getInitialValue } from '/@/lib/preferences/Util';
 import RefreshButton from '/@/lib/ui/RefreshButton.svelte';
 
@@ -36,6 +40,7 @@ const recordUI = $derived.by(() => {
     description: record.description,
     markdownDescription: record.markdownDescription,
     original: record,
+    experimental: record.experimental,
   };
 });
 
@@ -56,30 +61,51 @@ function updateResetButtonVisibility(recordValue: unknown) {
 function doResetToDefault() {
   resetToDefault = true;
 }
+
+function openGitHubDiscussion(): void {
+  if (!recordUI.experimental?.githubDiscussionLink) return;
+
+  window.openExternal(recordUI.experimental.githubDiscussionLink).catch(console.error);
+}
 </script>
 
-<div class="flex flex-row px-2 py-2 justify-between w-full text-[color:var(--pd-invert-content-card-text)]">
-  <div
-    class="flex flex-col {recordUI.original.type === 'string' &&
+<div class="flex flex-col px-2 py-2 w-full text-[color:var(--pd-invert-content-card-text)] space-y-2">
+  <div class="flex flex-row justify-between">
+    <div
+      class="flex flex-col {recordUI.original.type === 'string' &&
     (!recordUI.original.enum || recordUI.original.enum.length === 0)
       ? 'w-full'
       : ''}">
-    <div class="flex flex-row text-[color:var(--pd-invert-content-card-text)]">
-      {recordUI.title}
-      {#if showResetButton}
-        <div class="ml-2">
-          <RefreshButton label="Reset to default value" onclick={doResetToDefault} />
+      <div class="flex flex-row text-[color:var(--pd-invert-content-card-text)]">
+        <div class="flex flex-row space-x-1 items-center">
+          <span>{recordUI.title}</span>
+          {#if record.experimental?.githubDiscussionLink !== undefined}
+            <Fa title="experimental" size="xs" icon={faFlask}/>
+          {/if}
         </div>
+        {#if showResetButton}
+          <div class="ml-2">
+            <RefreshButton label="Reset to default value" onclick={doResetToDefault} />
+          </div>
+        {/if}
+      </div>
+      {#if recordUI.markdownDescription}
+        <div class="pt-1 text-[color:var(--pd-invert-content-card-text)] text-sm pr-2">
+          <Markdown markdown={recordUI.markdownDescription} />
+        </div>
+      {:else}
+        <div class="pt-1 text-[color:var(--pd-invert-content-card-text)] text-sm pr-2">{recordUI.description}</div>
+      {/if}
+      {#if recordUI.original.type === 'string' && (!recordUI.original.enum || recordUI.original.enum.length === 0)}
+        <PreferencesRenderingItemFormat
+          record={recordUI.original}
+          updateResetButtonVisibility={updateResetButtonVisibility}
+          resetToDefault={resetToDefault}
+          enableAutoSave={true}
+          initialValue={getInitialValue(recordUI.original)} />
       {/if}
     </div>
-    {#if recordUI.markdownDescription}
-      <div class="pt-1 text-[color:var(--pd-invert-content-card-text)] text-sm pr-2">
-        <Markdown markdown={recordUI.markdownDescription} />
-      </div>
-    {:else}
-      <div class="pt-1 text-[color:var(--pd-invert-content-card-text)] text-sm pr-2">{recordUI.description}</div>
-    {/if}
-    {#if recordUI.original.type === 'string' && (!recordUI.original.enum || recordUI.original.enum.length === 0)}
+    {#if recordUI.original.type !== 'string' || (recordUI.original.enum && recordUI.original.enum.length > 0)}
       <PreferencesRenderingItemFormat
         record={recordUI.original}
         updateResetButtonVisibility={updateResetButtonVisibility}
@@ -88,12 +114,12 @@ function doResetToDefault() {
         initialValue={getInitialValue(recordUI.original)} />
     {/if}
   </div>
-  {#if recordUI.original.type !== 'string' || (recordUI.original.enum && recordUI.original.enum.length > 0)}
-    <PreferencesRenderingItemFormat
-      record={recordUI.original}
-      updateResetButtonVisibility={updateResetButtonVisibility}
-      resetToDefault={resetToDefault}
-      enableAutoSave={true}
-      initialValue={getInitialValue(recordUI.original)} />
+  {#if record.experimental?.githubDiscussionLink !== undefined}
+    <Link aria-label="GitHub discussion link" on:click={openGitHubDiscussion} class="flex flex-row space-x-1 w-min items-center">
+      <span class="text-nowrap text-sm">
+        Join discussion on GitHub
+      </span>
+      <Fa icon={faArrowUpRightFromSquare}/>
+    </Link>
   {/if}
 </div>

--- a/packages/renderer/src/lib/ui/Badge.svelte
+++ b/packages/renderer/src/lib/ui/Badge.svelte
@@ -1,13 +1,19 @@
 <script lang="ts">
-import { onMount } from 'svelte';
+import { onMount, type Snippet } from 'svelte';
 
 import { AppearanceUtil } from '/@/lib/appearance/appearance-util';
 
-export let color: string | { light: string; dark: string } = 'bg-[var(--pd-badge-gray)]';
-export let label: string = '';
+interface Props {
+  color?: string | { light: string; dark: string };
+  label: string;
+  children?: Snippet;
+  class?: string;
+}
 
-let customStyle: string = '';
-let customClass: string = '';
+let { color = 'bg-[var(--pd-badge-gray)]', label = '', class: className, children }: Props = $props();
+
+let customStyle: string = $state('');
+let customClass: string = $state('');
 
 onMount(async () => {
   const appearanceUtil = new AppearanceUtil();
@@ -26,6 +32,10 @@ onMount(async () => {
 });
 </script>
 
-<div class="text-[var(--pd-badge-text)] text-xs me-2 px-1 py-0.5 rounded select-none {customClass} {$$props.class}" style={customStyle}>
-  {label}
+<div class="text-[var(--pd-badge-text)] text-xs me-2 px-1 py-0.5 rounded select-none {customClass} {className}" style={customStyle}>
+  {#if children}
+    {@render children()}
+  {:else}
+    {label}
+  {/if}
 </div>

--- a/packages/renderer/src/lib/ui/Badge.svelte
+++ b/packages/renderer/src/lib/ui/Badge.svelte
@@ -1,19 +1,13 @@
 <script lang="ts">
-import { onMount, type Snippet } from 'svelte';
+import { onMount } from 'svelte';
 
 import { AppearanceUtil } from '/@/lib/appearance/appearance-util';
 
-interface Props {
-  color?: string | { light: string; dark: string };
-  label: string;
-  children?: Snippet;
-  class?: string;
-}
+export let color: string | { light: string; dark: string } = 'bg-[var(--pd-badge-gray)]';
+export let label: string = '';
 
-let { color = 'bg-[var(--pd-badge-gray)]', label = '', class: className, children }: Props = $props();
-
-let customStyle: string = $state('');
-let customClass: string = $state('');
+let customStyle: string = '';
+let customClass: string = '';
 
 onMount(async () => {
   const appearanceUtil = new AppearanceUtil();
@@ -32,10 +26,6 @@ onMount(async () => {
 });
 </script>
 
-<div class="text-[var(--pd-badge-text)] text-xs me-2 px-1 py-0.5 rounded select-none {customClass} {className}" style={customStyle}>
-  {#if children}
-    {@render children()}
-  {:else}
-    {label}
-  {/if}
+<div class="text-[var(--pd-badge-text)] text-xs me-2 px-1 py-0.5 rounded select-none {customClass} {$$props.class}" style={customStyle}>
+  {label}
 </div>


### PR DESCRIPTION
### What does this PR do?

This PR change the `PreferencesRenderingItem.svelte` component to support redirecting the experimental GitHub discussion link we introduced in https://github.com/podman-desktop/podman-desktop/pull/10437.

> The goal would be to have a dedicated sections in the settings, next to the preferences, where we would group the experimental feature. We will duplicate the items, experimental preferences will always be visible on the preferences, the experimental section will be some kind of filtering.

> ⁉️ I added a flask icon on the title of the item to differentiate them from the others, I feel in the preferences we need to have some kind of indication, otherwise the user may wondering _Why some feature have a link and not others?_ @slemeur  made the remark that we may want to have `experimental` as a tooltip, or as text next to the flask, open to feedback. We can iterate and see.

### Screenshot / video of UI

![image](https://github.com/user-attachments/assets/13429ec1-0ac0-474d-b5e7-6f883e9fe741)

![image](https://github.com/user-attachments/assets/8bd92f0a-d7fc-4479-ae2f-2d0fa5f0756d)

### What issues does this PR fix or reference?

- Following https://github.com/podman-desktop/podman-desktop/pull/10437
- Part of https://github.com/podman-desktop/podman-desktop/issues/10223

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
