### PR TITLE
fix: experimental status bar typo

### DIFF
--- a/packages/main/src/plugin/statusbar/statusbar-providers-init.spec.ts
+++ b/packages/main/src/plugin/statusbar/statusbar-providers-init.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,12 +34,15 @@ test('should register a configuration', async () => {
   expect(configurationRegistryMock.registerConfigurations).toBeCalled();
   const configurationNode = vi.mocked(configurationRegistryMock.registerConfigurations).mock.calls[0]?.[0][0];
   expect(configurationNode?.id).toBe('preferences.experimental.statusbarProviders');
-  expect(configurationNode?.title).toBe('Experimental (Statusbar Providers)');
+  expect(configurationNode?.title).toBe('Experimental (Status Bar Providers)');
   expect(configurationNode?.properties).toBeDefined();
   expect(Object.keys(configurationNode?.properties ?? {}).length).toBe(1);
   expect(configurationNode?.properties?.['statusbarProviders.showProviders']).toBeDefined();
   expect(configurationNode?.properties?.['statusbarProviders.showProviders']?.type).toBe('boolean');
   expect(configurationNode?.properties?.['statusbarProviders.showProviders']?.default).toBe(true);
+  expect(configurationNode?.properties?.['statusbarProviders.showProviders']?.description).toBe(
+    'Show providers in the status bar',
+  );
 });
 
 test('False should be default if not in dev env', () => {

--- a/packages/main/src/plugin/statusbar/statusbar-providers-init.ts
+++ b/packages/main/src/plugin/statusbar/statusbar-providers-init.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,11 +24,11 @@ export class StatusbarProvidersInit {
   init(): void {
     const statusbarProvidersConfiguration: IConfigurationNode = {
       id: `preferences.experimental.statusbarProviders`,
-      title: 'Experimental (Statusbar Providers)',
+      title: 'Experimental (Status Bar Providers)',
       type: 'object',
       properties: {
         [`statusbarProviders.showProviders`]: {
-          description: 'Show providers in statusbar',
+          description: 'Show providers in the status bar',
           type: 'boolean',
           default: import.meta.env.DEV ? true : false,
         },


### PR DESCRIPTION
### What does this PR do?

Status bar is two words, fixing the typo.

### Screenshot / video of UI

Just typo fix.

### What issues does this PR fix or reference?

Part of #10784.

### How to test this PR?

Open Settings > Preferences > Experimental (Status Bar Providers).

- [x] Tests are covering the bug fix or the new feature