### PR TITLE
chore: add nsis target for testing daily builds on windows

### DIFF
--- a/.github/workflows/daily-testing-build.yaml
+++ b/.github/workflows/daily-testing-build.yaml
@@ -141,7 +141,7 @@ jobs:
       - name: Run Build on Windows
         if: startsWith(matrix.os, 'windows')
         timeout-minutes: 40
-        run: pnpm compile:next --win portable
+        run: pnpm compile:next --win nsis portable
 
   release:
     needs: [tag, build]


### PR DESCRIPTION
### What does this PR do?
Includes `nsis` build target to produce `setup.exe` on daily testing prereleases

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#10592 - partially
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
