### PR TITLE
fix: switched to sequential writing to containers.conf file

### DIFF
--- a/extensions/podman/packages/extension/package.json
+++ b/extensions/podman/packages/extension/package.json
@@ -392,6 +392,7 @@
   },
   "dependencies": {
     "@podman-desktop/api": "workspace:*",
+    "async-mutex": "^0.5.0",
     "compare-versions": "^6.1.1",
     "ps-list": "^8.1.1",
     "smol-toml": "1.3.1",

--- a/extensions/podman/packages/extension/src/podman-configuration.spec.ts
+++ b/extensions/podman/packages/extension/src/podman-configuration.spec.ts
@@ -181,11 +181,11 @@ test('updateProxySettings should be called one at the time', async () => {
   const call1 = podmanConfiguration.doUpdateProxySettings(undefined);
   const call2 = podmanConfiguration.doUpdateProxySettings(proxySettings);
 
-  await Promise.all([call1, call2]);
-
-  // Check that the proxy update was called twice
-  expect(updateProxySettingsMock).toHaveBeenCalledTimes(2);
-
+  await call1;
+  expect(updateProxySettingsMock).toHaveBeenCalledTimes(1);
   expect(updateProxySettingsMock.mock.calls[0][0]).toBe(undefined);
+
+  await call2;
+  expect(updateProxySettingsMock).toHaveBeenCalledTimes(2);
   expect(updateProxySettingsMock.mock.calls[1][0]).toBe(proxySettings);
 });

--- a/extensions/podman/packages/extension/src/podman-configuration.spec.ts
+++ b/extensions/podman/packages/extension/src/podman-configuration.spec.ts
@@ -18,6 +18,7 @@
 
 import * as fs from 'node:fs';
 
+import type { ProxySettings } from '@podman-desktop/api';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { PodmanConfiguration } from './podman-configuration';
@@ -164,4 +165,27 @@ describe('isRosettaEnabled', () => {
 
     expect(isEnabled).toBeFalsy();
   });
+});
+
+test('updateProxySettings should be called one at the time', async () => {
+  const proxySettings: ProxySettings = {
+    httpProxy: 'httpProxy',
+    httpsProxy: 'httpsProxy',
+    noProxy: 'noProxy',
+  };
+
+  // Mock updateProxySettings
+  const updateProxySettingsMock = vi.spyOn(podmanConfiguration, 'updateProxySettings');
+
+  // Simultaneously call the function twice
+  const call1 = podmanConfiguration.doUpdateProxySettings(undefined);
+  const call2 = podmanConfiguration.doUpdateProxySettings(proxySettings);
+
+  await Promise.all([call1, call2]);
+
+  // Check that the proxy update was called twice
+  expect(updateProxySettingsMock).toHaveBeenCalledTimes(2);
+
+  expect(updateProxySettingsMock.mock.calls[0][0]).toBe(undefined);
+  expect(updateProxySettingsMock.mock.calls[1][0]).toBe(proxySettings);
 });

--- a/extensions/podman/packages/extension/src/podman-configuration.ts
+++ b/extensions/podman/packages/extension/src/podman-configuration.ts
@@ -26,12 +26,12 @@ import { Mutex } from 'async-mutex';
 import * as toml from 'smol-toml';
 
 const configurationRosetta = 'setting.rosetta';
-const mutex = new Mutex();
 
 /**
  * Manages access to the containers.conf configuration file used to configure Podman
  */
 export class PodmanConfiguration {
+  private mutex: Mutex = new Mutex();
   async init(): Promise<void> {
     let httpProxy = undefined;
     let httpsProxy = undefined;
@@ -39,9 +39,7 @@ export class PodmanConfiguration {
 
     // we receive an update for the current proxy settings
     extensionApi.proxy.onDidUpdateProxy(async (proxySettings: ProxySettings) => {
-      await mutex.runExclusive(async () => {
-        await this.updateProxySettings(proxySettings);
-      });
+      await this.doUpdateProxySettings(proxySettings);
     });
 
     // in case of proxy being enabled or disabled we need to update the containers.conf file
@@ -49,13 +47,9 @@ export class PodmanConfiguration {
       // eslint-disable-next-line sonarjs/no-selector-parameter
       if (enabled) {
         const updatedProxySettings = extensionApi.proxy.getProxySettings();
-        await mutex.runExclusive(async () => {
-          await this.updateProxySettings(updatedProxySettings);
-        });
+        await this.doUpdateProxySettings(updatedProxySettings);
       } else {
-        await mutex.runExclusive(async () => {
-          await this.updateProxySettings(undefined);
-        });
+        await this.doUpdateProxySettings(undefined);
       }
     });
 
@@ -110,6 +104,15 @@ export class PodmanConfiguration {
           await this.handleRosettaSetting();
         }
       });
+    }
+  }
+
+  async doUpdateProxySettings(proxy: undefined | ProxySettings): Promise<void> {
+    const release = await this.mutex.acquire();
+    try {
+      await this.updateProxySettings(proxy);
+    } finally {
+      release();
     }
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -469,6 +469,9 @@ importers:
       '@podman-desktop/api':
         specifier: workspace:*
         version: link:../../../../packages/extension-api
+      async-mutex:
+        specifier: ^0.5.0
+        version: 0.5.0
       compare-versions:
         specifier: ^6.1.1
         version: 6.1.1
@@ -4669,6 +4672,9 @@ packages:
   async-exit-hook@2.0.1:
     resolution: {integrity: sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==}
     engines: {node: '>=0.12.0'}
+
+  async-mutex@0.5.0:
+    resolution: {integrity: sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==}
 
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
@@ -16392,6 +16398,10 @@ snapshots:
 
   async-exit-hook@2.0.1: {}
 
+  async-mutex@0.5.0:
+    dependencies:
+      tslib: 2.8.1
+
   async@3.2.6: {}
 
   asynckit@0.4.0: {}
@@ -19300,7 +19310,7 @@ snapshots:
 
   history@4.10.1:
     dependencies:
-      '@babel/runtime': 7.26.0
+      '@babel/runtime': 7.26.7
       loose-envify: 1.4.0
       resolve-pathname: 3.0.0
       tiny-invariant: 1.3.3


### PR DESCRIPTION
### What does this PR do?
Adds sequential mechanism for writing to containers.conf file to avoid simultaneous write

### Screenshot / video of UI

### What issues does this PR fix or reference?
Closes #10709 

### How to test this PR?
Go to PD, try to restart podman machine and while stopping/starting try to edit proxy settings switching between manual/disabled/system

- [x] Tests are covering the bug fix or the new feature
