### PR TITLE
refactor: remove search function work from Typeahead component

### DIFF
--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -28,6 +28,7 @@ let shortnameImages: string[] = [];
 let podmanFQN = '';
 let usePodmanFQN = false;
 let isValidName = true;
+let searchResult: string[] = [];
 
 export let imageToPull: string | undefined = undefined;
 
@@ -159,7 +160,7 @@ onMount(() => {
 let imageNameInvalid: string | undefined = undefined;
 let imageNameIsInvalid = imageToPull === undefined || imageToPull.trim() === '';
 function validateImageName(image: string): void {
-  if (imageToPull && (image === undefined || image.trim() === '')) {
+  if (image === undefined || image.trim() === '') {
     imageNameIsInvalid = true;
     imageNameInvalid = 'Please enter a value';
   } else {
@@ -245,6 +246,25 @@ function checkIfTagExist(image: string, tags: string[]): void {
 
   isValidName = tags.some(t => t === tag);
 }
+
+async function searchFunction(value: string): Promise<void> {
+  try {
+    searchResult = (await searchImages(value)).toSorted((a: string, b: string) => {
+      const dockerIoValue = `docker.io/${value}`;
+      const aStartsWithValue = a.startsWith(value) || a.startsWith(dockerIoValue);
+      const bStartsWithValue = b.startsWith(value) || b.startsWith(dockerIoValue);
+      if (aStartsWithValue === bStartsWithValue) {
+        return a.localeCompare(b);
+      } else if (aStartsWithValue && !bStartsWithValue) {
+        return -1;
+      } else {
+        return 1;
+      }
+    });
+  } catch (error: unknown) {
+    searchResult = [];
+  }
+}
 </script>
 
 <EngineFormPage
@@ -268,7 +288,9 @@ function checkIfTagExist(image: string, tags: string[]): void {
           id="imageName"
           name="imageName"
           placeholder="Image name"
-          searchFunction={searchImages}
+          onInputChange={searchFunction}
+          resultItems={searchResult}
+          sorted
           onChange={async (s: string): Promise<void> => {
             validateImageName(s);
             await resolveShortname();

--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -290,7 +290,6 @@ async function searchFunction(value: string): Promise<void> {
           placeholder="Image name"
           onInputChange={searchFunction}
           resultItems={searchResult}
-          sorted
           onChange={async (s: string): Promise<void> => {
             validateImageName(s);
             await resolveShortname();

--- a/packages/renderer/src/lib/ui/Typeahead.spec.ts
+++ b/packages/renderer/src/lib/ui/Typeahead.spec.ts
@@ -93,6 +93,7 @@ test('should list the result after the delay, and display spinner during loading
     initialFocus: true,
     onInputChange: searchFunction,
     resultItems: searchResult,
+    sort: true,
     delay: 10,
   });
 
@@ -132,6 +133,7 @@ test('should list items started with search term on top', async () => {
     initialFocus: true,
     onInputChange: searchFunction,
     resultItems: searchResult,
+    sort: true,
     delay: 10,
   });
 
@@ -166,6 +168,7 @@ test('should navigate in list with keys', async () => {
     initialFocus: true,
     onInputChange: searchFunction,
     resultItems: searchResult,
+    sort: true,
     delay: 10,
   });
   const input = screen.getByRole('textbox');

--- a/packages/renderer/src/lib/ui/Typeahead.spec.ts
+++ b/packages/renderer/src/lib/ui/Typeahead.spec.ts
@@ -84,13 +84,15 @@ test('initial focus is set with option', async () => {
 });
 
 test('should list the result after the delay, and display spinner during loading', async () => {
-  const searchFunction = async (s: string): Promise<string[]> => {
+  let searchResult: string[] = [];
+  const searchFunction = async (s: string): Promise<void> => {
     await new Promise(resolve => setTimeout(resolve, 100));
-    return [s + '01', s + '02', s + '03'];
+    searchResult = [s + '01', s + '02', s + '03'];
   };
-  render(Typeahead, {
+  const { rerender } = render(Typeahead, {
     initialFocus: true,
-    searchFunction,
+    onInputChange: searchFunction,
+    resultItems: searchResult,
     delay: 10,
   });
 
@@ -107,6 +109,9 @@ test('should list the result after the delay, and display spinner during loading
 
   await new Promise(resolve => setTimeout(resolve, 100));
   expect(screen.queryByRole('progressbar')).toBeNull();
+  await waitFor(() => expect(searchResult.length > 0).toBeTruthy());
+  await rerender({ resultItems: searchResult });
+  await tick();
   assertIsListVisible(true);
 
   const list = screen.getByRole('row');
@@ -118,19 +123,24 @@ test('should list the result after the delay, and display spinner during loading
 });
 
 test('should list items started with search term on top', async () => {
-  const searchFunction = async (s: string): Promise<string[]> => {
+  let searchResult: string[] = [];
+  const searchFunction = async (s: string): Promise<void> => {
     await new Promise(resolve => setTimeout(resolve, 100));
-    return ['z1' + s, s + '01', 'z0', s + '02', 'z2', s + '03'];
+    searchResult = ['z1' + s, s + '01', 'z0', s + '02', 'z2', s + '03'];
   };
-  render(Typeahead, {
+  const { rerender } = render(Typeahead, {
     initialFocus: true,
-    searchFunction,
+    onInputChange: searchFunction,
+    resultItems: searchResult,
     delay: 10,
   });
 
   const input = screen.getByRole('textbox');
 
   await userEvent.type(input, 'aze');
+  await waitFor(() => expect(searchResult.length > 0).toBeTruthy());
+  await rerender({ resultItems: searchResult });
+  await tick();
 
   await waitFor(() => {
     const list = screen.getByRole('row');
@@ -143,46 +153,27 @@ test('should list items started with search term on top', async () => {
   });
 });
 
-test('should list items started with docker.io + search term on top', async () => {
-  const searchFunction = async (): Promise<string[]> => {
-    await new Promise(resolve => setTimeout(resolve, 100));
-    return ['docker.io/aimage', 'docker.io/bimage', 'docker.io/cimage'];
-  };
-  render(Typeahead, {
-    initialFocus: true,
-    searchFunction,
-    delay: 10,
-  });
-
-  const input = screen.getByRole('textbox');
-
-  await userEvent.type(input, 'cimage');
-
-  await waitFor(() => {
-    const list = screen.getByRole('row');
-    const items = within(list).getAllByRole('button');
-    expect(items.length).toBe(3);
-    expect(items[0].textContent).toBe('docker.io/cimage');
-    expect(items[1].textContent).toBe('docker.io/aimage');
-    expect(items[2].textContent).toBe('docker.io/bimage');
-  });
-});
-
 test('should navigate in list with keys', async () => {
-  const searchFunction = async (s: string): Promise<string[]> => {
+  let searchResult: string[] = [];
+  const searchFunction = async (s: string): Promise<void> => {
     const result: string[] = [];
     for (let i = 1; i <= 15; i++) {
       result.push(s + `${i}`.padStart(2, '0'));
     }
-    return result;
+    searchResult = result;
   };
-  render(Typeahead, {
+  const { rerender } = render(Typeahead, {
     initialFocus: true,
-    searchFunction,
+    onInputChange: searchFunction,
+    resultItems: searchResult,
     delay: 10,
   });
   const input = screen.getByRole('textbox');
   await userEvent.type(input, 'term');
+
+  await waitFor(() => expect(searchResult.length > 0).toBeTruthy());
+  await rerender({ resultItems: searchResult });
+  await tick();
 
   await new Promise(resolve => setTimeout(resolve, 11));
 

--- a/packages/renderer/src/lib/ui/Typeahead.svelte
+++ b/packages/renderer/src/lib/ui/Typeahead.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
 import { Spinner } from '@podman-desktop/ui-svelte';
 
-type SearchFunction = (s: string) => Promise<string[]>;
-
 interface Props {
   placeholder?: string;
   required?: boolean;
@@ -12,7 +10,9 @@ interface Props {
   id?: string;
   name?: string;
   error?: boolean;
-  searchFunction?: SearchFunction;
+  resultItems?: string[];
+  sorted?: boolean;
+  onInputChange?: (s: string) => Promise<void>;
   onChange?: (value: string) => void;
   onEnter?: () => void;
   class?: string;
@@ -27,9 +27,11 @@ let {
   id,
   name,
   error = false,
-  searchFunction = async (_s: string): Promise<string[]> => [],
-  onChange = function (_s: string): void {},
-  onEnter = function (): void {},
+  resultItems = [],
+  sorted = false,
+  onInputChange,
+  onChange,
+  onEnter,
   class: className,
 }: Props = $props();
 
@@ -38,7 +40,19 @@ let input: HTMLInputElement | undefined = $state();
 let list: HTMLDivElement | undefined = $state();
 let scrollElements: HTMLElement[] = $state([]);
 let value: string = $state('');
-let items: string[] = $state([]);
+let items: string[] = $derived(
+  sorted
+    ? resultItems
+    : resultItems.toSorted((a: string, b: string) => {
+        if (a.startsWith(userValue) === b.startsWith(userValue)) {
+          return a.localeCompare(b);
+        } else if (a.startsWith(userValue) && !b.startsWith(userValue)) {
+          return -1;
+        } else {
+          return 1;
+        }
+      }),
+);
 let opened: boolean = $state(false);
 let highlightIndex: number = $state(-1);
 let pageStep: number = $state(10);
@@ -50,18 +64,17 @@ function onItemSelected(s: string): void {
   userValue = s;
   input?.focus();
   close();
-  onChange(s);
+  onChange?.(s);
 }
 
 function onInput(): void {
   userValue = value;
-  onChange(value);
+  onChange?.(value);
   clearTimeout(inputDelayTimeout);
   inputDelayTimeout = setTimeout(processInput, delay);
 }
 
 function onKeyDown(e: KeyboardEvent): void {
-  onChange(value);
   switch (e.key) {
     case 'ArrowDown':
       onDownKey(e);
@@ -82,6 +95,7 @@ function onKeyDown(e: KeyboardEvent): void {
       onEnterKey(e);
       break;
   }
+  onChange?.(value);
 }
 
 function onUpKey(e: KeyboardEvent): void {
@@ -144,7 +158,7 @@ function onEnterKey(e: KeyboardEvent): void {
     e.stopPropagation();
   } else {
     close();
-    onEnter();
+    onEnter?.();
   }
 }
 
@@ -158,30 +172,13 @@ function makeVisible(): void {
 
 function processInput(): void {
   loading = true;
-  searchFunction(value)
-    .then(result => {
-      // if the component has been disabled in the meantime
-      if (disabled) {
-        return;
-      }
-      items = result.toSorted((a: string, b: string) => {
-        const dockerIoValue = `docker.io/${value}`;
-        const aStartsWithValue = a.startsWith(value) || a.startsWith(dockerIoValue);
-        const bStartsWithValue = b.startsWith(value) || b.startsWith(dockerIoValue);
-        if ((aStartsWithValue && bStartsWithValue) || (!aStartsWithValue && !bStartsWithValue)) {
-          return a.localeCompare(b);
-        } else if (aStartsWithValue && !bStartsWithValue) {
-          return -1;
-        } else {
-          return 1;
-        }
-      });
+  onInputChange?.(value)
+    .then(() => {
       highlightIndex = -1;
       open();
     })
     .catch(() => {
       // We do not display the error
-      items = [];
     })
     .finally(() => {
       loading = false;

--- a/packages/renderer/src/lib/ui/Typeahead.svelte
+++ b/packages/renderer/src/lib/ui/Typeahead.svelte
@@ -11,7 +11,7 @@ interface Props {
   name?: string;
   error?: boolean;
   resultItems?: string[];
-  sorted?: boolean;
+  sort?: boolean;
   onInputChange?: (s: string) => Promise<void>;
   onChange?: (value: string) => void;
   onEnter?: () => void;
@@ -28,7 +28,7 @@ let {
   name,
   error = false,
   resultItems = [],
-  sorted = false,
+  sort = false,
   onInputChange,
   onChange,
   onEnter,
@@ -41,9 +41,8 @@ let list: HTMLDivElement | undefined = $state();
 let scrollElements: HTMLElement[] = $state([]);
 let value: string = $state('');
 let items: string[] = $derived(
-  sorted
-    ? resultItems
-    : resultItems.toSorted((a: string, b: string) => {
+  sort
+    ? resultItems.toSorted((a: string, b: string) => {
         if (a.startsWith(userValue) === b.startsWith(userValue)) {
           return a.localeCompare(b);
         } else if (a.startsWith(userValue) && !b.startsWith(userValue)) {
@@ -51,7 +50,8 @@ let items: string[] = $derived(
         } else {
           return 1;
         }
-      }),
+      })
+    : resultItems,
 );
 let opened: boolean = $state(false);
 let highlightIndex: number = $state(-1);


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR refactors the `Typeahead` component so that the search function happens in the parent component, and the result items are passed down as a property of `Typeahead`. In `PullImage`, the custom sorting is happening in that component, while `Typeahead` includes default sorting in case the resultItems that are passed down to it are not sorted (a separate `Typeahead` prop )

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Part of https://github.com/podman-desktop/podman-desktop/issues/10726

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
