### PR TITLE
fix: add extensionId to contributions metadata file

### DIFF
--- a/packages/main/src/plugin/contribution-manager.ts
+++ b/packages/main/src/plugin/contribution-manager.ts
@@ -95,7 +95,7 @@ export class ContributionManager {
     const allContribs = await Promise.all(
       matchingDirectories.map(async directory => {
         const metadata = await this.loadMetadata(directory);
-        const extensionId = metadata.name;
+        const extensionId = metadata.extensionId ? metadata.extensionId : metadata.name;
         // grab only UI contributions for now
         if (!metadata.ui) {
           return [];

--- a/packages/main/src/plugin/docker-extension/docker-desktop-installer.ts
+++ b/packages/main/src/plugin/docker-extension/docker-desktop-installer.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { cp, readFile } from 'node:fs/promises';
+import { cp, readFile, writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
 
 import type { ContributionManager } from '/@/plugin/contribution-manager.js';
@@ -56,10 +56,15 @@ export class DockerDesktopInstaller {
     sourceFolderPath: string,
     destFolderPath: string,
     reportLog: (message: string) => void,
+    catalogExtensionId?: string,
   ): Promise<void> {
     // ok now, we need to copy files that we're interested in by looking at the metadata.json file
     const metadataFile = await readFile(`${sourceFolderPath}/metadata.json`, 'utf8');
     const metadata = JSON.parse(metadataFile);
+    if (catalogExtensionId) {
+      metadata.extensionId = catalogExtensionId;
+      await writeFile(`${sourceFolderPath}/metadata.json`, JSON.stringify(metadata), 'utf8');
+    }
 
     // files or folder to grab
     const files: string[] = [];

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -2222,6 +2222,7 @@ export function initExposure(): void {
       imageName: string,
       logCallback: (data: string) => void,
       errorCallback: (data: string) => void,
+      catalogExtensionId?: string,
     ): Promise<void> => {
       onDataCallbacksShellInContainerExtensionInstallId++;
       onDataCallbacksShellInContainerExtension.set(onDataCallbacksShellInContainerExtensionInstallId, logCallback);
@@ -2233,6 +2234,7 @@ export function initExposure(): void {
         'extension-installer:install-from-image',
         imageName,
         onDataCallbacksShellInContainerExtensionInstallId,
+        catalogExtensionId,
       );
 
       return new Promise(resolve => {

--- a/packages/renderer/src/lib/extensions/CatalogExtension.spec.ts
+++ b/packages/renderer/src/lib/extensions/CatalogExtension.spec.ts
@@ -113,6 +113,7 @@ test('Expect to see featured and fetch button', async () => {
     'myLink',
     expect.any(Function),
     expect.any(Function),
+    'myId',
   );
 });
 

--- a/packages/renderer/src/lib/featured/FeaturedExtensionDownload.svelte
+++ b/packages/renderer/src/lib/featured/FeaturedExtensionDownload.svelte
@@ -60,6 +60,7 @@ async function installExtension(): Promise<void> {
         installInProgress = false;
         errorInstall = error;
       },
+      extension.id,
     );
     logs = [...logs, '☑️ installation finished !'];
     percentage = '100%';


### PR DESCRIPTION
### What does this PR do?
This PR adds the extensionId from the catalog to the metadata file of PD contributions.
More info about this bug can be found here https://github.com/podman-desktop/podman-desktop/issues/10005#issuecomment-2603455072

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Fixes https://github.com/podman-desktop/podman-desktop/issues/10005

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
