### PR TITLE
feat: make build task cancellable

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1322,6 +1322,13 @@ export class PluginSystem {
           cancellationTokenRegistry,
           cancellableTokenId,
         );
+
+        // add the cancellation to the task if provided
+        if (cancellableTokenId) {
+          task.cancellable = true;
+          task.cancellationTokenSourceId = cancellableTokenId;
+        }
+
         return containerProviderRegistry
           .buildImage(
             containerBuildContextDirectory,


### PR DESCRIPTION
### What does this PR do?

Reported in https://github.com/podman-desktop/podman-desktop/issues/10080, the build task is not cancellable from the task manager. 

Since a build is cancellable from the page, we uses a cancellation token, we can just check for cancellation token, and if it exists, make the task cancellable.

### Screenshot / video of UI

![image](https://github.com/user-attachments/assets/4cd8bca0-3070-4648-a43b-1b4a8f704ad0)

![image](https://github.com/user-attachments/assets/fcd21d7d-4386-4161-b8a2-ea9d82e3466b)

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/10080 (maybe ?)

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

> Tests were a bit hard to do :cry: 

You can try by creating a Containerfile such as

```Dockerfile
FROM docker.io/library/alpine:latest

RUN sleep 150000
```

And use it in the build page.
