### PR TITLE
docs: add license + latest release as GitHub badges in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Podman Desktop - A graphical tool for developing on containers and Kubernetes
+![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)
+![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/podman-desktop/podman-desktop)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9966/badge)](https://www.bestpractices.dev/projects/9966)
 
 <p align="center">


### PR DESCRIPTION
### What does this PR do?
while adding the OpenSSF badge I noticed we were missing 'classic badges' like the license and the latest release one so adding them there

### Screenshot / video of UI

![image](https://github.com/user-attachments/assets/d5c24730-ba4c-4c5d-9105-b30f306c9c05)

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
