### PR TITLE
chore: change order of welcome page for podman

### DIFF
--- a/packages/renderer/src/lib/welcome/WelcomePage.spec.ts
+++ b/packages/renderer/src/lib/welcome/WelcomePage.spec.ts
@@ -177,3 +177,73 @@ test('Expect welcome screen to show three checked onboarding providers', async (
   expect(checkbox3).toBeInTheDocument();
   expect(checkbox3).toBeChecked();
 });
+
+test('Make sure the provider with name podman appears first even if its 2nd in the list', async () => {
+  onboardingList.set([
+    {
+      extension: 'id',
+      title: 'onboarding',
+      name: 'foobar1',
+      displayName: 'FooBar1',
+      icon: 'data:image/png;base64,foobar1',
+      steps: [
+        {
+          id: 'step',
+          title: 'step',
+          state: 'failed',
+          completionEvents: [],
+        },
+      ],
+      enablement: 'true',
+    },
+    {
+      extension: 'id',
+      title: 'onboarding',
+      name: 'podman',
+      displayName: 'Podman',
+      icon: 'data:image/png;base64,podman',
+      steps: [
+        {
+          id: 'step',
+          title: 'step',
+          state: 'failed',
+          completionEvents: [],
+        },
+      ],
+      enablement: 'true',
+    },
+    {
+      extension: 'id',
+      title: 'onboarding',
+      name: 'foobar3',
+      displayName: 'FooBar3',
+      icon: 'data:image/png;base64,foobar3',
+      steps: [
+        {
+          id: 'step',
+          title: 'step',
+          state: 'failed',
+          completionEvents: [],
+        },
+      ],
+      enablement: 'true',
+    },
+  ]);
+
+  // wait until the onboarding list is populated
+  while (get(onboardingList).length === 0) {
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+
+  await waitRender({ showWelcome: true });
+
+  // wait until aria-label 'providerList' is populated
+  while (screen.queryAllByLabelText('providerList').length === 0) {
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+
+  // In the div 'providerList' the first div should be the one with the name 'podman'
+  const providerList = screen.getByLabelText('providerList');
+  const firstChild = providerList.children[0];
+  expect(firstChild).toHaveTextContent('Podman');
+});

--- a/packages/renderer/src/lib/welcome/WelcomePage.svelte
+++ b/packages/renderer/src/lib/welcome/WelcomePage.svelte
@@ -31,6 +31,8 @@ interface OnboardingInfoWithSelected extends OnboardingInfo {
 
 let onboardingProviders: OnboardingInfoWithSelected[] = [];
 
+const podmanProviderName = 'podman';
+
 onMount(async () => {
   const ver = await welcomeUtils.getVersion();
   if (!ver) {
@@ -46,13 +48,16 @@ onMount(async () => {
   podmanDesktopVersion = await window.getPodmanDesktopVersion();
 
   onboardingsUnsubscribe = onboardingList.subscribe(value => {
-    // Add "selected" property to each provider and add to onboardingEnabledProviders
-    onboardingProviders = value.map(provider => {
+    // Add "selected" property to each provider
+    const sortedProviders = value.map(provider => {
       return {
         ...provider,
         selected: true,
       };
     });
+
+    // Sort providers by podman name so it appears first
+    onboardingProviders = sortByPodmanName(sortedProviders);
   });
 });
 
@@ -70,6 +75,12 @@ async function closeWelcome() {
   if (showTelemetry) {
     await welcomeUtils.setTelemetry(telemetry);
   }
+}
+
+// Function to sort providers by "Podman" name, make sure that a provider with the name "podman" is always first
+function sortByPodmanName(providers: OnboardingInfoWithSelected[]): OnboardingInfoWithSelected[] {
+  // We slice to avoid mutating the original array
+  return providers.slice().sort((a, b) => (a.name === podmanProviderName ? -1 : b.name === podmanProviderName ? 1 : 0));
 }
 
 // Function to toggle provider selection


### PR DESCRIPTION
chore: change order of welcome page for podman

### What does this PR do?

* Adds a function that will re-sort the providers and make sure that
  Podman is first on the Welcome Page

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/podman-desktop/issues/10244

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
