### PR TITLE
refactor: extract analyzeExtension to a dedicated class

### DIFF
--- a/packages/main/src/plugin/color-registry.spec.ts
+++ b/packages/main/src/plugin/color-registry.spec.ts
@@ -24,7 +24,7 @@ import type { ApiSenderType } from '/@/plugin/api.js';
 import { AppearanceSettings } from '/@/plugin/appearance-settings.js';
 import type { ConfigurationRegistry, IConfigurationChangeEvent } from '/@/plugin/configuration-registry.js';
 import { Emitter } from '/@/plugin/events/emitter.js';
-import type { AnalyzedExtension } from '/@/plugin/extension/extension-loader.js';
+import type { AnalyzedExtension } from '/@/plugin/extension/extension-analyzer.js';
 import { Disposable } from '/@/plugin/types/disposable.js';
 import type { ColorDefinition } from '/@api/color-info.js';
 import type { RawThemeContribution } from '/@api/theme-info.js';

--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -18,7 +18,7 @@
 
 import type * as extensionApi from '@podman-desktop/api';
 
-import type { AnalyzedExtension } from '/@/plugin/extension/extension-loader.js';
+import type { AnalyzedExtension } from '/@/plugin/extension/extension-analyzer.js';
 import type { ColorDefinition, ColorInfo } from '/@api/color-info.js';
 import type { RawThemeContribution } from '/@api/theme-info.js';
 

--- a/packages/main/src/plugin/extension/extension-analyzer.spec.ts
+++ b/packages/main/src/plugin/extension/extension-analyzer.spec.ts
@@ -36,7 +36,7 @@ beforeEach(() => {
   extensionAnalyzer = new ExtensionAnalyzer();
 });
 
