### PR TITLE
chore: update css-color used by cssstyle and jsdom

### DIFF
--- a/package.json
+++ b/package.json
@@ -218,7 +218,8 @@
       "express>cookie": "^0.7.0",
       "@docusaurus/theme-mermaid>mermaid": "^10.9.3",
       "webpack-dev-server>http-proxy-middleware": "^2.0.7",
-      "@kubernetes/client-node>jsonpath-plus": "^10.0.7"
+      "@kubernetes/client-node>jsonpath-plus": "^10.0.7",
+      "cssstyle>@asamuzakjp/css-color": "^2.8.3-b.2"
     }
   },
   "packageManager": "pnpm@9.14.1+sha512.7f1de9cffea40ff4594c48a94776112a0db325e81fb18a9400362ff7b7247f4fbd76c3011611c9f8ac58743c3dc526017894e07948de9b72052f874ee2edfdcd"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   '@docusaurus/theme-mermaid>mermaid': ^10.9.3
   webpack-dev-server>http-proxy-middleware: ^2.0.7
   '@kubernetes/client-node>jsonpath-plus': ^10.0.7
+  cssstyle>@asamuzakjp/css-color: ^2.8.3-b.2
 
 importers:
 
@@ -1184,8 +1185,8 @@ packages:
     resolution: {integrity: sha512-z2B3EYVhDCDYlQwg55C/P8Xvbupb+XjmRHggIYl1R3yiNEBqy/kT9X/uOVMHxFyhLsM2PXsOOruugJoT11dB7Q==}
     engines: {node: '>=18.0.0'}
 
-  '@asamuzakjp/css-color@2.8.2':
-    resolution: {integrity: sha512-RtWv9jFN2/bLExuZgFFZ0I3pWWeezAHGgrmjqGGWclATl1aDe3yhCUaI0Ilkp6OCk9zX7+FjvDasEX8Q9Rxc5w==}
+  '@asamuzakjp/css-color@2.8.3-b.2':
+    resolution: {integrity: sha512-caREANPZtL+FpyN5cJMonkm4jJ0EMarV9PdGG8HkkqmPJIbnXZXn1h78WdorZKTgOt379aGkt1CRMd2YNV9ycg==}
 
   '@babel/code-frame@7.26.2':
     resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
@@ -7824,10 +7825,6 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
-  lru-cache@11.0.2:
-    resolution: {integrity: sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==}
-    engines: {node: 20 || >=22}
-
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -11566,13 +11563,13 @@ snapshots:
 
   '@argos-ci/util@2.2.1': {}
 
-  '@asamuzakjp/css-color@2.8.2':
+  '@asamuzakjp/css-color@2.8.3-b.2':
     dependencies:
       '@csstools/css-calc': 2.1.1(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-color-parser': 3.0.7(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
-      lru-cache: 11.0.2
+      lru-cache: 10.4.3
 
   '@babel/code-frame@7.26.2':
     dependencies:
@@ -17155,7 +17152,7 @@ snapshots:
 
   cssstyle@4.2.1:
     dependencies:
-      '@asamuzakjp/css-color': 2.8.2
+      '@asamuzakjp/css-color': 2.8.3-b.2
       rrweb-cssom: 0.8.0
 
   csstype@3.1.3: {}
@@ -19999,8 +19996,6 @@ snapshots:
   lowercase-keys@3.0.0: {}
 
   lru-cache@10.4.3: {}
-
-  lru-cache@11.0.2: {}
 
   lru-cache@5.1.1:
     dependencies:


### PR DESCRIPTION
### What does this PR do?
there is an error in the version used currently by jsdom
allows to make unit tests passing

dependency graph is

```
jsdom 26.0.0 peer
  └─┬ cssstyle 4.2.1
    └── @asamuzakjp/css-color 2.8.3-b.2
```

⚠️ this PR targets the dependabot jsdom branch

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/pull/10589

### How to test this PR?

PR check should be 💚 

- [x] Tests are covering the bug fix or the new feature
