### PR TITLE
chore: add Kubernetes providers to statusbar

### DIFF
--- a/packages/renderer/src/lib/statusbar/StatusBar.spec.ts
+++ b/packages/renderer/src/lib/statusbar/StatusBar.spec.ts
@@ -49,6 +49,14 @@ const providerMock2 = {
   images: {},
 } as unknown as ProviderInfo;
 
+const providerMock3 = {
+  name: 'provider2',
+  containerConnections: [],
+  kubernetesConnections: [],
+  status: 'ready' as ProviderStatus,
+  images: {},
+} as unknown as ProviderInfo;
+
 beforeEach(() => {
   Object.defineProperty(window, 'getConfigurationValue', { value: vi.fn() });
   onDidChangeConfiguration.addEventListener = vi.fn().mockImplementation((message: string, callback: () => void) => {
@@ -68,7 +76,7 @@ beforeEach(() => {
     },
   ]);
 
-  providerInfos.set([providerMock1, providerMock2]);
+  providerInfos.set([providerMock1, providerMock2, providerMock3]);
 });
 
 test('onMount should call getConfigurationValue', async () => {
@@ -113,8 +121,10 @@ test('providers should be visible when getConfigurationValue is true', async () 
   await vi.waitFor(() => {
     const provider1 = queryByLabelText('provider1');
     const provider2 = queryByLabelText('provider2');
+    const provider3 = queryByLabelText('provider3');
     expect(provider1).toBeInTheDocument();
-    expect(provider2).not.toBeInTheDocument();
+    expect(provider2).toBeInTheDocument();
+    expect(provider3).not.toBeInTheDocument();
   });
 });
 
@@ -123,7 +133,9 @@ test('providers should not be visible when getConfigurationValue is false', () =
 
   const { queryByLabelText } = render(StatusBar);
   const provider1 = queryByLabelText('provider1');
+  const provider2 = queryByLabelText('provider2');
   expect(provider1).toBeNull();
+  expect(provider2).toBeNull();
 });
 
 test('providers should show up when configuration changes from false to true', async () => {
@@ -132,7 +144,9 @@ test('providers should show up when configuration changes from false to true', a
   await tick();
 
   const provider1 = queryByLabelText('provider1');
+  const provider2 = queryByLabelText('provider2');
   expect(provider1).toBeNull();
+  expect(provider2).toBeNull();
 
   callbacks.get(`statusbarProviders.showProviders`)?.({
     detail: { key: `statusbarProviders.showProviders`, value: true },
@@ -143,8 +157,10 @@ test('providers should show up when configuration changes from false to true', a
   await vi.waitFor(() => {
     const provider1 = queryByLabelText('provider1');
     const provider2 = queryByLabelText('provider2');
+    const provider3 = queryByLabelText('provider3');
     expect(provider1).toBeInTheDocument();
-    expect(provider2).not.toBeInTheDocument();
+    expect(provider2).toBeInTheDocument();
+    expect(provider3).not.toBeInTheDocument();
   });
 });
 
@@ -156,8 +172,10 @@ test('providers are hidden when configuration changes from true to false', async
   await vi.waitFor(() => {
     const provider1 = queryByLabelText('provider1');
     const provider2 = queryByLabelText('provider2');
+    const provider3 = queryByLabelText('provider3');
     expect(provider1).toBeInTheDocument();
-    expect(provider2).not.toBeInTheDocument();
+    expect(provider2).toBeInTheDocument();
+    expect(provider3).not.toBeInTheDocument();
   });
 
   callbacks.get(`statusbarProviders.showProviders`)?.({
@@ -167,5 +185,7 @@ test('providers are hidden when configuration changes from true to false', async
   await tick();
 
   const provider1 = queryByLabelText('provider1');
+  const provider2 = queryByLabelText('provider2');
   expect(provider1).toBeNull();
+  expect(provider2).toBeNull();
 });

--- a/packages/renderer/src/lib/statusbar/StatusBar.svelte
+++ b/packages/renderer/src/lib/statusbar/StatusBar.svelte
@@ -16,6 +16,8 @@ let rightEntries: StatusBarEntry[] = $state([]);
 
 let containerProviders = $derived($providerInfos.filter(provider => provider.containerConnections.length > 0));
 
+let kubernetesProviders = $derived($providerInfos.filter(provider => provider.kubernetesConnections.length > 0));
+
 let experimentalTaskStatusBar: boolean = $state(false);
 let experimentalProvidersStatusBar: boolean = $state(false);
 
@@ -94,6 +96,9 @@ onDestroy(() => {
     {/each}
     {#if experimentalProvidersStatusBar}
       {#each containerProviders as entry}
+        <ProviderWidget entry={entry}/>
+      {/each}
+      {#each  kubernetesProviders as entry}
         <ProviderWidget entry={entry}/>
       {/each}
     {/if}

--- a/packages/renderer/src/lib/statusbar/StatusBar.svelte
+++ b/packages/renderer/src/lib/statusbar/StatusBar.svelte
@@ -98,7 +98,7 @@ onDestroy(() => {
       {#each containerProviders as entry}
         <ProviderWidget entry={entry}/>
       {/each}
-      {#each  kubernetesProviders as entry}
+      {#each kubernetesProviders as entry}
         <ProviderWidget entry={entry}/>
       {/each}
     {/if}


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR adds Kubernetes extensions providers to the statusbar

### Screenshot / video of UI
![Screenshot from 2025-01-16 10-05-47](https://github.com/user-attachments/assets/371050e9-58c3-4579-ad60-cd79d40f3be8)

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/podman-desktop/issues/9558

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
1. Turn on the statusbar provider experimental feature in preferences
2. Create one or more Kubernetes providers
3. Assert that they show up in the statusbar with the correct status

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
