### PR TITLE
feat: introduce a flag to be able to see 'show DevTools' even using production binaries

### DIFF
--- a/packages/main/src/development-mode-tracker.spec.ts
+++ b/packages/main/src/development-mode-tracker.spec.ts
@@ -1,0 +1,160 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Configuration } from '@podman-desktop/api';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { DevelopmentModeTracker } from './development-mode-tracker.js';
+import type { ConfigurationRegistry } from './plugin/configuration-registry.js';
+import { ExtensionLoaderSettings } from './plugin/extension-loader-settings.js';
+
+const configurationRegistry = {
+  getConfiguration: vi.fn(),
+  onDidChangeConfiguration: vi.fn(),
+  onDidUpdateConfiguration: vi.fn(),
+} as unknown as ConfigurationRegistry;
+
+let developmentModeTracker: TestDevelopmentModeTracker;
+
+class TestDevelopmentModeTracker extends DevelopmentModeTracker {
+  override refreshConfigurationValue(): void {
+    super.refreshConfigurationValue();
+  }
+}
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.resetAllMocks();
+  developmentModeTracker = new TestDevelopmentModeTracker(configurationRegistry);
+});
+
+test('foo', () => {
+  // mock refreshConfigurationValue method
+  const refreshConfigurationValueSpy = vi.spyOn(developmentModeTracker, 'refreshConfigurationValue');
+  refreshConfigurationValueSpy.mockReturnValue();
+  developmentModeTracker.init();
+
+  // check we called the onDidUpdateConfiguration method
+  expect(configurationRegistry.onDidUpdateConfiguration).toBeCalled();
+
+  // check we called the onDidChangeConfiguration method
+  expect(configurationRegistry.onDidChangeConfiguration).toBeCalled();
+
+  // check we called the refreshConfigurationValue method
+  expect(refreshConfigurationValueSpy).toBeCalled();
+
+  // now check that if we call onDidUpdateConfiguration callback it will call refreshConfigurationValue method
+  const onDidUpdateConfigurationCallback = vi.mocked(configurationRegistry.onDidUpdateConfiguration).mock.calls[0]?.[0];
+  expect(onDidUpdateConfigurationCallback).toBeDefined();
+  refreshConfigurationValueSpy.mockClear();
+  // send dummy event
+  onDidUpdateConfigurationCallback?.({ properties: ['fooEvent'] });
+  // should not trigger a refresh
+  expect(refreshConfigurationValueSpy).not.toBeCalled();
+  // now send the expected property
+  onDidUpdateConfigurationCallback?.({ properties: ['extensions.developmentMode'] });
+  // and check that the refresh was called
+  expect(refreshConfigurationValueSpy).toBeCalled();
+
+  // now check that if we call onDidChangeConfiguration callback it will call refreshConfigurationValue method
+  const onDidChangeConfigurationCallback = vi.mocked(configurationRegistry.onDidChangeConfiguration).mock.calls[0]?.[0];
+  expect(onDidChangeConfigurationCallback).toBeDefined();
+  refreshConfigurationValueSpy.mockClear();
+  // send dummy event
+  onDidChangeConfigurationCallback?.({ key: 'fooEvent', value: 'fooValue', scope: 'DEFAULT' });
+  // should not trigger a refresh
+  expect(refreshConfigurationValueSpy).not.toBeCalled();
+  // now send the expected property
+  onDidChangeConfigurationCallback?.({
+    key: `${ExtensionLoaderSettings.SectionName}.${ExtensionLoaderSettings.DevelopmentMode}`,
+    value: 'true',
+    scope: 'DEFAULT',
+  });
+  // and check that the refresh was called
+  expect(refreshConfigurationValueSpy).toBeCalled();
+});
+
+describe('refreshConfigurationValue', () => {
+  test('first launch is triggering event', () => {
+    // mock getConfiguration
+    vi.mocked(configurationRegistry.getConfiguration).mockReturnValue({
+      get: vi.fn().mockReturnValue(true),
+    } as unknown as Configuration);
+
+    // register a callback
+    const onDidChangeDevelopmentModeCallback = vi.fn();
+    developmentModeTracker.onDidChangeDevelopmentMode(onDidChangeDevelopmentModeCallback);
+
+    // call the refresh
+    developmentModeTracker.refreshConfigurationValue();
+
+    // check that the callback was called
+    expect(onDidChangeDevelopmentModeCallback).toBeCalledWith(true);
+  });
+
+  test('same value, no event triggered', () => {
+    // mock getConfiguration
+    vi.mocked(configurationRegistry.getConfiguration).mockReturnValue({
+      get: vi.fn().mockReturnValue(true),
+    } as unknown as Configuration);
+
+    // register a callback
+    const onDidChangeDevelopmentModeCallback = vi.fn();
+    developmentModeTracker.onDidChangeDevelopmentMode(onDidChangeDevelopmentModeCallback);
+
+    // call the refresh
+    developmentModeTracker.refreshConfigurationValue();
+
+    // clear the number of calls
+    onDidChangeDevelopmentModeCallback.mockClear();
+
+    // call the refresh again
+    developmentModeTracker.refreshConfigurationValue();
+
+    // check that the callback was not called
+    expect(onDidChangeDevelopmentModeCallback).not.toBeCalled();
+  });
+
+  test('different value, event triggered', () => {
+    // first call with true
+    vi.mocked(configurationRegistry.getConfiguration).mockReturnValueOnce({
+      get: vi.fn().mockReturnValue(true),
+    } as unknown as Configuration);
+    // second call with false
+    vi.mocked(configurationRegistry.getConfiguration).mockReturnValueOnce({
+      get: vi.fn().mockReturnValue(false),
+    } as unknown as Configuration);
+
+    // register a callback
+    const onDidChangeDevelopmentModeCallback = vi.fn();
+    developmentModeTracker.onDidChangeDevelopmentMode(onDidChangeDevelopmentModeCallback);
+
+    // call the refresh
+    developmentModeTracker.refreshConfigurationValue();
+
+    // first call, called with true
+    expect(onDidChangeDevelopmentModeCallback).toBeCalledWith(true);
+    onDidChangeDevelopmentModeCallback.mockClear();
+
+    // call the refresh again
+    developmentModeTracker.refreshConfigurationValue();
+
+    // second call, called with false
+    expect(onDidChangeDevelopmentModeCallback).toBeCalledWith(false);
+    onDidChangeDevelopmentModeCallback.mockClear();
+  });
+});