-describe('analyze extension and main', async () => {
+describe('analyze extension and main', () => {
   test('check for extension with main entry', async () => {
     // mock fs.existsSync
     const fsExistsSyncMock = vi.spyOn(fs, 'existsSync');

--- a/packages/main/src/plugin/extension/extension-analyzer.spec.ts
+++ b/packages/main/src/plugin/extension/extension-analyzer.spec.ts
@@ -1,0 +1,131 @@
+/**********************************************************************
+ * Copyright (C) 2023-2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import * as fs from 'node:fs';
+import { readFile, realpath } from 'node:fs/promises';
+import * as path from 'node:path';
+
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { ExtensionAnalyzer } from './extension-analyzer.js';
+
+let extensionAnalyzer: ExtensionAnalyzer;
+
+vi.mock('node:fs');
+vi.mock('node:fs/promises');
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  extensionAnalyzer = new ExtensionAnalyzer();
+});
+
+describe('analyze extension and main', async () => {
+  test('check for extension with main entry', async () => {
+    // mock fs.existsSync
+    const fsExistsSyncMock = vi.spyOn(fs, 'existsSync');
+    fsExistsSyncMock.mockReturnValue(true);
+
+    const readmeContent = 'This is my custom README';
+
+    vi.mocked(realpath).mockResolvedValue('/fake/path');
+    // mock readFile
+    vi.mocked(readFile).mockResolvedValue(readmeContent);
+
+    const fakeManifest = {
+      publisher: 'fooPublisher',
+      name: 'fooName',
+      main: 'main-entry.js',
+    };
+
+    // mock loadManifest
+    const loadManifestMock = vi.spyOn(extensionAnalyzer, 'loadManifest');
+    loadManifestMock.mockResolvedValue(fakeManifest);
+
+    const extension = await extensionAnalyzer.analyzeExtension(path.resolve('/', 'fake', 'path'), false);
+
+    expect(extension).toBeDefined();
+    expect(extension?.error).toBeDefined();
+    expect(extension?.mainPath).toBe(path.resolve('/', 'fake', 'path', 'main-entry.js'));
+    expect(extension.readme).toBe(readmeContent);
+    expect(extension?.id).toBe('fooPublisher.fooName');
+  });
+
+  test('check for extension with linked folder', async () => {
+    vi.mock('node:fs');
+    vi.mock('node:fs/promises');
+
+    // mock fs.existsSync
+    const fsExistsSyncMock = vi.spyOn(fs, 'existsSync');
+    fsExistsSyncMock.mockReturnValue(true);
+
+    const readmeContent = 'This is my custom README';
+
+    vi.mocked(realpath).mockResolvedValue('/fake/path');
+    // mock readFile
+    vi.mocked(readFile).mockResolvedValue(readmeContent);
+
+    const fakeManifest = {
+      publisher: 'fooPublisher',
+      name: 'fooName',
+      main: 'main-entry.js',
+    };
+
+    // mock loadManifest
+    const loadManifestMock = vi.spyOn(extensionAnalyzer, 'loadManifest');
+    loadManifestMock.mockResolvedValue(fakeManifest);
+
+    const extension = await extensionAnalyzer.analyzeExtension(path.resolve('/', 'linked', 'path'), false);
+
+    expect(extension).toBeDefined();
+    expect(extension?.error).toBeDefined();
+    expect(extension?.mainPath).toBe(path.resolve('/', 'fake', 'path', 'main-entry.js'));
+    expect(extension.readme).toBe(readmeContent);
+    expect(extension?.id).toBe('fooPublisher.fooName');
+  });
+
+  test('check for extension without main entry', async () => {
+    vi.mock('node:fs');
+
+    // mock fs.existsSync
+    const fsExistsSyncMock = vi.spyOn(fs, 'existsSync');
+    fsExistsSyncMock.mockReturnValue(true);
+
+    vi.mocked(realpath).mockResolvedValue('/fake/path');
+    vi.mocked(readFile).mockResolvedValue('empty');
+
+    const fakeManifest = {
+      publisher: 'fooPublisher',
+      name: 'fooName',
+      // no main entry
+    };
+
+    // mock loadManifest
+    const loadManifestMock = vi.spyOn(extensionAnalyzer, 'loadManifest');
+    loadManifestMock.mockResolvedValue(fakeManifest);
+
+    const extension = await extensionAnalyzer.analyzeExtension('/fake/path', false);
+
+    expect(extension).toBeDefined();
+    expect(extension?.error).toBeDefined();
+    // not set
+    expect(extension?.mainPath).toBeUndefined();
+    expect(extension?.id).toBe('fooPublisher.fooName');
+  });
+});

--- a/packages/main/src/plugin/extension/extension-analyzer.ts
+++ b/packages/main/src/plugin/extension/extension-analyzer.ts
@@ -1,0 +1,126 @@
+/**********************************************************************
+ * Copyright (C) 2022-2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import * as fs from 'node:fs';
+import { readFile, realpath } from 'node:fs/promises';
+import path from 'node:path';
+
+import type * as containerDesktopAPI from '@podman-desktop/api';
+
+export interface AnalyzedExtension {
+  id: string;
+  name: string;
+  // root folder (where is package.json)
+  path: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  manifest: any;
+  // main entry
+  mainPath?: string;
+  api?: typeof containerDesktopAPI;
+  removable: boolean;
+
+  readme: string;
+
+  update?: {
+    version: string;
+    ociUri: string;
+  };
+
+  missingDependencies?: string[];
+  circularDependencies?: string[];
+
+  error?: string;
+
+  readonly subscriptions: containerDesktopAPI.Disposable[];
+
+  dispose(): void;
+}
+
+export class ExtensionAnalyzer {
+  async analyzeExtension(extensionPath: string, removable: boolean): Promise<AnalyzedExtension> {
+    const resolvedExtensionPath = await realpath(extensionPath);
+    // do nothing if there is no package.json file
+    let error = undefined;
+    if (!fs.existsSync(path.resolve(resolvedExtensionPath, 'package.json'))) {
+      error = `Ignoring extension ${resolvedExtensionPath} without package.json file`;
+      console.warn(error);
+      const analyzedExtension: AnalyzedExtension = {
+        id: '<unknown>',
+        name: '<unknown>',
+        path: resolvedExtensionPath,
+        manifest: undefined,
+        readme: '',
+        api: <typeof containerDesktopAPI>{},
+        removable,
+        subscriptions: [],
+        dispose(): void {},
+        error,
+      };
+      return analyzedExtension;
+    }
+
+    // log error if the manifest is missing required entries
+    const manifest = await this.loadManifest(resolvedExtensionPath);
+    if (!manifest.name || !manifest.displayName || !manifest.version || !manifest.publisher || !manifest.description) {
+      error = `Extension ${resolvedExtensionPath} missing required manifest entry in package.json (name, displayName, version, publisher, description)`;
+      console.warn(error);
+    }
+
+    // create api object
+    const disposables: containerDesktopAPI.Disposable[] = [];
+
+    // is there a README.md file in the extension folder ?
+    let readme = '';
+    if (fs.existsSync(path.resolve(resolvedExtensionPath, 'README.md'))) {
+      readme = await readFile(path.resolve(resolvedExtensionPath, 'README.md'), 'utf8');
+    }
+
+    const analyzedExtension: AnalyzedExtension = {
+      id: `${manifest.publisher}.${manifest.name}`,
+      name: manifest.name,
+      manifest,
+      path: resolvedExtensionPath,
+      mainPath: manifest.main ? path.resolve(resolvedExtensionPath, manifest.main) : undefined,
+      readme,
+      removable,
+      subscriptions: disposables,
+      dispose(): void {
+        for (const disposable of disposables) {
+          disposable.dispose();
+        }
+      },
+      error,
+    };
+
+    return analyzedExtension;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async loadManifest(extensionPath: string): Promise<any> {
+    const manifestPath = path.join(extensionPath, 'package.json');
+    return new Promise((resolve, reject) => {
+      fs.readFile(manifestPath, 'utf8', (err, data) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(JSON.parse(data));
+        }
+      });
+    });
+  }
+}

--- a/packages/main/src/plugin/extension/extension-watcher.spec.ts
+++ b/packages/main/src/plugin/extension/extension-watcher.spec.ts
@@ -21,7 +21,8 @@ import type { FileMatcher } from 'get-tsconfig';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { FilesystemMonitoring } from '../filesystem-monitoring.js';
-import type { ActivatedExtension, AnalyzedExtension } from './extension-loader.js';
+import type { AnalyzedExtension } from './extension-analyzer.js';
+import type { ActivatedExtension } from './extension-loader.js';
 import { ExtensionWatcher } from './extension-watcher.js';
 
 vi.mock('get-tsconfig');

--- a/packages/main/src/plugin/extension/extension-watcher.ts
+++ b/packages/main/src/plugin/extension/extension-watcher.ts
@@ -23,7 +23,8 @@ import type { Event } from '../events/emitter.js';
 import { Emitter } from '../events/emitter.js';
 import type { FilesystemMonitoring } from '../filesystem-monitoring.js';
 import type { IDisposable } from '../types/disposable.js';
-import type { ActivatedExtension, AnalyzedExtension } from './extension-loader.js';
+import type { AnalyzedExtension } from './extension-analyzer.js';
+import type { ActivatedExtension } from './extension-loader.js';
 import { ExtensionTypeScriptConfigParser } from './extension-tsconfig-parser.js';
 
 // In charge of watching the extension and reloading it when it changes

--- a/packages/main/src/plugin/icon-registry.spec.ts
+++ b/packages/main/src/plugin/icon-registry.spec.ts
@@ -20,7 +20,7 @@ import path from 'node:path';
 
 import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
-import type { AnalyzedExtension } from '/@/plugin/extension/extension-loader.js';
+import type { AnalyzedExtension } from '/@/plugin/extension/extension-analyzer.js';
 
 import type { ApiSenderType } from './api.js';
 import { IconRegistry } from './icon-registry.js';

--- a/packages/main/src/plugin/icon-registry.ts
+++ b/packages/main/src/plugin/icon-registry.ts
@@ -18,7 +18,7 @@
 
 import { join } from 'node:path';
 
-import type { AnalyzedExtension } from '/@/plugin/extension/extension-loader.js';
+import type { AnalyzedExtension } from '/@/plugin/extension/extension-analyzer.js';
 import type { FontDefinition } from '/@api/font-info.js';
 import type { IconDefinition, IconInfo } from '/@api/icon-info.js';
 

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -150,6 +150,7 @@ import { EditorInit } from './editor-init.js';
 import type { Emitter } from './events/emitter.js';
 import { ExtensionsCatalog } from './extension/catalog/extensions-catalog.js';
 import type { CatalogExtension } from './extension/catalog/extensions-catalog-api.js';
+import { ExtensionAnalyzer } from './extension/extension-analyzer.js';
 import { ExtensionDevelopmentFolders } from './extension/extension-development-folders.js';
 import { ExtensionsUpdater } from './extension/updater/extensions-updater.js';
 import { Featured } from './featured/featured.js';
@@ -669,8 +670,14 @@ export class PluginSystem {
       onboardingRegistry,
     );
 
+    const extensionAnalyzer = new ExtensionAnalyzer();
+
     const extensionWatcher = new ExtensionWatcher(fileSystemMonitoring);
-    const extensionDevelopmentFolders = new ExtensionDevelopmentFolders(configurationRegistry, apiSender);
+    const extensionDevelopmentFolders = new ExtensionDevelopmentFolders(
+      configurationRegistry,
+      extensionAnalyzer,
+      apiSender,
+    );
     extensionDevelopmentFolders.init();
 
     this.extensionLoader = new ExtensionLoader(
@@ -711,9 +718,9 @@ export class PluginSystem {
       certificates,
       extensionWatcher,
       extensionDevelopmentFolders,
+      extensionAnalyzer,
     );
     await this.extensionLoader.init();
-    extensionDevelopmentFolders.setExtensionLoader(this.extensionLoader);
 
     const feedback = new FeedbackHandler(this.extensionLoader);
 

--- a/packages/main/src/plugin/install/extension-installer.spec.ts
+++ b/packages/main/src/plugin/install/extension-installer.spec.ts
@@ -25,7 +25,8 @@ import { beforeEach, expect, test, vi } from 'vitest';
 
 import type { ExtensionsCatalog } from '/@/plugin/extension/catalog/extensions-catalog.js';
 import type { CatalogFetchableExtension } from '/@/plugin/extension/catalog/extensions-catalog-api.js';
-import type { AnalyzedExtension, ExtensionLoader } from '/@/plugin/extension/extension-loader.js';
+import type { AnalyzedExtension } from '/@/plugin/extension/extension-analyzer.js';
+import type { ExtensionLoader } from '/@/plugin/extension/extension-loader.js';
 import type { ExtensionInfo } from '/@api/extension-info.js';
 
 import type { ApiSenderType } from '../api.js';

--- a/packages/main/src/plugin/install/extension-installer.ts
+++ b/packages/main/src/plugin/install/extension-installer.ts
@@ -27,7 +27,8 @@ import * as tarFs from 'tar-fs';
 
 import type { Directories } from '/@/plugin/directories.js';
 import type { ExtensionsCatalog } from '/@/plugin/extension/catalog/extensions-catalog.js';
-import type { AnalyzedExtension, ExtensionLoader } from '/@/plugin/extension/extension-loader.js';
+import type { AnalyzedExtension } from '/@/plugin/extension/extension-analyzer.js';
+import type { ExtensionLoader } from '/@/plugin/extension/extension-loader.js';
 
 import type { ApiSenderType } from '../api.js';
 import type { ContributionManager } from '../contribution-manager.js';
@@ -334,6 +335,7 @@ export class ExtensionInstaller {
 
     // load all extensions
     analyzedExtensions.forEach(extension => this.extensionLoader.ensureExtensionIsEnabled(extension.id));
+
     await this.extensionLoader.loadExtensions(analyzedExtensions);
 
     sendEnd('Extension Successfully installed.');

--- a/packages/main/src/plugin/onboarding-registry.spec.ts
+++ b/packages/main/src/plugin/onboarding-registry.spec.ts
@@ -20,7 +20,7 @@ import * as fs from 'node:fs';
 
 import { afterEach, beforeEach, describe, expect, expectTypeOf, test, vi } from 'vitest';
 
-import type { AnalyzedExtension } from '/@/plugin/extension/extension-loader.js';
+import type { AnalyzedExtension } from '/@/plugin/extension/extension-analyzer.js';
 import type { OnboardingState } from '/@api/onboarding.js';
 
 import type { ApiSenderType } from './api.js';

--- a/packages/main/src/plugin/onboarding-registry.ts
+++ b/packages/main/src/plugin/onboarding-registry.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 
 import * as path from 'node:path';
 
-import type { AnalyzedExtension } from '/@/plugin/extension/extension-loader.js';
+import type { AnalyzedExtension } from '/@/plugin/extension/extension-analyzer.js';
 import type { Onboarding, OnboardingInfo, OnboardingStatus } from '/@api/onboarding.js';
 
 import { getBase64Image } from '../util.js';


### PR DESCRIPTION
### What does this PR do?
move out analyze extension from extension-loader to a separate class


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/pull/10712#discussion_r1920355635

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
