### PR TITLE
fix: experimental typo below

### DIFF
--- a/extensions/kubectl-cli/src/extension.spec.ts
+++ b/extensions/kubectl-cli/src/extension.spec.ts
@@ -407,7 +407,7 @@ describe('postActivate', () => {
       tag: 'v1.1.0',
       id: -1,
     } as KubectlGithubReleaseArtifactMetadata);
-    // mock return value bellow current
+    // mock return value below current
     vi.mocked(KubectlGitHubReleases).mockReturnValue({
       grabLatestsReleasesMetadata: vi.fn().mockResolvedValue([
         {
@@ -467,7 +467,7 @@ describe('postActivate', () => {
           });
         }),
     );
-    // mock return value bellow current
+    // mock return value below current
     vi.mocked(KubectlGitHubReleases).mockReturnValue({
       grabLatestsReleasesMetadata: vi.fn().mockResolvedValue([
         {
@@ -523,7 +523,7 @@ describe('postActivate', () => {
       tag: 'v1.1.0',
       id: -1,
     } as KubectlGithubReleaseArtifactMetadata);
-    // mock return value bellow current
+    // mock return value below current
     vi.mocked(KubectlGitHubReleases).mockReturnValue({
       grabLatestsReleasesMetadata: vi.fn().mockResolvedValue([
         {
@@ -585,7 +585,7 @@ describe('postActivate', () => {
           });
         }),
     );
-    // mock return value bellow current
+    // mock return value below current
     vi.mocked(KubectlGitHubReleases).mockReturnValue({
       grabLatestsReleasesMetadata: vi.fn().mockResolvedValue([
         {
@@ -644,7 +644,7 @@ describe('postActivate', () => {
           });
         }),
     );
-    // mock return value bellow current
+    // mock return value below current
     vi.mocked(KubectlGitHubReleases).mockReturnValue({
       grabLatestsReleasesMetadata: vi.fn().mockResolvedValue([
         {

--- a/packages/renderer/src/lib/preferences/ExperimentalPage.svelte
+++ b/packages/renderer/src/lib/preferences/ExperimentalPage.svelte
@@ -66,7 +66,7 @@ $effect(() => {
           <span class="font-semibold">Enable all experimental features</span>
         </div>
         <div class="pt-1 text-[color:var(--pd-invert-content-card-text)] text-sm pr-2">
-          <Markdown markdown="Enable the section to turn on **all experimental features** and give feedback to developers. Or select individual features to try bellow." />
+          <Markdown markdown="Enable the section to turn on **all experimental features** and give feedback to developers. Or select individual features to try below." />
         </div>
       </div>
       <div class="flex flex-row text-start items-center justify-start">


### PR DESCRIPTION
### What does this PR do?

Fixes typo in 'bellow' (should be 'below') in both experimental page and some comments.

### Screenshot / video of UI

Just typo.

### What issues does this PR fix or reference?

Part of #10784.

### How to test this PR?

Open Settings > Experimental.