### PR TITLE
feat: display pods and deployments counts in experimental mode

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
@@ -173,6 +173,7 @@ describe.each([
     implemented: {
       health: true,
       resourcesCount: true,
+      undefinedCounts: true,
     },
     initMocks: (): void => {
       Object.defineProperty(global, 'window', {
@@ -206,6 +207,11 @@ describe.each([
           reachable: false,
           checking: false,
         },
+        {
+          contextName: 'context-name3',
+          reachable: true,
+          checking: false,
+        },
       ]);
     },
   },
@@ -214,6 +220,7 @@ describe.each([
     implemented: {
       health: true,
       resourcesCount: true,
+      undefinedCounts: false,
     },
     initMocks: (): void => {
       const state: Map<string, ContextGeneralState> = new Map();
@@ -243,6 +250,7 @@ describe.each([
     render(PreferencesKubernetesContextsRendering, {});
     const context1 = screen.getAllByRole('row')[0];
     const context2 = screen.getAllByRole('row')[1];
+    const context3 = screen.getAllByRole('row')[2];
     if (implemented.health) {
       await vi.waitFor(() => {
         expect(within(context1).queryByText('REACHABLE')).toBeInTheDocument();
@@ -271,6 +279,18 @@ describe.each([
     expect(podsCountContext2).not.toBeInTheDocument();
     const deploymentsCountContext2 = within(context2).queryByLabelText('Context Deployments Count');
     expect(deploymentsCountContext2).not.toBeInTheDocument();
+
+    if (implemented.undefinedCounts) {
+      const checkNoCount = (el: HTMLElement, label: string): void => {
+        const countEl = within(el).getByLabelText(label);
+        expect(countEl).toBeInTheDocument();
+        expect(countEl).toBeEmptyDOMElement();
+      };
+      expect(within(context3).queryByText('PODS')).toBeInTheDocument();
+      expect(within(context3).queryByText('DEPLOYMENTS')).toBeInTheDocument();
+      checkNoCount(context3, 'Context Pods Count');
+      checkNoCount(context3, 'Context Deployments Count');
+    }
   });
 });
 

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
@@ -25,6 +25,7 @@ import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 import { kubernetesContextsHealths } from '/@/stores/kubernetes-context-health';
 import { kubernetesContexts } from '/@/stores/kubernetes-contexts';
 import * as kubernetesContextsState from '/@/stores/kubernetes-contexts-state';
+import { kubernetesResourcesCount } from '/@/stores/kubernetes-resources-count';
 import type { KubeContext } from '/@api/kubernetes-context';
 import type { ContextGeneralState } from '/@api/kubernetes-contexts-states';
 
@@ -171,7 +172,7 @@ describe.each([
     name: 'experimental states',
     implemented: {
       health: true,
-      resourcesCount: false,
+      resourcesCount: true,
     },
     initMocks: (): void => {
       Object.defineProperty(global, 'window', {
@@ -181,6 +182,18 @@ describe.each([
           kubernetesRefreshContextState: vi.fn(),
         },
       });
+      kubernetesResourcesCount.set([
+        {
+          contextName: 'context-name',
+          resourceName: 'pods',
+          count: 1,
+        },
+        {
+          contextName: 'context-name',
+          resourceName: 'deployments',
+          count: 2,
+        },
+      ]);
       vi.mocked(window.getConfigurationValue<boolean>).mockResolvedValue(true);
       kubernetesContextsHealths.set([
         {

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -6,7 +6,9 @@ import { router } from 'tinro';
 
 import { kubernetesContextsHealths } from '/@/stores/kubernetes-context-health';
 import { kubernetesContextsCheckingStateDelayed, kubernetesContextsState } from '/@/stores/kubernetes-contexts-state';
+import { kubernetesResourcesCount } from '/@/stores/kubernetes-resources-count';
 import type { KubeContext } from '/@api/kubernetes-context';
+import type { SelectedResourceName } from '/@api/kubernetes-contexts-states';
 
 import { kubernetesContexts } from '../../stores/kubernetes-contexts';
 import { clearKubeUIContextErrors, setKubeUIContextError } from '../kube/KubeContextUI';
@@ -18,6 +20,8 @@ interface KubeContextWithStates extends KubeContext {
   isReachable: boolean;
   isKnown: boolean;
   isBeingChecked: boolean;
+  podsCount: number | undefined;
+  deploymentsCount: number | undefined;
 }
 
 const currentContextName = $derived($kubernetesContexts.find(c => c.currentContext)?.name);
@@ -31,6 +35,8 @@ const kubernetesContextsWithStates: KubeContextWithStates[] = $derived(
     isReachable: isContextReachable(kubeContext.name, experimentalStates),
     isKnown: isContextKnown(kubeContext.name, experimentalStates),
     isBeingChecked: isContextBeingChecked(kubeContext.name, experimentalStates),
+    podsCount: getResourcesCount(kubeContext.name, 'pods', experimentalStates),
+    deploymentsCount: getResourcesCount(kubeContext.name, 'deployments', experimentalStates),
   })),
 );
 
@@ -109,6 +115,19 @@ function isContextBeingChecked(contextName: string, experimental: boolean): bool
     );
   }
   return !!$kubernetesContextsCheckingStateDelayed?.get(contextName);
+}
+
+function getResourcesCount(
+  contextName: string,
+  resourceName: SelectedResourceName,
+  experimental: boolean,
+): number | undefined {
+  if (experimental) {
+    return $kubernetesResourcesCount.find(
+      resourcesCount => resourcesCount.contextName === contextName && resourcesCount.resourceName === resourceName,
+    )?.count;
+  }
+  return $kubernetesContextsState.get(contextName)?.resources[resourceName];
 }
 
 async function connect(contextName: string): Promise<void> {
@@ -197,7 +216,7 @@ async function connect(contextName: string): Promise<void> {
                   <div class="text-center">
                     <div class="font-bold text-[9px] text-[var(--pd-invert-content-card-text)]">PODS</div>
                     <div class="text-[16px] text-[var(--pd-invert-content-card-text)]" aria-label="Context Pods Count">
-                      {$kubernetesContextsState.get(context.name)?.resources.pods}
+                      {context.podsCount}
                     </div>
                   </div>
                   <div class="text-center">
@@ -205,7 +224,7 @@ async function connect(contextName: string): Promise<void> {
                     <div
                       class="text-[16px] text-[var(--pd-invert-content-card-text)]"
                       aria-label="Context Deployments Count">
-                      {$kubernetesContextsState.get(context.name)?.resources.deployments}
+                      {context.deploymentsCount}
                     </div>
                   </div>
                 </div>

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -20,8 +20,8 @@ interface KubeContextWithStates extends KubeContext {
   isReachable: boolean;
   isKnown: boolean;
   isBeingChecked: boolean;
-  podsCount: number | undefined;
-  deploymentsCount: number | undefined;
+  podsCount?: number;
+  deploymentsCount?: number;
 }
 
 const currentContextName = $derived($kubernetesContexts.find(c => c.currentContext)?.name);

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -216,7 +216,7 @@ async function connect(contextName: string): Promise<void> {
                   <div class="text-center">
                     <div class="font-bold text-[9px] text-[var(--pd-invert-content-card-text)]">PODS</div>
                     <div class="text-[16px] text-[var(--pd-invert-content-card-text)]" aria-label="Context Pods Count">
-                      {context.podsCount}
+                      {#if context.podsCount !== undefined}{context.podsCount}{/if}
                     </div>
                   </div>
                   <div class="text-center">
@@ -224,7 +224,7 @@ async function connect(contextName: string): Promise<void> {
                     <div
                       class="text-[16px] text-[var(--pd-invert-content-card-text)]"
                       aria-label="Context Deployments Count">
-                      {context.deploymentsCount}
+                      {#if context.deploymentsCount !== undefined}{context.deploymentsCount}{/if}
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Display pods and deployments counts in experimental mode in the page Settings > Kubernetes

### Screenshot / video of UI

![kube-resources-count-experimental](https://github.com/user-attachments/assets/dfec6905-8e72-4aae-a2bc-89ceac9de1a5)


### What issues does this PR fix or reference?

Fixes #10656

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
