### PR TITLE
chore: remove disablement of no-explicit any from kubectl-cli extension

### DIFF
--- a/extensions/kubectl-cli/src/detect.spec.ts
+++ b/extensions/kubectl-cli/src/detect.spec.ts
@@ -16,8 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 

--- a/extensions/kubectl-cli/src/download.spec.ts
+++ b/extensions/kubectl-cli/src/download.spec.ts
@@ -115,8 +115,11 @@ test('pick the 6th option option in the quickpickmenu and expect it to return th
   });
   const showQuickPickMock = vi.spyOn(extensionApi.window, 'showQuickPick');
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  showQuickPickMock.mockResolvedValue({ id: 129616500, label: 'Kubernetes v1.27.8', tag: 'v1.27.8' } as any);
+  showQuickPickMock.mockResolvedValue({
+    id: 129616500,
+    label: 'Kubernetes v1.27.8',
+    tag: 'v1.27.8',
+  } as KubectlGithubReleaseArtifactMetadata);
 
   // Expect the test to return the first release from the list (as the function simply returns the first one)
   const kubectlDownload = new KubectlDownload(extensionContext, kubectlGitHubReleasesMock, os);

--- a/extensions/kubectl-cli/src/extension.spec.ts
+++ b/extensions/kubectl-cli/src/extension.spec.ts
@@ -15,7 +15,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-/* eslint-disable @typescript-eslint/no-explicit-any */
 
 import * as fs from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -202,9 +201,11 @@ test('kubectl CLI tool not registered when version cannot be extracted from obje
   const wrongJsonStdout = {
     clientVersion: {
       ...jsonStdout.clientVersion,
+      gitVersion: jsonStdout.clientVersion.gitVersion || undefined,
     },
   };
-  delete (wrongJsonStdout.clientVersion as any).gitVersion;
+
+  delete wrongJsonStdout.clientVersion.gitVersion;
   vi.mocked(extensionApi.process.exec).mockResolvedValue({
     stderr: '',
     stdout: JSON.stringify(wrongJsonStdout),

--- a/extensions/kubectl-cli/src/handler.spec.ts
+++ b/extensions/kubectl-cli/src/handler.spec.ts
@@ -15,7 +15,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-/* eslint-disable @typescript-eslint/no-explicit-any */
 
 import type { Configuration } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Removes the disablement of no-explicit any from kubectl-cli extension

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/podman-desktop/issues/10597

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
