### PR TITLE
fix: typos in experimental features

### DIFF
--- a/extensions/kubectl-cli/src/extension.spec.ts
+++ b/extensions/kubectl-cli/src/extension.spec.ts
@@ -407,7 +407,7 @@ describe('postActivate', () => {
       tag: 'v1.1.0',
       id: -1,
     } as KubectlGithubReleaseArtifactMetadata);
-    // mock return value bellow current
+    // mock return value below current
     vi.mocked(KubectlGitHubReleases).mockReturnValue({
       grabLatestsReleasesMetadata: vi.fn().mockResolvedValue([
         {
@@ -467,7 +467,7 @@ describe('postActivate', () => {
           });
         }),
     );
-    // mock return value bellow current
+    // mock return value below current
     vi.mocked(KubectlGitHubReleases).mockReturnValue({
       grabLatestsReleasesMetadata: vi.fn().mockResolvedValue([
         {
@@ -523,7 +523,7 @@ describe('postActivate', () => {
       tag: 'v1.1.0',
       id: -1,
     } as KubectlGithubReleaseArtifactMetadata);
-    // mock return value bellow current
+    // mock return value below current
     vi.mocked(KubectlGitHubReleases).mockReturnValue({
       grabLatestsReleasesMetadata: vi.fn().mockResolvedValue([
         {
@@ -585,7 +585,7 @@ describe('postActivate', () => {
           });
         }),
     );
-    // mock return value bellow current
+    // mock return value below current
     vi.mocked(KubectlGitHubReleases).mockReturnValue({
       grabLatestsReleasesMetadata: vi.fn().mockResolvedValue([
         {
@@ -644,7 +644,7 @@ describe('postActivate', () => {
           });
         }),
     );
-    // mock return value bellow current
+    // mock return value below current
     vi.mocked(KubectlGitHubReleases).mockReturnValue({
       grabLatestsReleasesMetadata: vi.fn().mockResolvedValue([
         {

--- a/packages/main/src/plugin/statusbar/statusbar-providers-init.spec.ts
+++ b/packages/main/src/plugin/statusbar/statusbar-providers-init.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ test('should register a configuration', async () => {
   expect(configurationRegistryMock.registerConfigurations).toBeCalled();
   const configurationNode = vi.mocked(configurationRegistryMock.registerConfigurations).mock.calls[0]?.[0][0];
   expect(configurationNode?.id).toBe('preferences.experimental.statusbarProviders');
-  expect(configurationNode?.title).toBe('Experimental (Statusbar Providers)');
+  expect(configurationNode?.title).toBe('Experimental (Status Bar Providers)');
   expect(configurationNode?.properties).toBeDefined();
   expect(Object.keys(configurationNode?.properties ?? {}).length).toBe(1);
   expect(configurationNode?.properties?.['statusbarProviders.showProviders']).toBeDefined();

--- a/packages/main/src/plugin/statusbar/statusbar-providers-init.ts
+++ b/packages/main/src/plugin/statusbar/statusbar-providers-init.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,13 +24,16 @@ export class StatusbarProvidersInit {
   init(): void {
     const statusbarProvidersConfiguration: IConfigurationNode = {
       id: `preferences.experimental.statusbarProviders`,
-      title: 'Experimental (Statusbar Providers)',
+      title: 'Experimental (Status Bar Providers)',
       type: 'object',
       properties: {
         [`statusbarProviders.showProviders`]: {
-          description: 'Show providers in statusbar',
+          description: 'Show providers in the status bar',
           type: 'boolean',
           default: import.meta.env.DEV ? true : false,
+          experimental: {
+            githubDiscussionLink: 'https://github.com/podman-desktop/podman-desktop/discussions/10802',
+          },
         },
       },
     };

--- a/packages/renderer/src/lib/preferences/ExperimentalPage.svelte
+++ b/packages/renderer/src/lib/preferences/ExperimentalPage.svelte
@@ -66,7 +66,7 @@ $effect(() => {
           <span class="font-semibold">Enable all experimental features</span>
         </div>
         <div class="pt-1 text-[color:var(--pd-invert-content-card-text)] text-sm pr-2">
-          <Markdown markdown="Enable the section to turn on **all experimental features** and give feedback to developers. Or select individual features to try bellow." />
+          <Markdown markdown="Enable the section to turn on **all experimental features** and give feedback to developers. Or select individual features to try below." />
         </div>
       </div>
       <div class="flex flex-row text-start items-center justify-start">


### PR DESCRIPTION
### What does this PR do?

Fixes three things:
- Typo in 'bellow', should be 'below' (also found in a few comments).
- 'Statusbar' should be two words: 'status bar'.
- Status bar providers wasn't marked as experimental.

### Screenshot / video of UI

![Screenshot 2025-01-23 at 12 57 44 PM](https://github.com/user-attachments/assets/c8195f87-88d7-4b7b-b8a6-b8d8b1b9bb96)

### What issues does this PR fix or reference?

Part of #10784.

### How to test this PR?

Open Settings > Experimental to see the typo fixes and providers appearing correctly.

- [x] Tests are covering the bug fix or the new feature