### PR TITLE
feat: update create container workflow

### DIFF
--- a/packages/api/src/navigation-page.ts
+++ b/packages/api/src/navigation-page.ts
@@ -21,7 +21,7 @@ export enum NavigationPage {
   CONTAINERS = 'containers',
   CONTAINER_EXPORT = 'container-export',
   CONTAINER = 'container',
-  CONTAINER_CREATE_EXISITNG_IMAGE = 'create-container-existing-image',
+  EXISITNG_IMAGE_CREATE_CONTAINER = 'existing-image-create-container',
   CONTAINER_LOGS = 'container-logs',
   CONTAINER_INSPECT = 'container-inspect',
   CONTAINER_TERMINAL = 'container-terminal',

--- a/packages/api/src/navigation-page.ts
+++ b/packages/api/src/navigation-page.ts
@@ -21,6 +21,7 @@ export enum NavigationPage {
   CONTAINERS = 'containers',
   CONTAINER_EXPORT = 'container-export',
   CONTAINER = 'container',
+  CONTAINER_CREATE_EXISITNG_IMAGE = 'create-container-existing-image',
   CONTAINER_LOGS = 'container-logs',
   CONTAINER_INSPECT = 'container-inspect',
   CONTAINER_TERMINAL = 'container-terminal',

--- a/packages/api/src/navigation-page.ts
+++ b/packages/api/src/navigation-page.ts
@@ -21,7 +21,7 @@ export enum NavigationPage {
   CONTAINERS = 'containers',
   CONTAINER_EXPORT = 'container-export',
   CONTAINER = 'container',
-  EXISITNG_IMAGE_CREATE_CONTAINER = 'existing-image-create-container',
+  EXISTING_IMAGE_CREATE_CONTAINER = 'existing-image-create-container',
   CONTAINER_LOGS = 'container-logs',
   CONTAINER_INSPECT = 'container-inspect',
   CONTAINER_TERMINAL = 'container-terminal',

--- a/packages/api/src/navigation-request.ts
+++ b/packages/api/src/navigation-request.ts
@@ -29,6 +29,7 @@ export interface NavigationParameters {
   [NavigationPage.CONTAINER_INSPECT]: { id: string };
   [NavigationPage.CONTAINER_TERMINAL]: { id: string };
   [NavigationPage.CONTAINER_KUBE]: { id: string };
+  [NavigationPage.EXISITNG_IMAGE_CREATE_CONTAINER]: never;
   [NavigationPage.DEPLOY_TO_KUBE]: { id: string; engineId: string };
   [NavigationPage.IMAGES]: never;
   [NavigationPage.IMAGE_BUILD]: never;

--- a/packages/api/src/navigation-request.ts
+++ b/packages/api/src/navigation-request.ts
@@ -29,7 +29,7 @@ export interface NavigationParameters {
   [NavigationPage.CONTAINER_INSPECT]: { id: string };
   [NavigationPage.CONTAINER_TERMINAL]: { id: string };
   [NavigationPage.CONTAINER_KUBE]: { id: string };
-  [NavigationPage.EXISITNG_IMAGE_CREATE_CONTAINER]: never;
+  [NavigationPage.EXISTING_IMAGE_CREATE_CONTAINER]: never;
   [NavigationPage.DEPLOY_TO_KUBE]: { id: string; engineId: string };
   [NavigationPage.IMAGES]: never;
   [NavigationPage.IMAGE_BUILD]: never;

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -156,7 +156,7 @@ window.events?.receive('kubernetes-navigation', (args: unknown) => {
           <ContainerList searchTerm={meta.query.filter || ''} />
         </Route>
         <Route path="/containers/:id/*" let:meta firstmatch>
-          <Route path="/create-container-existing-image" breadcrumb="Select image" >
+          <Route path="/existing-image-create-container" breadcrumb="Select image" >
             <CreateContainerFromExisitingImage />
           </Route>
           <Route path="/export" breadcrumb="Export Container">

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -19,7 +19,7 @@ import SecretDetails from './lib/configmaps-secrets/SecretDetails.svelte';
 import ContainerDetails from './lib/container/ContainerDetails.svelte';
 import ContainerExport from './lib/container/ContainerExport.svelte';
 import ContainerList from './lib/container/ContainerList.svelte';
-import CreateContainerFromExisitingImage from './lib/container/CreateContainerFromExistingImage.svelte';
+import CreateContainerFromExistingImage from './lib/container/CreateContainerFromExistingImage.svelte';
 import ContextKey from './lib/context/ContextKey.svelte';
 import CronJobDetails from './lib/cronjob/CronJobDetails.svelte';
 import CronJobList from './lib/cronjob/CronJobList.svelte';
@@ -156,9 +156,6 @@ window.events?.receive('kubernetes-navigation', (args: unknown) => {
           <ContainerList searchTerm={meta.query.filter || ''} />
         </Route>
         <Route path="/containers/:id/*" let:meta firstmatch>
-          <Route path="/existing-image-create-container" breadcrumb="Select image" >
-            <CreateContainerFromExisitingImage />
-          </Route>
           <Route path="/export" breadcrumb="Export Container">
             <ContainerExport containerID={meta.params.id} />
           </Route>
@@ -175,6 +172,9 @@ window.events?.receive('kubernetes-navigation', (args: unknown) => {
         </Route>
         <Route path="/images" breadcrumb="Images" navigationHint="root">
           <ImagesList />
+        </Route>
+        <Route path="/images/existing-image-create-container" breadcrumb="Select image" >
+          <CreateContainerFromExistingImage />
         </Route>
         <Route path="/images/:id/:engineId" breadcrumb="Images" let:meta navigationHint="root">
           <ImagesList searchTerm={meta.params.id} imageEngineId={meta.params.engineId} />

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -19,7 +19,7 @@ import SecretDetails from './lib/configmaps-secrets/SecretDetails.svelte';
 import ContainerDetails from './lib/container/ContainerDetails.svelte';
 import ContainerExport from './lib/container/ContainerExport.svelte';
 import ContainerList from './lib/container/ContainerList.svelte';
-import CreateContainerFromExisitingImage from './lib/container/CreateContainerFromExisitingImage.svelte';
+import CreateContainerFromExisitingImage from './lib/container/CreateContainerFromExistingImage.svelte';
 import ContextKey from './lib/context/ContextKey.svelte';
 import CronJobDetails from './lib/cronjob/CronJobDetails.svelte';
 import CronJobList from './lib/cronjob/CronJobList.svelte';
@@ -155,10 +155,11 @@ window.events?.receive('kubernetes-navigation', (args: unknown) => {
         <Route path="/containers" breadcrumb="Containers" navigationHint="root">
           <ContainerList searchTerm={meta.query.filter || ''} />
         </Route>
-        <Route path="/create-container-existing-image" breadcrumb="Select image" >
-          <CreateContainerFromExisitingImage />
-        </Route>
         <Route path="/containers/:id/*" let:meta firstmatch>
+          <Route path="/create-container-existing-image" breadcrumb="Select image" >
+            {console.log('create container')}
+            <CreateContainerFromExisitingImage />
+          </Route>
           <Route path="/export" breadcrumb="Export Container">
             <ContainerExport containerID={meta.params.id} />
           </Route>

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -19,6 +19,7 @@ import SecretDetails from './lib/configmaps-secrets/SecretDetails.svelte';
 import ContainerDetails from './lib/container/ContainerDetails.svelte';
 import ContainerExport from './lib/container/ContainerExport.svelte';
 import ContainerList from './lib/container/ContainerList.svelte';
+import CreateContainerFromExisitingImage from './lib/container/CreateContainerFromExisitingImage.svelte';
 import ContextKey from './lib/context/ContextKey.svelte';
 import CronJobDetails from './lib/cronjob/CronJobDetails.svelte';
 import CronJobList from './lib/cronjob/CronJobList.svelte';
@@ -153,6 +154,9 @@ window.events?.receive('kubernetes-navigation', (args: unknown) => {
         </Route>
         <Route path="/containers" breadcrumb="Containers" navigationHint="root">
           <ContainerList searchTerm={meta.query.filter || ''} />
+        </Route>
+        <Route path="/create-container-existing-image" breadcrumb="Select image" >
+          <CreateContainerFromExisitingImage />
         </Route>
         <Route path="/containers/:id/*" let:meta firstmatch>
           <Route path="/export" breadcrumb="Export Container">

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -157,7 +157,6 @@ window.events?.receive('kubernetes-navigation', (args: unknown) => {
         </Route>
         <Route path="/containers/:id/*" let:meta firstmatch>
           <Route path="/create-container-existing-image" breadcrumb="Select image" >
-            {console.log('create container')}
             <CreateContainerFromExisitingImage />
           </Route>
           <Route path="/export" breadcrumb="Export Container">

--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -61,7 +61,7 @@ $: updateContainers(containersInfo, globalContext, viewContributions, searchTerm
 
 function fromExistingImage(): void {
   openChoiceModal = false;
-  handleNavigation({ page: NavigationPage.EXISITNG_IMAGE_CREATE_CONTAINER });
+  handleNavigation({ page: NavigationPage.EXISTING_IMAGE_CREATE_CONTAINER });
 }
 
 $: providerConnections = $providerInfos

--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -61,7 +61,7 @@ $: updateContainers(containersInfo, globalContext, viewContributions, searchTerm
 
 function fromExistingImage(): void {
   openChoiceModal = false;
-  handleNavigation({ page: NavigationPage.CONTAINER_CREATE_EXISITNG_IMAGE });
+  handleNavigation({ page: NavigationPage.EXISITNG_IMAGE_CREATE_CONTAINER });
 }
 
 $: providerConnections = $providerInfos

--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -61,7 +61,7 @@ $: updateContainers(containersInfo, globalContext, viewContributions, searchTerm
 
 function fromExistingImage(): void {
   openChoiceModal = false;
-  handleNavigation({ page: NavigationPage.IMAGES });
+  handleNavigation({ page: NavigationPage.CONTAINER_CREATE_EXISITNG_IMAGE });
 }
 
 $: providerConnections = $providerInfos

--- a/packages/renderer/src/lib/container/CreateContainerFromExisitingImage.svelte
+++ b/packages/renderer/src/lib/container/CreateContainerFromExisitingImage.svelte
@@ -1,0 +1,313 @@
+<script lang="ts">
+import { faArrowCircleDown, faCircleCheck } from '@fortawesome/free-solid-svg-icons';
+import { Button, Dropdown, ErrorMessage } from '@podman-desktop/ui-svelte';
+import type { Terminal } from '@xterm/xterm';
+import { onMount, tick } from 'svelte';
+import { router } from 'tinro';
+
+import { lastPage } from '/@/stores/breadcrumb';
+import { runImageInfo } from '/@/stores/run-image-store';
+import type { ImageSearchOptions } from '/@api/image-registry';
+import type { ProviderContainerConnectionInfo } from '/@api/provider-info';
+import type { PullEvent } from '/@api/pull-event';
+
+import { providerInfos } from '../../stores/providers';
+import { ImageUtils } from '../image/image-utils';
+import ImageIcon from '../images/ImageIcon.svelte';
+import EngineFormPage from '../ui/EngineFormPage.svelte';
+import TerminalWindow from '../ui/TerminalWindow.svelte';
+import Typeahead from '../ui/Typeahead.svelte';
+import WarningMessage from '../ui/WarningMessage.svelte';
+
+const DOCKER_PREFIX = 'docker.io';
+const DOCKER_PREFIX_WITH_SLASH = DOCKER_PREFIX + '/';
+
+const imageUtils = new ImageUtils();
+
+let logsPull: Terminal;
+let pullError = '';
+let pullInProgress = false;
+let pullFinished = false;
+let isValidName = true;
+let matchingLocalImages: string[] = [];
+
+let imageToPull: string = '';
+
+$: providerConnections = $providerInfos
+  .map(provider => provider.containerConnections)
+  .flat()
+  .filter(providerContainerConnection => providerContainerConnection.status === 'started');
+
+let selectedProviderConnection: ProviderContainerConnectionInfo | undefined;
+
+const lineNumberPerId = new Map<string, number>();
+let lineIndex = 0;
+
+function callback(event: PullEvent) {
+  let lineIndexToWrite;
+  if (event.status && event.id) {
+    const lineNumber = lineNumberPerId.get(event.id);
+    if (lineNumber) {
+      lineIndexToWrite = lineNumber;
+    } else {
+      lineIndex++;
+      lineIndexToWrite = lineIndex;
+      lineNumberPerId.set(event.id, lineIndex);
+    }
+  }
+  // no index, append
+  if (!lineIndexToWrite) {
+    lineIndex++;
+    lineIndexToWrite = lineIndex;
+  }
+
+  if (event.status) {
+    // move cursor to the home
+    logsPull.write(`\u001b[${lineIndexToWrite};0H`);
+    // erase the line
+    logsPull.write('\u001B[2K');
+    // do we have id ?
+    if (event.id) {
+      logsPull.write(`${event.id}: `);
+    }
+    logsPull.write(event.status);
+    // do we have progress ?
+    if (event.progress && event.progress !== '') {
+      logsPull.write(event.progress);
+    } else if (event?.progressDetail?.current && event?.progressDetail?.total) {
+      logsPull.write(` ${Math.round((event.progressDetail.current / event.progressDetail.total) * 100)}%`);
+    }
+    // write end of line
+    logsPull.write('\n\r');
+  } else if (event.error) {
+    logsPull.write(event.error.replaceAll('\n', '\n\r') + '\n\r');
+  }
+}
+
+async function pullImage() {
+  if (!selectedProviderConnection) {
+    pullError = 'No current provider connection';
+    return;
+  }
+
+  if (!imageToPull) {
+    pullError = 'No image to pull';
+    return;
+  }
+
+  lineNumberPerId.clear();
+  lineIndex = 0;
+  await tick();
+  logsPull?.reset();
+
+  // reset error
+  pullError = '';
+
+  pullInProgress = true;
+  try {
+    await window.pullImage(selectedProviderConnection, imageToPull.trim(), callback);
+    pullInProgress = false;
+    pullFinished = true;
+  } catch (error: any) {
+    const errorMessage = error.message ? error.message : error;
+    pullError = `Error while pulling image from ${selectedProviderConnection.name}: ${errorMessage}`;
+    pullInProgress = false;
+  }
+}
+
+onMount(() => {
+  if (!selectedProviderConnection) {
+    selectedProviderConnection = providerConnections.length > 0 ? providerConnections[0] : undefined;
+  }
+});
+
+let imageNameInvalid: string | undefined = undefined;
+let imageNameIsInvalid = imageToPull === undefined || imageToPull.trim() === '';
+function validateImageName(image: string): void {
+  if (imageToPull && (image === undefined || image.trim() === '')) {
+    imageNameIsInvalid = true;
+    imageNameInvalid = 'Please enter a value';
+  } else {
+    imageNameIsInvalid = false;
+    imageNameInvalid = undefined;
+  }
+  imageToPull = image;
+}
+
+// allTags is defined if last search was a query to search tags of an image
+let allTags: string[] | undefined = undefined;
+async function searchImages(value: string): Promise<string[]> {
+  if (value.includes(':')) {
+    if (allTags !== undefined) {
+      return allTags.filter(i => i.startsWith(value));
+    }
+    const parts = value.split(':');
+    const originalImage = parts[0];
+    let image = parts[0];
+    if (image.startsWith(DOCKER_PREFIX_WITH_SLASH)) {
+      image = image.slice(DOCKER_PREFIX_WITH_SLASH.length);
+    }
+    const tags = await window.listImageTagsInRegistry({ image });
+    allTags = tags.map(t => `${originalImage}:${t}`);
+    return allTags.filter(i => i.startsWith(value));
+  }
+  allTags = undefined;
+  if (value === undefined || value.trim() === '') {
+    return [];
+  }
+  const options: ImageSearchOptions = {
+    query: '',
+  };
+  if (!value.includes('/')) {
+    options.registry = DOCKER_PREFIX;
+    options.query = value;
+  } else {
+    const [registry, ...rest] = value.split('/');
+    options.registry = registry;
+    options.query = rest.join('/');
+  }
+  let result: string[];
+  const searchResult = await window.searchImageInRegistry(options);
+  result = searchResult.map(r => {
+    return [options.registry, r.name].join('/');
+  });
+  return result;
+}
+
+async function searchLocalImages(value: string): Promise<string[]> {
+  const listImages = await window.listImages();
+  const localImagesNames = listImages.map(image => {
+    if (image.RepoTags) {
+      return image.RepoTags;
+    }
+    return [];
+  });
+  matchingLocalImages = localImagesNames.flat().filter(image => image.includes(value) && image !== '');
+  return matchingLocalImages;
+}
+
+let latestTagMessage: string | undefined = undefined;
+async function searchLatestTag(): Promise<void> {
+  if (imageNameIsInvalid || !imageToPull) {
+    latestTagMessage = undefined;
+    return;
+  }
+  try {
+    let image = imageToPull;
+    if (image.startsWith(DOCKER_PREFIX_WITH_SLASH)) {
+      image = image.slice(DOCKER_PREFIX_WITH_SLASH.length);
+    }
+    const tags = await window.listImageTagsInRegistry({ image });
+    if (imageToPull.includes(':')) {
+      latestTagMessage = undefined;
+      checkIfTagExist(image, tags);
+      return;
+    }
+    isValidName = Boolean(tags);
+    const latestFound = tags.includes('latest');
+    if (!latestFound) {
+      latestTagMessage = '"latest" tag not found. You can search a tag by appending ":" to the image name';
+      isValidName = false;
+    } else {
+      latestTagMessage = undefined;
+    }
+  } catch {
+    isValidName = false;
+    latestTagMessage = undefined;
+  }
+}
+
+function checkIfTagExist(image: string, tags: string[]): void {
+  const tag = image.split(':')[1];
+
+  isValidName = tags.some(t => t === tag);
+}
+
+async function buildContainerFromImage(): Promise<void> {
+  const localImages = (await window.listImages()).filter(
+    image => (image.RepoTags?.filter(repoTag => repoTag.includes(imageToPull)) ?? []).length > 0,
+  );
+  console.log(localImages);
+  if (localImages.length > 0) {
+    const chosenImage = imageUtils.getImagesInfoUI(localImages[0], []);
+    if (chosenImage.length > 0) {
+      runImageInfo.set(chosenImage[0]);
+      router.goto('/image/run/basic');
+    }
+  }
+}
+</script>
+
+<EngineFormPage title="Select an image">
+  <svelte:fragment slot="icon">
+    <ImageIcon />
+  </svelte:fragment>
+  <div slot="content" class="space-y-2 flex flex-col">
+    <Typeahead
+      id="imageName"
+      name="imageName"
+      placeholder="Select am exisiting image"
+      searchFunctions={[searchLocalImages, searchImages]}
+      headings={['Local Images', 'Registry Images']}
+      onChange={async (s: string) => {
+        validateImageName(s);
+        await searchLatestTag();
+      }}
+      disabled={pullFinished || pullInProgress}
+      error={!isValidName}
+      required
+      initialFocus />
+    {#if imageNameInvalid}
+      <ErrorMessage error={imageNameInvalid} />
+    {/if}
+    {#if latestTagMessage}
+      <WarningMessage error={latestTagMessage} />
+    {/if}
+
+    {#if providerConnections.length > 1}
+      <div class="pt-4">
+        <label for="providerChoice" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]"
+          >Container Engine</label>
+        <Dropdown
+          id="providerChoice"
+          name="providerChoice"
+          bind:value={selectedProviderConnection}
+          options={providerConnections.map(providerConnection => ({
+            label: providerConnection.name,
+            value: providerConnection,
+          }))}>
+        </Dropdown>
+      </div>
+    {/if}
+    {#if providerConnections.length === 1}
+      <input type="hidden" name="providerChoice" readonly bind:value={selectedProviderConnection} />
+    {/if}
+  
+    <footer>
+      <div class="w-full flex flex-row justify-end gap-3 my-3">
+        <Button type="secondary" class="mr-3 w-full" on:click={() => router.goto($lastPage.path)}>Cancel</Button>
+        {#if !matchingLocalImages.includes(imageToPull) && imageToPull !== ''}
+          {#if !pullFinished}
+            <Button
+              icon={faArrowCircleDown}
+              class="w-full"
+              bind:disabled={imageNameIsInvalid}
+              on:click={() => pullImage()}
+              bind:inProgress={pullInProgress}>
+              Pull image {console.log('pull image ' + imageToPull)}
+            </Button>
+          {:else}
+            <Button class="w-full" on:click={() => buildContainerFromImage()}>Select image</Button>
+          {/if}
+        {:else}
+          <Button icon={faCircleCheck} class="w-full" on:click={() => buildContainerFromImage()}>Select image {console.log('select image ' + imageToPull)}</Button>
+        {/if}
+        {#if pullError}
+          <ErrorMessage error={pullError} />
+        {/if}
+      </div>
+    </footer>
+    <TerminalWindow bind:terminal={logsPull} />
+  </div>
+</EngineFormPage>
+

--- a/packages/renderer/src/lib/container/CreateContainerFromExistingImage.spec.ts
+++ b/packages/renderer/src/lib/container/CreateContainerFromExistingImage.spec.ts
@@ -217,4 +217,21 @@ test('Expect a local image to have an active select image button', async () => {
   expect(router.goto).toHaveBeenCalledWith('/image/run/basic');
 });
 
-test('Expect no user input to show only local images', async () => {});
+test('Expect no user input to show only local images', async () => {
+  vi.mocked(window.searchImageInRegistry).mockResolvedValue([
+    { name: 'image12', description: '', star_count: 3, is_official: true },
+  ]);
+  render(CreateContainerFromExistingImage);
+  await tick();
+
+  const inputBox = screen.getByPlaceholderText('Select an exisiting image');
+  expect(inputBox).toBeInTheDocument();
+  await userEvent.type(inputBox, ' ');
+
+  await tick();
+  await waitFor(() => expect(screen.queryByRole('row')).toBeInTheDocument());
+
+  const list = screen.getByRole('row');
+  const items = within(list).getAllByRole('button');
+  expect(items.length).toBe(6);
+});

--- a/packages/renderer/src/lib/container/CreateContainerFromExistingImage.spec.ts
+++ b/packages/renderer/src/lib/container/CreateContainerFromExistingImage.spec.ts
@@ -158,7 +158,7 @@ test('Expect that typeahead menu has Local Images and Registry Images headings',
   expect(screen.getByText('Registry Images')).toBeInTheDocument();
 });
 
-test('Expect not a local image to have an active pull image button', async () => {
+test('Expect not a local image to have an active pull image and run button', async () => {
   vi.mocked(window.searchImageInRegistry).mockResolvedValue([
     { name: 'image12', description: '', star_count: 3, is_official: true },
   ]);
@@ -177,7 +177,7 @@ test('Expect not a local image to have an active pull image button', async () =>
 
   await userEvent.keyboard('[ArrowDown]');
 
-  const pullImagebutton = screen.getByRole('button', { name: 'Pull Image' });
+  const pullImagebutton = screen.getByRole('button', { name: 'Pull Image and Run' });
 
   expect(pullImagebutton).toBeInTheDocument();
   expect(pullImagebutton).not.toBeDisabled();

--- a/packages/renderer/src/lib/container/CreateContainerFromExistingImage.spec.ts
+++ b/packages/renderer/src/lib/container/CreateContainerFromExistingImage.spec.ts
@@ -153,9 +153,11 @@ test('Expect that typeahead menu has Local Images and Registry Images headings',
   expect(inputBox).toBeInTheDocument();
   await userEvent.type(inputBox, 'f');
 
-  await waitFor(() => expect(screen.queryByRole('row')).toBeInTheDocument());
-  expect(screen.getByText('Local Images')).toBeInTheDocument();
-  expect(screen.getByText('Registry Images')).toBeInTheDocument();
+  await waitFor(() => {
+    expect(screen.queryByRole('row')).toBeInTheDocument();
+    expect(screen.getByText('Local Images')).toBeInTheDocument();
+    expect(screen.getByText('Registry Images')).toBeInTheDocument();
+  });
 });
 
 test('Expect not a local image to have an active pull image and run button', async () => {
@@ -169,11 +171,11 @@ test('Expect not a local image to have an active pull image and run button', asy
   expect(inputBox).toBeInTheDocument();
   await userEvent.type(inputBox, 'image12');
 
-  await waitFor(() => expect(screen.queryByRole('row')).toBeInTheDocument());
-
-  const list = screen.getByRole('row');
-  const items = within(list).getAllByRole('button');
-  expect(items.length).toBe(2);
+  await waitFor(() => {
+    const list = screen.getByRole('row');
+    const items = within(list).getAllByRole('button');
+    expect(items.length).toBe(2);
+  });
 
   await userEvent.keyboard('[ArrowDown]');
 

--- a/packages/renderer/src/lib/container/CreateContainerFromExistingImage.spec.ts
+++ b/packages/renderer/src/lib/container/CreateContainerFromExistingImage.spec.ts
@@ -96,8 +96,8 @@ beforeEach(() => {
     value: () => {
       return {
         matches: false,
-        addListener: () => {},
-        removeListener: () => {},
+        addListener: (): void => {},
+        removeListener: (): void => {},
       };
     },
   });
@@ -141,7 +141,7 @@ test('Expect that textbox and two buttons show up when page opened', async () =>
   expect(cancelButton).toBeInTheDocument();
   expect(cancelButton).not.toBeDisabled();
 
-  const actionButton = screen.getByRole('button', { name: 'Select image' });
+  const actionButton = screen.getByRole('button', { name: 'Select Image' });
   expect(actionButton).toBeInTheDocument();
   expect(actionButton).toBeDisabled();
 });
@@ -175,7 +175,7 @@ test('Expect not a local image to have an active pull image button', async () =>
 
   const list = screen.getByRole('row');
   const items = within(list).getAllByRole('button');
-  expect(items.length).toBe(3);
+  expect(items.length).toBe(2);
 
   await userEvent.keyboard('[ArrowDown]');
 

--- a/packages/renderer/src/lib/container/CreateContainerFromExistingImage.spec.ts
+++ b/packages/renderer/src/lib/container/CreateContainerFromExistingImage.spec.ts
@@ -1,0 +1,220 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import type { ImageInfo, ProviderStatus } from '@podman-desktop/api';
+import { render, screen, waitFor, within } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { tick } from 'svelte';
+import { router } from 'tinro';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { providerInfos } from '/@/stores/providers';
+import type { ImageSearchResult } from '/@api/image-registry';
+import type { ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provider-info';
+
+import CreateContainerFromExistingImage from './CreateContainerFromExistingImage.svelte';
+
+const registryImageList: ImageSearchResult[] = [
+  { name: 'image12', description: '', star_count: 3, is_official: true },
+  { name: 'mysql21', description: '', star_count: 5, is_official: true },
+  { name: 'fedora21', description: '', star_count: 5, is_official: false },
+];
+const localImageList = [
+  {
+    Id: 'sha256:1234567890123',
+    RepoTags: ['fedora1:3'],
+    Created: 1644009612,
+    Size: 123,
+    engineId: 'podman',
+    engineName: 'podman',
+  } as unknown as ImageInfo,
+  {
+    Id: 'sha256:1234567890123',
+    RepoTags: ['helloworld1:2'],
+    Created: 1644009612,
+    Size: 123,
+    engineId: 'docker',
+    engineName: 'docker',
+  } as unknown as ImageInfo,
+  {
+    Id: 'sha256:1234567890123',
+    RepoTags: ['fedora2:3'],
+    Created: 1644009612,
+    Size: 123,
+    engineId: 'podman',
+    engineName: 'podman',
+  } as unknown as ImageInfo,
+  {
+    Id: 'sha256:2345678901234',
+    RepoTags: ['image1:3'],
+    Created: 1644009612,
+    Size: 123,
+    engineId: 'podman',
+    engineName: 'podman',
+  } as unknown as ImageInfo,
+  {
+    Id: 'sha256:3456789012345',
+    RepoTags: ['fedora:4'],
+    Created: 1644009612,
+    Size: 123,
+    engineId: 'podman',
+    engineName: 'podman',
+  } as unknown as ImageInfo,
+];
+
+vi.mock('tinro', () => {
+  return {
+    router: {
+      goto: vi.fn(),
+    },
+  };
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(window.listImages).mockResolvedValue(localImageList);
+  vi.mocked(window.searchImageInRegistry).mockResolvedValue(registryImageList);
+  window.HTMLElement.prototype.scrollIntoView = vi.fn();
+  Object.defineProperty(window, 'matchMedia', {
+    value: () => {
+      return {
+        matches: false,
+        addListener: () => {},
+        removeListener: () => {},
+      };
+    },
+  });
+});
+
+const pStatus: ProviderStatus = 'started';
+const pInfo: ProviderContainerConnectionInfo = {
+  name: 'test',
+  displayName: 'test',
+  status: 'started',
+  endpoint: {
+    socketPath: '',
+  },
+  type: 'podman',
+};
+const providerInfo = {
+  id: 'test',
+  internalId: 'id',
+  name: '',
+  containerConnections: [pInfo],
+  kubernetesConnections: undefined,
+  status: pStatus,
+  containerProviderConnectionCreation: false,
+  containerProviderConnectionInitialization: false,
+  kubernetesProviderConnectionCreation: false,
+  kubernetesProviderConnectionInitialization: false,
+  links: undefined,
+  detectionChecks: undefined,
+  warnings: undefined,
+  images: undefined,
+  installationSupport: undefined,
+} as unknown as ProviderInfo;
+providerInfos.set([providerInfo]);
+
+test('Expect that textbox and two buttons show up when page opened', async () => {
+  render(CreateContainerFromExistingImage);
+
+  const entry = screen.getByPlaceholderText('Select an exisiting image');
+  expect(entry).toBeInTheDocument();
+  const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+  expect(cancelButton).toBeInTheDocument();
+  expect(cancelButton).not.toBeDisabled();
+
+  const actionButton = screen.getByRole('button', { name: 'Select image' });
+  expect(actionButton).toBeInTheDocument();
+  expect(actionButton).toBeDisabled();
+});
+
+test('Expect that typeahead menu has Local Images and Registry Images headings', async () => {
+  render(CreateContainerFromExistingImage);
+
+  const inputBox = screen.getByPlaceholderText('Select an exisiting image');
+  expect(inputBox).toBeInTheDocument();
+  await userEvent.type(inputBox, 'f');
+
+  await tick();
+  await waitFor(() => expect(screen.queryByRole('row')).toBeInTheDocument());
+  expect(screen.getByText('Local Images')).toBeInTheDocument();
+  expect(screen.getByText('Registry Images')).toBeInTheDocument();
+});
+
+test('Expect not a local image to have an active pull image button', async () => {
+  vi.mocked(window.searchImageInRegistry).mockResolvedValue([
+    { name: 'image12', description: '', star_count: 3, is_official: true },
+  ]);
+  render(CreateContainerFromExistingImage);
+  await tick();
+
+  const inputBox = screen.getByPlaceholderText('Select an exisiting image');
+  expect(inputBox).toBeInTheDocument();
+  await userEvent.type(inputBox, 'image12');
+
+  await tick();
+  await waitFor(() => expect(screen.queryByRole('row')).toBeInTheDocument());
+
+  const list = screen.getByRole('row');
+  const items = within(list).getAllByRole('button');
+  expect(items.length).toBe(3);
+
+  await userEvent.keyboard('[ArrowDown]');
+
+  const pullImagebutton = screen.getByRole('button', { name: 'Pull Image' });
+
+  expect(pullImagebutton).toBeInTheDocument();
+  expect(pullImagebutton).not.toBeDisabled();
+
+  await userEvent.click(pullImagebutton);
+  expect(window.pullImage).toHaveBeenCalledWith(pInfo, 'docker.io/image12', expect.any(Function));
+});
+
+test('Expect a local image to have an active select image button', async () => {
+  vi.mocked(window.searchImageInRegistry).mockResolvedValue([
+    { name: 'fedora21', description: '', star_count: 5, is_official: false },
+  ]);
+  render(CreateContainerFromExistingImage);
+  await tick();
+
+  const inputBox = screen.getByPlaceholderText('Select an exisiting image');
+  expect(inputBox).toBeInTheDocument();
+  await userEvent.type(inputBox, 'fedora');
+
+  await tick();
+  await waitFor(() => expect(screen.queryByRole('row')).toBeInTheDocument());
+
+  const list = screen.getByRole('row');
+  const items = within(list).getAllByRole('button');
+  expect(items.length).toBe(6);
+
+  await userEvent.keyboard('[ArrowDown]');
+
+  const selectImagebutton = screen.getByRole('button', { name: 'Select Image' });
+
+  expect(selectImagebutton).toBeInTheDocument();
+  expect(selectImagebutton).not.toBeDisabled();
+
+  await userEvent.click(selectImagebutton);
+  expect(router.goto).toHaveBeenCalledWith('/image/run/basic');
+});
+
+test('Expect no user input to show only local images', async () => {});

--- a/packages/renderer/src/lib/container/CreateContainerFromExistingImage.spec.ts
+++ b/packages/renderer/src/lib/container/CreateContainerFromExistingImage.spec.ts
@@ -135,13 +135,13 @@ providerInfos.set([providerInfo]);
 test('Expect that textbox and two buttons show up when page opened', async () => {
   render(CreateContainerFromExistingImage);
 
-  const entry = screen.getByPlaceholderText('Select an existing image');
+  const entry = screen.getByPlaceholderText('Select or enter an image to run');
   expect(entry).toBeInTheDocument();
   const cancelButton = screen.getByRole('button', { name: 'Cancel' });
   expect(cancelButton).toBeInTheDocument();
   expect(cancelButton).not.toBeDisabled();
 
-  const actionButton = screen.getByRole('button', { name: 'Select Image' });
+  const actionButton = screen.getByRole('button', { name: 'Run Image' });
   expect(actionButton).toBeInTheDocument();
   expect(actionButton).toBeDisabled();
 });
@@ -149,7 +149,7 @@ test('Expect that textbox and two buttons show up when page opened', async () =>
 test('Expect that typeahead menu has Local Images and Registry Images headings', async () => {
   render(CreateContainerFromExistingImage);
 
-  const inputBox = screen.getByPlaceholderText('Select an existing image');
+  const inputBox = screen.getByPlaceholderText('Select or enter an image to run');
   expect(inputBox).toBeInTheDocument();
   await userEvent.type(inputBox, 'f');
 
@@ -165,7 +165,7 @@ test('Expect not a local image to have an active pull image button', async () =>
   render(CreateContainerFromExistingImage);
   await tick();
 
-  const inputBox = screen.getByPlaceholderText('Select an existing image');
+  const inputBox = screen.getByPlaceholderText('Select or enter an image to run');
   expect(inputBox).toBeInTheDocument();
   await userEvent.type(inputBox, 'image12');
 
@@ -186,14 +186,14 @@ test('Expect not a local image to have an active pull image button', async () =>
   expect(window.pullImage).toHaveBeenCalledWith(pInfo, 'docker.io/image12', expect.any(Function));
 });
 
-test('Expect a local image to have an active select image button', async () => {
+test('Expect a local image to have an active run image button', async () => {
   vi.mocked(window.searchImageInRegistry).mockResolvedValue([
     { name: 'fedora21', description: '', star_count: 5, is_official: false },
   ]);
   render(CreateContainerFromExistingImage);
   await tick();
 
-  const inputBox = screen.getByPlaceholderText('Select an existing image');
+  const inputBox = screen.getByPlaceholderText('Select or enter an image to run');
   expect(inputBox).toBeInTheDocument();
   await userEvent.type(inputBox, 'fedora');
 
@@ -205,7 +205,7 @@ test('Expect a local image to have an active select image button', async () => {
 
   await userEvent.keyboard('[ArrowDown]');
 
-  const selectImagebutton = screen.getByRole('button', { name: 'Select Image' });
+  const selectImagebutton = screen.getByRole('button', { name: 'Run Image' });
 
   expect(selectImagebutton).toBeInTheDocument();
   expect(selectImagebutton).not.toBeDisabled();
@@ -221,7 +221,7 @@ test('Expect no user input to show only local images', async () => {
   render(CreateContainerFromExistingImage);
   await tick();
 
-  const inputBox = screen.getByPlaceholderText('Select an existing image');
+  const inputBox = screen.getByPlaceholderText('Select or enter an image to run');
   expect(inputBox).toBeInTheDocument();
   await userEvent.type(inputBox, ' ');
 

--- a/packages/renderer/src/lib/container/CreateContainerFromExistingImage.spec.ts
+++ b/packages/renderer/src/lib/container/CreateContainerFromExistingImage.spec.ts
@@ -153,7 +153,6 @@ test('Expect that typeahead menu has Local Images and Registry Images headings',
   expect(inputBox).toBeInTheDocument();
   await userEvent.type(inputBox, 'f');
 
-  await tick();
   await waitFor(() => expect(screen.queryByRole('row')).toBeInTheDocument());
   expect(screen.getByText('Local Images')).toBeInTheDocument();
   expect(screen.getByText('Registry Images')).toBeInTheDocument();
@@ -170,7 +169,6 @@ test('Expect not a local image to have an active pull image button', async () =>
   expect(inputBox).toBeInTheDocument();
   await userEvent.type(inputBox, 'image12');
 
-  await tick();
   await waitFor(() => expect(screen.queryByRole('row')).toBeInTheDocument());
 
   const list = screen.getByRole('row');
@@ -199,7 +197,6 @@ test('Expect a local image to have an active select image button', async () => {
   expect(inputBox).toBeInTheDocument();
   await userEvent.type(inputBox, 'fedora');
 
-  await tick();
   await waitFor(() => expect(screen.queryByRole('row')).toBeInTheDocument());
 
   const list = screen.getByRole('row');
@@ -228,7 +225,6 @@ test('Expect no user input to show only local images', async () => {
   expect(inputBox).toBeInTheDocument();
   await userEvent.type(inputBox, ' ');
 
-  await tick();
   await waitFor(() => expect(screen.queryByRole('row')).toBeInTheDocument());
 
   const list = screen.getByRole('row');

--- a/packages/renderer/src/lib/container/CreateContainerFromExistingImage.spec.ts
+++ b/packages/renderer/src/lib/container/CreateContainerFromExistingImage.spec.ts
@@ -135,7 +135,7 @@ providerInfos.set([providerInfo]);
 test('Expect that textbox and two buttons show up when page opened', async () => {
   render(CreateContainerFromExistingImage);
 
-  const entry = screen.getByPlaceholderText('Select an exisiting image');
+  const entry = screen.getByPlaceholderText('Select an existing image');
   expect(entry).toBeInTheDocument();
   const cancelButton = screen.getByRole('button', { name: 'Cancel' });
   expect(cancelButton).toBeInTheDocument();
@@ -149,7 +149,7 @@ test('Expect that textbox and two buttons show up when page opened', async () =>
 test('Expect that typeahead menu has Local Images and Registry Images headings', async () => {
   render(CreateContainerFromExistingImage);
 
-  const inputBox = screen.getByPlaceholderText('Select an exisiting image');
+  const inputBox = screen.getByPlaceholderText('Select an existing image');
   expect(inputBox).toBeInTheDocument();
   await userEvent.type(inputBox, 'f');
 
@@ -165,7 +165,7 @@ test('Expect not a local image to have an active pull image button', async () =>
   render(CreateContainerFromExistingImage);
   await tick();
 
-  const inputBox = screen.getByPlaceholderText('Select an exisiting image');
+  const inputBox = screen.getByPlaceholderText('Select an existing image');
   expect(inputBox).toBeInTheDocument();
   await userEvent.type(inputBox, 'image12');
 
@@ -193,7 +193,7 @@ test('Expect a local image to have an active select image button', async () => {
   render(CreateContainerFromExistingImage);
   await tick();
 
-  const inputBox = screen.getByPlaceholderText('Select an exisiting image');
+  const inputBox = screen.getByPlaceholderText('Select an existing image');
   expect(inputBox).toBeInTheDocument();
   await userEvent.type(inputBox, 'fedora');
 
@@ -221,7 +221,7 @@ test('Expect no user input to show only local images', async () => {
   render(CreateContainerFromExistingImage);
   await tick();
 
-  const inputBox = screen.getByPlaceholderText('Select an exisiting image');
+  const inputBox = screen.getByPlaceholderText('Select an existing image');
   expect(inputBox).toBeInTheDocument();
   await userEvent.type(inputBox, ' ');
 

--- a/packages/renderer/src/lib/container/CreateContainerFromExistingImage.svelte
+++ b/packages/renderer/src/lib/container/CreateContainerFromExistingImage.svelte
@@ -322,7 +322,7 @@ async function onEnterOperation(): Promise<void> {
   if (imageToPull === '') {
     return;
   }
-  if (!matchingLocalImages.includes(imageToPull)) {
+  if (matchingLocalImages.includes(imageToPull)) {
     await buildContainerFromImage();
   } else {
     await pullImage();
@@ -342,7 +342,7 @@ async function onEnterOperation(): Promise<void> {
       <Typeahead
         id="imageName"
         name="imageName"
-        placeholder="Select an existing image"
+        placeholder="Select or enter an image to run"
         onInputChange={searchFunction}
         resultItems={values}
         compare={sortResults}
@@ -409,10 +409,10 @@ async function onEnterOperation(): Promise<void> {
                 Pull Image
               </Button>
             {:else}
-              <Button class="w-full" on:click={buildContainerFromImage} bind:disabled={imageNameIsInvalid}>Select Image</Button>
+              <Button class="w-full" on:click={buildContainerFromImage} bind:disabled={imageNameIsInvalid}>Run Image</Button>
             {/if}
           {:else}
-            <Button icon={faCircleCheck} class="w-full" bind:disabled={imageNameIsInvalid} on:click={buildContainerFromImage}>Select Image</Button>
+            <Button icon={faCircleCheck} class="w-full" bind:disabled={imageNameIsInvalid} on:click={buildContainerFromImage}>Run Image</Button>
           {/if}
         </div>
         {#if pullError}

--- a/packages/renderer/src/lib/container/CreateContainerFromExistingImage.svelte
+++ b/packages/renderer/src/lib/container/CreateContainerFromExistingImage.svelte
@@ -388,7 +388,7 @@ async function onEnterOperation(): Promise<void> {
               bind:disabled={imageNameIsInvalid}
               on:click={() => pullImage()}
               bind:inProgress={pullInProgress}>
-              Pull Image {console.log('pull image ' + imageToPull)}
+              Pull Image
             </Button>
           {:else}
             <Button class="w-full" on:click={() => buildContainerFromImage()} bind:disabled={imageNameIsInvalid}>Select Image</Button>

--- a/packages/renderer/src/lib/container/CreateContainerFromExistingImage.svelte
+++ b/packages/renderer/src/lib/container/CreateContainerFromExistingImage.svelte
@@ -6,21 +6,20 @@ import { onMount, tick } from 'svelte';
 import Fa from 'svelte-fa';
 import { router } from 'tinro';
 
+import { ImageUtils } from '/@/lib/image/image-utils';
+import RecommendedRegistry from '/@/lib/image/RecommendedRegistry.svelte';
+import ImageIcon from '/@/lib/images/ImageIcon.svelte';
+import EngineFormPage from '/@/lib/ui/EngineFormPage.svelte';
+import TerminalWindow from '/@/lib/ui/TerminalWindow.svelte';
+import type { TypeaheadItem } from '/@/lib/ui/Typeahead';
+import Typeahead from '/@/lib/ui/Typeahead.svelte';
+import WarningMessage from '/@/lib/ui/WarningMessage.svelte';
 import { lastPage } from '/@/stores/breadcrumb';
+import { providerInfos } from '/@/stores/providers';
 import { runImageInfo } from '/@/stores/run-image-store';
 import type { ImageSearchOptions } from '/@api/image-registry';
 import type { ProviderContainerConnectionInfo } from '/@api/provider-info';
 import type { PullEvent } from '/@api/pull-event';
-
-import { providerInfos } from '../../stores/providers';
-import { ImageUtils } from '../image/image-utils';
-import RecommendedRegistry from '../image/RecommendedRegistry.svelte';
-import ImageIcon from '../images/ImageIcon.svelte';
-import EngineFormPage from '../ui/EngineFormPage.svelte';
-import TerminalWindow from '../ui/TerminalWindow.svelte';
-import type { TypeaheadItem } from '../ui/Typeahead';
-import Typeahead from '../ui/Typeahead.svelte';
-import WarningMessage from '../ui/WarningMessage.svelte';
 
 const DOCKER_PREFIX = 'docker.io';
 const DOCKER_PREFIX_WITH_SLASH = DOCKER_PREFIX + '/';
@@ -318,6 +317,11 @@ async function searchFunction(value: string): Promise<void> {
   ];
 }
 
+async function pullImageAndRun(): Promise<void> {
+  await pullImage();
+  await buildContainerFromImage();
+}
+
 async function onEnterOperation(): Promise<void> {
   if (imageToPull === '') {
     return;
@@ -325,7 +329,7 @@ async function onEnterOperation(): Promise<void> {
   if (matchingLocalImages.includes(imageToPull)) {
     await buildContainerFromImage();
   } else {
-    await pullImage();
+    await pullImageAndRun();
   }
 }
 </script>
@@ -399,18 +403,14 @@ async function onEnterOperation(): Promise<void> {
         <div class="flex flex-row">
           <Button type="secondary" class="mr-3 w-full" on:click={(): void => router.goto($lastPage.path)}>Cancel</Button>
           {#if !matchingLocalImages.includes(imageToPull) && imageToPull !== ''}
-            {#if !pullFinished}
-              <Button
-                icon={faArrowCircleDown}
-                class="w-full"
-                bind:disabled={imageNameIsInvalid}
-                on:click={pullImage}
-                bind:inProgress={pullInProgress}>
-                Pull Image
-              </Button>
-            {:else}
-              <Button class="w-full" on:click={buildContainerFromImage} bind:disabled={imageNameIsInvalid}>Run Image</Button>
-            {/if}
+            <Button
+              icon={faArrowCircleDown}
+              class="w-full"
+              bind:disabled={imageNameIsInvalid}
+              on:click={pullImageAndRun}
+              bind:inProgress={pullInProgress}>
+              Pull Image and Run
+            </Button>
           {:else}
             <Button icon={faCircleCheck} class="w-full" bind:disabled={imageNameIsInvalid} on:click={buildContainerFromImage}>Run Image</Button>
           {/if}

--- a/packages/renderer/src/lib/container/CreateContainerFromExistingImage.svelte
+++ b/packages/renderer/src/lib/container/CreateContainerFromExistingImage.svelte
@@ -334,7 +334,7 @@ async function onEnterOperation(): Promise<void> {
       <Typeahead
         id="imageName"
         name="imageName"
-        placeholder="Select an exisiting image"
+        placeholder="Select an existing image"
         onInputChange={searchFunction}
         resultItems={values}
         compare={sortResults}

--- a/packages/renderer/src/lib/container/CreateContainerFromExistingImage.svelte
+++ b/packages/renderer/src/lib/container/CreateContainerFromExistingImage.svelte
@@ -270,7 +270,9 @@ function checkIfTagExist(image: string, tags: string[]): void {
 
 async function buildContainerFromImage(): Promise<void> {
   const localImages = (await window.listImages()).filter(
-    image => (image.RepoTags?.filter(repoTag => repoTag.includes(imageToPull)) ?? []).length > 0,
+    image =>
+      (image.RepoTags?.filter(repoTag => repoTag.includes(podmanFQN && usePodmanFQN ? podmanFQN : imageToPull)) ?? [])
+        .length > 0,
   );
   if (localImages.length > 0) {
     const chosenImage = imageUtils.getImagesInfoUI(localImages[0], []);

--- a/packages/renderer/src/navigation.ts
+++ b/packages/renderer/src/navigation.ts
@@ -49,8 +49,8 @@ export const handleNavigation = (request: InferredNavigationRequest<NavigationPa
     case NavigationPage.CONTAINER:
       router.goto(`/containers/${request.parameters.id}/`);
       break;
-    case NavigationPage.CONTAINER_CREATE_EXISITNG_IMAGE:
-      router.goto(`/containers/0/create-container-existing-image`);
+    case NavigationPage.EXISITNG_IMAGE_CREATE_CONTAINER:
+      router.goto(`/containers/0/existing-image-create-container`);
       break;
     case NavigationPage.CONTAINER_LOGS:
       router.goto(`/containers/${request.parameters.id}/logs`);

--- a/packages/renderer/src/navigation.ts
+++ b/packages/renderer/src/navigation.ts
@@ -49,6 +49,9 @@ export const handleNavigation = (request: InferredNavigationRequest<NavigationPa
     case NavigationPage.CONTAINER:
       router.goto(`/containers/${request.parameters.id}/`);
       break;
+    case NavigationPage.CONTAINER_CREATE_EXISITNG_IMAGE:
+      router.goto(`/create-container-existing-image`);
+      break;
     case NavigationPage.CONTAINER_LOGS:
       router.goto(`/containers/${request.parameters.id}/logs`);
       break;

--- a/packages/renderer/src/navigation.ts
+++ b/packages/renderer/src/navigation.ts
@@ -50,7 +50,7 @@ export const handleNavigation = (request: InferredNavigationRequest<NavigationPa
       router.goto(`/containers/${request.parameters.id}/`);
       break;
     case NavigationPage.CONTAINER_CREATE_EXISITNG_IMAGE:
-      router.goto(`/create-container-existing-image`);
+      router.goto(`/containers/0/create-container-existing-image`);
       break;
     case NavigationPage.CONTAINER_LOGS:
       router.goto(`/containers/${request.parameters.id}/logs`);

--- a/packages/renderer/src/navigation.ts
+++ b/packages/renderer/src/navigation.ts
@@ -49,8 +49,8 @@ export const handleNavigation = (request: InferredNavigationRequest<NavigationPa
     case NavigationPage.CONTAINER:
       router.goto(`/containers/${request.parameters.id}/`);
       break;
-    case NavigationPage.EXISITNG_IMAGE_CREATE_CONTAINER:
-      router.goto(`/containers/0/existing-image-create-container`);
+    case NavigationPage.EXISTING_IMAGE_CREATE_CONTAINER:
+      router.goto(`/images/existing-image-create-container`);
       break;
     case NavigationPage.CONTAINER_LOGS:
       router.goto(`/containers/${request.parameters.id}/logs`);


### PR DESCRIPTION
### What does this PR do?
This PR updates the create container from existing image workflow. When choosing this option, the user will be taken to a separate page similar to the `Pull Image` page, where they'll have the option to either select a local image or pull one from a registry to use. After selecting the image, the user will be moved to the build container page.
Most of the search image in remote registry and pull image code is taken from `PullImage.svelte`

### Screenshot / video of UI
<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->
[Screencast from 2025-02-24 15-23-15.webm](https://github.com/user-attachments/assets/fa870987-266d-4e53-8e20-aceb0bc2fb40)


### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/podman-desktop/issues/9978

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
