### PR TITLE
fix: disable build button if no arch is selected

### DIFF
--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
@@ -271,6 +271,33 @@ test('Select multiple platforms without image name should disable Build button',
   expect(buildButton).toBeDisabled();
 });
 
+test('Selecting no platforms should disable Build button', async () => {
+  // Auto select amd64
+  vi.mocked(window.getOsArch).mockResolvedValue('amd64');
+  setup();
+  await waitRender();
+
+  const containerFilePath = screen.getByRole('textbox', { name: 'Containerfile path' });
+  expect(containerFilePath).toBeInTheDocument();
+  await userEvent.type(containerFilePath, '/somepath/containerfile');
+
+  // Wait until 'linux/arm64' checkboxes exist and are enabled
+  await waitFor(() => {
+    const linuxAmd64Button = screen.getByRole('checkbox', { name: 'Intel and AMD x86_64 systems' });
+    expect(linuxAmd64Button).toBeInTheDocument();
+    expect(linuxAmd64Button).toBeChecked();
+  });
+
+  // disable the platform
+  const linuxAmd64Button = screen.getByRole('button', { name: 'linux/amd64' });
+  expect(linuxAmd64Button).toBeInTheDocument();
+  await userEvent.click(linuxAmd64Button);
+
+  const buildButton = screen.getByRole('button', { name: 'Build' });
+  expect(buildButton).toBeInTheDocument();
+  expect(buildButton).toBeDisabled();
+});
+
 test('Selecting one platform only calls buildImage once with the selected platform, make sure that it has a name', async () => {
   // Auto select amd64
   vi.mocked(window.getOsArch).mockResolvedValue('amd64');

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
@@ -50,7 +50,10 @@ const contextDialogOptions: OpenDialogOptions = { title: 'Select Root Context', 
 
 $: platforms = containerBuildPlatform ? containerBuildPlatform.split(',') : [];
 $: hasInvalidFields =
-  !containerFilePath || !containerBuildContextDirectory || (platforms.length > 1 && !containerImageName);
+  !containerFilePath ||
+  !containerBuildContextDirectory ||
+  (platforms.length > 1 && !containerImageName) ||
+  platforms.length === 0;
 $: if (containerFilePath && !containerBuildContextDirectory) {
   // select the parent directory of the file as default
   // eslint-disable-next-line no-useless-escape


### PR DESCRIPTION
### What does this PR do?
disable build button if no arch is selected

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/podman-desktop/podman-desktop/issues/10279

### How to test this PR?

Deselect all platforms and ensure the build button is disabled

- [x] Tests are covering the bug fix or the new feature
