### PR TITLE
fix: fire on*DidUpdateContainerConnection events after connection is started ans the api is setup

### DIFF
--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -109,6 +109,9 @@ export class ContainerProviderRegistry {
   private readonly _onEvent = new Emitter<JSONEvent>();
   readonly onEvent: Event<JSONEvent> = this._onEvent.event;
 
+  private readonly _onApiAttached = new Emitter<string>();
+  readonly onApiAttached: Event<string> = this._onApiAttached.event;
+
   // delay in ms before retrying to connect to the provider when /events connection fails
   protected retryDelayEvents: number = 5000;
 
@@ -300,6 +303,11 @@ export class ContainerProviderRegistry {
 
     this.handleEvents(internalProvider.api, errorHandler);
     this.apiSender.send('provider-change', {});
+    this._onApiAttached.fire(internalProvider.id);
+  }
+
+  isApiAttached(id: string): boolean {
+    return !!this.internalProviders.get(id)?.api;
   }
 
   registerContainerConnection(


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

- Fire on*DidUpdateContainerConnection('starting') events
- Fire on*DidUpdateContainerConnection('started') events after the api of the connection is setup

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #10319 

### How to test this PR?

- [ ] Tests are covering the bug fix or the new feature (TODO)
