### PR TITLE
chore: adding status bar task to experimental

### DIFF
--- a/packages/main/src/plugin/tasks/task-manager.spec.ts
+++ b/packages/main/src/plugin/tasks/task-manager.spec.ts
@@ -87,6 +87,18 @@ test('task manager init should register a configuration option', async () => {
           },
         }),
       }),
+      expect.objectContaining({
+        properties: expect.objectContaining({
+          'tasks.StatusBar': {
+            type: 'boolean',
+            description: 'Show running tasks in the status bar',
+            default: false,
+            experimental: {
+              githubDiscussionLink: expect.stringContaining('github.com/podman-desktop/podman-desktop/discussions'),
+            },
+          },
+        }),
+      }),
     ]),
   );
 });

--- a/packages/main/src/plugin/tasks/task-manager.ts
+++ b/packages/main/src/plugin/tasks/task-manager.ts
@@ -68,6 +68,9 @@ export class TaskManager {
             description: 'Show running tasks in the status bar',
             type: 'boolean',
             default: false,
+            experimental: {
+              githubDiscussionLink: 'https://github.com/podman-desktop/podman-desktop/discussions/10777',
+            },
           },
           [`${ExperimentalTasksSettings.SectionName}.${ExperimentalTasksSettings.Toast}`]: {
             description: 'Display a notification toast when task is created',


### PR DESCRIPTION
### What does this PR do?

Adding https://github.com/podman-desktop/podman-desktop/discussions/10777 discussion to the configuration status bar.

### Screenshot / video of UI

![image](https://github.com/user-attachments/assets/c93cf47d-b4ef-454a-b0f1-2a2ff9a0908d)

### What issues does this PR fix or reference?


### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
