### PR TITLE
test: globally mock windows#addEventListener

### DIFF
--- a/packages/renderer/vite.tests.setup.js
+++ b/packages/renderer/vite.tests.setup.js
@@ -24,6 +24,7 @@ import { expect } from 'vitest';
 
 global.window.matchMedia = () => {};
 global.window.addEventListener = vi.fn();
+global.window.removeEventListener = vi.fn();
 
 // read the given path and extract the method names from the Window interface
 function extractWindowMethods(filePath) {

--- a/packages/renderer/vite.tests.setup.js
+++ b/packages/renderer/vite.tests.setup.js
@@ -23,6 +23,7 @@ import typescript from 'typescript';
 import { expect } from 'vitest';
 
 global.window.matchMedia = () => {};
+global.window.addEventListener = vi.fn();
 
 // read the given path and extract the method names from the Window interface
 function extractWindowMethods(filePath) {


### PR DESCRIPTION
### What does this PR do?

As suggested in https://github.com/podman-desktop/podman-desktop/pull/10531#discussion_r1905646391 moving the `windows#addEventListener` to the `packages/renderer/vite.tests.setup.js`.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Required for https://github.com/podman-desktop/podman-desktop/pull/10531 (not required, but preferably)

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Pipeline should be :green_circle: 