--- a/packages/main/src/development-mode-tracker.ts
+++ b/packages/main/src/development-mode-tracker.ts
@@ -1,0 +1,70 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { ConfigurationRegistry } from './plugin/configuration-registry.js';
+import { Emitter } from './plugin/events/emitter.js';
+import { ExtensionLoaderSettings } from './plugin/extension-loader-settings.js';
+
+// track the changes of the development mode and provides a single event to update
+export class DevelopmentModeTracker {
+  // event that will be fired
+  #onDidChangeDevelopmentMode: Emitter<boolean> = new Emitter<boolean>();
+  onDidChangeDevelopmentMode = this.#onDidChangeDevelopmentMode.event;
+
+  #configurationRegistry: ConfigurationRegistry;
+
+  // default value is the development mode flag
+  #currentValue: undefined | boolean = undefined;
+
+  constructor(configurationRegistry: ConfigurationRegistry) {
+    this.#configurationRegistry = configurationRegistry;
+  }
+
+  protected refreshConfigurationValue(): void {
+    const newValue = this.#configurationRegistry
+      .getConfiguration(ExtensionLoaderSettings.SectionName)
+      .get<boolean>(ExtensionLoaderSettings.DevelopmentMode, import.meta.env.DEV);
+
+    // first launch ? send the initial value as well
+    // or when value is being changed
+    if (this.#currentValue === undefined || this.#currentValue !== newValue) {
+      this.#currentValue = newValue;
+      this.#onDidChangeDevelopmentMode.fire(newValue);
+    }
+  }
+
+  init(): void {
+    this.refreshConfigurationValue();
+
+    // refresh the value when the property is registered (with its default value)
+    this.#configurationRegistry.onDidUpdateConfiguration(event => {
+      if (
+        event.properties.includes(`${ExtensionLoaderSettings.SectionName}.${ExtensionLoaderSettings.DevelopmentMode}`)
+      ) {
+        this.refreshConfigurationValue();
+      }
+    });
+
+    // update when the value is being changed
+    this.#configurationRegistry.onDidChangeConfiguration(event => {
+      if (event.key === `${ExtensionLoaderSettings.SectionName}.${ExtensionLoaderSettings.DevelopmentMode}`) {
+        this.refreshConfigurationValue();
+      }
+    });
+  }
+}

