### PR TITLE
fix: handle property the watch mode for extension in development mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,6 +160,7 @@
     "eslint-plugin-sonarjs": "^3.0.1",
     "eslint-plugin-unicorn": "^56.0.1",
     "fzstd": "^0.1.1",
+    "get-tsconfig": "^4.8.1",
     "globals": "^15.14.0",
     "husky": "^9.1.7",
     "js-yaml": "^4.1.0",

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -1725,7 +1725,7 @@ export class ExtensionLoader {
       Array.from(this.activatedExtensions.keys()).map(extensionId => this.deactivateExtension(extensionId)),
     );
     this.kubernetesClient.dispose();
-    this.extensionWatcher.stop();
+    this.extensionWatcher.dispose();
   }
 
   async startExtension(extensionId: string): Promise<void> {

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -53,6 +53,7 @@ import type { Directories } from './directories.js';
 import type { Event } from './events/emitter.js';
 import { Emitter } from './events/emitter.js';
 import { DEFAULT_TIMEOUT, ExtensionLoaderSettings } from './extension-loader-settings.js';
+import type { ExtensionWatcher } from './extension-watcher.js';
 import type { FilesystemMonitoring } from './filesystem-monitoring.js';
 import type { IconRegistry } from './icon-registry.js';
 import type { ImageCheckerImpl } from './image-checker.js';
@@ -141,7 +142,6 @@ export class ExtensionLoader {
 
   protected activatedExtensions = new Map<string, ActivatedExtension>();
   protected analyzedExtensions = new Map<string, AnalyzedExtension>();
-  private watcherExtensions = new Map<string, containerDesktopAPI.FileSystemWatcher>();
   private reloadInProgressExtensions = new Map<string, boolean>();
   protected extensionState = new Map<string, string>();
   protected extensionStateErrors = new Map<string, unknown>();
@@ -194,6 +194,7 @@ export class ExtensionLoader {
     private dialogRegistry: DialogRegistry,
     private safeStorageRegistry: SafeStorageRegistry,
     private certificates: Certificates,
+    private extensionWatcher: ExtensionWatcher,
   ) {
     this.pluginsDirectory = directories.getPluginsDirectory();
     this.pluginsScanDirectory = directories.getPluginsScanDirectory();
@@ -431,6 +432,13 @@ export class ExtensionLoader {
 
     // now we have all extensions, we can load them
     await this.loadExtensions(analyzedExtensions);
+
+    // handle the reload extensions callback
+    this.extensionWatcher.onNeedToReloadExtension(extension => {
+      this.reloadExtension(extension, false).catch((error: unknown) => {
+        console.error('error while reloading extension', error);
+      });
+    });
   }
 
   async analyzeExtension(extensionPath: string, removable: boolean): Promise<AnalyzedExtension> {
@@ -652,8 +660,7 @@ export class ExtensionLoader {
   }
 
   protected async reloadExtension(extension: AnalyzedExtension, removable: boolean): Promise<void> {
-    const inProgress = this.reloadInProgressExtensions.get(extension.id);
-    if (inProgress) {
+    if (this.reloadInProgressExtensions.has(extension.id)) {
       return;
     }
 
@@ -673,8 +680,18 @@ export class ExtensionLoader {
     } catch (error) {
       console.error('error while reloading extension', error);
     } finally {
-      this.reloadInProgressExtensions.set(extension.id, false);
+      this.reloadInProgressExtensions.delete(extension.id);
     }
+
+    const notification = this.notificationRegistry.addNotification({
+      extensionId: extension.id,
+      type: 'info',
+      title: `Extension ${extension.manifest.displayName} has been updated`,
+    });
+    // remove the notification after few seconds
+    setTimeout(() => {
+      notification.dispose();
+    }, 2_000);
   }
 
   async loadExtension(extension: AnalyzedExtension, checkForMissingDependencies = false): Promise<void> {
@@ -754,19 +771,10 @@ export class ExtensionLoader {
 
     try {
       // in development mode, watch if the extension is updated and reload it
-      if (import.meta.env.DEV && !this.watcherExtensions.has(extension.id)) {
-        const extensionWatcher = this.fileSystemMonitoring.createFileSystemWatcher(extension.path);
-        extensionWatcher.onDidChange(async () => {
-          // wait 1 second before trying to reload the extension
-          // this is to avoid reloading the extension while it is still being updated
-          setTimeout(() => {
-            this.reloadExtension(extension, extension.removable).catch((error: unknown) =>
-              console.error('error while reloading extension', error),
-            );
-          }, 1000);
-        });
-        this.watcherExtensions.set(extension.id, extensionWatcher);
+      if (import.meta.env.DEV) {
+        await this.extensionWatcher.monitor(extension);
       }
+
       if (!this.getDisabledExtensionIds().includes(extension.id)) {
         const beforeLoadingRuntime = performance.now();
         const runtime = this.loadRuntime(extension);
@@ -1697,8 +1705,10 @@ export class ExtensionLoader {
       }
     }
 
-    const watcher = this.watcherExtensions.get(extensionId);
-    watcher?.dispose();
+    // dispose resources for a given extension only if not in a reload
+    if (!this.reloadInProgressExtensions.has(extensionId)) {
+      this.extensionWatcher.untrack(extension);
+    }
 
     const analyzedExtension = this.analyzedExtensions.get(extensionId);
     // dispose subscriptions if any
@@ -1715,6 +1725,7 @@ export class ExtensionLoader {
       Array.from(this.activatedExtensions.keys()).map(extensionId => this.deactivateExtension(extensionId)),
     );
     this.kubernetesClient.dispose();
+    this.extensionWatcher.stop();
   }
 
   async startExtension(extensionId: string): Promise<void> {

--- a/packages/main/src/plugin/extension-tsconfig-parser.spec.ts
+++ b/packages/main/src/plugin/extension-tsconfig-parser.spec.ts
@@ -17,6 +17,7 @@
  ***********************************************************************/
 
 import { existsSync } from 'node:fs';
+import { sep } from 'node:path';
 
 import type { FileMatcher, TsConfigResult } from 'get-tsconfig';
 import { createFilesMatcher, getTsconfig } from 'get-tsconfig';
@@ -38,7 +39,7 @@ test('no tsconfig.json file means it returns undefined', async () => {
 
   const result = await extensionTypeScriptConfigParser.analyze();
 
-  expect(existsSync).toHaveBeenCalledWith(expect.stringContaining('fakePath/tsconfig.json'));
+  expect(existsSync).toHaveBeenCalledWith(expect.stringContaining(`fakePath${sep}tsconfig.json`));
   expect(vi.mocked(getTsconfig)).not.toHaveBeenCalled();
   expect(result).toBe(undefined);
 });
@@ -54,7 +55,7 @@ test('with a tsconfig.json file means it returns undefined', async () => {
   vi.mocked(createFilesMatcher).mockReturnValue(fakeFilesMatcher);
 
   const result = await extensionTypeScriptConfigParser.analyze();
-  expect(existsSync).toHaveBeenCalledWith(expect.stringContaining('fakePath/tsconfig.json'));
+  expect(existsSync).toHaveBeenCalledWith(expect.stringContaining(`fakePath${sep}tsconfig.json`));
 
   // check we called the getTsconfig function
   expect(vi.mocked(getTsconfig)).toHaveBeenCalled();

--- a/packages/main/src/plugin/extension-tsconfig-parser.spec.ts
+++ b/packages/main/src/plugin/extension-tsconfig-parser.spec.ts
@@ -1,0 +1,67 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { existsSync } from 'node:fs';
+
+import type { FileMatcher, TsConfigResult } from 'get-tsconfig';
+import { createFilesMatcher, getTsconfig } from 'get-tsconfig';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { ExtensionTypeScriptConfigParser } from './extension-tsconfig-parser.js';
+
+vi.mock('node:fs');
+vi.mock('get-tsconfig');
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.resetAllMocks();
+});
+
+test('no tsconfig.json file means it returns undefined', async () => {
+  const fakePath = 'fakePath';
+  const extensionTypeScriptConfigParser = new ExtensionTypeScriptConfigParser(fakePath);
+
+  const result = await extensionTypeScriptConfigParser.analyze();
+
+  expect(existsSync).toHaveBeenCalledWith(expect.stringContaining('fakePath/tsconfig.json'));
+  expect(vi.mocked(getTsconfig)).not.toHaveBeenCalled();
+  expect(result).toBe(undefined);
+});
+
+test('with a tsconfig.json file means it returns undefined', async () => {
+  vi.mocked(existsSync).mockReturnValue(true);
+  const fakePath = 'fakePath';
+  const extensionTypeScriptConfigParser = new ExtensionTypeScriptConfigParser(fakePath);
+
+  const fakeTsConfig = {} as unknown as TsConfigResult;
+  const fakeFilesMatcher = {} as unknown as FileMatcher;
+  vi.mocked(getTsconfig).mockReturnValue(fakeTsConfig);
+  vi.mocked(createFilesMatcher).mockReturnValue(fakeFilesMatcher);
+
+  const result = await extensionTypeScriptConfigParser.analyze();
+  expect(existsSync).toHaveBeenCalledWith(expect.stringContaining('fakePath/tsconfig.json'));
+
+  // check we called the getTsconfig function
+  expect(vi.mocked(getTsconfig)).toHaveBeenCalled();
+
+  // check we called the createFilesMatcher function
+  expect(vi.mocked(createFilesMatcher)).toHaveBeenCalledWith(fakeTsConfig);
+
+  // check we have a valid file matcher in that case
+  expect(result).toBe(fakeFilesMatcher);
+});

--- a/packages/main/src/plugin/extension-tsconfig-parser.ts
+++ b/packages/main/src/plugin/extension-tsconfig-parser.ts
@@ -1,0 +1,52 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import type { FileMatcher } from 'get-tsconfig';
+import { createFilesMatcher, getTsconfig } from 'get-tsconfig';
+
+/**
+ * Responsible to parse all the tsconfig.json files from an extension
+ * and provide a list of all pattern having source files
+ */
+export class ExtensionTypeScriptConfigParser {
+  #rootPath: string;
+
+  constructor(rootPath: string) {
+    this.#rootPath = rootPath;
+  }
+
+  async analyze(): Promise<FileMatcher | undefined> {
+    // read all tsconfig.json files not being in node_modules
+    // and parse them to extract all the patterns
+
+    // find all tsconfig.json files from rootPath folder
+    // do we have a tsconfig.json file in the rootPath ?
+    const tsConfigJsonPath = resolve(this.#rootPath, 'tsconfig.json');
+
+    if (existsSync(tsConfigJsonPath)) {
+      const tsConfig = getTsconfig(tsConfigJsonPath);
+      if (tsConfig) {
+        return createFilesMatcher(tsConfig);
+      }
+    }
+    return undefined;
+  }
+}

--- a/packages/main/src/plugin/extension-watcher.spec.ts
+++ b/packages/main/src/plugin/extension-watcher.spec.ts
@@ -183,9 +183,9 @@ describe('untrack', () => {
   });
 });
 
-test('stop', async () => {
+test('dispose', async () => {
   await extensionWatcher.monitor(fakeAnalyzedExtension);
-  extensionWatcher.stop();
+  extensionWatcher.dispose();
 
   expect(fileSystemDisposeMock).toHaveBeenCalled();
 });

--- a/packages/main/src/plugin/extension-watcher.spec.ts
+++ b/packages/main/src/plugin/extension-watcher.spec.ts
@@ -1,0 +1,221 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { FileSystemWatcher } from '@podman-desktop/api';
+import type { FileMatcher } from 'get-tsconfig';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { ActivatedExtension, AnalyzedExtension } from './extension-loader.js';
+import { ExtensionWatcher } from './extension-watcher.js';
+import type { FilesystemMonitoring } from './filesystem-monitoring.js';
+
+vi.mock('get-tsconfig');
+
+const fileSystemMonitoring = {
+  createFileSystemWatcher: vi.fn(),
+} as unknown as FilesystemMonitoring;
+
+class TestExtensionWatcher extends ExtensionWatcher {
+  public override isWatched(extension: AnalyzedExtension): boolean {
+    return super.isWatched(extension);
+  }
+
+  public override reloadExtension(extension: AnalyzedExtension): void {
+    super.reloadExtension(extension);
+  }
+
+  public override async getTsConfigFileMatcher(extension: AnalyzedExtension): Promise<FileMatcher | undefined> {
+    return super.getTsConfigFileMatcher(extension);
+  }
+
+  public override getWatcher(extension: ActivatedExtension): FileSystemWatcher | undefined {
+    return super.getWatcher(extension);
+  }
+}
+
+let extensionWatcher: TestExtensionWatcher;
+const fakeAnalyzedExtension = {
+  id: 'my.extensionId',
+  path: 'fakePath',
+} as unknown as AnalyzedExtension;
+const fakeActivatedExtension = {
+  id: 'my.extensionId',
+} as unknown as ActivatedExtension;
+
+const fileSystemOnDidChangeMock = vi.fn();
+const fileSystemDisposeMock = vi.fn();
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.resetAllMocks();
+
+  // mock createFileSystemWatcher
+  vi.mocked(fileSystemMonitoring.createFileSystemWatcher).mockReturnValue({
+    onDidChange: fileSystemOnDidChangeMock,
+    dispose: fileSystemDisposeMock,
+  } as unknown as FileSystemWatcher);
+
+  extensionWatcher = new TestExtensionWatcher(fileSystemMonitoring);
+});
+
+describe('monitor', () => {
+  test('check without tsconfig / fileMatcher', async () => {
+    const reloadSpy = vi.spyOn(extensionWatcher, 'reloadExtension');
+
+    // call monitor
+    await extensionWatcher.monitor(fakeAnalyzedExtension);
+
+    // check that we called the createFileSystemWatcher method on fileSystemMonitoring
+    expect(fileSystemMonitoring.createFileSystemWatcher).toHaveBeenCalled();
+
+    //get argument of onDidChangeMock
+    const onDidChangeCallback = fileSystemOnDidChangeMock.mock.calls[0]?.[0];
+    expect(onDidChangeCallback).toBeDefined();
+
+    // call the callback
+    onDidChangeCallback({ fsPath: 'fakePath' });
+
+    // check that we call reloadExtension method
+    await vi.waitFor(() => expect(reloadSpy).toHaveBeenCalled());
+  });
+
+  test('check with tsconfig but in the source file', async () => {
+    const reloadSpy = vi.spyOn(extensionWatcher, 'reloadExtension');
+
+    // say that the file is part of the source
+    const fakeFileMatcher = vi.fn().mockReturnValue(true) as FileMatcher;
+    vi.spyOn(extensionWatcher, 'getTsConfigFileMatcher').mockResolvedValue(fakeFileMatcher);
+
+    // call monitor
+    await extensionWatcher.monitor(fakeAnalyzedExtension);
+
+    // check that we called the createFileSystemWatcher method on fileSystemMonitoring
+    expect(fileSystemMonitoring.createFileSystemWatcher).toHaveBeenCalled();
+
+    //get argument of onDidChangeMock
+    const onDidChangeCallback = fileSystemOnDidChangeMock.mock.calls[0]?.[0];
+    expect(onDidChangeCallback).toBeDefined();
+
+    // call the callback
+    onDidChangeCallback({ fsPath: 'fakePath' });
+
+    // check that we don't call reloadExtension method as we detected a change in the source file
+    await vi.waitFor(() => expect(reloadSpy).not.toHaveBeenCalled());
+  });
+
+  test('check with tsconfig and not in the source file', async () => {
+    const reloadSpy = vi.spyOn(extensionWatcher, 'reloadExtension');
+
+    // say that the file is not part of the source
+    const fakeFileMatcher = vi.fn().mockReturnValue(undefined) as FileMatcher;
+    vi.spyOn(extensionWatcher, 'getTsConfigFileMatcher').mockResolvedValue(fakeFileMatcher);
+
+    // call monitor
+    await extensionWatcher.monitor(fakeAnalyzedExtension);
+
+    // check that we called the createFileSystemWatcher method on fileSystemMonitoring
+    expect(fileSystemMonitoring.createFileSystemWatcher).toHaveBeenCalled();
+
+    //get argument of onDidChangeMock
+    const onDidChangeCallback = fileSystemOnDidChangeMock.mock.calls[0]?.[0];
+    expect(onDidChangeCallback).toBeDefined();
+
+    // call the callback
+    onDidChangeCallback({ fsPath: 'fakePath' });
+
+    // check that we call reloadExtension method as we detected a change but not in the source file
+    await vi.waitFor(() => expect(reloadSpy).toHaveBeenCalled());
+  });
+
+  test('check skip if already tracked', async () => {
+    // replace the isWatched method to return true
+    vi.spyOn(extensionWatcher, 'isWatched').mockReturnValue(true);
+    const reloadSpy = vi.spyOn(extensionWatcher, 'reloadExtension');
+    // call monitor
+    await extensionWatcher.monitor(fakeAnalyzedExtension);
+
+    // check that we didn't called the createFileSystemWatcher method on fileSystemMonitoring
+    expect(fileSystemMonitoring.createFileSystemWatcher).not.toHaveBeenCalled();
+
+    // and we didn't call reloadExtension method
+    expect(reloadSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('untrack', () => {
+  test('dispose watcher', async () => {
+    const fakeWatcher = {
+      dispose: vi.fn(),
+    } as unknown as FileSystemWatcher;
+
+    // mock getWatcher to return the fakeWatcher
+    const getWatcherSpy = vi.spyOn(extensionWatcher, 'getWatcher').mockReturnValue(fakeWatcher);
+
+    // call untrack
+    extensionWatcher.untrack(fakeActivatedExtension);
+
+    // check that we called the dispose method on the watcher
+    expect(fakeWatcher.dispose).toHaveBeenCalled();
+    expect(getWatcherSpy).toHaveBeenCalled();
+  });
+
+  test('do not dispose watcher', async () => {
+    // call untrack
+    extensionWatcher.untrack(fakeActivatedExtension);
+
+    // check that we didn't called the dispose method on the watcher
+    expect(fileSystemMonitoring.createFileSystemWatcher).not.toHaveBeenCalled();
+  });
+});
+
+test('stop', async () => {
+  await extensionWatcher.monitor(fakeAnalyzedExtension);
+  extensionWatcher.stop();
+
+  expect(fileSystemDisposeMock).toHaveBeenCalled();
+});
+
+describe('reloadExtension', () => {
+  test('check reloadExtension cancel timeout', async () => {
+    let extensionReloadEvent: AnalyzedExtension | undefined;
+    let eventCalledNumber = 0;
+    // subscribe to events
+    extensionWatcher.onNeedToReloadExtension(event => {
+      extensionReloadEvent = event;
+      eventCalledNumber++;
+    });
+
+    // make several calls to reloadExtension in a row to check how is working the dismiss of previous timeouts
+    extensionWatcher.reloadExtension(fakeAnalyzedExtension);
+    for (let i = 0; i < 10; i++) {
+      // wait 100ms using setTimeout
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      // perform another call
+      extensionWatcher.reloadExtension(fakeAnalyzedExtension);
+    }
+
+    // and now wait that we're calling the event
+    await vi.waitFor(() => expect(extensionReloadEvent).toBeDefined(), { timeout: 3_000 });
+
+    expect(extensionReloadEvent?.id).toBe(fakeAnalyzedExtension.id);
+
+    // expect only one callback even if we spawn multiple orders
+    expect(eventCalledNumber).toBe(1);
+  });
+});

--- a/packages/main/src/plugin/extension-watcher.ts
+++ b/packages/main/src/plugin/extension-watcher.ts
@@ -1,0 +1,127 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { FileSystemWatcher } from '@podman-desktop/api';
+import type { FileMatcher } from 'get-tsconfig';
+
+import type { Event } from './events/emitter.js';
+import { Emitter } from './events/emitter.js';
+import type { ActivatedExtension, AnalyzedExtension } from './extension-loader.js';
+import { ExtensionTypeScriptConfigParser } from './extension-tsconfig-parser.js';
+import type { FilesystemMonitoring } from './filesystem-monitoring.js';
+
+// In charge of watching the extension and reloading it when it changes
+export class ExtensionWatcher {
+  #watcherExtensions: Map<string, FileSystemWatcher>;
+
+  #reloadExtensionTimeouts: Map<string, NodeJS.Timeout>;
+
+  #fileSystemMonitoring: FilesystemMonitoring;
+
+  #onNeedToReloadExtension = new Emitter<AnalyzedExtension>();
+  readonly onNeedToReloadExtension: Event<AnalyzedExtension> = this.#onNeedToReloadExtension.event;
+
+  constructor(fileSystemMonitoring: FilesystemMonitoring) {
+    this.#fileSystemMonitoring = fileSystemMonitoring;
+    this.#watcherExtensions = new Map<string, FileSystemWatcher>();
+    this.#reloadExtensionTimeouts = new Map<string, NodeJS.Timeout>();
+  }
+
+  // detected that the extension needs to be reloaded
+  // we do not this immediately to avoid reloading the extension while it is still being updated
+  protected reloadExtension(extension: AnalyzedExtension): void {
+    // do we already have a timeout asking to reload the extension ?
+    // if yes, cancel the existing one and create a new one
+    if (this.#reloadExtensionTimeouts.has(extension.id)) {
+      clearTimeout(this.#reloadExtensionTimeouts.get(extension.id));
+    }
+
+    // wait 1 second before trying to reload the extension
+    // this is to avoid reloading the extension while it is still being updated
+    const timeout = setTimeout(() => {
+      this.#onNeedToReloadExtension.fire(extension);
+    }, 1_000);
+
+    this.#reloadExtensionTimeouts.set(extension.id, timeout);
+  }
+
+  protected isWatched(extension: AnalyzedExtension): boolean {
+    return this.#watcherExtensions.has(extension.id);
+  }
+
+  protected async getTsConfigFileMatcher(extension: AnalyzedExtension): Promise<FileMatcher | undefined> {
+    const extensionTypeScriptConfigParser = new ExtensionTypeScriptConfigParser(extension.path);
+    return extensionTypeScriptConfigParser.analyze();
+  }
+
+  async monitor(extension: AnalyzedExtension): Promise<void> {
+    // track only if not already tracking
+    if (this.isWatched(extension)) {
+      return;
+    }
+
+    // analyze all tsconfig.json files from
+    const tsConfigFileMatcher = await this.getTsConfigFileMatcher(extension);
+
+    const extensionWatcher = this.#fileSystemMonitoring.createFileSystemWatcher(extension.path);
+    this.#watcherExtensions.set(extension.id, extensionWatcher);
+
+    extensionWatcher.onDidChange(async event => {
+      // check if it's matching the source pattern of an existing typescript config
+      let isInSource = false;
+      const hasTsConfig = tsConfigFileMatcher !== undefined;
+      if (tsConfigFileMatcher) {
+        const matchingJsonEvent = tsConfigFileMatcher(event.fsPath);
+        isInSource = matchingJsonEvent !== undefined;
+      }
+
+      if (!hasTsConfig || !isInSource) {
+        this.reloadExtension(extension);
+      }
+    });
+  }
+
+  protected getWatcher(extension: ActivatedExtension): FileSystemWatcher | undefined {
+    return this.#watcherExtensions.get(extension.id);
+  }
+
+  untrack(extension: ActivatedExtension): void {
+    // dispose the watcher
+    const watcher = this.getWatcher(extension);
+    if (watcher) {
+      watcher.dispose();
+    }
+    this.#watcherExtensions.delete(extension.id);
+  }
+
+  stop(): void {
+    // dispose all watchers
+    for (const watcher of this.#watcherExtensions.values()) {
+      watcher.dispose();
+    }
+
+    // clear all timeouts
+    for (const timeout of this.#reloadExtensionTimeouts.values()) {
+      clearTimeout(timeout);
+    }
+
+    // reset all map
+    this.#watcherExtensions.clear();
+    this.#reloadExtensionTimeouts.clear();
+  }
+}

--- a/packages/main/src/plugin/extension-watcher.ts
+++ b/packages/main/src/plugin/extension-watcher.ts
@@ -24,9 +24,10 @@ import { Emitter } from './events/emitter.js';
 import type { ActivatedExtension, AnalyzedExtension } from './extension-loader.js';
 import { ExtensionTypeScriptConfigParser } from './extension-tsconfig-parser.js';
 import type { FilesystemMonitoring } from './filesystem-monitoring.js';
+import type { IDisposable } from './types/disposable.js';
 
 // In charge of watching the extension and reloading it when it changes
-export class ExtensionWatcher {
+export class ExtensionWatcher implements IDisposable {
   #watcherExtensions: Map<string, FileSystemWatcher>;
 
   #reloadExtensionTimeouts: Map<string, NodeJS.Timeout>;
@@ -109,7 +110,7 @@ export class ExtensionWatcher {
     this.#watcherExtensions.delete(extension.id);
   }
 
-  stop(): void {
+  dispose(): void {
     // dispose all watchers
     for (const watcher of this.#watcherExtensions.values()) {
       watcher.dispose();

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -144,6 +144,7 @@ import type {
 import { EditorInit } from './editor-init.js';
 import type { Emitter } from './events/emitter.js';
 import { ExtensionLoader } from './extension-loader.js';
+import { ExtensionWatcher } from './extension-watcher.js';
 import { ExtensionsCatalog } from './extensions-catalog/extensions-catalog.js';
 import type { CatalogExtension } from './extensions-catalog/extensions-catalog-api.js';
 import { ExtensionsUpdater } from './extensions-updater/extensions-updater.js';
@@ -664,6 +665,8 @@ export class PluginSystem {
       onboardingRegistry,
     );
 
+    const extensionWatcher = new ExtensionWatcher(fileSystemMonitoring);
+
     this.extensionLoader = new ExtensionLoader(
       commandRegistry,
       menuRegistry,
@@ -700,6 +703,7 @@ export class PluginSystem {
       dialogRegistry,
       safeStorageRegistry,
       certificates,
+      extensionWatcher,
     );
     await this.extensionLoader.init();
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -247,6 +247,9 @@ importers:
       fzstd:
         specifier: ^0.1.1
         version: 0.1.1
+      get-tsconfig:
+        specifier: ^4.8.1
+        version: 4.8.1
       globals:
         specifier: ^15.14.0
         version: 15.14.0


### PR DESCRIPTION
### What does this PR do?
current implementation is broken:
- remove watcher on the first reload (called in deactivate)
- trigger reload even if changes are in the source repository

Move the detection of changes/callback to a separate class handling only the reload
handle properly debounce (do not refresh 10 times if we call the reload method several times in few seconds)
ignore the changes from the source directory

⚠️ introduce the [get-tsconfig](https://www.npmjs.com/package/get-tsconfig) library handling the includes section of the tsconfig.json with matchers. It is being downloaded over 10M each week

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/podman-desktop/podman-desktop/issues/10619


### How to test this PR?

Use an extension (like ai lab, boot-c) in development mode
Having the extension in watch mode (and Podman Desktop)
change a file in the frontend or backend and wait to see a refresh upon the new build of the extension

- [x] Tests are covering the bug fix or the new feature
