### PR TITLE
feat: allow to use production binary to develop extensions

### DIFF
--- a/packages/renderer/src/lib/extensions/ExtensionList.spec.ts
+++ b/packages/renderer/src/lib/extensions/ExtensionList.spec.ts
@@ -212,3 +212,18 @@ test('Search catalog page searches also description', async () => {
   const extensionIdB = screen.queryByRole('group', { name: 'B Extension' });
   expect(extensionIdB).not.toBeInTheDocument();
 });
+
+test('Expect to see local extensions tab content', async () => {
+  catalogExtensionInfos.set([]);
+  extensionInfos.set([]);
+
+  render(ExtensionList);
+
+  // select the local extensions tab
+  const localModeTab = screen.getByRole('button', { name: 'Local Extensions' });
+  await fireEvent.click(localModeTab);
+
+  // expect to see empty screen
+  const emptyText = screen.getByText('Enable Preferences > Extensions > Development Mode to test local extensions');
+  expect(emptyText).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/extensions/ExtensionList.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionList.svelte
@@ -11,6 +11,7 @@ import { featuredExtensionInfos } from '/@/stores/featuredExtensions';
 
 import type { CatalogExtensionInfoUI } from './catalog-extension-info-ui';
 import CatalogExtensionList from './CatalogExtensionList.svelte';
+import DevelopmentExtensionList from './dev-mode/DevelopmentExtensionList.svelte';
 import { ExtensionsUtils } from './extensions-utils';
 import InstallManuallyExtensionModal from './InstallManuallyExtensionModal.svelte';
 
@@ -66,7 +67,7 @@ function closeModal(): void {
   installManualImageModal = false;
 }
 
-let screen: 'installed' | 'catalog' = 'installed';
+let screen: 'installed' | 'catalog' | 'development' = 'installed';
 
 let installManualImageModal: boolean = false;
 </script>
@@ -108,7 +109,13 @@ let installManualImageModal: boolean = false;
         screen = 'catalog';
       }}
       selected={screen === 'catalog'}>Catalog</Button>
