### PR TITLE
feat: support children render for badge component

### DIFF
--- a/packages/renderer/src/lib/ui/Badge.spec.ts
+++ b/packages/renderer/src/lib/ui/Badge.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -108,4 +108,11 @@ test('Should display badge with custom class', async () => {
   expect(label).toBeInTheDocument();
 
   await vi.waitFor(() => expect(label).toHaveClass('text-right'));
+});
+
+test('children should be rendered if defined', async () => {
+  const children = vi.fn();
+  render(Badge, { label: 'customLabel', class: 'text-right', children });
+
+  await vi.waitFor(() => expect(children).toHaveBeenCalled());
 });

--- a/packages/renderer/src/lib/ui/Badge.svelte
+++ b/packages/renderer/src/lib/ui/Badge.svelte
@@ -1,13 +1,19 @@
 <script lang="ts">
-import { onMount } from 'svelte';
+import { onMount, type Snippet } from 'svelte';
 
 import { AppearanceUtil } from '/@/lib/appearance/appearance-util';
 
-export let color: string | { light: string; dark: string } = 'bg-[var(--pd-badge-gray)]';
-export let label: string = '';
+interface Props {
+  color?: string | { light: string; dark: string };
+  label: string;
+  children?: Snippet;
+  class?: string;
+}
 
-let customStyle: string = '';
-let customClass: string = '';
+let { color = 'bg-[var(--pd-badge-gray)]', label = '', class: className, children }: Props = $props();
+
+let customStyle: string = $state('');
+let customClass: string = $state('');
 
 onMount(async () => {
   const appearanceUtil = new AppearanceUtil();
@@ -26,6 +32,10 @@ onMount(async () => {
 });
 </script>
 
-<div class="text-[var(--pd-badge-text)] text-xs me-2 px-1 py-0.5 rounded select-none {customClass} {$$props.class}" style={customStyle}>
-  {label}
+<div class="text-[var(--pd-badge-text)] text-xs me-2 px-1 py-0.5 rounded select-none {customClass} {className}" style={customStyle}>
+  {#if children}
+    {@render children()}
+  {:else}
+    {label}
+  {/if}
 </div>


### PR DESCRIPTION
### What does this PR do?

For https://github.com/podman-desktop/podman-desktop/pull/10534 we need to have the badge with an icon. See UX bellow

![image](https://github.com/user-attachments/assets/25b24947-942c-4ae1-8091-bd010f4b9ee9)

To allow adding the icon, two options

- adding an `icon: ?` field
- using default slot

I decided to use the default slot for flexibility.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Required for https://github.com/podman-desktop/podman-desktop/pull/10534

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
