### PR TITLE
fix(feedback): confirmation dialogs

### DIFF
--- a/packages/renderer/src/lib/feedback/SendFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/SendFeedback.spec.ts
@@ -58,17 +58,17 @@ test('Expect confirmation dialog to be displayed if content changed', async () =
   render(SendFeedback, {});
 
   expect(DevelopersFeedback).toHaveBeenCalledWith(expect.anything(), {
-    close: expect.any(Function),
+    onCloseForm: expect.any(Function),
     contentChange: expect.any(Function),
   });
 
-  const { close, contentChange } = vi.mocked(DevelopersFeedback).mock.calls[0][1];
+  const { onCloseForm, contentChange } = vi.mocked(DevelopersFeedback).mock.calls[0][1];
 
   // 1. simulate content change
   contentChange(true);
 
   // 2. close
-  close(true);
+  onCloseForm(true);
 
   // expect confirm dialog
   expect(window.showMessageBox).toHaveBeenCalledWith({
@@ -83,14 +83,14 @@ test('Expect no confirmation dialog to be displayed if content has not changed',
   render(SendFeedback, {});
 
   expect(DevelopersFeedback).toHaveBeenCalledWith(expect.anything(), {
-    close: expect.any(Function),
+    onCloseForm: expect.any(Function),
     contentChange: expect.any(Function),
   });
 
-  const { close } = vi.mocked(DevelopersFeedback).mock.calls[0][1];
+  const { onCloseForm } = vi.mocked(DevelopersFeedback).mock.calls[0][1];
 
   // 2. close
-  close(true);
+  onCloseForm(true);
 
   // expect no confirm dialog
   expect(window.showMessageBox).not.toHaveBeenCalled();
@@ -110,7 +110,7 @@ test('Expect GitHubIssue feedback form to be rendered if category is not develop
   await fireEvent.click(bugCategory);
   // click on a smiley
   expect(vi.mocked(GitHubIssueFeedback)).toHaveBeenNthCalledWith(1, expect.anything(), {
-    close: expect.any(Function),
+    onCloseForm: expect.any(Function),
     category: 'bug',
     contentChange: expect.any(Function),
   });
@@ -122,7 +122,7 @@ test('Expect GitHubIssue feedback form to be rendered if category is not develop
   const featureCategory = screen.getByRole('button', { name: /Feature/ });
   await fireEvent.click(featureCategory);
   expect(vi.mocked(GitHubIssueFeedback)).toHaveBeenNthCalledWith(2, expect.anything(), {
-    close: expect.any(Function),
+    onCloseForm: expect.any(Function),
     category: 'feature',
     contentChange: expect.any(Function),
   });

--- a/packages/renderer/src/lib/feedback/SendFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/SendFeedback.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2024 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
-import { beforeAll, expect, test, vi } from 'vitest';
+import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
 import DevelopersFeedback from './feedbackForms/DevelopersFeedback.svelte';
 import GitHubIssueFeedback from './feedbackForms/GitHubIssueFeedback.svelte';
@@ -43,10 +43,57 @@ beforeAll(() => {
   };
 });
 
-test('Expect developers feedback form to be rendered by default', async () => {
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('Expect developers feedback form to be rendered by default', () => {
+  render(SendFeedback);
+
+  expect(DevelopersFeedback).toHaveBeenCalledOnce();
+  expect(GitHubIssueFeedback).not.toHaveBeenCalled();
+});
+
+test('Expect confirmation dialog to be displayed if content changed', async () => {
   render(SendFeedback, {});
 
-  expect(vi.mocked(DevelopersFeedback)).toBeCalled();
+  expect(DevelopersFeedback).toHaveBeenCalledWith(expect.anything(), {
+    close: expect.any(Function),
+    contentChange: expect.any(Function),
+  });
+
+  const { close, contentChange } = vi.mocked(DevelopersFeedback).mock.calls[0][1];
+
+  // 1. simulate content change
+  contentChange(true);
+
+  // 2. close
+  close(true);
+
+  // expect confirm dialog
+  expect(window.showMessageBox).toHaveBeenCalledWith({
+    title: 'Close Feedback form',
+    message: 'Do you want to close the Feedback form?\nClosing will erase your input.',
+    type: 'warning',
+    buttons: ['Yes', 'No'],
+  });
+});
+
+test('Expect no confirmation dialog to be displayed if content has not changed', async () => {
+  render(SendFeedback, {});
+
+  expect(DevelopersFeedback).toHaveBeenCalledWith(expect.anything(), {
+    close: expect.any(Function),
+    contentChange: expect.any(Function),
+  });
+
+  const { close } = vi.mocked(DevelopersFeedback).mock.calls[0][1];
+
+  // 2. close
+  close(true);
+
+  // expect no confirm dialog
+  expect(window.showMessageBox).not.toHaveBeenCalled();
 });
 
 test('Expect GitHubIssue feedback form to be rendered if category is not developers', async () => {
@@ -63,7 +110,7 @@ test('Expect GitHubIssue feedback form to be rendered if category is not develop
   await fireEvent.click(bugCategory);
   // click on a smiley
   expect(vi.mocked(GitHubIssueFeedback)).toHaveBeenNthCalledWith(1, expect.anything(), {
-    onCloseForm: expect.any(Function),
+    close: expect.any(Function),
     category: 'bug',
     contentChange: expect.any(Function),
   });
@@ -75,7 +122,7 @@ test('Expect GitHubIssue feedback form to be rendered if category is not develop
   const featureCategory = screen.getByRole('button', { name: /Feature/ });
   await fireEvent.click(featureCategory);
   expect(vi.mocked(GitHubIssueFeedback)).toHaveBeenNthCalledWith(2, expect.anything(), {
-    onCloseForm: expect.any(Function),
+    close: expect.any(Function),
     category: 'feature',
     contentChange: expect.any(Function),
   });

--- a/packages/renderer/src/lib/feedback/SendFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/SendFeedback.svelte
@@ -70,11 +70,11 @@ function handleUpdate(e: boolean): void {
     </div>
 
     {#if category === 'developers'}
-      <DevelopersFeedback close={hideModal} contentChange={handleUpdate}/>
+      <DevelopersFeedback onCloseForm={hideModal} contentChange={handleUpdate}/>
     {:else if category === 'bug'}
-      <GitHubIssueFeedback close={hideModal} category="bug" contentChange={handleUpdate}/>
+      <GitHubIssueFeedback onCloseForm={hideModal} category="bug" contentChange={handleUpdate}/>
     {:else if category === 'feature'}
-      <GitHubIssueFeedback close={hideModal} category="feature" contentChange={handleUpdate}/>
+      <GitHubIssueFeedback onCloseForm={hideModal} category="feature" contentChange={handleUpdate}/>
     {/if}
   </Modal>
 </div>

--- a/packages/renderer/src/lib/feedback/SendFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/SendFeedback.svelte
@@ -27,10 +27,12 @@ function closeModal(): void {
   category = DEFAULT_CATEGORY;
 }
 
-async function hideModal(): Promise<void> {
+async function hideModal(confirm = true): Promise<void> {
   // If all of the form fields are empty/ in default state dont show the dialog
-  if (!hasContent) {
+  if (!hasContent || !confirm) {
     closeModal();
+    // reset
+    hasContent = false;
     return;
   }
 
@@ -54,11 +56,10 @@ function handleUpdate(e: boolean): void {
 
 {#if displayModal}
 <div class='z-40'>
-  <Modal name="Share your feedback" on:close={hideModal}>
+  <Modal name="Share your feedback" on:close={(): Promise<void> => hideModal()}>
     <div class="flex items-center justify-between pl-4 pr-3 py-3 space-x-2 text-[var(--pd-modal-header-text)]">
       <h1 class="grow text-lg font-bold capitalize">Share your feedback</h1>
-
-      <CloseButton on:click={hideModal} />
+      <CloseButton on:click={(): Promise<void> => hideModal()} />
     </div>
 
     <div class="relative text-[var(--pd-modal-text)] px-10 pt-4">
@@ -69,11 +70,11 @@ function handleUpdate(e: boolean): void {
     </div>
 
     {#if category === 'developers'}
-      <DevelopersFeedback onCloseForm={hideModal} contentChange={handleUpdate}/>
+      <DevelopersFeedback close={hideModal} contentChange={handleUpdate}/>
     {:else if category === 'bug'}
-      <GitHubIssueFeedback onCloseForm={hideModal} category="bug" contentChange={handleUpdate}/>
+      <GitHubIssueFeedback close={hideModal} category="bug" contentChange={handleUpdate}/>
     {:else if category === 'feature'}
-      <GitHubIssueFeedback onCloseForm={hideModal} category="feature" contentChange={handleUpdate}/>
+      <GitHubIssueFeedback close={hideModal} category="feature" contentChange={handleUpdate}/>
     {/if}
   </Modal>
 </div>

--- a/packages/renderer/src/lib/feedback/feedbackForms/DevelopersFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/feedbackForms/DevelopersFeedback.spec.ts
@@ -41,14 +41,14 @@ beforeEach(() => {
 });
 
 test('Expect that the button is disabled when loading the page', () => {
-  render(DevelopersFeedback, { contentChange: vi.fn() });
+  render(DevelopersFeedback, { contentChange: vi.fn(), close: vi.fn() });
   const button = screen.getByRole('button', { name: 'Send feedback' });
   expect(button).toBeInTheDocument();
   expect(button).toBeDisabled();
 });
 
 test('Expect that the button is enabled after clicking on a smiley', async () => {
-  render(DevelopersFeedback, { contentChange: vi.fn() });
+  render(DevelopersFeedback, { contentChange: vi.fn(), close: vi.fn() });
   const button = screen.getByRole('button', { name: 'Send feedback' });
 
   // expect to have indication why the button is disabled
@@ -66,7 +66,7 @@ test('Expect that the button is enabled after clicking on a smiley', async () =>
 });
 
 test('Expect very sad smiley errors without feedback', async () => {
-  render(DevelopersFeedback, { contentChange: vi.fn() });
+  render(DevelopersFeedback, { contentChange: vi.fn(), close: vi.fn() });
   const button = screen.getByRole('button', { name: 'Send feedback' });
   expect(button).toBeDisabled();
 
@@ -94,7 +94,7 @@ test('Expect very sad smiley errors without feedback', async () => {
 });
 
 test('Expect sad smiley warns without feedback', async () => {
-  render(DevelopersFeedback, { contentChange: vi.fn() });
+  render(DevelopersFeedback, { contentChange: vi.fn(), close: vi.fn() });
   const button = screen.getByRole('button', { name: 'Send feedback' });
   expect(button).toBeDisabled();
 
@@ -121,7 +121,7 @@ test('Expect sad smiley warns without feedback', async () => {
 });
 
 test('Expect message for very-happy-smiley to use love', async () => {
-  const { getByRole, getByLabelText } = render(DevelopersFeedback, { contentChange: vi.fn() });
+  const { getByRole, getByLabelText } = render(DevelopersFeedback, { contentChange: vi.fn(), close: vi.fn() });
 
   // click on a smiley
   const smiley = getByRole('button', { name: 'very-happy-smiley' });
@@ -133,7 +133,7 @@ test('Expect message for very-happy-smiley to use love', async () => {
 });
 
 test('Expect message for happy-smiley to use like', async () => {
-  const { getByRole, getByLabelText } = render(DevelopersFeedback, { contentChange: vi.fn() });
+  const { getByRole, getByLabelText } = render(DevelopersFeedback, { contentChange: vi.fn(), close: vi.fn() });
 
   // click on a smiley
   const smiley = getByRole('button', { name: 'happy-smiley' });
@@ -145,7 +145,7 @@ test('Expect message for happy-smiley to use like', async () => {
 });
 
 test('Expect GitHub dialog visible when very-happy-smiley selected', async () => {
-  render(DevelopersFeedback, { contentChange: vi.fn() });
+  render(DevelopersFeedback, { contentChange: vi.fn(), close: vi.fn() });
 
   // click on a smiley
   const smiley = screen.getByRole('button', { name: 'very-happy-smiley' });
@@ -164,7 +164,8 @@ test('Expect GitHub dialog visible when very-happy-smiley selected', async () =>
 });
 
 test('Expect category to be sent', async () => {
-  render(DevelopersFeedback, { contentChange: vi.fn() });
+  const closeMock = vi.fn();
+  render(DevelopersFeedback, { contentChange: vi.fn(), close: closeMock });
 
   // click on a smiley
   const smiley = screen.getByRole('button', { name: 'very-happy-smiley' });
@@ -182,4 +183,15 @@ test('Expect category to be sent', async () => {
       rating: 4,
     });
   });
+
+  // expect nice message to be displayed
+  expect(window.showMessageBox).toHaveBeenCalledWith({
+    title: 'Thanks for your feedback',
+    message: 'Your input is valuable in helping us better understand and tailor Podman Desktop.',
+    type: 'info',
+    buttons: ['OK'],
+  });
+
+  // expect close to have been call with confirmation=false
+  expect(closeMock).toHaveBeenCalledWith(false);
 });

--- a/packages/renderer/src/lib/feedback/feedbackForms/DevelopersFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/feedbackForms/DevelopersFeedback.spec.ts
@@ -41,14 +41,14 @@ beforeEach(() => {
 });
 
 test('Expect that the button is disabled when loading the page', () => {
-  render(DevelopersFeedback, { contentChange: vi.fn(), close: vi.fn() });
+  render(DevelopersFeedback, { contentChange: vi.fn(), onCloseForm: vi.fn() });
   const button = screen.getByRole('button', { name: 'Send feedback' });
   expect(button).toBeInTheDocument();
   expect(button).toBeDisabled();
 });
 
 test('Expect that the button is enabled after clicking on a smiley', async () => {
-  render(DevelopersFeedback, { contentChange: vi.fn(), close: vi.fn() });
+  render(DevelopersFeedback, { contentChange: vi.fn(), onCloseForm: vi.fn() });
   const button = screen.getByRole('button', { name: 'Send feedback' });
 
   // expect to have indication why the button is disabled
@@ -66,7 +66,7 @@ test('Expect that the button is enabled after clicking on a smiley', async () =>
 });
 
 test('Expect very sad smiley errors without feedback', async () => {
-  render(DevelopersFeedback, { contentChange: vi.fn(), close: vi.fn() });
+  render(DevelopersFeedback, { contentChange: vi.fn(), onCloseForm: vi.fn() });
   const button = screen.getByRole('button', { name: 'Send feedback' });
   expect(button).toBeDisabled();
 
@@ -94,7 +94,7 @@ test('Expect very sad smiley errors without feedback', async () => {
 });
 
 test('Expect sad smiley warns without feedback', async () => {
-  render(DevelopersFeedback, { contentChange: vi.fn(), close: vi.fn() });
+  render(DevelopersFeedback, { contentChange: vi.fn(), onCloseForm: vi.fn() });
   const button = screen.getByRole('button', { name: 'Send feedback' });
   expect(button).toBeDisabled();
 
@@ -121,7 +121,7 @@ test('Expect sad smiley warns without feedback', async () => {
 });
 
 test('Expect message for very-happy-smiley to use love', async () => {
-  const { getByRole, getByLabelText } = render(DevelopersFeedback, { contentChange: vi.fn(), close: vi.fn() });
+  const { getByRole, getByLabelText } = render(DevelopersFeedback, { contentChange: vi.fn(), onCloseForm: vi.fn() });
 
   // click on a smiley
   const smiley = getByRole('button', { name: 'very-happy-smiley' });
@@ -133,7 +133,7 @@ test('Expect message for very-happy-smiley to use love', async () => {
 });
 
 test('Expect message for happy-smiley to use like', async () => {
-  const { getByRole, getByLabelText } = render(DevelopersFeedback, { contentChange: vi.fn(), close: vi.fn() });
+  const { getByRole, getByLabelText } = render(DevelopersFeedback, { contentChange: vi.fn(), onCloseForm: vi.fn() });
 
   // click on a smiley
   const smiley = getByRole('button', { name: 'happy-smiley' });
@@ -145,7 +145,7 @@ test('Expect message for happy-smiley to use like', async () => {
 });
 
 test('Expect GitHub dialog visible when very-happy-smiley selected', async () => {
-  render(DevelopersFeedback, { contentChange: vi.fn(), close: vi.fn() });
+  render(DevelopersFeedback, { contentChange: vi.fn(), onCloseForm: vi.fn() });
 
   // click on a smiley
   const smiley = screen.getByRole('button', { name: 'very-happy-smiley' });
@@ -165,7 +165,7 @@ test('Expect GitHub dialog visible when very-happy-smiley selected', async () =>
 
 test('Expect category to be sent', async () => {
   const closeMock = vi.fn();
-  render(DevelopersFeedback, { contentChange: vi.fn(), close: closeMock });
+  render(DevelopersFeedback, { contentChange: vi.fn(), onCloseForm: closeMock });
 
   // click on a smiley
   const smiley = screen.getByRole('button', { name: 'very-happy-smiley' });

--- a/packages/renderer/src/lib/feedback/feedbackForms/DevelopersFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/feedbackForms/DevelopersFeedback.svelte
@@ -17,7 +17,7 @@ import type { FeedbackProperties } from '/@api/feedback';
 import WarningMessage from '../../ui/WarningMessage.svelte';
 
 interface Props {
-  onCloseForm?: () => void;
+  close: (confirmation: boolean) => void;
   contentChange: (e: boolean) => void;
 }
 
@@ -30,7 +30,7 @@ let hasFeedback = $derived(
     (contactInformation && contactInformation.trim().length > 4),
 );
 
-let { onCloseForm = (): void => {}, contentChange }: Props = $props();
+let { close, contentChange }: Props = $props();
 
 $effect(() => contentChange(Boolean(smileyRating || tellUsWhyFeedback || contactInformation)));
 
@@ -52,14 +52,23 @@ async function sendFeedback(): Promise<void> {
     properties.contact = contactInformation;
   }
 
-  // send
+  // 1. send the feedback
   await window.sendFeedback(properties);
-  // close the form
-  onCloseForm();
+
+  // 2. close the form without confirmation
+  close(false);
+
+  // 3. Display confirmation dialog
+  await window.showMessageBox({
+    title: 'Thanks for your feedback',
+    message: 'Your input is valuable in helping us better understand and tailor Podman Desktop.',
+    type: 'info',
+    buttons: ['OK'],
+  });
 }
 
 async function openGitHub(): Promise<void> {
-  onCloseForm();
+  close(false);
   await window.telemetryTrack('feedback.openGitHub');
   await window.openExternal('https://github.com/containers/podman-desktop');
 }

--- a/packages/renderer/src/lib/feedback/feedbackForms/DevelopersFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/feedbackForms/DevelopersFeedback.svelte
@@ -17,7 +17,7 @@ import type { FeedbackProperties } from '/@api/feedback';
 import WarningMessage from '../../ui/WarningMessage.svelte';
 
 interface Props {
-  close: (confirmation: boolean) => void;
+  onCloseForm: (confirmation: boolean) => void;
   contentChange: (e: boolean) => void;
 }
 
@@ -30,7 +30,7 @@ let hasFeedback = $derived(
     (contactInformation && contactInformation.trim().length > 4),
 );
 
-let { close, contentChange }: Props = $props();
+let { onCloseForm, contentChange }: Props = $props();
 
 $effect(() => contentChange(Boolean(smileyRating || tellUsWhyFeedback || contactInformation)));
 
@@ -56,7 +56,7 @@ async function sendFeedback(): Promise<void> {
   await window.sendFeedback(properties);
 
   // 2. close the form without confirmation
-  close(false);
+  onCloseForm(false);
 
   // 3. Display confirmation dialog
   await window.showMessageBox({
@@ -68,7 +68,7 @@ async function sendFeedback(): Promise<void> {
 }
 
 async function openGitHub(): Promise<void> {
-  close(false);
+  onCloseForm(false);
   await window.telemetryTrack('feedback.openGitHub');
   await window.openExternal('https://github.com/containers/podman-desktop');
 }

--- a/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.spec.ts
@@ -99,7 +99,7 @@ function renderGitHubIssueFeedback(props: ComponentProps<typeof GitHubIssueFeedb
 test('Expect feedback form to to be GitHub issue feedback form', async () => {
   const { title, description, includeSystemInfo } = renderGitHubIssueFeedback({
     category: 'bug',
-    close: vi.fn(),
+    onCloseForm: vi.fn(),
     contentChange: vi.fn(),
   });
 
@@ -111,7 +111,7 @@ test('Expect feedback form to to be GitHub issue feedback form', async () => {
 test('Expect Preview on GitHub button to be disabled if there is no title or description', async () => {
   const { title, description, preview } = renderGitHubIssueFeedback({
     category: 'bug',
-    close: vi.fn(),
+    onCloseForm: vi.fn(),
     contentChange: vi.fn(),
   });
 
@@ -144,7 +144,7 @@ test.each([
 ])('$category should have specific placeholders', async ({ category, placeholders }) => {
   const { title, description } = renderGitHubIssueFeedback({
     category: category as FeedbackCategory,
-    close: vi.fn(),
+    onCloseForm: vi.fn(),
     contentChange: vi.fn(),
   });
 
@@ -164,7 +164,7 @@ test.each([
 ])('$category should have specific issues link', async ({ category, link }) => {
   const { getByLabelText } = renderGitHubIssueFeedback({
     category: category as FeedbackCategory,
-    close: vi.fn(),
+    onCloseForm: vi.fn(),
     contentChange: vi.fn(),
   });
 
@@ -178,7 +178,7 @@ test.each([
 test.each(['bug', 'feature'])('Expect %s to be included in previewOnGitHub call', async category => {
   const { preview, title, description } = renderGitHubIssueFeedback({
     category: category as FeedbackCategory,
-    close: vi.fn(),
+    onCloseForm: vi.fn(),
     contentChange: vi.fn(),
   });
 
@@ -205,7 +205,7 @@ describe('includeSystemInfo', () => {
   test('should not be visible on category feature', async () => {
     const { includeSystemInfo } = renderGitHubIssueFeedback({
       category: 'feature',
-      close: vi.fn(),
+      onCloseForm: vi.fn(),
       contentChange: vi.fn(),
     });
     expect(includeSystemInfo).toBeUndefined();
@@ -214,7 +214,7 @@ describe('includeSystemInfo', () => {
   test('should be visible on category bug and enabled by default', async () => {
     const { includeSystemInfo } = renderGitHubIssueFeedback({
       category: 'bug',
-      close: vi.fn(),
+      onCloseForm: vi.fn(),
       contentChange: vi.fn(),
     });
     expect(includeSystemInfo).toBeInTheDocument();
@@ -226,7 +226,7 @@ describe('includeSystemInfo', () => {
   test('uncheck the Include system information should set includeSystemInfo to false', async () => {
     const { preview, title, description, includeSystemInfo } = renderGitHubIssueFeedback({
       category: 'bug',
-      close: vi.fn(),
+      onCloseForm: vi.fn(),
       contentChange: vi.fn(),
     });
 
@@ -254,7 +254,7 @@ describe('includeExtensionInfo', () => {
   test('should not be visible on category feature', async () => {
     const { includeExtensionInfo } = renderGitHubIssueFeedback({
       category: 'feature',
-      close: vi.fn(),
+      onCloseForm: vi.fn(),
       contentChange: vi.fn(),
     });
     expect(includeExtensionInfo).toBeUndefined();
@@ -263,7 +263,7 @@ describe('includeExtensionInfo', () => {
   test('should be visible on category bug and enabled by default', async () => {
     const { includeExtensionInfo } = renderGitHubIssueFeedback({
       category: 'bug',
-      close: vi.fn(),
+      onCloseForm: vi.fn(),
       contentChange: vi.fn(),
     });
     expect(includeExtensionInfo).toBeInTheDocument();
@@ -275,7 +275,7 @@ describe('includeExtensionInfo', () => {
   test('uncheck the Include system information should set includeSystemInfo to false', async () => {
     const { preview, title, description, includeExtensionInfo } = renderGitHubIssueFeedback({
       category: 'bug',
-      close: vi.fn(),
+      onCloseForm: vi.fn(),
       contentChange: vi.fn(),
     });
 
@@ -303,7 +303,7 @@ test('Expect close confirmation to be true if cancel clicked', async () => {
   const closeMock = vi.fn();
   const { cancel } = renderGitHubIssueFeedback({
     category: 'bug',
-    close: closeMock,
+    onCloseForm: closeMock,
     contentChange: vi.fn(),
   });
 

--- a/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.spec.ts
@@ -57,6 +57,7 @@ function renderGitHubIssueFeedback(props: ComponentProps<typeof GitHubIssueFeedb
   title: HTMLInputElement;
   description: HTMLTextAreaElement;
   preview: HTMLButtonElement;
+  cancel: HTMLButtonElement;
   includeSystemInfo?: HTMLElement;
   includeExtensionInfo?: HTMLElement;
 } & RenderResult<Component<ComponentProps<typeof GitHubIssueFeedback>>> {
@@ -73,6 +74,10 @@ function renderGitHubIssueFeedback(props: ComponentProps<typeof GitHubIssueFeedb
   const preview = getByRole('button', { name: 'Preview on GitHub' });
   expect(preview).toBeInstanceOf(HTMLButtonElement);
 
+  // button
+  const cancel = getByRole('button', { name: 'Cancel' });
+  expect(cancel).toBeInstanceOf(HTMLButtonElement);
+
   // checkbox
   const includeSystemInfo = queryByTitle('Include system information') ?? undefined;
 
@@ -82,6 +87,7 @@ function renderGitHubIssueFeedback(props: ComponentProps<typeof GitHubIssueFeedb
     title: title as HTMLInputElement,
     description: description as HTMLTextAreaElement,
     preview: preview as HTMLButtonElement,
+    cancel: cancel as HTMLButtonElement,
     includeSystemInfo,
     includeExtensionInfo,
     getByRole,
@@ -93,7 +99,7 @@ function renderGitHubIssueFeedback(props: ComponentProps<typeof GitHubIssueFeedb
 test('Expect feedback form to to be GitHub issue feedback form', async () => {
   const { title, description, includeSystemInfo } = renderGitHubIssueFeedback({
     category: 'bug',
-    onCloseForm: vi.fn(),
+    close: vi.fn(),
     contentChange: vi.fn(),
   });
 
@@ -105,7 +111,7 @@ test('Expect feedback form to to be GitHub issue feedback form', async () => {
 test('Expect Preview on GitHub button to be disabled if there is no title or description', async () => {
   const { title, description, preview } = renderGitHubIssueFeedback({
     category: 'bug',
-    onCloseForm: vi.fn(),
+    close: vi.fn(),
     contentChange: vi.fn(),
   });
 
@@ -138,7 +144,7 @@ test.each([
 ])('$category should have specific placeholders', async ({ category, placeholders }) => {
   const { title, description } = renderGitHubIssueFeedback({
     category: category as FeedbackCategory,
-    onCloseForm: vi.fn(),
+    close: vi.fn(),
     contentChange: vi.fn(),
   });
 
@@ -158,7 +164,7 @@ test.each([
 ])('$category should have specific issues link', async ({ category, link }) => {
   const { getByLabelText } = renderGitHubIssueFeedback({
     category: category as FeedbackCategory,
-    onCloseForm: vi.fn(),
+    close: vi.fn(),
     contentChange: vi.fn(),
   });
 
@@ -172,7 +178,7 @@ test.each([
 test.each(['bug', 'feature'])('Expect %s to be included in previewOnGitHub call', async category => {
   const { preview, title, description } = renderGitHubIssueFeedback({
     category: category as FeedbackCategory,
-    onCloseForm: vi.fn(),
+    close: vi.fn(),
     contentChange: vi.fn(),
   });
 
@@ -199,7 +205,7 @@ describe('includeSystemInfo', () => {
   test('should not be visible on category feature', async () => {
     const { includeSystemInfo } = renderGitHubIssueFeedback({
       category: 'feature',
-      onCloseForm: vi.fn(),
+      close: vi.fn(),
       contentChange: vi.fn(),
     });
     expect(includeSystemInfo).toBeUndefined();
@@ -208,7 +214,7 @@ describe('includeSystemInfo', () => {
   test('should be visible on category bug and enabled by default', async () => {
     const { includeSystemInfo } = renderGitHubIssueFeedback({
       category: 'bug',
-      onCloseForm: vi.fn(),
+      close: vi.fn(),
       contentChange: vi.fn(),
     });
     expect(includeSystemInfo).toBeInTheDocument();
@@ -220,7 +226,7 @@ describe('includeSystemInfo', () => {
   test('uncheck the Include system information should set includeSystemInfo to false', async () => {
     const { preview, title, description, includeSystemInfo } = renderGitHubIssueFeedback({
       category: 'bug',
-      onCloseForm: vi.fn(),
+      close: vi.fn(),
       contentChange: vi.fn(),
     });
 
@@ -248,7 +254,7 @@ describe('includeExtensionInfo', () => {
   test('should not be visible on category feature', async () => {
     const { includeExtensionInfo } = renderGitHubIssueFeedback({
       category: 'feature',
-      onCloseForm: vi.fn(),
+      close: vi.fn(),
       contentChange: vi.fn(),
     });
     expect(includeExtensionInfo).toBeUndefined();
@@ -257,7 +263,7 @@ describe('includeExtensionInfo', () => {
   test('should be visible on category bug and enabled by default', async () => {
     const { includeExtensionInfo } = renderGitHubIssueFeedback({
       category: 'bug',
-      onCloseForm: vi.fn(),
+      close: vi.fn(),
       contentChange: vi.fn(),
     });
     expect(includeExtensionInfo).toBeInTheDocument();
@@ -269,7 +275,7 @@ describe('includeExtensionInfo', () => {
   test('uncheck the Include system information should set includeSystemInfo to false', async () => {
     const { preview, title, description, includeExtensionInfo } = renderGitHubIssueFeedback({
       category: 'bug',
-      onCloseForm: vi.fn(),
+      close: vi.fn(),
       contentChange: vi.fn(),
     });
 
@@ -291,4 +297,20 @@ describe('includeExtensionInfo', () => {
       }),
     );
   });
+});
+
+test('Expect close confirmation to be true if cancel clicked', async () => {
+  const closeMock = vi.fn();
+  const { cancel } = renderGitHubIssueFeedback({
+    category: 'bug',
+    close: closeMock,
+    contentChange: vi.fn(),
+  });
+
+  // click on a cancel
+  await userEvent.click(cancel);
+
+  // expect close to have been call with confirmation=true
+  expect(closeMock).toHaveBeenCalledOnce();
+  expect(closeMock).toHaveBeenCalledWith(true);
 });

--- a/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.svelte
@@ -5,12 +5,12 @@ import FeedbackForm from '/@/lib/feedback/FeedbackForm.svelte';
 import type { FeedbackCategory, GitHubIssue } from '/@api/feedback';
 
 interface Props {
-  onCloseForm: () => void;
+  close: (confirm: boolean) => void;
   category: FeedbackCategory;
   contentChange: (e: boolean) => void;
 }
 
-let { onCloseForm = (): void => {}, category = 'bug', contentChange }: Props = $props();
+let { close = (): void => {}, category = 'bug', contentChange }: Props = $props();
 
 let issueTitle = $state('');
 let issueDescription = $state('');
@@ -43,7 +43,7 @@ let existingIssuesLink = $state(
 $effect(() => contentChange(Boolean(issueTitle || issueDescription)));
 
 async function openGitHubIssues(): Promise<void> {
-  onCloseForm();
+  close(false);
   await window.openExternal(existingIssuesLink);
 }
 
@@ -57,7 +57,7 @@ async function previewOnGitHub(): Promise<void> {
   };
   try {
     await window.previewOnGitHub(issueProperties);
-    onCloseForm();
+    close(false);
   } catch (error: unknown) {
     console.error('There was a problem with preview on GitHub', error);
   }
@@ -113,7 +113,7 @@ async function previewOnGitHub(): Promise<void> {
     {/if}
   </svelte:fragment>
   <svelte:fragment slot="buttons">
-    <Button class="underline" type="link" aria-label="Cancel" on:click={onCloseForm}>Cancel</Button>
+    <Button class="underline" type="link" aria-label="Cancel" on:click={(): void => close(true)}>Cancel</Button>
     <Button aria-label="Preview on GitHub" on:click={previewOnGitHub} disabled={!issueTitle || !issueDescription}>Preview on GitHub</Button>
   </svelte:fragment>
 </FeedbackForm>

--- a/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.svelte
@@ -5,12 +5,12 @@ import FeedbackForm from '/@/lib/feedback/FeedbackForm.svelte';
 import type { FeedbackCategory, GitHubIssue } from '/@api/feedback';
 
 interface Props {
-  close: (confirm: boolean) => void;
+  onCloseForm: (confirm: boolean) => void;
   category: FeedbackCategory;
   contentChange: (e: boolean) => void;
 }
 
-let { close = (): void => {}, category = 'bug', contentChange }: Props = $props();
+let { onCloseForm, category = 'bug', contentChange }: Props = $props();
 
 let issueTitle = $state('');
 let issueDescription = $state('');
@@ -43,7 +43,7 @@ let existingIssuesLink = $state(
 $effect(() => contentChange(Boolean(issueTitle || issueDescription)));
 
 async function openGitHubIssues(): Promise<void> {
-  close(false);
+  onCloseForm(false);
   await window.openExternal(existingIssuesLink);
 }
 
@@ -57,7 +57,7 @@ async function previewOnGitHub(): Promise<void> {
   };
   try {
     await window.previewOnGitHub(issueProperties);
-    close(false);
+    onCloseForm(false);
   } catch (error: unknown) {
     console.error('There was a problem with preview on GitHub', error);
   }
@@ -113,7 +113,7 @@ async function previewOnGitHub(): Promise<void> {
     {/if}
   </svelte:fragment>
   <svelte:fragment slot="buttons">
-    <Button class="underline" type="link" aria-label="Cancel" on:click={(): void => close(true)}>Cancel</Button>
+    <Button class="underline" type="link" aria-label="Cancel" on:click={(): void => onCloseForm(true)}>Cancel</Button>
     <Button aria-label="Preview on GitHub" on:click={previewOnGitHub} disabled={!issueTitle || !issueDescription}>Preview on GitHub</Button>
   </svelte:fragment>
 </FeedbackForm>


### PR DESCRIPTION
### What does this PR do?


### Changes

- Adding confirm parameter to `SendFeedback#hideModal` function
- Make the Developer feedback close the modal without confirmation
- Make the Developer feedback display a nice message (might need improvement please share any idea) to confirm it has been sent
- Renaming `onCloseModal` to `close`, this is not an event, but a request, so no `on` prefix

### Screenshot / video of UI

![image](https://github.com/user-attachments/assets/d40a87f6-9f4d-4338-a312-378c7a776e01)

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/10828

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
