### PR TITLE
chore: add informers and backend for k8s cronjob

### DIFF
--- a/packages/api/src/kubernetes-contexts-states.ts
+++ b/packages/api/src/kubernetes-contexts-states.ts
@@ -37,6 +37,7 @@ export const secondaryResources = [
   'nodes',
   'persistentvolumeclaims',
   'events',
+  'cronjobs',
 ] as const;
 
 export type SecondaryResourceName = (typeof secondaryResources)[number];

--- a/packages/main/src/plugin/kubernetes/contexts-states-registry.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-states-registry.ts
@@ -62,6 +62,7 @@ export const dispatchAllResources: ResourcesDispatchOptions = {
   ingresses: true,
   routes: true,
   configmaps: true,
+  cronjobs: true,
   secrets: true,
   events: true,
   // add new resources here when adding new informers
@@ -214,6 +215,7 @@ export class ContextsStatesRegistry {
           ingresses: [],
           routes: [],
           configmaps: [],
+          cronjobs: [],
           secrets: [],
           events: [],
           // add new resources here when adding new informers

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -27,6 +27,7 @@ import type {
   Context,
   KubernetesObject,
   V1ConfigMap,
+  V1CronJob,
   V1Deployment,
   V1Ingress,
   V1NamespaceList,
@@ -1968,6 +1969,13 @@ export function initExposure(): void {
     },
   );
 
+  contextBridge.exposeInMainWorld(
+    'kubernetesReadNamespacedCronJob',
+    async (name: string, namespace: string): Promise<V1CronJob | undefined> => {
+      return ipcInvoke('kubernetes-client:readNamespacedCronJob', name, namespace);
+    },
+  );
+
   contextBridge.exposeInMainWorld('kubernetesIsAPIGroupSupported', async (group: string): Promise<boolean> => {
     return ipcInvoke('kubernetes-client:isAPIGroupSupported', group);
   });
@@ -2032,6 +2040,10 @@ export function initExposure(): void {
 
   contextBridge.exposeInMainWorld('kubernetesDeleteSecret', async (name: string): Promise<void> => {
     return ipcInvoke('kubernetes-client:deleteSecret', name);
+  });
+
+  contextBridge.exposeInMainWorld('kubernetesDeleteCronJob', async (name: string): Promise<void> => {
+    return ipcInvoke('kubernetes-client:deleteCronJob', name);
   });
 
   contextBridge.exposeInMainWorld('kubernetesDeletePersistentVolumeClaim', async (name: string): Promise<void> => {


### PR DESCRIPTION
chore: add informers and backend for k8s cronjob

### What does this PR do?

* Adds informers for CronJob
* Adds API calls needed for CronJob support
* Back-end ONLY, renderer code coming later.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Part of https://github.com/podman-desktop/podman-desktop/issues/10560

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

Tests covering implementation

- [X] Tests are covering the bug fix or the new feature

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
