### PR TITLE
refactor: migrate TerminalWindow to svelte5

### DIFF
--- a/packages/renderer/src/lib/ui/TerminalWindow.svelte
+++ b/packages/renderer/src/lib/ui/TerminalWindow.svelte
@@ -10,14 +10,27 @@ import TerminalSearchControls from '/@/lib/ui/TerminalSearchControls.svelte';
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
 import { getTerminalTheme } from '../../../../main/src/plugin/terminal-theme';
 
-export let terminal: Terminal;
-export let convertEol: boolean | undefined = undefined;
-export let disableStdIn: boolean = true;
-export let screenReaderMode: boolean | undefined = undefined;
-export let showCursor: boolean = false;
-export let search: boolean = false;
+interface Props {
+  terminal?: Terminal;
+  convertEol?: boolean;
+  disableStdIn?: boolean;
+  screenReaderMode?: boolean;
+  showCursor?: boolean;
+  search?: boolean;
+  class?: string;
+}
 
-let logsXtermDiv: HTMLDivElement;
+let {
+  terminal = $bindable(),
+  convertEol,
+  disableStdIn = true,
+  screenReaderMode,
+  showCursor = false,
+  search = false,
+  class: className,
+}: Props = $props();
+
+let logsXtermDiv: HTMLDivElement | undefined;
 let resizeHandler: () => void;
 
 const dispatch = createEventDispatcher();
@@ -75,4 +88,4 @@ onDestroy(() => {
 {#if search && terminal}
   <TerminalSearchControls terminal={terminal} />
 {/if}
-<div class="{$$props.class} p-[5px] pr-0 bg-[var(--pd-terminal-background)]" role="term" bind:this={logsXtermDiv}></div>
+<div class="{className} p-[5px] pr-0 bg-[var(--pd-terminal-background)]" role="term" bind:this={logsXtermDiv}></div>

--- a/packages/renderer/src/lib/ui/TerminalWindows.spec.ts
+++ b/packages/renderer/src/lib/ui/TerminalWindows.spec.ts
@@ -55,7 +55,7 @@ test('expect terminal constructor to have been called on mount', async () => {
 test('expect terminal constructor to reflect props', async () => {
   render(TerminalWindow, {
     terminal: writable() as unknown as Terminal,
-    disableStdin: true,
+    disableStdIn: true,
     convertEol: true,
     screenReaderMode: true,
   });


### PR DESCRIPTION
### What does this PR do?

While trying to migrate `PullImage` component to svelte5 I face a typecheck issues with the TerminalWindows with the `bind:terminal`. I fixed it by migrating the TerminalWindows to svelte 5.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Following https://github.com/podman-desktop/podman-desktop/pull/10727
Required for https://github.com/podman-desktop/podman-desktop/issues/10726

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
