### PR TITLE
feat: kube play build support

### DIFF
--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -6001,7 +6001,7 @@ describe('kube play', () => {
           build: true,
         },
       );
-    }).rejects.toThrowError('kube play build is not supported on podman: Podman 5.3 and above support this feature');
+    }).rejects.toThrowError('kube play build is not supported on podman: Podman 5.3.0 and above supports this feature');
   });
 
   test('build option false should use playKube with YAML file', async () => {

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -2471,7 +2471,7 @@ export class ContainerProviderRegistry {
       const buildSupported: boolean = await this.isTarPlayBuildSupported(provider);
       if (!buildSupported)
         throw new Error(
-          `kube play build is not supported on ${provider.connection.name}: Podman 5.3 and above support this feature`,
+          `kube play build is not supported on ${provider.connection.name}: Podman 5.3.0 and above supports this feature`,
         );
 
       const kubePlay = KubePlayContext.fromFile(kubernetesYamlFilePath);

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -2440,7 +2440,6 @@ export class ContainerProviderRegistry {
     }
 
     const version = await internalProvider.api.version();
-    console.log('[container-registry] isTarPlayBuildSupported', version);
 
     // let's nicely format it
     const coerced = coerce(version.Version);
@@ -2462,8 +2461,6 @@ export class ContainerProviderRegistry {
       if (!provider?.libpodApi) {
         throw new Error('No provider with a running engine');
       }
-
-      console.log('[container-registry] playKube with', options);
 
       // if we don't build, we use the file directory
       if (!options?.build) {

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -2477,9 +2477,6 @@ export class ContainerProviderRegistry {
       const kubePlay = KubePlayContext.fromFile(kubernetesYamlFilePath);
       await kubePlay.init();
 
-      const contexts = kubePlay.getBuildContexts();
-      console.log('[container-registry] playKube contexts', contexts);
-
       // if we have no context let's just use the the yaml
       if (kubePlay.getBuildContexts().length === 0) {
         return provider.libpodApi.playKube(kubernetesYamlFilePath);

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -945,8 +945,11 @@ export class PluginSystem {
         _listener,
         yamlFilePath: string,
         selectedProvider: ProviderContainerConnectionInfo,
+        options?: {
+          build?: boolean;
+        },
       ): Promise<PlayKubeInfo> => {
-        return containerProviderRegistry.playKube(yamlFilePath, selectedProvider);
+        return containerProviderRegistry.playKube(yamlFilePath, selectedProvider, options);
       },
     );
     this.ipcHandle(

--- a/packages/main/src/plugin/podman/kube.spec.ts
+++ b/packages/main/src/plugin/podman/kube.spec.ts
@@ -1,6 +1,34 @@
-import { expect, test } from 'vitest';
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
 
-import { getImageNamePrefix } from '/@/plugin/podman/kube.js';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { getImageNamePrefix, KubePlayContext } from '/@/plugin/podman/kube.js';
+
+vi.mock('node:fs');
+vi.mock('node:fs/promises');
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
 
 test.each([
   {
@@ -34,4 +62,100 @@ test.each([
 ])('expect $image to be $expected', ({ image, expected }) => {
   const result = getImageNamePrefix(image);
   expect(result).toBe(expected);
+});
+
+const PLAY_POD_YAML = `apiVersion: v1
+kind: Pod
+metadata:
+  name: demo-build-remote
+spec:
+  containers:
+    - name: container
+      image: foobar
+      ports:
+        - name: http
+          containerPort: 80
+`;
+
+const PLAY_MULTI_YAML = `apiVersion: v1
+kind: Pod
+metadata:
+  name: demo-build-remote
+spec:
+  containers:
+    - name: container-0
+      image: foo
+      ports:
+        - name: http
+          containerPort: 80
+    - name: container-1
+      image: bar
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: demo-service
+spec:
+  selector:
+    name: demo-build-remote
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 8080
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: demo-build-remote-2
+spec:
+  containers:
+    - name: container
+      image: foo
+`;
+
+describe('KubePlayContext', () => {
+  test('calling getBuildContexts with non-initialized should throw an error', async () => {
+    const kube = KubePlayContext.fromContent('foo', 'bar');
+
+    expect(() => {
+      kube.getBuildContexts();
+    }).toThrowError('KubePlayContext must be initialized');
+  });
+
+  test('analyse should check for container file', async () => {
+    const kube = KubePlayContext.fromContent(PLAY_POD_YAML, 'foo-bar');
+    await kube.init();
+
+    // should check for possible container file
+    expect(existsSync).toHaveBeenCalledWith(path.join('foo-bar', 'foobar', 'Containerfile'));
+    expect(existsSync).toHaveBeenCalledWith(path.join('foo-bar', 'foobar', 'Dockerfile'));
+  });
+
+  test('existing Containerfile should consider as valid build context', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+
+    const kube = KubePlayContext.fromContent(PLAY_POD_YAML, 'foo-bar');
+    await kube.init();
+
+    expect(existsSync).toHaveBeenCalledWith(path.join('foo-bar', 'foobar', 'Containerfile'));
+
+    const contexts = kube.getBuildContexts();
+    expect(contexts).toHaveLength(1);
+    expect(contexts[0]).toStrictEqual(path.join('foo-bar', 'foobar'));
+  });
+
+  test('multi resources object should be properly analysed', async () => {
+    // mock only two time
+    vi.mocked(existsSync).mockReturnValueOnce(true);
+    vi.mocked(existsSync).mockReturnValueOnce(true);
+
+    const kube = KubePlayContext.fromContent(PLAY_MULTI_YAML, 'foo-bar');
+    await kube.init();
+
+    const contexts = kube.getBuildContexts();
+    expect(contexts).toHaveLength(2);
+    expect(contexts[0]).toStrictEqual(path.join('foo-bar', 'foo'));
+    expect(contexts[1]).toStrictEqual(path.join('foo-bar', 'bar'));
+  });
 });

--- a/packages/main/src/plugin/podman/kube.spec.ts
+++ b/packages/main/src/plugin/podman/kube.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from 'vitest';
+
+import { getImageNamePrefix } from '/@/plugin/podman/kube.js';
+
+test.each([
+  {
+    image: 'foobar',
+    expected: 'foobar',
+  },
+  {
+    image: 'foobar:latest',
+    expected: 'foobar',
+  },
+  {
+    image: 'foo/bar:latest',
+    expected: 'bar',
+  },
+  {
+    image: 'aa/bb/cc:latest',
+    expected: 'cc',
+  },
+  {
+    image: 'foo/bar',
+    expected: 'bar',
+  },
+  {
+    image: 'foo@bar',
+    expected: 'foo',
+  },
+  {
+    image: 'foo@bar:latest',
+    expected: 'foo',
+  },
+])('expect $image to be $expected', ({ image, expected }) => {
+  const result = getImageNamePrefix(image);
+  expect(result).toBe(expected);
+});

--- a/packages/main/src/plugin/podman/kube.ts
+++ b/packages/main/src/plugin/podman/kube.ts
@@ -1,0 +1,40 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/**
+ * This function is a re-implementation of the imageNamePrefix on the podman repository
+ * https://github.com/containers/podman/blob/de856dab99ef8816392972347678fcb49ae57e50/pkg/domain/infra/abi/play.go#L1606
+ * @param content
+ */
+export function getImageNamePrefix(content: string): string {
+  let prefix: string = content;
+  let split: string[] = prefix.split(':');
+  if (split[0]) {
+    prefix = split[0];
+  }
+  split = prefix.split('/');
+  const index = split.length - 1;
+  if (split[index]) {
+    prefix = split[index];
+  }
+  split = prefix.split('@');
+  if (split[0]) {
+    prefix = split[0];
+  }
+  return prefix;
+}

--- a/packages/main/src/plugin/podman/kube.ts
+++ b/packages/main/src/plugin/podman/kube.ts
@@ -139,6 +139,8 @@ export class KubePlayContext {
       finalize: false,
       entries: Array.from(this.#buildContexts.keys()),
       finish(stream: Pack): void {
+        // inside the tar we need a play.yaml file as per spec
+        // https://docs.podman.io/en/latest/_static/api.html#tag/containers/operation/PlayKubeLibpod
         stream.entry({ name: `play.yaml` }, content);
         stream.finalize();
       },

--- a/packages/main/src/plugin/podman/kube.ts
+++ b/packages/main/src/plugin/podman/kube.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,14 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
+
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { loadAll } from 'js-yaml';
+import type { Pack } from 'tar-fs';
+import tar from 'tar-fs';
 
 /**
  * This function is a re-implementation of the imageNamePrefix on the podman repository
@@ -37,4 +45,117 @@ export function getImageNamePrefix(content: string): string {
     prefix = split[0];
   }
   return prefix;
+}
+
+export class KubePlayContext {
+  #initialized: boolean = false;
+  #file: string | undefined;
+  // context directory
+  #context: string;
+
+  // raw YAML content
+  #content: string | undefined;
+  // contexts
+  #buildContexts: Map<string, string>;
+
+  protected constructor(options: {
+    file?: string;
+    content?: string;
+    context: string;
+  }) {
+    if (!options.file && !options.content) throw new Error('either a file or raw content must be provided');
+
+    this.#file = options.file;
+    this.#content = options.content;
+    this.#context = options.context;
+
+    this.#buildContexts = new Map();
+  }
+
+  static fromContent(content: string, context: string): KubePlayContext {
+    return new KubePlayContext({
+      content: content,
+      context: context,
+    });
+  }
+
+  static fromFile(file: string, context?: string): KubePlayContext {
+    return new KubePlayContext({
+      file: file,
+      context: context ?? path.dirname(file),
+    });
+  }
+
+  protected analyze(): void {
+    if (!this.#content) throw new Error('KubePlayContext: error while analysing content: content cannot be undefined');
+    const resources: unknown[] = loadAll(this.#content);
+
+    // for each resource
+    for (const resource of resources) {
+      // ensure resource is valid object
+      if (!resource || typeof resource !== 'object') throw new Error(`invalid resource`);
+
+      // ensure kind property exists
+      if (!('kind' in resource) || typeof resource.kind !== 'string')
+        throw new Error(`invalid kubernetes resource: missing kind field`);
+
+      // ignore non-pod resource
+      if (resource.kind.toLowerCase() !== 'pod') continue;
+
+      // ensure containers exists on pod resource
+      if (!('spec' in resource) || !resource.spec || typeof resource.spec !== 'object')
+        throw new Error(`invalid kubernetes resource: pod missing spec field`);
+      if (
+        !('containers' in resource.spec) ||
+        typeof resource.spec.containers !== 'object' ||
+        !Array.isArray(resource.spec.containers)
+      )
+        throw new Error(`invalid kubernetes resource: pod missing spec field`);
+
+      for (const container of resource.spec.containers) {
+        if (!('image' in container || typeof container.image !== 'string'))
+          throw new Error(`invalid kubernetes resource in: pod has a container without defined image`);
+
+        const image: string = container.image;
+        const buildDirectory = path.join(this.#context, getImageNamePrefix(image));
+
+        // search for containerfile in the build directory
+        const containerfile: string | undefined = ['Containerfile', 'Dockerfile'].find(file =>
+          existsSync(path.join(buildDirectory, file)),
+        );
+        if (!containerfile) continue;
+
+        this.#buildContexts.set(image, buildDirectory);
+      }
+    }
+  }
+
+  build(): NodeJS.ReadableStream {
+    if (!this.#initialized) throw new Error('KubePlayContext must be initialized');
+    if (!this.#content) throw new Error('content is undefined');
+    const content = this.#content;
+
+    return tar.pack(this.#context, {
+      finalize: false,
+      entries: Array.from(this.#buildContexts.keys()),
+      finish(stream: Pack): void {
+        stream.entry({ name: `play.yaml` }, content);
+        stream.finalize();
+      },
+    }) as unknown as NodeJS.ReadableStream;
+  }
+
+  async init(): Promise<void> {
+    if (this.#file) {
+      this.#content = await readFile(this.#file, 'utf8');
+    }
+
+    this.analyze();
+    this.#initialized = true;
+  }
+
+  getBuildContexts(): string[] {
+    if (!this.#initialized) throw new Error('KubePlayContext must be initialized');
+    return Array.from(this.#buildContexts.values());
+  }
 }

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -350,8 +350,11 @@ export function initExposure(): void {
     async (
       relativeContainerfilePath: string,
       selectedProvider: ProviderContainerConnectionInfo,
+      options?: {
+        build?: boolean;
+      },
     ): Promise<PlayKubeInfo> => {
-      return ipcInvoke('container-provider-registry:playKube', relativeContainerfilePath, selectedProvider);
+      return ipcInvoke('container-provider-registry:playKube', relativeContainerfilePath, selectedProvider, options);
     },
   );
 

--- a/packages/renderer/src/lib/kube/KubePlayYAML.spec.ts
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.spec.ts
@@ -230,3 +230,48 @@ test('expect runtime boxes have the correct selection borders', async () => {
   expect(kubeOption.parentElement?.parentElement).toHaveClass('border-[var(--pd-content-card-border-selected)]');
   expect(kubeOption.parentElement?.parentElement).not.toHaveClass('border-[var(--pd-content-card-border)]');
 });
+
+test('build checkbox should be disabled by default', async () => {
+  setup();
+  const { getByRole } = render(KubePlayYAML, {});
+
+  const checkbox = await vi.waitFor(() => {
+    const element = getByRole('checkbox', { name: 'Enable build' });
+    expect(element).toBeInstanceOf(HTMLInputElement);
+    return element;
+  });
+
+  expect(checkbox).not.toBeChecked();
+});
+
+test('build checkbox checked should propagate to window#kubePlay', async () => {
+  setup();
+  const { getByRole, getByLabelText } = render(KubePlayYAML, {});
+
+  const checkbox = await vi.waitFor(() => {
+    const element = getByRole('checkbox', { name: 'Enable build' });
+    expect(element).toBeInstanceOf(HTMLInputElement);
+    return element;
+  });
+
+  // check
+  await userEvent.click(checkbox);
+
+  const browseButton = getByLabelText('browse');
+  expect(browseButton).toBeInTheDocument();
+  await userEvent.click(browseButton);
+
+  // Simulate clicking the "Play" button
+  const playButton = screen.getByRole('button', { name: 'Play' });
+  expect(playButton).toBeInTheDocument();
+  await userEvent.click(playButton);
+
+  // ensure the play kube function was called with the appropriate options
+  expect(window.playKube).toHaveBeenCalledWith(
+    'Containerfile',
+    expect.anything(),
+    expect.objectContaining({
+      build: true,
+    }),
+  );
+});

--- a/packages/renderer/src/lib/kube/KubePlayYAML.svelte
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.svelte
@@ -9,7 +9,7 @@ let providerUnsubscribe: Unsubscriber;
 import { faCircleCheck } from '@fortawesome/free-solid-svg-icons';
 import type { V1NamespaceList } from '@kubernetes/client-node/dist/api';
 import type { OpenDialogOptions } from '@podman-desktop/api';
-import { Button, Dropdown, ErrorMessage, Input } from '@podman-desktop/ui-svelte';
+import { Button, Checkbox, Dropdown, ErrorMessage, Input } from '@podman-desktop/ui-svelte';
 import Fa from 'svelte-fa';
 
 import { handleNavigation } from '/@/navigation';
@@ -26,6 +26,7 @@ import WarningMessage from '../ui/WarningMessage.svelte';
 let runStarted = false;
 let runFinished = false;
 let runError = '';
+let kubeBuild: boolean = false;
 let runWarning = '';
 let kubernetesYamlFilePath: string | undefined = undefined;
 let hasInvalidFields = true;
@@ -191,6 +192,10 @@ function goBackToPodsPage(): void {
           options={kubeFileDialogOptions}
           class="w-full p-2" />
       </div>
+
+      <Checkbox class="mx-1 my-auto" bind:checked={kubeBuild} >
+        <div>Enable build</div>
+      </Checkbox>
 
       <div class="text-base font-bold text-[var(--pd-content-card-header-text)]">Runtime</div>
 

--- a/packages/renderer/src/lib/kube/KubePlayYAML.svelte
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.svelte
@@ -195,7 +195,7 @@ function goBackToPodsPage(): void {
           class="w-full p-2" />
       </div>
 
-      <Checkbox class="mx-1 my-auto" bind:checked={kubeBuild} >
+      <Checkbox class="mx-1 my-auto" title="Enable build" bind:checked={kubeBuild} >
         <div>Enable build</div>
       </Checkbox>
 

--- a/packages/renderer/src/lib/kube/KubePlayYAML.svelte
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.svelte
@@ -81,7 +81,9 @@ async function playKubeFile(): Promise<void> {
     // depending on the user choice, do podman or kubernetes
     if (userChoice === 'podman') {
       try {
-        const result = await window.playKube(kubernetesYamlFilePath, selectedProvider);
+        const result = await window.playKube(kubernetesYamlFilePath, selectedProvider, {
+          build: kubeBuild,
+        });
 
         // remove the null values from the result
         playKubeResultRaw = JSON.stringify(removeEmptyOrNull(result), undefined, 2);


### PR DESCRIPTION
### What does this PR do?

Adding build support for kube play. Learn more in https://docs.podman.io/en/latest/markdown/podman-kube-play.1.html#build

### Screenshot / video of UI

![image](https://github.com/user-attachments/assets/2682a4f6-7038-4acb-a508-9f286f781029)

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/10091

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

**Testing manually**

**Requirements**
- **Podman 5.3 and** above

1. Create tmp dir
2. Create play.yaml file
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: demo-build-remote
spec:
  containers:
    - name: container
      image: foobar
      ports:
        - name: http
          containerPort: 80
```
3. Create foobar/Containerfile
```
FROM docker.io/library/nginx:alpine

LABEL "quadlet"="demo-kube"
```
4. Go to **Pods > Play Kubernetes YAML** page
![image](https://github.com/user-attachments/assets/cf723697-0a76-45ee-b20a-f449c0745c8a)
5. Select your `play.yaml` file you created
6. Check `build` checkbox
7. Click Play
8. assert pod running
![image](https://github.com/user-attachments/assets/854267e0-f3b7-41cc-842e-e795ad7d6353)
9. open container details
![image](https://github.com/user-attachments/assets/7d39cbc3-4352-4955-86b8-17cf89090f90)
10. assert image is `localhost/foobar:latest`
11. Open corresponding image
12. assert label is visible
![image](https://github.com/user-attachments/assets/c941a9bd-dc64-47b0-ad54-75f97e5d6197)

