### PR TITLE
fix: use section titles and re-capitalize entry ids

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.spec.ts
@@ -92,7 +92,7 @@ test('props title full should use full record id', async () => {
   });
 
   await vi.waitFor(() => {
-    const element = getByText('Hello world foo Bar');
+    const element = getByText('Hello Foo Bar');
     expect(element).toBeDefined();
     expect(element).toHaveClass('font-semibold');
   });

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
@@ -30,19 +30,11 @@ const recordUI = $derived.by(() => {
   const id = record.id;
 
   // split id
-  const split: string[] = id?.split('.') ?? [''];
-
-  // take string after the last dot
-  let key: string;
-  switch (title) {
-    case 'full':
-      key = split.join(' ');
-      break;
-    case 'short':
-      key = split[split.length - 1];
-      break;
+  let key = id?.substring(id?.lastIndexOf('.') + 1) ?? '';
+  key = startCase(key);
+  if (title === 'full') {
+    key = `${record.title} ${key}`;
   }
-  // const key = id?.substring(id?.lastIndexOf('.') + 1) ?? '';
 
   // define bread crumb as first part before the last dot
   const breadCrumb = id?.substring(0, id?.lastIndexOf('.')) ?? '';
@@ -50,7 +42,7 @@ const recordUI = $derived.by(() => {
   const breadCrumbUI = breadCrumb.replace(/\./g, ' > ').concat(':');
 
   return {
-    title: startCase(key),
+    title: key,
     breadCrumb: breadCrumbUI,
     description: record.description,
     markdownDescription: record.markdownDescription,


### PR DESCRIPTION
### What does this PR do?

Reverts the key back to what it was before, but immediately uses startCase(), then prefixes the record title if necessary.

### Screenshot / video of UI

Before:

![Screenshot 2025-01-23 at 1 43 08 PM](https://github.com/user-attachments/assets/ae40fe91-6e31-4d65-a199-9ad753e88422)

After:

![Screenshot 2025-01-23 at 1 20 09 PM](https://github.com/user-attachments/assets/9ca4c337-6a00-4e49-a601-e1d2062328f7)

### What issues does this PR fix or reference?

Fixes #10808.

### How to test this PR?

Open Settings > Experimental.

- [x] Tests are covering the bug fix or the new feature