### PR TITLE
fix(ContainerDetailsTerminal): flaky test macos

### DIFF
--- a/packages/renderer/src/lib/container/ContainerDetailsTerminal.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerDetailsTerminal.spec.ts
@@ -241,7 +241,7 @@ test('terminal active/ restarts connection after restarting a container', async 
 
   await renderObject.rerender({ container: container, screenReaderMode: true });
 
-  await tick();
-
-  expect(shellInContainerMock).toHaveBeenCalledTimes(2);
+  await vi.waitFor(() => {
+    expect(shellInContainerMock).toHaveBeenCalledTimes(2);
+  });
 });


### PR DESCRIPTION
### What does this PR do?

https://github.com/podman-desktop/podman-desktop/pull/10407 did not solve the problem (or at least not for long) :(

This PR is about removing the `await new Promise(resolve => setTimeout(resolve, 1000));` and replace them with a `await vi.waitFor` more resilient with 2000 ms timeout.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/10405 🤞 

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
