### PR TITLE
fix(docs): adds horizontal padding to front page

### DIFF
--- a/website/src/components/PodmanAILabBanner.tsx
+++ b/website/src/components/PodmanAILabBanner.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 function Banner(): JSX.Element {
   return (
-    <div className="w-full flex flex-row justify-center items-center py-4 bg-purple-700 overflow-hidden">
+    <div className="w-full flex flex-row justify-center items-center py-4 bg-purple-700 overflow-hidden px-5">
       <div className="bg-[#fcd34d] rounded-xl text-black px-3 py-1">NEW FEATURE</div>
       <div className="mx-3 relative text-white">
         We have a new <span className="font-bold text-lg">Podman AI Lab</span> extension!{' '}


### PR DESCRIPTION
### What does this PR do?
Adds `px-5` horizontal padding to front page with New feature banner

### Screenshot / video of UI

Prev: 

![Image](https://github.com/user-attachments/assets/51c02907-d415-4353-a39e-e3d3a8bb03db)

Now:
![image](https://github.com/user-attachments/assets/721f5ac7-0f1d-43ef-89eb-f7a0eec6a905)


### What issues does this PR fix or reference?
Closes [#10027](https://github.com/podman-desktop/podman-desktop/issues/10027)

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
