### PR TITLE
feat: adding search controls logs window

### DIFF
--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -49,6 +49,7 @@
     "vitest": "^2.1.6",
     "@xterm/xterm": "^5.5.0",
     "@xterm/addon-fit": "^0.10.0",
+    "@xterm/addon-search": "^0.15.0",
     "vitest-canvas-mock": "^0.3.3",
     "yaml": "^2.7.0"
   },

--- a/packages/renderer/src/lib/container/ContainerDetails.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerDetails.spec.ts
@@ -55,13 +55,8 @@ const myContainer: ContainerInfo = {
 const deleteContainerMock = vi.fn();
 const getContributedMenusMock = vi.fn();
 
-vi.mock('@xterm/xterm', () => {
-  return {
-    Terminal: vi
-      .fn()
-      .mockReturnValue({ loadAddon: vi.fn(), open: vi.fn(), write: vi.fn(), clear: vi.fn(), dispose: vi.fn() }),
-  };
-});
+vi.mock('@xterm/xterm');
+vi.mock('@xterm/addon-search');
 
 const getConfigurationValueMock = vi.fn().mockReturnValue(12);
 

--- a/packages/renderer/src/lib/container/ContainerDetailsLogs.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerDetailsLogs.spec.ts
@@ -25,6 +25,8 @@ import { beforeAll, expect, test, vi } from 'vitest';
 import ContainerDetailsLogs from './ContainerDetailsLogs.svelte';
 import type { ContainerInfoUI } from './ContainerInfoUI';
 
+vi.mock('@xterm/addon-search');
+
 vi.mock('@xterm/xterm', () => {
   const writeMock = vi.fn();
   return {

--- a/packages/renderer/src/lib/container/ContainerDetailsLogs.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsLogs.svelte
@@ -88,5 +88,5 @@ onDestroy(() => {
   class:h-0={noLogs === true}
   class:h-full={noLogs === false}
   bind:this={terminalParentDiv}>
-  <TerminalWindow on:init={afterTerminalInit} class="h-full" bind:terminal={logsTerminal} convertEol disableStdIn />
+  <TerminalWindow search on:init={afterTerminalInit} class="h-full" bind:terminal={logsTerminal} convertEol disableStdIn />
 </div>

--- a/packages/renderer/src/lib/ui/TerminalSearchControls.spec.ts
+++ b/packages/renderer/src/lib/ui/TerminalSearchControls.spec.ts
@@ -1,0 +1,159 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { SearchAddon } from '@xterm/addon-search';
+import type { Terminal } from '@xterm/xterm';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import TerminalSearchControls from './TerminalSearchControls.svelte';
+
+vi.mock('@xterm/addon-search');
+
+const TerminalMock: Terminal = {
+  onWriteParsed: vi.fn(),
+  onResize: vi.fn(),
+  dispose: vi.fn(),
+} as unknown as Terminal;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('search addon should be loaded to the terminal', () => {
+  render(TerminalSearchControls, {
+    terminal: TerminalMock,
+  });
+
+  expect(SearchAddon.prototype.activate).toHaveBeenCalledOnce();
+  expect(SearchAddon.prototype.activate).toHaveBeenCalledWith(TerminalMock);
+});
+
+test('search addon should be disposed on component destroy', async () => {
+  const { unmount } = render(TerminalSearchControls, {
+    terminal: TerminalMock,
+  });
+
+  unmount();
+
+  await vi.waitFor(() => {
+    expect(SearchAddon.prototype.dispose).toHaveBeenCalledOnce();
+  });
+});
+
+test('input should call findNext on search addon', async () => {
+  const user = userEvent.setup();
+  const { getByRole } = render(TerminalSearchControls, {
+    terminal: TerminalMock,
+  });
+
+  const searchTextbox = getByRole('textbox', {
+    name: 'Find',
+  });
+
+  expect(searchTextbox).toBeInTheDocument();
+  await user.type(searchTextbox, 'hello');
+
+  await vi.waitFor(() => {
+    expect(SearchAddon.prototype.findNext).toHaveBeenCalledWith('hello', {
+      incremental: false,
+    });
+  });
+});
+
+test('key Enter should call findNext with incremental', async () => {
+  const user = userEvent.setup();
+  const { getByRole } = render(TerminalSearchControls, {
+    terminal: TerminalMock,
+  });
+
+  const searchTextbox = getByRole('textbox', {
+    name: 'Find',
+  });
+
+  expect(searchTextbox).toBeInTheDocument();
+  await user.type(searchTextbox, 'hello{Enter}');
+
+  await vi.waitFor(() => {
+    expect(SearchAddon.prototype.findNext).toHaveBeenCalledWith('hello', {
+      incremental: true,
+    });
+  });
+});
+
+test('arrow down should call findNext', async () => {
+  const { getByRole } = render(TerminalSearchControls, {
+    terminal: TerminalMock,
+  });
+
+  const upBtn = getByRole('button', {
+    name: 'Next Match',
+  });
+
+  expect(upBtn).toBeInTheDocument();
+  await fireEvent.click(upBtn);
+
+  await vi.waitFor(() => {
+    expect(SearchAddon.prototype.findNext).toHaveBeenCalledWith('', {
+      incremental: true,
+    });
+  });
+});
+
+test('arrow up should call findPrevious', async () => {
+  const { getByRole } = render(TerminalSearchControls, {
+    terminal: TerminalMock,
+  });
+
+  const upBtn = getByRole('button', {
+    name: 'Previous Match',
+  });
+
+  expect(upBtn).toBeInTheDocument();
+  await fireEvent.click(upBtn);
+
+  await vi.waitFor(() => {
+    expect(SearchAddon.prototype.findPrevious).toHaveBeenCalledWith('', {
+      incremental: true,
+    });
+  });
+});
+
+test('ctrl+F should focus input', async () => {
+  const { getByRole, container } = render(TerminalSearchControls, {
+    terminal: TerminalMock,
+  });
+
+  const searchTextbox: HTMLInputElement = getByRole('textbox', {
+    name: 'Find',
+  }) as HTMLInputElement;
+
+  const focusSpy = vi.spyOn(searchTextbox, 'focus');
+
+  await fireEvent.keyUp(container, {
+    ctrlKey: true,
+    key: 'f',
+  });
+
+  await vi.waitFor(() => {
+    expect(focusSpy).toHaveBeenCalled();
+  });
+});

--- a/packages/renderer/src/lib/ui/TerminalSearchControls.svelte
+++ b/packages/renderer/src/lib/ui/TerminalSearchControls.svelte
@@ -12,7 +12,7 @@ interface Props {
 
 let { terminal }: Props = $props();
 
-let searchAddon: SearchAddon;
+let searchAddon: SearchAddon | undefined;
 let searchTerm: string = $state('');
 
 let input: HTMLInputElement | undefined = $state();
@@ -33,13 +33,13 @@ function onKeyPressed(event: KeyboardEvent): void {
 }
 
 function onSearchNext(incremental = false): void {
-  searchAddon.findNext(searchTerm, {
+  searchAddon?.findNext(searchTerm, {
     incremental: incremental,
   });
 }
 
 function onSearchPrevious(incremental = false): void {
-  searchAddon.findPrevious(searchTerm, {
+  searchAddon?.findPrevious(searchTerm, {
     incremental: incremental,
   });
 }
@@ -50,7 +50,6 @@ function onSearch(event: Event): void {
 }
 
 function onKeyUp(e: KeyboardEvent): void {
-  console.log('onKeyUp', e);
   if (e.ctrlKey && e.key === 'f') {
     input?.focus();
   }

--- a/packages/renderer/src/lib/ui/TerminalSearchControls.svelte
+++ b/packages/renderer/src/lib/ui/TerminalSearchControls.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+import { faArrowDown, faArrowUp } from '@fortawesome/free-solid-svg-icons';
+import { Input } from '@podman-desktop/ui-svelte';
+import { SearchAddon } from '@xterm/addon-search';
+import type { Terminal } from '@xterm/xterm';
+import { onDestroy, onMount } from 'svelte';
+import Fa from 'svelte-fa';
+
+interface Props {
+  terminal: Terminal;
+}
+
+let { terminal }: Props = $props();
+
+let searchAddon: SearchAddon;
+let searchTerm: string = $state('');
+
+let input: HTMLInputElement | undefined = $state();
+
+onMount(() => {
+  searchAddon = new SearchAddon();
+  searchAddon.activate(terminal);
+});
+
+onDestroy(() => {
+  searchAddon?.dispose();
+});
+
+function onKeyPressed(event: KeyboardEvent): void {
+  if (event.key === 'Enter') {
+    onSearchNext(true);
+  }
+}
+
+function onSearchNext(incremental = false): void {
+  searchAddon.findNext(searchTerm, {
+    incremental: incremental,
+  });
+}
+
+function onSearchPrevious(incremental = false): void {
+  searchAddon.findPrevious(searchTerm, {
+    incremental: incremental,
+  });
+}
+
+function onSearch(event: Event): void {
+  searchTerm = (event.target as HTMLInputElement).value;
+  onSearchNext();
+}
+
+function onKeyUp(e: KeyboardEvent): void {
+  console.log('onKeyUp', e);
+  if (e.ctrlKey && e.key === 'f') {
+    input?.focus();
+  }
+}
+</script>
+
+<svelte:window
+  on:keyup|preventDefault={onKeyUp}
+/>
+<div class="flex flex-row py-2 h-[40px] items-center">
+  <div
+    class="w-200px mx-4">
+    <Input
+      bind:element={input}
+      placeholder="Find"
+      aria-label="Find"
+      type="text"
+      on:keypress={onKeyPressed}
+      on:input={onSearch}
+      value={searchTerm}
+    />
+  </div>
+  <div class="space-x-1">
+    <button aria-label="Previous Match" class="p-2 rounded hover:bg-[var(--pd-action-button-details-bg)]" onclick={() => onSearchPrevious(true)}>
+      <Fa icon={faArrowUp}/>
+    </button>
+    <button aria-label="Next Match" class="p-2 rounded hover:bg-[var(--pd-action-button-details-bg)]" onclick={() => onSearchNext(true)}>
+      <Fa icon={faArrowDown}/>
+    </button>
+  </div>
+</div>

--- a/packages/renderer/src/lib/ui/TerminalWindow.svelte
+++ b/packages/renderer/src/lib/ui/TerminalWindow.svelte
@@ -5,6 +5,8 @@ import { FitAddon } from '@xterm/addon-fit';
 import { Terminal } from '@xterm/xterm';
 import { createEventDispatcher, onDestroy, onMount } from 'svelte';
 
+import TerminalSearchControls from '/@/lib/ui/TerminalSearchControls.svelte';
+
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
 import { getTerminalTheme } from '../../../../main/src/plugin/terminal-theme';
 
@@ -13,6 +15,7 @@ export let convertEol: boolean | undefined = undefined;
 export let disableStdIn: boolean = true;
 export let screenReaderMode: boolean | undefined = undefined;
 export let showCursor: boolean = false;
+export let search: boolean = false;
 
 let logsXtermDiv: HTMLDivElement;
 let resizeHandler: () => void;
@@ -69,4 +72,7 @@ onDestroy(() => {
 });
 </script>
 
+{#if search && terminal}
+  <TerminalSearchControls terminal={terminal} />
+{/if}
 <div class="{$$props.class} p-[5px] pr-0 bg-[var(--pd-terminal-background)]" role="term" bind:this={logsXtermDiv}></div>

--- a/packages/renderer/src/lib/ui/TerminalWindows.spec.ts
+++ b/packages/renderer/src/lib/ui/TerminalWindows.spec.ts
@@ -32,6 +32,8 @@ vi.mock('@xterm/xterm');
 
 vi.mock('@xterm/addon-fit');
 
+vi.mock('@xterm/addon-search');
+
 beforeEach(() => {
   vi.resetAllMocks();
 });
@@ -148,4 +150,17 @@ test('matchMedia resize listener should trigger fit addon', async () => {
   listener();
 
   expect(FitAddon.prototype.fit).toHaveBeenCalled();
+});
+
+test('search props should add terminal search controls', async () => {
+  const { getByRole } = render(TerminalWindow, {
+    terminal: writable() as unknown as Terminal,
+    search: true,
+  });
+
+  const searchTextbox = getByRole('textbox', {
+    name: 'Find',
+  });
+
+  expect(searchTextbox).toBeInTheDocument();
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -612,6 +612,9 @@ importers:
       '@xterm/addon-fit':
         specifier: ^0.10.0
         version: 0.10.0(@xterm/xterm@5.5.0)
+      '@xterm/addon-search':
+        specifier: ^0.15.0
+        version: 0.15.0(@xterm/xterm@5.5.0)
       '@xterm/addon-serialize':
         specifier: ^0.13.0
         version: 0.13.0(@xterm/xterm@5.5.0)
@@ -4282,6 +4285,11 @@ packages:
 
   '@xterm/addon-fit@0.10.0':
     resolution: {integrity: sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==}
+    peerDependencies:
+      '@xterm/xterm': ^5.0.0
+
+  '@xterm/addon-search@0.15.0':
+    resolution: {integrity: sha512-ZBZKLQ+EuKE83CqCmSSz5y1tx+aNOCUaA7dm6emgOX+8J9H1FWXZyrKfzjwzV+V14TV3xToz1goIeRhXBS5qjg==}
     peerDependencies:
       '@xterm/xterm': ^5.0.0
 
@@ -14021,11 +14029,11 @@ snapshots:
 
   '@isaacs/cliui@8.0.2':
     dependencies:
-      string-width: 5.1.2
+      string-width: 4.2.3
       string-width-cjs: string-width@4.2.3
       strip-ansi: 7.1.0
       strip-ansi-cjs: strip-ansi@6.0.1
-      wrap-ansi: 8.1.0
+      wrap-ansi: 7.0.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
   '@isaacs/fs-minipass@4.0.1':
@@ -15747,6 +15755,10 @@ snapshots:
   '@xmldom/xmldom@0.8.10': {}
 
   '@xterm/addon-fit@0.10.0(@xterm/xterm@5.5.0)':
+    dependencies:
+      '@xterm/xterm': 5.5.0
+
+  '@xterm/addon-search@0.15.0(@xterm/xterm@5.5.0)':
     dependencies:
       '@xterm/xterm': 5.5.0
 


### PR DESCRIPTION
### What does this PR do?

Using the [@xterm/addon-search](https://www.npmjs.com/package/@xterm/addon-search) to allow searching in the terminal. This PR add a very basic `TerminalSearchControls` component, that will be placed above the terminal when needed.

For this PR I only enabled the search for the container logs as a demo. We can enable it in every logs after this PR.

### Screenshot / video of UI

![image](https://github.com/user-attachments/assets/07a9b372-c307-4ba6-938c-1532b485278b)


https://github.com/user-attachments/assets/19d79a07-eb53-46c4-acc6-c372679862d6

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/9726 (I decided to add the logs to the containers instead of pods for this first PR)

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

1. go to container details
2. go to logs tab 
3. assert search bar visible
4. `ctrl+f` to auto focus in
5. assert arrow up / down working 