### PR TITLE
feat(ui): adding iconPosition property to settings nav item component

### DIFF
--- a/packages/ui/src/lib/settingsNavItem/SettingsNavItem.spec.ts
+++ b/packages/ui/src/lib/settingsNavItem/SettingsNavItem.spec.ts
@@ -22,7 +22,7 @@ import '@testing-library/jest-dom/vitest';
 
 import { faBookOpen } from '@fortawesome/free-solid-svg-icons';
 import { fireEvent, render, screen } from '@testing-library/svelte';
-import { beforeAll, expect, test, vi } from 'vitest';
+import { beforeAll, describe, expect, test, vi } from 'vitest';
 
 import MyIcon from './IconTest.svelte';
 import SettingsNavItem from './SettingsNavItem.svelte';
@@ -134,4 +134,31 @@ test('svg icon should be visible', () => {
   });
   const svg = screen.getByRole('img', { hidden: true });
   expect(svg).toBeInTheDocument();
+});
+
+describe('icon position', () => {
+  test('default icon position should be left', () => {
+    const { getByRole } = render(SettingsNavItem, {
+      title: 'DummyTitle',
+      href: '/dummy/path',
+      selected: false,
+      icon: MyIcon,
+    });
+    const svg = getByRole('img', { hidden: true });
+    expect(svg).toBeInTheDocument();
+    expect(svg.parentElement).toHaveClass('flex-row');
+  });
+
+  test('icon position right should use reverse row', () => {
+    const { getByRole } = render(SettingsNavItem, {
+      title: 'DummyTitle',
+      href: '/dummy/path',
+      selected: false,
+      icon: MyIcon,
+      iconPosition: 'right',
+    });
+    const svg = getByRole('img', { hidden: true });
+    expect(svg).toBeInTheDocument();
+    expect(svg.parentElement).toHaveClass('flex-row-reverse');
+  });
 });

--- a/packages/ui/src/lib/settingsNavItem/SettingsNavItem.svelte
+++ b/packages/ui/src/lib/settingsNavItem/SettingsNavItem.svelte
@@ -13,6 +13,7 @@ interface Props {
   child?: boolean;
   selected?: boolean;
   icon?: IconDefinition | Component;
+  iconPosition?: 'left' | 'right';
   onClick?: () => void;
 }
 
@@ -24,6 +25,7 @@ let {
   child = false,
   selected = false,
   icon = undefined,
+  iconPosition = 'left',
   onClick = (): void => {},
 }: Props = $props();
 
@@ -67,18 +69,20 @@ function click(): void {
     class:hover:text-[color:var(--pd-secondary-nav-text-hover)]={!selected}
     class:hover:bg-[var(--pd-secondary-nav-text-hover-bg)]={!selected}
     class:hover:border-[var(--pd-secondary-nav-text-hover-bg)]={!selected}>
-    <span class="group-hover:block flex flex-row items-center" class:capitalize={!child}>
+    <span
+      class="group-hover:block flex gap-x-4 items-center"
+      class:flex-row={iconPosition === 'left'}
+      class:flex-row-reverse={iconPosition === 'right'}
+      class:capitalize={!child}>
       {#if icon}
         {#if isFontAwesomeIcon(icon)}
-          <Fa class="mr-4" {icon} />
+          <Fa {icon} />
         {:else}
           {@const Icon = icon}
-          <div class="mr-4">
-            <Icon size="14" />
-          </div>
+          <Icon size="14" />
         {/if}
       {/if}
-      {title}
+      <span>{title}</span>
     </span>
     {#if section}
       <div class="px-2 relative w-4 h-4 text-[color:var(--pd-secondary-nav-expander)]">


### PR DESCRIPTION
### What does this PR do?

In the experimental settings mockups we have a flask icon on the right (see https://github.com/podman-desktop/podman-desktop/issues/10223#issuecomment-2587089067).

Adding a `iconPosition` optional property to `SettingsNavItem` component defaulting to left for backward compatiblity.

### Screenshot / video of UI

![image](https://github.com/user-attachments/assets/6be85b60-ef44-4c5f-9501-d48bcc6f68d0)

### What issues does this PR fix or reference?

Required for https://github.com/podman-desktop/podman-desktop/issues/10226

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
