### PR TITLE
feat: adding version to container provider connection

### DIFF
--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -3251,6 +3251,8 @@ test('activate and autostart should not duplicate machines ', async () => {
 test('ensure updateMachines check for machine version', async () => {
   // setup env as linux
   vi.mocked(extensionApi.env).isLinux = true;
+  // init extension
+  extension.initExtensionContext({ subscriptions: [] } as unknown as extensionApi.ExtensionContext);
   // mock process#exec
   vi.spyOn(extensionApi.process, 'exec').mockImplementation(
     (_command, args) =>
@@ -3271,9 +3273,6 @@ test('ensure updateMachines check for machine version', async () => {
         }
       }),
   );
-
-  // init extension
-  extension.initExtensionContext({ subscriptions: [] } as unknown as extensionApi.ExtensionContext);
   // run update machines workflow
   await extension.updateMachines(provider, podmanConfiguration);
 

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -3277,8 +3277,11 @@ test('ensure updateMachines check for machine version', async () => {
   // run update machines workflow
   await extension.updateMachines(provider, podmanConfiguration);
 
-  // ensure we registered a container provider connection
-  expect(provider.registerContainerProviderConnection).toHaveBeenCalledOnce();
+  await vi.waitFor(() => {
+    // ensure we registered a container provider connection
+    expect(provider.registerContainerProviderConnection).toHaveBeenCalledOnce();
+  });
+
   // let's extract the ContainerProviderConnection#version function we provided
   const { version } = vi.mocked(provider.registerContainerProviderConnection).mock.calls[0][0];
   // ensure the version is defined and we are getting the version we mocked

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -1230,7 +1230,7 @@ test('ensure started machine reports default configuration', async () => {
   extension.initExtensionContext({ subscriptions: [] } as unknown as extensionApi.ExtensionContext);
   vi.spyOn(extensionApi.process, 'exec').mockImplementation(
     (_command, args) =>
-      new Promise<extensionApi.RunResult>(resolve => {
+      new Promise<extensionApi.RunResult>((resolve, reject) => {
         if (args?.[0] === 'machine' && args?.[1] === 'list') {
           resolve({ stdout: JSON.stringify([fakeMachineJSON[0]]) } as extensionApi.RunResult);
         } else if (args?.[0] === 'machine' && args?.[1] === 'inspect') {
@@ -1241,6 +1241,8 @@ test('ensure started machine reports default configuration', async () => {
           } as extensionApi.RunResult);
         } else if (args?.[0] === '--version') {
           resolve({ stdout: 'podman version 4.9.0' } as extensionApi.RunResult);
+        } else {
+          reject(new Error(`unknown arguments ${args}`));
         }
       }),
   );
@@ -1260,7 +1262,7 @@ test('ensure stopped machine reports stopped provider', async () => {
   vi.mocked(extensionApi.env).isMac = true;
   vi.spyOn(extensionApi.process, 'exec').mockImplementation(
     (_command, args) =>
-      new Promise<extensionApi.RunResult>(resolve => {
+      new Promise<extensionApi.RunResult>((resolve, reject) => {
         if (args?.[0] === 'machine' && args?.[1] === 'list') {
           const fakeStoppedMachine = JSON.parse(JSON.stringify(fakeMachineJSON[0]));
           fakeStoppedMachine.Running = false;
@@ -1274,6 +1276,8 @@ test('ensure stopped machine reports stopped provider', async () => {
           } as extensionApi.RunResult);
         } else if (args?.[0] === '--version') {
           resolve({ stdout: 'podman version 4.9.0' } as extensionApi.RunResult);
+        } else {
+          reject(new Error(`unknown arguments ${args}`));
         }
       }),
   );
@@ -1321,7 +1325,7 @@ test('ensure running and not starting machine reports ready provider', async () 
   vi.mocked(extensionApi.env).isMac = true;
   vi.spyOn(extensionApi.process, 'exec').mockImplementation(
     (_command, args) =>
-      new Promise<extensionApi.RunResult>(resolve => {
+      new Promise<extensionApi.RunResult>((resolve, reject) => {
         if (args?.[0] === 'machine' && args?.[1] === 'list') {
           const fakeStoppedMachine = JSON.parse(JSON.stringify(fakeMachineJSON[0]));
           fakeStoppedMachine.Running = true;
@@ -1336,6 +1340,8 @@ test('ensure running and not starting machine reports ready provider', async () 
           } as extensionApi.RunResult);
         } else if (args?.[0] === '--version') {
           resolve({ stdout: 'podman version 4.9.0' } as extensionApi.RunResult);
+        } else {
+          reject(new Error(`unknown arguments ${args}`));
         }
       }),
   );
@@ -1350,7 +1356,7 @@ test('ensure started machine reports configuration', async () => {
   extension.initExtensionContext({ subscriptions: [] } as unknown as extensionApi.ExtensionContext);
   vi.spyOn(extensionApi.process, 'exec').mockImplementation(
     (_command, args) =>
-      new Promise<extensionApi.RunResult>(resolve => {
+      new Promise<extensionApi.RunResult>((resolve, reject) => {
         if (args?.[0] === 'machine' && args?.[1] === 'list') {
           resolve({ stdout: JSON.stringify([fakeMachineJSON[0]]) } as extensionApi.RunResult);
         } else if (args?.[0] === 'machine' && args?.[1] === 'inspect') {
@@ -1361,6 +1367,8 @@ test('ensure started machine reports configuration', async () => {
           } as extensionApi.RunResult);
         } else if (args?.[0] === '--version') {
           resolve({ stdout: 'podman version 4.9.0' } as extensionApi.RunResult);
+        } else {
+          reject(new Error(`unknown arguments ${args}`));
         }
       }),
   );

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -1225,35 +1225,6 @@ test('handlecompatibilitymodesetting: disable compatibility called when configur
   expect(disableMock).toHaveBeenCalled();
 });
 
-test('ensure started machine check for machine version', async () => {
-  vi.mocked(extensionApi.env).isLinux = true;
-  extension.initExtensionContext({ subscriptions: [] } as unknown as extensionApi.ExtensionContext);
-  vi.spyOn(extensionApi.process, 'exec').mockImplementation(
-    (_command, args) =>
-      new Promise<extensionApi.RunResult>(resolve => {
-        if (args?.[0] === 'machine' && args?.[1] === 'list') {
-          resolve({ stdout: JSON.stringify([fakeMachineJSON[0]]) } as extensionApi.RunResult);
-        } else if (args?.[0] === 'machine' && args?.[1] === 'inspect') {
-          resolve({} as extensionApi.RunResult);
-        } else if (args?.[0] === 'system' && args?.[1] === 'connection' && args?.[2] === 'list') {
-          resolve({
-            stdout: JSON.stringify([{ Name: fakeMachineJSON[0].Name, Default: true }]),
-          } as extensionApi.RunResult);
-        } else if (args?.[0] === '--version') {
-          resolve({ stdout: 'podman version 4.9.0' } as extensionApi.RunResult);
-        } else if (args?.[0] === '--connection' && args?.[1] === 'podman-machine-default' && args?.[2] === 'version') {
-          resolve({ stdout: JSON.stringify({ Server: { Version: '1.2.3' } }) } as extensionApi.RunResult);
-        }
-      }),
-  );
-
-  await extension.updateMachines(provider, podmanConfiguration);
-  expect(provider.registerContainerProviderConnection).toHaveBeenCalled();
-  const { version } = vi.mocked(provider.registerContainerProviderConnection).mock.calls[0][0];
-  expect(version).toBeDefined();
-  expect(version?.()).toBe('1.2.3');
-});
-
 test('ensure started machine reports default configuration', async () => {
   vi.mocked(extensionApi.env).isLinux = true;
   extension.initExtensionContext({ subscriptions: [] } as unknown as extensionApi.ExtensionContext);
@@ -3275,4 +3246,42 @@ test('activate and autostart should not duplicate machines ', async () => {
   // should be only 1 but we allow some more calls (if there is not a check to check during the autostart it would be 100+ calls)
   expect(podmanMachineListCalls).toBeLessThan(5);
   expect(promiseAutoStart).toBeDefined();
+});
+
+test('ensure updateMachines check for machine version', async () => {
+  // setup env as linux
+  vi.mocked(extensionApi.env).isLinux = true;
+  // mock process#exec
+  vi.spyOn(extensionApi.process, 'exec').mockImplementation(
+    (_command, args) =>
+      new Promise<extensionApi.RunResult>(resolve => {
+        if (args?.[0] === 'machine' && args?.[1] === 'list') {
+          resolve({ stdout: JSON.stringify([fakeMachineJSON[0]]) } as extensionApi.RunResult);
+        } else if (args?.[0] === 'machine' && args?.[1] === 'inspect') {
+          resolve({} as extensionApi.RunResult);
+        } else if (args?.[0] === 'system' && args?.[1] === 'connection' && args?.[2] === 'list') {
+          resolve({
+            stdout: JSON.stringify([{ Name: fakeMachineJSON[0].Name, Default: true }]),
+          } as extensionApi.RunResult);
+        } else if (args?.[0] === '--version') {
+          resolve({ stdout: 'podman version 4.9.0' } as extensionApi.RunResult);
+        } else if (args?.[0] === '--connection' && args?.[1] === 'podman-machine-default' && args?.[2] === 'version') {
+          // simulate result of podman --connection=podman-machine-default version
+          resolve({ stdout: JSON.stringify({ Server: { Version: '1.2.3' } }) } as extensionApi.RunResult);
+        }
+      }),
+  );
+
+  // init extension
+  extension.initExtensionContext({ subscriptions: [] } as unknown as extensionApi.ExtensionContext);
+  // run update machines workflow
+  await extension.updateMachines(provider, podmanConfiguration);
+
+  // ensure we registered a container provider connection
+  expect(provider.registerContainerProviderConnection).toHaveBeenCalledOnce();
+  // let's extract the ContainerProviderConnection#version function we provided
+  const { version } = vi.mocked(provider.registerContainerProviderConnection).mock.calls[0][0];
+  // ensure the version is defined and we are getting the version we mocked
+  expect(version).toBeDefined();
+  expect(version?.()).toBe('1.2.3');
 });

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -867,7 +867,7 @@ export async function registerProviderFor(
     },
     vmType: machineInfo.vmType,
     vmTypeDisplayName: getProviderLabel(machineInfo.vmType),
-    version: () => podmanServerVersions.get(machineInfo.name) ?? 'unknown',
+    version: () => podmanServerVersions.get(machineInfo.name),
   };
 
   // Since Podman 4.5, machines are using the same path for all sockets of machines

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -1930,15 +1930,8 @@ export async function getJSONMachineListByProvider(containerMachineProvider?: st
 }
 
 export async function deactivate(): Promise<void> {
-  console.log('stopping podman extension');
-  // cleanup
   stopLoop = true;
-  listeners.clear();
-  podmanServerVersions.clear();
-  podmanMachinesInfo.clear();
-  currentConnections.clear();
-  containerProviderConnections.clear();
-
+  console.log('stopping podman extension');
   await stopAutoStartedMachine().then(() => {
     if (autoMachineStarted) {
       console.log('stopped autostarted machine', autoMachineName);
@@ -1950,6 +1943,7 @@ export async function deactivate(): Promise<void> {
   podmanMachinesInfo.clear();
   currentConnections.clear();
   containerProviderConnections.clear();
+  podmanServerVersions.clear();
 }
 
 const PODMAN_MINIMUM_VERSION_FOR_NOW_FLAG_INIT = '4.0.0';

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -777,6 +777,11 @@ function prettyMachineName(machineName: string): string {
   return name;
 }
 
+/**
+ * This function will check for the version of a podman connection
+ * @param machineInfo
+ * @param force
+ */
 async function updatePodmanServer(machineInfo: { name: string; vmType?: string }, force = false): Promise<void> {
   // do not check if we already have
   if (podmanServerVersions.has(machineInfo.name) && !force) return;

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -1930,8 +1930,15 @@ export async function getJSONMachineListByProvider(containerMachineProvider?: st
 }
 
 export async function deactivate(): Promise<void> {
-  stopLoop = true;
   console.log('stopping podman extension');
+  // cleanup
+  stopLoop = true;
+  listeners.clear();
+  podmanServerVersions.clear();
+  podmanMachinesInfo.clear();
+  currentConnections.clear();
+  containerProviderConnections.clear();
+
   await stopAutoStartedMachine().then(() => {
     if (autoMachineStarted) {
       console.log('stopped autostarted machine', autoMachineName);

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -778,7 +778,7 @@ function prettyMachineName(machineName: string): string {
 }
 
 /**
- * This function will check for the version of a podman connection
+ * This function will check for the version of a podman connection and populate podmanServerVersions with it
  * @param machineInfo
  * @param force
  */

--- a/packages/api/src/provider-info.ts
+++ b/packages/api/src/provider-info.ts
@@ -39,6 +39,7 @@ export interface ProviderContainerConnectionInfo {
   lifecycleMethods?: LifecycleMethod[];
   type: 'docker' | 'podman';
   vmType?: { id: string; name: string };
+  version?: string;
 }
 
 export interface ProviderKubernetesConnectionInfo {

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -402,7 +402,7 @@ declare module '@podman-desktop/api' {
      */
     vmTypeDisplayName?: string;
     // the remote may be different from the client version
-    version?(): string;
+    version?(): string | undefined;
   }
 
   export interface PodCreatePortOptions {

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -401,6 +401,8 @@ declare module '@podman-desktop/api' {
      * the vmTypeDisplayName property cannot be set if vmType is undefined
      */
     vmTypeDisplayName?: string;
+    // the remote may be different from the client version
+    version?(): string;
   }
 
   export interface PodCreatePortOptions {

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -401,7 +401,9 @@ declare module '@podman-desktop/api' {
      * the vmTypeDisplayName property cannot be set if vmType is undefined
      */
     vmTypeDisplayName?: string;
-    // the remote may be different from the client version
+    /**
+     * the remote may be different from the client version
+     */
     version?(): string | undefined;
   }
 

--- a/packages/main/src/plugin/provider-registry.spec.ts
+++ b/packages/main/src/plugin/provider-registry.spec.ts
@@ -1547,3 +1547,24 @@ test('should retrieve provider info from provider internal id', async () => {
   expect(provider2?.name).toBe('internal2name');
   expect(provider2?.extensionId).toBe('id2');
 });
+
+test('should use connection version method', async () => {
+  const versionMock = vi.fn();
+  versionMock.mockReturnValue('1.5.6');
+  const connection: ContainerProviderConnection = {
+    name: 'podman-machine-default',
+    displayName: 'connection',
+    type: 'podman',
+    endpoint: {
+      socketPath: '/endpoint1.sock',
+    },
+    lifecycle: undefined,
+    status: () => 'started',
+    version: versionMock,
+  };
+
+  const info = providerRegistry.getProviderContainerConnectionInfo(connection);
+
+  expect(versionMock).toHaveBeenCalled();
+  expect(info?.version).toStrictEqual('1.5.6');
+});

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -667,6 +667,7 @@ export class ProviderRegistry {
               name: connection.vmTypeDisplayName ?? connection.vmType,
             }
           : undefined,
+        version: connection.version?.(),
       };
     } else {
       providerConnection = {

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
@@ -60,6 +60,7 @@ const providerInfo: ProviderInfo = {
         id: 'libkrun',
         name: 'libkrun',
       },
+      version: '1.2.3',
     },
     {
       name: secondaryContainerConnectionName,
@@ -210,6 +211,18 @@ describe('provider connections', () => {
     expect(endpointSpan.textContent).toBe('unix://socket');
     const connectionType = within(region).getByLabelText('Connection Type');
     expect(connectionType.textContent).equal('Libkrun');
+  });
+
+  test('Expect version to be reported for Container engine', async () => {
+    providerInfos.set([providerInfo]);
+
+    const { getByRole } = render(PreferencesResourcesRendering, {});
+
+    // get the region containing the content for the default connection
+    const region = getByRole('region', { name: defaultContainerConnectionName });
+
+    const version = within(region).getByLabelText(`Connection Version`);
+    expect(version.textContent).toContain(providerInfo.containerConnections[0].version);
   });
 
   test('Expect type to be reported for Docker engines', async () => {

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -551,7 +551,7 @@ function hasAnyConfiguration(provider: ProviderInfo): boolean {
               <div class="mt-1.5 text-[var(--pd-content-sub-header)] text-[9px] flex justify-between">
                 <div aria-label="Connection Version">
                   {provider.name}
-                  {container.version ? `v${container.version}` : ''}
+                  {container.version ?? ''}
                 </div>
                 <div aria-label="Connection Type">{container.vmType ? capitalize(container.vmType.name) : ''}</div>
               </div>

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -551,7 +551,7 @@ function hasAnyConfiguration(provider: ProviderInfo): boolean {
               <div class="mt-1.5 text-[var(--pd-content-sub-header)] text-[9px] flex justify-between">
                 <div aria-label="Connection Version">
                   {provider.name}
-                  {provider.version ? `v${provider.version}` : ''}
+                  {container.version ? `v${container.version}` : ''}
                 </div>
                 <div aria-label="Connection Type">{container.vmType ? capitalize(container.vmType.name) : ''}</div>
               </div>


### PR DESCRIPTION
### What does this PR do?

Podman machines may have a different version that the CLI, and several machines may have different version too.

Solution proposal for https://github.com/podman-desktop/podman-desktop/issues/4215 

See https://github.com/podman-desktop/podman-desktop/issues/4215#issuecomment-2607178592 for more details

### Screenshot / video of UI

![image](https://github.com/user-attachments/assets/2d51f5f7-188a-45a3-be48-4f20b05e7d27)

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/4215

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

**Testing manually**

1. assert have a old podman machine ( machine < 5.4 )
2. install podman 5.4 (cli)
3. go to podman desktop
4. assert the version on the card is the expected version (should match `podman machine ssh "podman --version"`)