-  {/snippet}
+      <Button
+      type="tab"
+      on:click={(): void => {
+        screen = 'development';
+      }}
+      selected={screen === 'development'}>Local Extensions</Button>
+ {/snippet}
 
   {#snippet content()}
   <div class="flex min-w-full h-full">
@@ -121,7 +128,7 @@ let installManualImageModal: boolean = false;
           on:resetFilter={(): string => (searchTerm = '')} />
       {/if}
       <InstalledExtensionList extensionInfos={$filteredInstalledExtensions} />
-    {:else}
+    {:else if screen === 'catalog'}
       {#if searchTerm && $filteredCatalogExtensions.length === 0}
         <FilteredEmptyScreen
           icon={ExtensionIcon}
@@ -130,6 +137,8 @@ let installManualImageModal: boolean = false;
           on:resetFilter={(): string => (searchTerm = '')} />
       {/if}
       <CatalogExtensionList showEmptyScreen={!searchTerm} catalogExtensions={$filteredCatalogExtensions} />
+    {:else if screen === 'development'}
+      <DevelopmentExtensionList />
     {/if}
   </div>
   {/snippet}

--- a/packages/renderer/src/lib/extensions/dev-mode/DevelopmentExtensionEmptyScreen.spec.ts
+++ b/packages/renderer/src/lib/extensions/dev-mode/DevelopmentExtensionEmptyScreen.spec.ts
@@ -1,0 +1,30 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import DevelopmentExtensionEmptyScreen from './DevelopmentExtensionEmptyScreen.svelte';
+
+test('Expect we see the text of the empty screen', async () => {
+  render(DevelopmentExtensionEmptyScreen);
+  const emptyText = screen.getByText('Enable Preferences > Extensions > Development Mode to test local extensions');
+  expect(emptyText).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/extensions/dev-mode/DevelopmentExtensionEmptyScreen.svelte
+++ b/packages/renderer/src/lib/extensions/dev-mode/DevelopmentExtensionEmptyScreen.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+import { faCog } from '@fortawesome/free-solid-svg-icons';
+import { Button, EmptyScreen } from '@podman-desktop/ui-svelte';
+
+async function openExtensionDocumentation(): Promise<void> {
+  await window.openExternal('https://podman-desktop.io/docs/extensions/developing');
+}
+</script>
+
+<EmptyScreen
+  icon={faCog}
+  title="Local extensions (developer mode)"
+  message="Enable Preferences > Extensions > Development Mode to test local extensions">
+  <div class="flex gap-2 justify-center">
+    <Button type="link" on:click={openExtensionDocumentation}>How to write your first extension</Button>
+  </div>
+</EmptyScreen>

--- a/packages/renderer/src/lib/extensions/dev-mode/DevelopmentExtensionList.spec.ts
+++ b/packages/renderer/src/lib/extensions/dev-mode/DevelopmentExtensionList.spec.ts
@@ -1,0 +1,129 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { extensionDevelopmentFolders } from '/@/stores/extensionDevelopmentFolders';
+import { extensionInfos } from '/@/stores/extensions';
+import type { ExtensionInfo } from '/@api/extension-info';
+
+import DevelopmentExtensionList from './DevelopmentExtensionList.svelte';
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.resetAllMocks();
+  extensionDevelopmentFolders.set([]);
+  extensionInfos.set([]);
+});
+
+const devModeNotEnabledText = 'Enable Preferences > Extensions > Development Mode to test local extensions';
+
+test('Expect empty list if dev mode is not enabled', async () => {
+  // not enabled
+  vi.mocked(window.getConfigurationValue).mockResolvedValue(false);
+
+  render(DevelopmentExtensionList);
+
+  // wait the getConfigurationValue to be called
+  await vi.waitFor(() => expect(window.getConfigurationValue).toHaveBeenCalled());
+
+  // expect to find the text devModeNotEnabledText
+  expect(screen.getByText(devModeNotEnabledText)).toBeInTheDocument();
+});
+
+test('Expect no empty screen if dev mode is enabled but table is empty', async () => {
+  // enabled
+  vi.mocked(window.getConfigurationValue).mockResolvedValue(true);
+
+  render(DevelopmentExtensionList);
+
+  // wait the getConfigurationValue to be called
+  await vi.waitFor(() => expect(window.getConfigurationValue).toHaveBeenCalled());
+
+  // expect the text devModeNotEnabledText is not there
+  await vi.waitFor(() => expect(screen.queryByText(devModeNotEnabledText)).not.toBeInTheDocument());
+
+  // expect No extension for now to be displayed
+  expect(screen.getByText('No extension for now')).toBeInTheDocument();
+});
+
+test('expect addLocalFolderExtension is working', async () => {
+  // enabled
+  vi.mocked(window.getConfigurationValue).mockResolvedValue(true);
+
+  render(DevelopmentExtensionList);
+
+  // mock openDialog and returning the foo folder
+  vi.mocked(window.openDialog).mockResolvedValue(['foo']);
+
+  // wait the button 'Add a local folder extension is there
+  await vi.waitFor(() =>
+    expect(screen.getByRole('button', { name: 'Add a local folder extension...' })).toBeInTheDocument(),
+  );
+
+  const addButton = screen.getByRole('button', { name: 'Add a local folder extension...' });
+  await userEvent.click(addButton);
+
+  // check it call trackExtensionFolder with the foo folder
+  await vi.waitFor(() => expect(window.trackExtensionFolder).toHaveBeenCalledWith('foo'));
+});
+
+test('expect report error of addLocalFolderExtension', async () => {
+  // enabled
+  vi.mocked(window.getConfigurationValue).mockResolvedValue(true);
+
+  render(DevelopmentExtensionList);
+
+  // mock openDialog and returning the foo folder
+  vi.mocked(window.openDialog).mockResolvedValue(['foo']);
+
+  // mock trackExtensionFolder to throw an error
+  vi.mocked(window.trackExtensionFolder).mockRejectedValue(new Error('dummy error'));
+
+  // wait the button 'Add a local folder extension is there
+  await vi.waitFor(() =>
+    expect(screen.getByRole('button', { name: 'Add a local folder extension...' })).toBeInTheDocument(),
+  );
+
+  const addButton = screen.getByRole('button', { name: 'Add a local folder extension...' });
+  await userEvent.click(addButton);
+
+  // check it call trackExtensionFolder with the foo folder
+  await vi.waitFor(() => expect(window.trackExtensionFolder).toHaveBeenCalledWith('foo'));
+
+  // expect the error to be displayed
+  await vi.waitFor(() => expect(vi.mocked(window.showMessageBox).mock.calls[0][0].message).toContain('dummy error'));
+});
+
+test('expect list displayed if enabled', async () => {
+  // create a folder and an extension having the same path
+  extensionDevelopmentFolders.set([{ path: 'foo' }]);
+  extensionInfos.set([{ id: 'extensionid', name: 'extension A', path: 'foo' } as ExtensionInfo]);
+
+  // enabled
+  vi.mocked(window.getConfigurationValue).mockResolvedValue(true);
+
+  render(DevelopmentExtensionList);
+
+  // wait the text "extension A" to be displayed
+  await vi.waitFor(() => expect(screen.getByText('extension A')).toBeInTheDocument());
+});

--- a/packages/renderer/src/lib/extensions/dev-mode/DevelopmentExtensionList.svelte
+++ b/packages/renderer/src/lib/extensions/dev-mode/DevelopmentExtensionList.svelte
@@ -84,7 +84,7 @@ async function addLocalFolderExtension(): Promise<void> {
       <!-- List all -->
       <div class="bg-[var(--pd-content-bg)] rounded flex flex-col p-2">
         <div class="flex flex-row w-full">
-          <div class="text font-medium first-letter:uppercase pb-2">Local extension folders being tracked:</div>
+          <div class="text font-medium first-letter:uppercase pb-2">Local extension folders being tracked</div>
           <div class="flex-grow flex flex-col items-end">
             <Button on:click={addLocalFolderExtension}>Add a local folder extension...</Button>
           </div>

--- a/packages/renderer/src/lib/extensions/dev-mode/DevelopmentExtensionList.svelte
+++ b/packages/renderer/src/lib/extensions/dev-mode/DevelopmentExtensionList.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+import { Button } from '@podman-desktop/ui-svelte';
+import { onDestroy, onMount } from 'svelte';
+import type { Unsubscriber } from 'svelte/store';
+
+import DevelopmentExtensionListTable from '/@/lib/extensions/dev-mode/table/ListTable.svelte';
+import { extensionDevelopmentFolders } from '/@/stores/extensionDevelopmentFolders';
+import { extensionInfos } from '/@/stores/extensions';
+import type { ExtensionDevelopmentFolderInfo } from '/@api/extension-development-folders-info';
+import type { ExtensionInfo } from '/@api/extension-info';
+import { ExtensionLoaderSettings } from '/@api/extension-loader-settings';
+
+import type { SelectableExtensionDevelopmentFolderInfoUI } from './development-folder-info-ui';
+import DevelopmentExtensionEmptyScreen from './DevelopmentExtensionEmptyScreen.svelte';
+
+let isDevelopmentModeEnabled = $state(false);
+
+const unsubscribers: Unsubscriber[] = [];
+
+let currentExtFolders: ExtensionDevelopmentFolderInfo[] = $state([]);
+let currentExtensionInfos: ExtensionInfo[] = $state([]);
+
+const selectableExtensionDevelopmentFolders: SelectableExtensionDevelopmentFolderInfoUI[] = $derived(
+  currentExtFolders.map(folder => {
+    // do we have a matching extension
+    const matchingExtension = currentExtensionInfos.find(ext => ext.path === folder.path);
+    let extension = undefined;
+    if (matchingExtension) {
+      extension = { name: matchingExtension.name, state: matchingExtension.state, id: matchingExtension.id };
+    }
+
+    return { ...folder, selected: false, name: folder.path, extension };
+  }),
+);
+
+onMount(async () => {
+  //
+  // Check if development mode is enabled
+  isDevelopmentModeEnabled =
+    (await window.getConfigurationValue(
+      `${ExtensionLoaderSettings.SectionName}.${ExtensionLoaderSettings.DevelopmentMode}`,
+    )) ?? false;
+
+  // subscribe to extension changes
+  unsubscribers.push(
+    extensionInfos.subscribe(value => {
+      currentExtensionInfos = value;
+    }),
+  );
+  unsubscribers.push(
+    extensionDevelopmentFolders.subscribe(value => {
+      currentExtFolders = value;
+    }),
+  );
+});
+
+onDestroy(() => {
+  for (const unsubscriber of unsubscribers) {
+    unsubscriber();
+  }
+});
+
+async function addLocalFolderExtension(): Promise<void> {
+  // call the openDialog
+  const result = await window.openDialog({
+    selectors: ['openDirectory'],
+    openLabel: 'Select folder',
+    title: 'Track a new extension folder',
+  });
+  if (result?.[0]) {
+    try {
+      await window.trackExtensionFolder(result[0]);
+    } catch (error: unknown) {
+      // show error
+      await window.showMessageBox({ title: 'Error adding the folder', message: String(error), type: 'error' });
+    }
+  }
+}
+</script>
+
+{#if isDevelopmentModeEnabled}
+  <div class="bg-[var(--pd-content-card-bg)] m-2 w-full space-y-2 p-4 rounded-lg">
+    <div class="flex flex-col">
+      <!-- List all -->
+      <div class="bg-[var(--pd-content-bg)] rounded flex flex-col p-2">
+        <div class="flex flex-row w-full">
+          <div class="text font-medium first-letter:uppercase pb-2">Local extension folders being tracked:</div>
+          <div class="flex-grow flex flex-col items-end">
+            <Button on:click={addLocalFolderExtension}>Add a local folder extension...</Button>
+          </div>
+        </div>
+
+        <!-- List of extensions in development mode -->
+        {#if selectableExtensionDevelopmentFolders.length === 0}
+          <div class="italic">No extension for now</div>
+        {:else}
+          <div class="mr-8">
+            <DevelopmentExtensionListTable extensionFolderUIInfos={selectableExtensionDevelopmentFolders} />
+          </div>
+        {/if}
+      </div>
+    </div>
+  </div>
+{:else}
+  <DevelopmentExtensionEmptyScreen />
+{/if}

--- a/packages/renderer/src/lib/extensions/dev-mode/development-folder-info-ui.ts
+++ b/packages/renderer/src/lib/extensions/dev-mode/development-folder-info-ui.ts
@@ -1,0 +1,29 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { ExtensionDevelopmentFolderInfo } from '/@api/extension-development-folders-info';
+
+export interface SelectableExtensionDevelopmentFolderInfoUI extends ExtensionDevelopmentFolderInfo {
+  selected: boolean;
+  name: string;
+  extension?: {
+    id: string;
+    name: string;
+    state?: string;
+  };
+}

--- a/packages/renderer/src/lib/extensions/dev-mode/selectable/ActionStart.spec.ts
+++ b/packages/renderer/src/lib/extensions/dev-mode/selectable/ActionStart.spec.ts
@@ -1,0 +1,69 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { SelectableExtensionDevelopmentFolderInfoUI } from '/@/lib/extensions/dev-mode/development-folder-info-ui';
+
+import ActionStart from './ActionStart.svelte';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+const extensionFolderWithExtensionStopped: SelectableExtensionDevelopmentFolderInfoUI = {
+  path: 'foo',
+  extension: {
+    id: 'extensionid',
+    name: 'My Extension',
+    state: 'stopped',
+  },
+} as unknown as SelectableExtensionDevelopmentFolderInfoUI;
+
+const extensionFolderWithExtensionStarted: SelectableExtensionDevelopmentFolderInfoUI = {
+  path: 'foo',
+  extension: {
+    id: 'extensionid',
+    name: 'My Extension',
+    state: 'started',
+  },
+} as unknown as SelectableExtensionDevelopmentFolderInfoUI;
+
+test('Expect start action being displayed if there is an extension stopped', async () => {
+  render(ActionStart, { extensionFolder: extensionFolderWithExtensionStopped });
+  const stopButton = screen.getByRole('button', { name: 'Start the extension' });
+  expect(stopButton).toBeInTheDocument();
+
+  // click on the button
+  await fireEvent.click(stopButton);
+
+  // expect the window.startExtension to be called
+  expect(window.startExtension).toHaveBeenCalledWith(extensionFolderWithExtensionStopped.extension?.id);
+});
+
+test('Expect start action being hidden if extension is started', async () => {
+  render(ActionStart, { extensionFolder: extensionFolderWithExtensionStarted });
+  const stopButton = screen.getByRole('button', { name: 'Start the extension' });
+  expect(stopButton).toBeInTheDocument();
+
+  // expect the button is hidden
+  expect(stopButton).toHaveClass('hidden');
+});

--- a/packages/renderer/src/lib/extensions/dev-mode/selectable/ActionStart.svelte
+++ b/packages/renderer/src/lib/extensions/dev-mode/selectable/ActionStart.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+import { faPlay } from '@fortawesome/free-solid-svg-icons';
+
+import type { SelectableExtensionDevelopmentFolderInfoUI } from '/@/lib/extensions/dev-mode/development-folder-info-ui';
+import ListItemButtonIcon from '/@/lib/ui/ListItemButtonIcon.svelte';
+
+interface Props {
+  extensionFolder: SelectableExtensionDevelopmentFolderInfoUI;
+}
+const { extensionFolder }: Props = $props();
+
+async function startExtension(): Promise<void> {
+  if (!extensionFolder.extension) {
+    return;
+  }
+  await window.startExtension(extensionFolder.extension.id);
+}
+</script>
+
+<ListItemButtonIcon
+  title="Start the extension"
+  onClick={startExtension}
+  hidden={!extensionFolder.extension || extensionFolder.extension?.state === 'started'}
+  icon={faPlay} />

--- a/packages/renderer/src/lib/extensions/dev-mode/selectable/ActionStop.spec.ts
+++ b/packages/renderer/src/lib/extensions/dev-mode/selectable/ActionStop.spec.ts
@@ -1,0 +1,69 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { SelectableExtensionDevelopmentFolderInfoUI } from '/@/lib/extensions/dev-mode/development-folder-info-ui';
+
+import ActionStop from './ActionStop.svelte';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+const extensionFolderWithExtensionStopped: SelectableExtensionDevelopmentFolderInfoUI = {
+  path: 'foo',
+  extension: {
+    id: 'extensionid',
+    name: 'My Extension',
+    state: 'stopped',
+  },
+} as unknown as SelectableExtensionDevelopmentFolderInfoUI;
+
+const extensionFolderWithExtensionStarted: SelectableExtensionDevelopmentFolderInfoUI = {
+  path: 'foo',
+  extension: {
+    id: 'extensionid',
+    name: 'My Extension',
+    state: 'started',
+  },
+} as unknown as SelectableExtensionDevelopmentFolderInfoUI;
+
+test('Expect stop action being displayed if there is an extension started', async () => {
+  render(ActionStop, { extensionFolder: extensionFolderWithExtensionStarted });
+  const stopButton = screen.getByRole('button', { name: 'Stop the extension' });
+  expect(stopButton).toBeInTheDocument();
+
+  // click on the button
+  await fireEvent.click(stopButton);
+
+  // expect the window.stopExtension to be called
+  expect(window.stopExtension).toHaveBeenCalledWith(extensionFolderWithExtensionStopped.extension?.id);
+});
+
+test('Expect stop action being hidden if extension is stopped', async () => {
+  render(ActionStop, { extensionFolder: extensionFolderWithExtensionStopped });
+  const stopButton = screen.getByRole('button', { name: 'Stop the extension' });
+  expect(stopButton).toBeInTheDocument();
+
+  // expect the button is hidden
+  expect(stopButton).toHaveClass('hidden');
+});

--- a/packages/renderer/src/lib/extensions/dev-mode/selectable/ActionStop.svelte
+++ b/packages/renderer/src/lib/extensions/dev-mode/selectable/ActionStop.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+import { faStop } from '@fortawesome/free-solid-svg-icons';
+
+import type { SelectableExtensionDevelopmentFolderInfoUI } from '/@/lib/extensions/dev-mode/development-folder-info-ui';
+import ListItemButtonIcon from '/@/lib/ui/ListItemButtonIcon.svelte';
+
+interface Props {
+  extensionFolder: SelectableExtensionDevelopmentFolderInfoUI;
+}
+const { extensionFolder }: Props = $props();
+
+async function stopExtension(): Promise<void> {
+  if (!extensionFolder.extension) {
+    return;
+  }
+  await window.stopExtension(extensionFolder.extension.id);
+}
+</script>
+
+<ListItemButtonIcon
+  title="Stop the extension"
+  onClick={stopExtension}
+  hidden={!extensionFolder.extension || extensionFolder.extension?.state === 'stopped'}
+  icon={faStop} />

--- a/packages/renderer/src/lib/extensions/dev-mode/selectable/ActionUntrack.spec.ts
+++ b/packages/renderer/src/lib/extensions/dev-mode/selectable/ActionUntrack.spec.ts
@@ -1,0 +1,68 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { SelectableExtensionDevelopmentFolderInfoUI } from '../development-folder-info-ui';
+import ActionUntrack from './ActionUntrack.svelte';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+const extensionFolderWithExtensionFound: SelectableExtensionDevelopmentFolderInfoUI = {
+  path: 'foo',
+  extension: {
+    id: 'extensionid',
+    name: 'My Extension',
+    state: 'stopped',
+  },
+} as unknown as SelectableExtensionDevelopmentFolderInfoUI;
+
+const extensionFolderWithExtensionStarted: SelectableExtensionDevelopmentFolderInfoUI = {
+  path: 'foo',
+  extension: {
+    id: 'extensionid',
+    name: 'My Extension',
+    state: 'started',
+  },
+} as unknown as SelectableExtensionDevelopmentFolderInfoUI;
+
+test('Expect untrack action being displayed if there is stopped extension', async () => {
+  render(ActionUntrack, { extensionFolder: extensionFolderWithExtensionFound });
+  const untrackButton = screen.getByRole('button', { name: 'Untrack extension folder' });
+  expect(untrackButton).toBeInTheDocument();
+
+  // click on the button
+  await fireEvent.click(untrackButton);
+
+  // expect the window.untrackExtensionFolder to be called
+  expect(window.untrackExtensionFolder).toHaveBeenCalledWith(extensionFolderWithExtensionFound.path);
+});
+
+test('Expect untrack action being hidden if there is started extension', async () => {
+  render(ActionUntrack, { extensionFolder: extensionFolderWithExtensionStarted });
+  const untrackButton = screen.getByRole('button', { name: 'Untrack extension folder' });
+  expect(untrackButton).toBeInTheDocument();
+
+  // expect the button is hidden
+  expect(untrackButton).toHaveClass('hidden');
+});

--- a/packages/renderer/src/lib/extensions/dev-mode/selectable/ActionUntrack.svelte
+++ b/packages/renderer/src/lib/extensions/dev-mode/selectable/ActionUntrack.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+import { faTrash } from '@fortawesome/free-solid-svg-icons';
+
+import type { SelectableExtensionDevelopmentFolderInfoUI } from '/@/lib/extensions/dev-mode/development-folder-info-ui';
+import ListItemButtonIcon from '/@/lib/ui/ListItemButtonIcon.svelte';
+
+interface Props {
+  extensionFolder: SelectableExtensionDevelopmentFolderInfoUI;
+}
+const { extensionFolder }: Props = $props();
+
+async function untrackExtensionFolder(): Promise<void> {
+  await window.untrackExtensionFolder(extensionFolder.path);
+  // ensure it's cleared from the disabled list
+  if (extensionFolder.extension) {
+    await window.removeExtension(extensionFolder.extension.id);
+  }
+}
+</script>
+
+<ListItemButtonIcon
+  title="Untrack extension folder"
+  hidden={extensionFolder.extension && extensionFolder.extension?.state !== 'stopped'}
+  onClick={untrackExtensionFolder}
+  icon={faTrash} />

--- a/packages/renderer/src/lib/extensions/dev-mode/selectable/Actions.spec.ts
+++ b/packages/renderer/src/lib/extensions/dev-mode/selectable/Actions.spec.ts
@@ -1,0 +1,61 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import type { SelectableExtensionDevelopmentFolderInfoUI } from '/@/lib/extensions/dev-mode/development-folder-info-ui';
+import Actions from '/@/lib/extensions/dev-mode/selectable/Actions.svelte';
+
+const extensionFolderWithExtensionStopped: SelectableExtensionDevelopmentFolderInfoUI = {
+  path: 'foo',
+  extension: {
+    id: 'extensionid',
+    name: 'My Extension',
+    state: 'stopped',
+  },
+} as unknown as SelectableExtensionDevelopmentFolderInfoUI;
+
+const extensionFolderWithExtensionStarted: SelectableExtensionDevelopmentFolderInfoUI = {
+  path: 'foo',
+  extension: {
+    id: 'extensionid',
+    name: 'My Extension',
+    state: 'started',
+  },
+} as unknown as SelectableExtensionDevelopmentFolderInfoUI;
+
+test('Expect start action being displayed', async () => {
+  render(Actions, { extensionFolder: extensionFolderWithExtensionStopped });
+  const startButton = screen.getByRole('button', { name: 'Start the extension' });
+  expect(startButton).toBeInTheDocument();
+});
+
+test('Expect stop action being displayed', async () => {
+  render(Actions, { extensionFolder: extensionFolderWithExtensionStarted });
+  const stopButton = screen.getByRole('button', { name: 'Stop the extension' });
+  expect(stopButton).toBeInTheDocument();
+});
+
+test('Expect untrack action being displayed', async () => {
+  render(Actions, { extensionFolder: extensionFolderWithExtensionStopped });
+  const untrackButton = screen.getByRole('button', { name: 'Untrack extension folder' });
+  expect(untrackButton).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/extensions/dev-mode/selectable/Actions.svelte
+++ b/packages/renderer/src/lib/extensions/dev-mode/selectable/Actions.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+import type { SelectableExtensionDevelopmentFolderInfoUI } from '/@/lib/extensions/dev-mode/development-folder-info-ui';
+
+import ActionStart from './ActionStart.svelte';
+import ActionStop from './ActionStop.svelte';
+import ActionUntrack from './ActionUntrack.svelte';
+
+interface Props {
+  extensionFolder: SelectableExtensionDevelopmentFolderInfoUI;
+}
+const { extensionFolder }: Props = $props();
+</script>
+
+<ActionStart {extensionFolder} />
+<ActionStop {extensionFolder} />
+<ActionUntrack {extensionFolder} />

--- a/packages/renderer/src/lib/extensions/dev-mode/table/ActionsColumn.spec.ts
+++ b/packages/renderer/src/lib/extensions/dev-mode/table/ActionsColumn.spec.ts
@@ -1,0 +1,62 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import type { SelectableExtensionDevelopmentFolderInfoUI } from '/@/lib/extensions/dev-mode/development-folder-info-ui';
+
+import ActionsColumn from './ActionsColumn.svelte';
+
+const extensionFolderWithExtensionStopped: SelectableExtensionDevelopmentFolderInfoUI = {
+  path: 'foo',
+  extension: {
+    id: 'extensionid',
+    name: 'My Extension',
+    state: 'stopped',
+  },
+} as unknown as SelectableExtensionDevelopmentFolderInfoUI;
+
+const extensionFolderWithExtensionStarted: SelectableExtensionDevelopmentFolderInfoUI = {
+  path: 'foo',
+  extension: {
+    id: 'extensionid',
+    name: 'My Extension',
+    state: 'started',
+  },
+} as unknown as SelectableExtensionDevelopmentFolderInfoUI;
+
+test('Expect start action being displayed', async () => {
+  render(ActionsColumn, { object: extensionFolderWithExtensionStopped });
+  const startButton = screen.getByRole('button', { name: 'Start the extension' });
+  expect(startButton).toBeInTheDocument();
+});
+
+test('Expect stop action being displayed', async () => {
+  render(ActionsColumn, { object: extensionFolderWithExtensionStarted });
+  const stopButton = screen.getByRole('button', { name: 'Stop the extension' });
+  expect(stopButton).toBeInTheDocument();
+});
+
+test('Expect untrack action being displayed', async () => {
+  render(ActionsColumn, { object: extensionFolderWithExtensionStopped });
+  const untrackButton = screen.getByRole('button', { name: 'Untrack extension folder' });
+  expect(untrackButton).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/extensions/dev-mode/table/ActionsColumn.svelte
+++ b/packages/renderer/src/lib/extensions/dev-mode/table/ActionsColumn.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+import type { SelectableExtensionDevelopmentFolderInfoUI } from '/@/lib/extensions/dev-mode/development-folder-info-ui';
+import Actions from '/@/lib/extensions/dev-mode/selectable/Actions.svelte';
+
+export let object: SelectableExtensionDevelopmentFolderInfoUI;
+</script>
+
+<Actions extensionFolder={object} />

--- a/packages/renderer/src/lib/extensions/dev-mode/table/ListTable.spec.ts
+++ b/packages/renderer/src/lib/extensions/dev-mode/table/ListTable.spec.ts
@@ -1,0 +1,63 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import type { SelectableExtensionDevelopmentFolderInfoUI } from '/@/lib/extensions/dev-mode/development-folder-info-ui';
+
+import DevelopmentExtensionListTable from './ListTable.svelte';
+
+const extensionFolderWithExtensionStopped: SelectableExtensionDevelopmentFolderInfoUI = {
+  path: 'foo',
+  name: 'Extension A',
+  extension: {
+    id: 'extension.id-a',
+    name: 'My Extension A',
+    state: 'stopped',
+  },
+} as unknown as SelectableExtensionDevelopmentFolderInfoUI;
+
+const extensionFolderWithExtensionStarted: SelectableExtensionDevelopmentFolderInfoUI = {
+  path: 'bar',
+  name: 'Extension B',
+  extension: {
+    id: 'extension.id-b',
+    name: 'My Extension B',
+    state: 'started',
+  },
+} as unknown as SelectableExtensionDevelopmentFolderInfoUI;
+
+test('Expect dev folders being displayed', async () => {
+  const extensionFolderUIInfos: SelectableExtensionDevelopmentFolderInfoUI[] = [
+    extensionFolderWithExtensionStopped,
+    extensionFolderWithExtensionStarted,
+  ];
+  render(DevelopmentExtensionListTable, { extensionFolderUIInfos, selectedItemsNumber: 0 });
+
+  // get all rows
+  const rows = screen.getAllByRole('row');
+  // check if all folders are displayed
+  expect(rows).toHaveLength(3);
+
+  // check if all ext folders are displayed
+  expect(screen.getByText('Extension A')).toBeInTheDocument();
+  expect(screen.getByText('Extension B')).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/extensions/dev-mode/table/ListTable.svelte
+++ b/packages/renderer/src/lib/extensions/dev-mode/table/ListTable.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+import { faTrash } from '@fortawesome/free-solid-svg-icons';
+import { Button, Table, TableColumn, TableRow, TableSimpleColumn } from '@podman-desktop/ui-svelte';
+
+import { withBulkConfirmation } from '/@/lib/actions/BulkActions';
+import type { SelectableExtensionDevelopmentFolderInfoUI } from '/@/lib/extensions/dev-mode/development-folder-info-ui';
+import DevelopmentExtensionTableActionsColumn from '/@/lib/extensions/dev-mode/table/ActionsColumn.svelte';
+
+interface Props {
+  selectedItemsNumber?: number;
+  extensionFolderUIInfos: SelectableExtensionDevelopmentFolderInfoUI[];
+}
+
+let { extensionFolderUIInfos, selectedItemsNumber = $bindable(0) }: Props = $props();
+
+const nameColumn = new TableColumn<SelectableExtensionDevelopmentFolderInfoUI, string>('Name', {
+  width: '3fr',
+  renderer: TableSimpleColumn,
+  renderMapping: (extensionFolder): string => extensionFolder.name,
+  comparator: (a, b): number => a.name.localeCompare(b.name),
+});
+
+const extensionNameColumn = new TableColumn<SelectableExtensionDevelopmentFolderInfoUI, string>('Extension', {
+  width: '2fr',
+  renderer: TableSimpleColumn,
+  renderMapping: (extensionFolder): string => extensionFolder.extension?.name ?? 'Unknown',
+  comparator: (a, b): number => a.name.localeCompare(b.name),
+});
+const extensionStateColumn = new TableColumn<SelectableExtensionDevelopmentFolderInfoUI, string>('State', {
+  width: '2fr',
+  renderer: TableSimpleColumn,
+  renderMapping: (extensionFolder): string => extensionFolder.extension?.state ?? '',
+  comparator: (a, b): number => a.name.localeCompare(b.name),
+});
+const actionsColumn = new TableColumn<SelectableExtensionDevelopmentFolderInfoUI>('Actions', {
+  align: 'right',
+  width: '150px',
+  renderer: DevelopmentExtensionTableActionsColumn,
+  overflow: true,
+});
+
+const columns = [nameColumn, extensionNameColumn, extensionStateColumn, actionsColumn];
+
+const row = new TableRow<SelectableExtensionDevelopmentFolderInfoUI>({
+  selectable: (): boolean => true,
+});
+
+function deleteSelectedFolders(): void {}
+let bulkDeleteInProgress = false;
+</script>
+
+<Table
+  kind="extensions"
+  data={extensionFolderUIInfos}
+  {columns}
+  {row}
+  bind:selectedItemsNumber
+  defaultSortColumn="Name"
+  on:update={(): SelectableExtensionDevelopmentFolderInfoUI[] => (extensionFolderUIInfos = [...extensionFolderUIInfos])}>
+</Table>
+
+<div class="h-5 px-6 mb-2">
+  {#if selectedItemsNumber > 0}
+    <Button
+      on:click={(): void =>
+        withBulkConfirmation(
+          deleteSelectedFolders,
+          `Untrack loading extension from ${selectedItemsNumber} folder${selectedItemsNumber > 1 ? 's' : ''}`,
+        )}
+      title="Untrack {selectedItemsNumber} selected items"
+      inProgress={bulkDeleteInProgress}
+      icon={faTrash} />
+    <span>On {selectedItemsNumber} selected items.</span>
+  {:else}
+    <div>&nbsp;</div>
+  {/if}
+</div>


### PR DESCRIPTION
### What does this PR do?
Allow to add/track folder having extensions after turning on the development mode flag


### Screenshot / video of UI

![image](https://github.com/user-attachments/assets/445ddfed-7985-4452-8026-2e4334f218d0)

### What issues does this PR fix or reference?

fixes https://github.com/podman-desktop/podman-desktop/issues/8616

### How to test this PR?

Unit tests added

Manual test:

1.  start Podman Desktop in watch mode (but without an --extension-folder flag on the CLI) or production mode 
1. enable the 'development mode' in the settings/preferences for extensions
1. go to the puzzle icon/extension in main navbar on the left
1. click on the add... button in the list and select the backend/extension folder of an extension (you can select a dummy folder but it'll report an error asking you to select a valid extension folder)
1. then you should see the extension being loaded.

you can even restart Podman Desktop, the extension should be still there


- [x] Tests are covering the bug fix or the new feature
