### PR TITLE
docs: fix path in macos docker context create example command

### DIFF
--- a/website/docs/migrating-from-docker/using-the-docker_host-environment-variable.md
+++ b/website/docs/migrating-from-docker/using-the-docker_host-environment-variable.md
@@ -25,7 +25,7 @@ Alternatively, you can add a `podman` context by using the `docker context creat
 
 - For example, set the value of the context in this pattern on a macOS machine:
 
-  `docker context create podman --docker "host=unix://$HOME.local/share/containers/podman/machine/podman.sock"`
+  `docker context create podman --docker "host=unix://${HOME}/.local/share/containers/podman/machine/podman.sock"`
 
   Where, the path specified after the `unix://` scheme denotes the `DOCKER_HOST` value.
 


### PR DESCRIPTION
### What does this PR do?

Fixes an incorrect command on this documentation page https://podman-desktop.io/docs/migrating-from-docker/using-the-docker_host-environment-variable

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

There doesn't appear to be an issue filed

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