--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -24,6 +24,7 @@ import { app, autoUpdater, BrowserWindow, ipcMain, nativeTheme, screen } from 'e
 import contextMenu from 'electron-context-menu';
 
 import { buildDevelopmentMenu } from './development-menu-builder.js';
+import { DevelopmentModeTracker } from './development-mode-tracker.js';
 import { NavigationItemsMenuBuilder } from './navigation-items-menu-builder.js';
 import { OpenDevTools } from './open-dev-tools.js';
 import type { ConfigurationRegistry } from './plugin/configuration-registry.js';
@@ -32,6 +33,9 @@ import { isLinux, isMac, stoppedExtensions } from './util.js';
 
 const openDevTools = new OpenDevTools();
 let navigationItemsMenuBuilder: NavigationItemsMenuBuilder;
+
+// development mode for extensions
+let isExtensionsDevelopmentModeEnabled = false;
 
 async function createWindow(): Promise<BrowserWindow> {
   const INITIAL_APP_WIDTH = 1050;
@@ -108,6 +112,13 @@ async function createWindow(): Promise<BrowserWindow> {
   let configurationRegistry: ConfigurationRegistry;
   ipcMain.on('configuration-registry', (_, data) => {
     configurationRegistry = data;
+
+    // refresh the value of the development mode config property
+    const developmentModeTracker = new DevelopmentModeTracker(configurationRegistry);
+    developmentModeTracker.onDidChangeDevelopmentMode(enabled => {
+      isExtensionsDevelopmentModeEnabled = enabled;
+    });
+    developmentModeTracker.init();
 
     navigationItemsMenuBuilder = new NavigationItemsMenuBuilder(configurationRegistry);
 
@@ -188,7 +199,7 @@ async function createWindow(): Promise<BrowserWindow> {
     showInspectElement: import.meta.env.DEV,
     showServices: false,
     prepend: (_defaultActions, parameters) => {
-      return buildDevelopmentMenu(parameters, browserWindow, import.meta.env.DEV);
+      return buildDevelopmentMenu(parameters, browserWindow, isExtensionsDevelopmentModeEnabled);
     },
     append: (_defaultActions, parameters) => {
       return navigationItemsMenuBuilder?.buildNavigationMenu(parameters) ?? [];

--- a/packages/main/src/plugin/extension-loader-settings.ts
+++ b/packages/main/src/plugin/extension-loader-settings.ts
@@ -22,4 +22,6 @@ export enum ExtensionLoaderSettings {
   SectionName = 'extensions',
   MaxActivationTime = 'maxActivationTime',
   Disabled = 'disabled',
+  DevelopmentMode = 'developmentMode',
+  DevelopmentExtensionsFolders = 'developmentExtensionsFolders',
 }

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -325,7 +325,25 @@ export class ExtensionLoader {
       },
     };
 
-    this.configurationRegistry.registerConfigurations([maxActivationTimeConfiguration, disabledExtensionConfiguration]);
+    const developmentModeExtensionConfiguration: IConfigurationNode = {
+      id: 'preferences.extensions',
+      title: 'Extensions',
+      type: 'object',
+      properties: {
+        [`${ExtensionLoaderSettings.SectionName}.${ExtensionLoaderSettings.DevelopmentMode}`]: {
+          description: 'Development Mode. If enabled, allow to develop extensions locally.',
+          type: 'boolean',
+          default: import.meta.env.DEV,
+          hidden: false,
+        },
+      },
+    };
+
+    this.configurationRegistry.registerConfigurations([
+      maxActivationTimeConfiguration,
+      disabledExtensionConfiguration,
+      developmentModeExtensionConfiguration,
+    ]);
   }
 
   getDisabledExtensionIds(): string[] {


### PR DESCRIPTION
### What does this PR do?
Introduce a configuration flag, allowing to turn on development mode
using this flag it's then possible to show the debug menu in the UI like 'show Devtools' while right clicking on the webview icon


### Screenshot / video of UI


### What issues does this PR fix or reference?

related to #8616 

### How to test this PR?

unit tests added

manual tests:
Launch in dev mode, turn off the property and see that right click on a webview icon is not showing the view Devtools menu
turn again the property and see it's working.
Build a production binary, then check you can see the menu (depending on the selected config value)

- [x] Tests are covering the bug fix or the new feature
