### PR TITLE
refactor: migrate typeahead to svelte5

### DIFF
--- a/packages/renderer/src/lib/ui/Typeahead.svelte
+++ b/packages/renderer/src/lib/ui/Typeahead.svelte
@@ -3,36 +3,52 @@ import { Spinner } from '@podman-desktop/ui-svelte';
 
 type SearchFunction = (s: string) => Promise<string[]>;
 
-// the text displayed when no option is selected
-export let placeholder: string | undefined = undefined;
-export let required: boolean = false;
-export let delay: number = 200;
-export let disabled: boolean = false;
-export let initialFocus: boolean = false;
-export let id: string | undefined = undefined;
-export let name: string | undefined = undefined;
-export let error: boolean = false;
+interface Props {
+  placeholder?: string;
+  required?: boolean;
+  delay?: number;
+  disabled?: boolean;
+  initialFocus?: boolean;
+  id?: string;
+  name?: string;
+  error?: boolean;
+  searchFunction?: SearchFunction;
+  onChange?: (value: string) => void;
+  onEnter?: () => void;
+  class?: string;
+}
 
-export let searchFunction: SearchFunction = async (_s: string) => [];
-export let onChange = function (_s: string) {};
-export let onEnter = function () {};
+let {
+  placeholder,
+  required = false,
+  delay = 200,
+  disabled = false,
+  initialFocus = false,
+  id,
+  name,
+  error = false,
+  searchFunction = async (_s: string) => [],
+  onChange = function (_s: string) {},
+  onEnter = function () {},
+  class: className,
+}: Props = $props();
 
-let input: HTMLInputElement;
-let list: HTMLDivElement;
-let scrollElements: HTMLElement[] = [];
-let value: string;
-let items: string[] = [];
-let inputDelayTimeout: NodeJS.Timeout;
-let opened: boolean = false;
-let highlightIndex: number = -1;
-let pageStep = 10;
-let userValue: string = '';
-let loading: boolean = false;
+let inputDelayTimeout: NodeJS.Timeout | undefined = undefined;
+let input: HTMLInputElement | undefined = $state();
+let list: HTMLDivElement | undefined = $state();
+let scrollElements: HTMLElement[] = $state([]);
+let value: string = $state('');
+let items: string[] = $state([]);
+let opened: boolean = $state(false);
+let highlightIndex: number = $state(-1);
+let pageStep: number = $state(10);
+let userValue: string = $state('');
+let loading: boolean = $state(false);
 
 function onItemSelected(s: string): void {
   value = s;
   userValue = s;
-  input.focus();
+  input?.focus();
   close();
   onChange(s);
 }
@@ -195,8 +211,7 @@ function onWindowClick(e: Event): void {
 
 <svelte:window on:click={onWindowClick} />
 <div
-  class="flex flex-row grow items-center px-1 py-1 group bg-[var(--pd-input-field-bg)] border-[1px] border-transparent {$$props.class ||
-    ''}"
+  class="flex flex-row grow items-center px-1 py-1 group bg-[var(--pd-input-field-bg)] border-[1px] border-transparent {className}"
   class:not(focus-within):hover:bg-[var(--pd-input-field-hover-bg)]={!disabled}
   class:focus-within:bg-[var(--pd-input-field-focused-bg)]={!disabled}
   class:focus-within:rounded-md={!disabled}
@@ -221,8 +236,8 @@ function onWindowClick(e: Event): void {
     disabled={disabled}
     id={id}
     name={name}
-    on:input={onInput}
-    on:keydown={onKeyDown}
+    oninput={onInput}
+    onkeydown={onKeyDown}
     use:requestFocus />
   {#if loading}
     <Spinner size="1em" />
@@ -238,8 +253,8 @@ function onWindowClick(e: Event): void {
         bind:this={scrollElements[i]}
         class:bg-[var(--pd-content-card-hover-bg)]={i === highlightIndex}
         class="p-1 text-start w-full cursor-pointer"
-        on:click={() => onItemSelected(item)}
-        on:pointerenter={() => {
+        onclick={() => onItemSelected(item)}
+        onpointerenter={() => {
           highlightIndex = i;
         }}>{item}</button>
     {/each}


### PR DESCRIPTION
### What does this PR do?

Migrate the Typeahead component to ease refactoring.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Step 1 of https://github.com/podman-desktop/podman-desktop/issues/10726

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
