### PR TITLE
fix: make the closebutton color match the Toast's title

### DIFF
--- a/packages/renderer/src/lib/toast/ToastCustomUi.svelte
+++ b/packages/renderer/src/lib/toast/ToastCustomUi.svelte
@@ -52,7 +52,7 @@ const executeAction = async (): Promise<void> => {
     {/if}
 
     <div class="flex flex-grow flex-col items-end">
-      <CloseButton on:click={closeAction} />
+      <CloseButton class="text-[var(--pd-modal-text)]" on:click={closeAction} />
     </div>
   </div>
   <div class="flex flex-row items-center italic line-clamp-4">


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR adjust the close button of `ToastCustomUi` to be the same color as the Toast's title

### Screenshot / video of UI
![Screenshot from 2025-01-23 11-23-47](https://github.com/user-attachments/assets/141be345-927e-49c7-82fb-7587d487853a)
![Screenshot from 2025-01-23 11-46-01](https://github.com/user-attachments/assets/7b9b4846-6ef7-4c90-8f52-138a50a9e3a4)


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Fixes https://github.com/podman-desktop/podman-desktop/issues/10544

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
