### PR TITLE
refactor: migrate pull image svelte 5

### DIFF
--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -261,6 +261,11 @@ function checkIfTagExist(image: string, tags: string[]): void {
 
   isValidName = tags.some(t => t === tag);
 }
+
+function onSelectProvider(value: unknown): void {
+  if (!value || typeof value !== 'string') return;
+  selectedProviderConnection = providerConnections.find(connection => connection.endpoint.socketPath === value);
+}
 </script>
 
 <EngineFormPage
@@ -321,9 +326,7 @@ function checkIfTagExist(image: string, tags: string[]): void {
           <Dropdown
             id="providerChoice"
             name="providerChoice"
-            onChange={(value) => {
-              selectedProviderConnection = providerConnections.find((connection) => connection.endpoint.socketPath === value);
-            }}
+            onChange={onSelectProvider}
             value={selectedProviderConnection?.endpoint?.socketPath}
             options={providerConnections.map(providerConnection => ({
               label: providerConnection.name,

--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -321,10 +321,13 @@ function checkIfTagExist(image: string, tags: string[]): void {
           <Dropdown
             id="providerChoice"
             name="providerChoice"
-            bind:value={selectedProviderConnection}
+            onChange={(value) => {
+              selectedProviderConnection = providerConnections.find((connection) => connection.endpoint.socketPath === value);
+            }}
+            value={selectedProviderConnection?.endpoint?.socketPath}
             options={providerConnections.map(providerConnection => ({
               label: providerConnection.name,
-              value: providerConnection,
+              value: providerConnection.endpoint.socketPath,
             }))}>
           </Dropdown>
         </div>


### PR DESCRIPTION
### What does this PR do?

Migrate the PullImage component which uses the Typeahead component. Will be easier to continue working on https://github.com/podman-desktop/podman-desktop/issues/10726 by having them both to svelte5

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Following https://github.com/podman-desktop/podman-desktop/pull/10727

Need rebase after the following
- https://github.com/podman-desktop/podman-desktop/pull/10728
- https://github.com/podman-desktop/podman-desktop/pull/10733

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
