### PR TITLE
chore: add Container providers using ProviderWidget

### DIFF
--- a/packages/main/src/plugin/statusbar/statusbar-providers-init.ts
+++ b/packages/main/src/plugin/statusbar/statusbar-providers-init.ts
@@ -31,7 +31,6 @@ export class StatusbarProvidersInit {
           description: 'Show providers in statusbar',
           type: 'boolean',
           default: import.meta.env.DEV ? true : false,
-          hidden: true,
         },
       },
     };

--- a/packages/renderer/src/lib/statusbar/StatusBar.svelte
+++ b/packages/renderer/src/lib/statusbar/StatusBar.svelte
@@ -25,7 +25,7 @@ function onDidChangeConfigurationCallback(e: Event): void {
   }
   if ('key' in e.detail && 'value' in e.detail) {
     const detail = e.detail as { key: string; value: boolean };
-    if (`statusbarProviders.showProviders` === detail.key) {
+    if ('statusbarProviders.showProviders' === detail.key) {
       experimentalProvidersStatusBar = detail.value;
     }
   }
@@ -76,11 +76,11 @@ onMount(async () => {
   experimentalProvidersStatusBar =
     (await window.getConfigurationValue<boolean>('statusbarProviders.showProviders')) ?? false;
 
-  onDidChangeConfiguration.addEventListener(`statusbarProviders.showProviders`, onDidChangeConfigurationCallback);
+  onDidChangeConfiguration.addEventListener('statusbarProviders.showProviders', onDidChangeConfigurationCallback);
 });
 
 onDestroy(() => {
-  onDidChangeConfiguration.removeEventListener(`statusbarProviders.showProviders`, onDidChangeConfigurationCallback);
+  onDidChangeConfiguration.removeEventListener('statusbarProviders.showProviders', onDidChangeConfigurationCallback);
 });
 </script>
 

--- a/packages/renderer/src/lib/statusbar/StatusBar.svelte
+++ b/packages/renderer/src/lib/statusbar/StatusBar.svelte
@@ -2,16 +2,33 @@
 import { onMount } from 'svelte';
 
 import TaskIndicator from '/@/lib/statusbar/TaskIndicator.svelte';
+import { onDidChangeConfiguration } from '/@/stores/configurationProperties';
+import { providerInfos } from '/@/stores/providers';
 import { statusBarEntries } from '/@/stores/statusbar';
 import { ExperimentalTasksSettings } from '/@api/tasks-preferences';
 
 import type { StatusBarEntry } from '../../../../main/src/plugin/statusbar/statusbar-registry';
+import ProviderWidget from './ProviderWidget.svelte';
 import StatusBarItem from './StatusBarItem.svelte';
+
+onDidChangeConfiguration.addEventListener(`statusbarProviders.showProviders`, onDidChangeConfigurationCallback);
 
 let leftEntries: StatusBarEntry[] = $state([]);
 let rightEntries: StatusBarEntry[] = $state([]);
 
+let containerProviders = $derived($providerInfos.filter(provider => provider.containerConnections.length > 0));
+
 let experimentalTaskStatusBar: boolean = $state(false);
+let experimentalProvidersStatusBar: boolean = $state(false);
+
+function onDidChangeConfigurationCallback(e: Event): void {
+  if ('detail' in e) {
+    const detail = e.detail as { key: string; value: boolean };
+    if (`statusbarProviders.showProviders` === detail?.key) {
+      experimentalProvidersStatusBar = detail.value;
+    }
+  }
+}
 
 onMount(async () => {
   statusBarEntries.subscribe(value => {
@@ -54,6 +71,9 @@ onMount(async () => {
     (await window.getConfigurationValue<boolean>(
       `${ExperimentalTasksSettings.SectionName}.${ExperimentalTasksSettings.StatusBar}`,
     )) ?? false;
+
+  experimentalProvidersStatusBar =
+    (await window.getConfigurationValue<boolean>('statusbarProviders.showProviders')) ?? false;
 });
 </script>
 
@@ -61,10 +81,15 @@ onMount(async () => {
   class="flex justify-between px-1 bg-[var(--pd-statusbar-bg)] text-[var(--pd-statusbar-text)] text-sm space-x-2 z-40"
   role="contentinfo"
   aria-label="Status Bar">
-  <div class="flex flex-wrap gap-x-1.5 h-full">
+  <div class="flex flex-nowrap gap-x-1.5 h-full truncate">
     {#each leftEntries as entry}
       <StatusBarItem entry={entry} />
     {/each}
+    {#if experimentalProvidersStatusBar}
+      {#each containerProviders as entry}
+        <ProviderWidget entry={entry}/>
+      {/each}
+    {/if}
   </div>
   <div class="flex flex-wrap flex-row-reverse gap-x-1.5 h-full place-self-end">
     {#each rightEntries as entry}

--- a/packages/renderer/src/lib/statusbar/StatusBar.svelte
+++ b/packages/renderer/src/lib/statusbar/StatusBar.svelte
@@ -25,9 +25,8 @@ function onDidChangeConfigurationCallback(e: Event): void {
   }
   if ('key' in e.detail && 'value' in e.detail) {
     const detail = e.detail as { key: string; value: boolean };
-    if (`statusbarProviders.showProviders` === detail?.key) {
+    if (`statusbarProviders.showProviders` === detail.key) {
       experimentalProvidersStatusBar = detail.value;
-      console.log('>>>> new value: ' + experimentalProvidersStatusBar);
     }
   }
 }


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR adds the experimental container providers in the statusbar using `ProviderWidget`

### Screenshot / video of UI
[Screencast from 2025-01-13 17-03-19.webm](https://github.com/user-attachments/assets/1c2d5201-cdd4-4931-b54e-426e7454d69d)


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/podman-desktop/issues/9556
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
