### PR TITLE
chore: move extension loader settings to api package

### DIFF
--- a/packages/api/src/extension-loader-settings.ts
+++ b/packages/api/src/extension-loader-settings.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,5 +23,4 @@ export enum ExtensionLoaderSettings {
   MaxActivationTime = 'maxActivationTime',
   Disabled = 'disabled',
   DevelopmentMode = 'developmentMode',
-  DevelopmentExtensionsFolders = 'developmentExtensionsFolders',
 }

--- a/packages/main/src/development-mode-tracker.spec.ts
+++ b/packages/main/src/development-mode-tracker.spec.ts
@@ -19,7 +19,7 @@
 import type { Configuration } from '@podman-desktop/api';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { ExtensionLoaderSettings } from '/@/plugin/extension/extension-loader-settings.js';
+import { ExtensionLoaderSettings } from '/@api/extension-loader-settings.js';
 
 import { DevelopmentModeTracker } from './development-mode-tracker.js';
 import type { ConfigurationRegistry } from './plugin/configuration-registry.js';

--- a/packages/main/src/development-mode-tracker.ts
+++ b/packages/main/src/development-mode-tracker.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { ExtensionLoaderSettings } from '/@/plugin/extension/extension-loader-settings.js';
+import { ExtensionLoaderSettings } from '/@api/extension-loader-settings.js';
 
 import type { ConfigurationRegistry } from './plugin/configuration-registry.js';
 import { Emitter } from './plugin/events/emitter.js';

--- a/packages/main/src/plugin/extension/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension/extension-loader.spec.ts
@@ -32,6 +32,7 @@ import type { KubeGeneratorRegistry } from '/@/plugin/kubernetes/kube-generator-
 import { NavigationManager } from '/@/plugin/navigation/navigation-manager.js';
 import type { WebviewRegistry } from '/@/plugin/webview/webview-registry.js';
 import type { ContributionInfo } from '/@api/contribution-info.js';
+import { ExtensionLoaderSettings } from '/@api/extension-loader-settings.js';
 import { NavigationPage } from '/@api/navigation-page.js';
 import type { OnboardingInfo } from '/@api/onboarding.js';
 import type { WebviewInfo } from '/@api/webview-info.js';
@@ -73,7 +74,6 @@ import { Exec } from '../util/exec.js';
 import type { ViewRegistry } from '../view-registry.js';
 import type { ActivatedExtension, AnalyzedExtension, RequireCacheDict } from './extension-loader.js';
 import { ExtensionLoader } from './extension-loader.js';
-import { ExtensionLoaderSettings } from './extension-loader-settings.js';
 import type { ExtensionWatcher } from './extension-watcher.js';
 
 class TestExtensionLoader extends ExtensionLoader {

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -33,6 +33,7 @@ import type { MenuRegistry } from '/@/plugin/menu-registry.js';
 import type { NavigationManager } from '/@/plugin/navigation/navigation-manager.js';
 import type { WebviewRegistry } from '/@/plugin/webview/webview-registry.js';
 import type { ExtensionError, ExtensionInfo, ExtensionUpdateInfo } from '/@api/extension-info.js';
+import { DEFAULT_TIMEOUT, ExtensionLoaderSettings } from '/@api/extension-loader-settings.js';
 import type { ImageInspectInfo } from '/@api/image-inspect-info.js';
 
 import { securityRestrictionCurrentHandler } from '../../security-restrictions-handler.js';
@@ -85,7 +86,6 @@ import { TelemetryTrustedValue } from '../types/telemetry.js';
 import { Uri } from '../types/uri.js';
 import type { Exec } from '../util/exec.js';
 import type { ViewRegistry } from '../view-registry.js';
-import { DEFAULT_TIMEOUT, ExtensionLoaderSettings } from './extension-loader-settings.js';
 import type { ExtensionWatcher } from './extension-watcher.js';
 
 /**


### PR DESCRIPTION
### What does this PR do?
move extension loader settings to api package
so configuration properties could be read from client side

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

#8616 

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
