### PR TITLE
fix: add experimental link to status bar providers

### DIFF
--- a/packages/main/src/plugin/statusbar/statusbar-providers-init.spec.ts
+++ b/packages/main/src/plugin/statusbar/statusbar-providers-init.spec.ts
@@ -43,6 +43,9 @@ test('should register a configuration', async () => {
   expect(configurationNode?.properties?.['statusbarProviders.showProviders']?.description).toBe(
     'Show providers in the status bar',
   );
+  expect(configurationNode?.properties?.['statusbarProviders.showProviders']?.experimental?.githubDiscussionLink).toBe(
+    'https://github.com/podman-desktop/podman-desktop/discussions/10802',
+  );
 });
 
 test('False should be default if not in dev env', () => {

--- a/packages/main/src/plugin/statusbar/statusbar-providers-init.ts
+++ b/packages/main/src/plugin/statusbar/statusbar-providers-init.ts
@@ -31,6 +31,9 @@ export class StatusbarProvidersInit {
           description: 'Show providers in the status bar',
           type: 'boolean',
           default: import.meta.env.DEV ? true : false,
+          experimental: {
+            githubDiscussionLink: 'https://github.com/podman-desktop/podman-desktop/discussions/10802',
+          },
         },
       },
     };


### PR DESCRIPTION
### What does this PR do?

Adds the missing GitHub discussion link (already opened) to status bar providers.

### Screenshot / video of UI

Shows up in Settings > Experimental now:

![Screenshot 2025-01-23 at 1 43 08 PM](https://github.com/user-attachments/assets/061648ed-e1ee-4357-bf8b-3aaedfc96c1f)

### What issues does this PR fix or reference?

Part of #10784.

### How to test this PR?

Go to Settings > Experimental and make sure the entry appears, and link is correct.

- [x] Tests are covering the bug fix or the new feature