### PR TITLE
chore: adding docker compatibility experimental link

### DIFF
--- a/packages/main/src/plugin/docker/docker-compatibility.spec.ts
+++ b/packages/main/src/plugin/docker/docker-compatibility.spec.ts
@@ -102,7 +102,7 @@ test('should register a configuration', async () => {
   expect(configurationNode?.properties?.[TestDockerCompatibility.ENABLED_FULL_KEY]?.hidden).toBeFalsy();
   expect(
     configurationNode?.properties?.[TestDockerCompatibility.ENABLED_FULL_KEY]?.experimental?.githubDiscussionLink,
-  ).toBe(expect.stringContaining('github.com/podman-desktop/podman-desktop/discussions/'));
+  ).toStrictEqual(expect.stringContaining('github.com/podman-desktop/podman-desktop/discussions/'));
 });
 
 describe('getTypeFromServerInfo', async () => {

--- a/packages/main/src/plugin/docker/docker-compatibility.spec.ts
+++ b/packages/main/src/plugin/docker/docker-compatibility.spec.ts
@@ -100,6 +100,9 @@ test('should register a configuration', async () => {
   expect(configurationNode?.properties?.[TestDockerCompatibility.ENABLED_FULL_KEY]?.type).toBe('boolean');
   expect(configurationNode?.properties?.[TestDockerCompatibility.ENABLED_FULL_KEY]?.default).toBeFalsy();
   expect(configurationNode?.properties?.[TestDockerCompatibility.ENABLED_FULL_KEY]?.hidden).toBeFalsy();
+  expect(
+    configurationNode?.properties?.[TestDockerCompatibility.ENABLED_FULL_KEY]?.experimental?.githubDiscussionLink,
+  ).toBe(expect.stringContaining('github.com/podman-desktop/podman-desktop/discussions/'));
 });
 
 describe('getTypeFromServerInfo', async () => {

--- a/packages/main/src/plugin/docker/docker-compatibility.ts
+++ b/packages/main/src/plugin/docker/docker-compatibility.ts
@@ -53,6 +53,9 @@ export class DockerCompatibility {
           description: 'Enable the section for Docker compatibility.',
           type: 'boolean',
           default: false,
+          experimental: {
+            githubDiscussionLink: 'https://github.com/podman-desktop/podman-desktop/discussions/10769',
+          },
         },
       },
     };


### PR DESCRIPTION
### What does this PR do?

Linking https://github.com/podman-desktop/podman-desktop/discussions/10769 to docker compatibility option

### Screenshot / video of UI

![image](https://github.com/user-attachments/assets/d2d6e6c6-16c7-4215-94dc-f04d78b95506)

> ⚠️ we cannot change the title `Enabled`... It is the key used which is defined in
> https://github.com/podman-desktop/podman-desktop/blob/bb05b74ed04974001844767da6f0dd413d85463c/packages/api/src/docker-compatibility-info.ts#L21
> Changing the title would mean changing the key in `settings.json`.

### What issues does this PR fix or reference?

Related to https://github.com/podman-desktop/podman-desktop/issues/10227

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
