### PR TITLE
chore: use correct contexts if a custom docker config is set

### DIFF
--- a/extensions/docker/package.json
+++ b/extensions/docker/package.json
@@ -44,6 +44,11 @@
           "markdownDescription": "Select the active Docker CLI context:",
           "group": "podman-desktop.docker",
           "scope": "DockerCompatibility"
+        },
+        "docker.config": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Docker Config directory. See [documentation](https://docs.docker.com/reference/cli/docker/#configuration-files)"
         }
       }
     }

--- a/extensions/docker/src/docker-config.spec.ts
+++ b/extensions/docker/src/docker-config.spec.ts
@@ -1,0 +1,88 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Configuration } from '@podman-desktop/api';
+import { configuration } from '@podman-desktop/api';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { DockerConfig } from './docker-config.js';
+
+vi.mock('@podman-desktop/api', async () => {
+  return {
+    configuration: {
+      getConfiguration: vi.fn(),
+      onDidChangeConfiguration: vi.fn(),
+    },
+  };
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('check default path if there is no config', async () => {
+  // mock configuration.getConfiguration
+  vi.mocked(configuration.getConfiguration).mockReturnValue({
+    get: vi.fn(() => undefined),
+  } as unknown as Configuration);
+
+  const dockerConfig = new DockerConfig();
+  const path = dockerConfig.getPath();
+  expect(path).toBe(DockerConfig.DEFAULT_CONFIG_FOLDER);
+});
+
+test('check path if there is a config', async () => {
+  const myFakeConfig = 'myCustomPath';
+
+  // mock configuration.getConfiguration
+  vi.mocked(configuration.getConfiguration).mockReturnValue({
+    get: vi.fn(() => myFakeConfig),
+  } as unknown as Configuration);
+
+  const dockerConfig = new DockerConfig();
+  const path = dockerConfig.getPath();
+  expect(path).toBe(myFakeConfig);
+});
+
+test('check path is updated if the config changes', async () => {
+  // mock configuration.getConfiguration with an undefined value
+  vi.mocked(configuration.getConfiguration).mockReturnValue({
+    get: vi.fn(() => undefined),
+  } as unknown as Configuration);
+
+  const dockerConfig = new DockerConfig();
+
+  const path = dockerConfig.getPath();
+  expect(path).toBe(DockerConfig.DEFAULT_CONFIG_FOLDER);
+
+  // now change the value
+  const differentValuePath = 'differentValue';
+  vi.mocked(configuration.getConfiguration).mockReturnValue({
+    get: vi.fn(() => differentValuePath),
+  } as unknown as Configuration);
+
+  // capture the callback sent to onDidChangeConfiguration
+  // and call the data
+  const callback = vi.mocked(configuration.onDidChangeConfiguration).mock.calls[0][0];
+  // call the callback
+  callback({ affectsConfiguration: vi.fn(() => true) });
+
+  // check the new value is updated
+  const newPath = dockerConfig.getPath();
+  expect(newPath).toBe(differentValuePath);
+});

--- a/extensions/docker/src/docker-config.ts
+++ b/extensions/docker/src/docker-config.ts
@@ -1,0 +1,53 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import { configuration } from '@podman-desktop/api';
+
+/**
+ * Manages the access to the Docker configuration settings.
+ */
+export class DockerConfig {
+  static readonly DEFAULT_CONFIG_FOLDER = join(homedir(), '.docker');
+
+  #dockerConfigFolder: string;
+
+  constructor() {
+    // if we have a custom DOCKER_CONFIG property, use it
+    this.#dockerConfigFolder = this.readConfiguration();
+
+    // update the value if the configuration changes
+    configuration.onDidChangeConfiguration(event => {
+      if (event.affectsConfiguration('docker.config')) {
+        // refresh the value
+        this.#dockerConfigFolder = this.readConfiguration();
+      }
+    });
+  }
+
+  protected readConfiguration(): string {
+    return configuration.getConfiguration('docker').get('config') ?? DockerConfig.DEFAULT_CONFIG_FOLDER;
+  }
+
+  // Returns the path to the Docker configuration file.
+  getPath(): string {
+    return this.#dockerConfigFolder;
+  }
+}

--- a/extensions/docker/src/extension.ts
+++ b/extensions/docker/src/extension.ts
@@ -24,6 +24,7 @@ import * as extensionApi from '@podman-desktop/api';
 import { UNIX_SOCKET_PATH, WINDOWS_NPIPE } from './docker-api';
 import { getDockerInstallation } from './docker-cli';
 import { DockerCompatibilitySetup } from './docker-compatibility-setup';
+import { DockerConfig } from './docker-config';
 import { DockerContextHandler } from './docker-context-handler';
 
 let stopLoop = false;
@@ -168,7 +169,8 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
     socketPath = UNIX_SOCKET_PATH;
   }
 
-  const dockerContextHandler = new DockerContextHandler();
+  const dockerConfig = new DockerConfig();
+  const dockerContextHandler = new DockerContextHandler(dockerConfig);
   const dockerCompatibilitySetup = new DockerCompatibilitySetup(dockerContextHandler);
   dockerCompatibilitySetup.init().catch((err: unknown) => {
     console.error('Error while initializing docker compatibility setup', err);


### PR DESCRIPTION
### What does this PR do?
Allow to specify a custom docker config (DOCKER_CONFIG) for the docker extension that will then allow to search for contexts in another directory

there is another commit that is just bringing the DOCKER_CONFIG setup

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/9351

### How to test this PR?

use DOCKER_CONFIG in your terminal for a docker command, then check that you see the same values in the terminal and the UI

- [x] Tests are covering the bug fix or the new feature
