### PR TITLE
docs(website): removed outdated icons

### DIFF
--- a/website/docs/containers/creating-a-pod.md
+++ b/website/docs/containers/creating-a-pod.md
@@ -23,7 +23,7 @@ Consider running containers in a pod to:
 
 #### Procedure
 
-1. Go to **<Icon icon="fa-solid fa-cube" size="lg" /> Containers**.
+1. Go to **Containers** from the left navigation pane.
 1. Click the checkbox in the container line for your containers, such as `database` and `frontend`.
 1. Click **<Icon icon="fa-solid fa-cubes" size="lg" />**.
 1. In the **Copy containers to a pod** screen:

--- a/website/docs/containers/images/building-an-image.md
+++ b/website/docs/containers/images/building-an-image.md
@@ -16,7 +16,7 @@ With Podman Desktop, you can build an image from a Containerfile on your contain
 
 #### Procedure
 
-1. Go to **<Icon icon="fa-solid fa-cloud" size="lg" /> Images**.
+1. Go to **Images** from the left navigation pane.
 1. Click **<Icon icon="fa-solid fa-cube" size="lg" /> Build an image**.
 1. On the **Build Image from Containerfile** screen
    1. **Containerfile path**: select the `Containerfile` or `Dockerfile` to build.

--- a/website/docs/containers/images/pulling-an-image.md
+++ b/website/docs/containers/images/pulling-an-image.md
@@ -17,7 +17,7 @@ With Podman Desktop, you can pull an image from a registry, to your container en
 
 #### Procedure
 
-1. Go to **<Icon icon="fa-solid fa-cloud" size="lg" /> Images**.
+1. Go to **Images** from the left navigation pane.
 1. Click **<Icon icon="fa-solid fa-arrow-circle-down" size="lg" /> Pull an image**.
 1. On the **Image to Pull** screen:
    1. **Image to pull**: enter the image name, such as `quay.io/podman/hello`. Prefer the fully qualified image name that specifies the registry, to the short name that might lead to registry resolution mistakes.

--- a/website/docs/containers/images/pushing-an-image-to-a-registry.md
+++ b/website/docs/containers/images/pushing-an-image-to-a-registry.md
@@ -18,7 +18,7 @@ With Podman Desktop, you can push an image to registries.
 
 #### Procedure
 
-1. Go to **<Icon icon="fa-solid fa-cloud" size="lg" /> Images**.
+1. Go to **Images** from the left navigation pane.
 1. On your image line, click **<Icon icon="fa-solid fa-ellipsis-v" size="lg" /> > <Icon icon="fa-solid fa-arrow-up" size="lg" />Push Image**.
 1. Select the Image tag for your registry.
 1. Click **<Icon icon="fa-solid fa-arrow-up" size="lg" />Push Image**.


### PR DESCRIPTION
### What does this PR do?

- Removes outdated icons from the Containers category of the doc
- Buttons that were presented as icons are rectified in this [procedure correction PR](https://github.com/podman-desktop/podman-desktop/pull/10540/)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/10444
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
