### PR TITLE
feat(ui): using full record id as title in experimental page

### DIFF
--- a/packages/renderer/src/lib/preferences/ExperimentalPage.svelte
+++ b/packages/renderer/src/lib/preferences/ExperimentalPage.svelte
@@ -86,7 +86,7 @@ $effect(() => {
     {#each experimental as configItem}
       <div>
         <div class="bg-[var(--pd-invert-content-card-bg)] rounded-md mt-2 ml-2">
-          <PreferencesRenderingItem record={configItem} />
+          <PreferencesRenderingItem title="full" record={configItem} />
         </div>
       </div>
     {/each}

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.spec.ts
@@ -26,7 +26,7 @@ import PreferencesRenderingItem from '/@/lib/preferences/PreferencesRenderingIte
 import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 
 const EXPERIMENTAL_RECORD: IConfigurationPropertyRecordedSchema = {
-  id: 'record',
+  id: 'hello.world.fooBar',
   title: 'Hello',
   parentId: 'parent.record',
   description: 'record-description',
@@ -70,5 +70,30 @@ test('experimental record should have flask icon', async () => {
     const elements = queryAllByRole('img', { hidden: true });
     expect(elements.length).toBeGreaterThan(0);
     expect(elements.find(element => element.textContent === 'experimental')).toBeDefined();
+  });
+});
+
+test('record should have short title by default', async () => {
+  const { getByText } = render(PreferencesRenderingItem, {
+    record: EXPERIMENTAL_RECORD,
+  });
+
+  await vi.waitFor(() => {
+    const element = getByText('Foo Bar');
+    expect(element).toBeDefined();
+    expect(element).toHaveClass('font-semibold');
+  });
+});
+
+test('props title full should use full record id', async () => {
+  const { getByText } = render(PreferencesRenderingItem, {
+    record: EXPERIMENTAL_RECORD,
+    title: 'full',
+  });
+
+  await vi.waitFor(() => {
+    const element = getByText('Hello world foo Bar');
+    expect(element).toBeDefined();
+    expect(element).toHaveClass('font-semibold');
   });
 });

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
@@ -13,9 +13,10 @@ import PreferencesRenderingItemFormat from './PreferencesRenderingItemFormat.sve
 
 interface Props {
   record: IConfigurationPropertyRecordedSchema;
+  title?: 'full' | 'short';
 }
 
-const { record }: Props = $props();
+const { record, title = 'short' }: Props = $props();
 let showResetButton = $state(false);
 let resetToDefault = $state(false);
 
@@ -27,8 +28,21 @@ function startCase(str: string): string {
 }
 const recordUI = $derived.by(() => {
   const id = record.id;
+
+  // split id
+  const split: string[] = id?.split('.') ?? [''];
+
   // take string after the last dot
-  const key = id?.substring(id?.lastIndexOf('.') + 1) ?? '';
+  let key: string;
+  switch (title) {
+    case 'full':
+      key = split.join(' ');
+      break;
+    case 'short':
+      key = split[split.length - 1];
+      break;
+  }
+  // const key = id?.substring(id?.lastIndexOf('.') + 1) ?? '';
 
   // define bread crumb as first part before the last dot
   const breadCrumb = id?.substring(0, id?.lastIndexOf('.')) ?? '';


### PR DESCRIPTION
### What does this PR do?

For the **Settings > Preferences** we use only the last part of a configuration property as title.

![image](https://github.com/user-attachments/assets/fcdbfb52-b46a-408f-8c3d-e642f5633806)

This PR add a possibility to display the full record id, so the experimental page is more explicit on what it is.

### Screenshot / video of UI

![image](https://github.com/user-attachments/assets/c1ded7a4-427c-4f66-9950-647483a34b5d)

### What issues does this PR fix or reference?


### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
