### PR TITLE
feat: kube pods page

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -43,6 +43,7 @@ import IngressesRoutesList from './lib/ingresses-routes/IngressesRoutesList.svel
 import RouteDetails from './lib/ingresses-routes/RouteDetails.svelte';
 import KubePlayYAML from './lib/kube/KubePlayYAML.svelte';
 import KubernetesDashboard from './lib/kube/KubernetesDashboard.svelte';
+import KubePodsList from './lib/kube/pods/PodsList.svelte';
 import PortForwardingList from './lib/kubernetes-port-forward/PortForwardingList.svelte';
 import ManifestDetails from './lib/manifest/ManifestDetails.svelte';
 import NodeDetails from './lib/node/NodeDetails.svelte';
@@ -256,6 +257,9 @@ window.events?.receive('navigate', (navigationRequest: unknown) => {
           </Route>
           <Route path="/kubernetes/nodes/:name/*" breadcrumb="Node Details" let:meta navigationHint="details">
             <NodeDetails name={decodeURI(meta.params.name)} />
+          </Route>
+          <Route path="/kubernetes/pods" breadcrumb="Pods" navigationHint="root">
+            <KubePodsList />
           </Route>
           <Route path="/kubernetes/persistentvolumeclaims" breadcrumb="Persistent Volume Claims" navigationHint="root">
             <PVCList />

--- a/packages/renderer/src/AppNavigation.spec.ts
+++ b/packages/renderer/src/AppNavigation.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2024 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,6 +61,7 @@ test('Test rendering of the navigation bar with empty items', async (_arg: unkno
 
   // mock no kubernetes resources
   vi.mocked(kubeContextStore).kubernetesCurrentContextDeployments = readable<KubernetesObject[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextPods = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextServices = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextIngresses = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextRoutes = readable<KubernetesObject[]>([]);

--- a/packages/renderer/src/lib/kube/KubernetesDashboard.spec.ts
+++ b/packages/renderer/src/lib/kube/KubernetesDashboard.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2024 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,6 +55,7 @@ beforeEach(() => {
 test('Verify basic page', async () => {
   // mock no kubernetes resources
   vi.mocked(kubeContextStore).kubernetesCurrentContextDeployments = readable<KubernetesObject[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextPods = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextServices = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextIngresses = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextRoutes = readable<KubernetesObject[]>([]);
@@ -84,6 +85,7 @@ test('Verify documentation link works', async () => {
 test('Verify basic page with cluster', async () => {
   // mock no kubernetes resources
   vi.mocked(kubeContextStore).kubernetesCurrentContextDeployments = readable<KubernetesObject[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextPods = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextServices = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextIngresses = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextRoutes = readable<KubernetesObject[]>([]);
@@ -112,7 +114,7 @@ test('Verify basic page with cluster', async () => {
 
   const metrics = screen.getByText('Metrics');
   expect(metrics).toBeInTheDocument();
-  expect(metrics.nextElementSibling?.childElementCount).toBe(6);
+  expect(metrics.nextElementSibling?.childElementCount).toBe(7);
 
   const guides = screen.getByText('Explore articles and blog posts');
   expect(guides).toBeInTheDocument();

--- a/packages/renderer/src/lib/kube/KubernetesDashboard.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesDashboard.svelte
@@ -10,6 +10,7 @@ import {
   kubernetesCurrentContextIngresses,
   kubernetesCurrentContextNodes,
   kubernetesCurrentContextPersistentVolumeClaims,
+  kubernetesCurrentContextPods,
   kubernetesCurrentContextRoutes,
   kubernetesCurrentContextSecrets,
   kubernetesCurrentContextServices,
@@ -22,6 +23,7 @@ import ConfigMapSecretIcon from '../images/ConfigMapSecretIcon.svelte';
 import DeploymentIcon from '../images/DeploymentIcon.svelte';
 import IngressRouteIcon from '../images/IngressRouteIcon.svelte';
 import NodeIcon from '../images/NodeIcon.svelte';
+import PodIcon from '../images/PodIcon.svelte';
 import PvcIcon from '../images/PVCIcon.svelte';
 import ServiceIcon from '../images/ServiceIcon.svelte';
 import { fadeSlide } from '../ui/animations';
@@ -54,6 +56,7 @@ let activeDeploymentsCount = $derived(
     deployment => deployment.spec?.replicas > 0,
   ).length,
 );
+let podCount = $derived($kubernetesCurrentContextPods.length);
 let serviceCount = $derived($kubernetesCurrentContextServices.length);
 let ingressRouteCount = $derived($kubernetesCurrentContextIngresses.length + $kubernetesCurrentContextRoutes.length);
 let pvcCount = $derived($kubernetesCurrentContextPersistentVolumeClaims.length);
@@ -118,6 +121,7 @@ async function openKubernetesDocumentation(): Promise<void> {
                 <div class="grid grid-cols-4 gap-4">
                     <KubernetesDashboardResourceCard type='Nodes' Icon={NodeIcon} activeCount={activeNodeCount} count={nodeCount} link='/kubernetes/nodes'/>
                     <KubernetesDashboardResourceCard type='Deployments' Icon={DeploymentIcon} activeCount={activeDeploymentsCount} count={deploymentCount} link='/kubernetes/deployments'/>
+                    <KubernetesDashboardResourceCard type='Pods' Icon={PodIcon} count={podCount} link='/kubernetes/pods'/>
                     <KubernetesDashboardResourceCard type='Services' Icon={ServiceIcon} count={serviceCount} link='/kubernetes/services'/>
                     <KubernetesDashboardResourceCard type='Ingresses & Routes' Icon={IngressRouteIcon} count={ingressRouteCount} link='/kubernetes/ingressesRoutes'/>
                     <KubernetesDashboardResourceCard type='Persistent Volume Claims' Icon={PvcIcon} count={pvcCount} link='/kubernetes/persistentvolumeclaims'/>

--- a/packages/renderer/src/lib/kube/pods/PodActions.spec.ts
+++ b/packages/renderer/src/lib/kube/pods/PodActions.spec.ts
@@ -1,0 +1,158 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
+
+import type { V1Route } from '/@api/openshift-types';
+
+import type { PodInfoContainerUI } from '../../pod/PodInfoUI';
+import PodActions from './PodActions.svelte';
+import type { PodUI } from './PodUI';
+
+const updateMock = vi.fn();
+const restartMock = vi.fn();
+const deleteMock = vi.fn();
+const showMessageBoxMock = vi.fn();
+const kubernetesGetCurrentNamespaceMock = vi.fn();
+const kubernetesReadNamespacedPodMock = vi.fn();
+const openExternalMock = vi.fn();
+
+class PodUIImpl {
+  #status: string;
+  constructor(
+    public name: string,
+    initialStatus: string,
+    public namespace: string,
+    public selected: boolean,
+    public containers: PodInfoContainerUI[],
+  ) {
+    this.#status = initialStatus;
+  }
+  set status(status: string) {
+    this.#status = status;
+  }
+  get status(): string {
+    return this.#status;
+  }
+}
+
+const pod: PodUI = new PodUIImpl('', '', '', false, []);
+
+class ResizeObserver {
+  observe = vi.fn();
+  disconnect = vi.fn();
+  unobserve = vi.fn();
+}
+
+beforeAll(() => {
+  Object.defineProperty(window, 'ResizeObserver', { value: ResizeObserver });
+  Object.defineProperty(window, 'kubernetesGetCurrentNamespace', { value: kubernetesGetCurrentNamespaceMock });
+  Object.defineProperty(window, 'kubernetesReadNamespacedPod', { value: kubernetesReadNamespacedPodMock });
+  Object.defineProperty(window, 'restartKubernetesPod', { value: restartMock });
+  Object.defineProperty(window, 'kubernetesDeletePod', { value: deleteMock });
+  Object.defineProperty(window, 'kubernetesListRoutes', { value: vi.fn() });
+  Object.defineProperty(window, 'showMessageBox', { value: showMessageBoxMock });
+  Object.defineProperty(window, 'openExternal', { value: openExternalMock });
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  vi.mocked(window.kubernetesListRoutes).mockResolvedValue([]);
+
+  kubernetesGetCurrentNamespaceMock.mockResolvedValue('ns');
+  kubernetesReadNamespacedPodMock.mockResolvedValue({ metadata: { labels: { app: 'foo' } } });
+});
+
+test('Check deleting pod', async () => {
+  showMessageBoxMock.mockResolvedValue({ response: 0 });
+
+  render(PodActions, { pod, onUpdate: updateMock });
+
+  // click on delete button
+  const deleteButton = screen.getByRole('button', { name: 'Delete Pod' });
+  await fireEvent.click(deleteButton);
+  expect(showMessageBoxMock).toHaveBeenCalledOnce();
+
+  // Wait for confirmation modal to disappear after clicking on delete
+  await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+
+  expect(pod.status).toEqual('DELETING');
+  expect(updateMock).toHaveBeenCalled();
+  expect(deleteMock).toHaveBeenCalled();
+});
+
+test('Check restarting pod', async () => {
+  showMessageBoxMock.mockResolvedValue({ response: 0 });
+
+  render(PodActions, { pod, onUpdate: updateMock });
+
+  // click on restart button
+  const restartButton = screen.getByRole('button', { name: 'Restart Pod' });
+  await fireEvent.click(restartButton);
+
+  expect(pod.status).toEqual('RESTARTING');
+  expect(updateMock).toHaveBeenCalled();
+  expect(restartMock).toHaveBeenCalled();
+});
+
+test('Expect kubernetes route to be displayed', async () => {
+  const routeName = 'route.name';
+  const routeHost = 'host.local';
+
+  vi.mocked(window.kubernetesListRoutes).mockResolvedValue([
+    { metadata: { labels: { app: 'foo' }, name: routeName }, spec: { host: routeHost } } as unknown as V1Route,
+  ]);
+
+  render(PodActions, { pod: pod });
+
+  const openRouteButton = await screen.findByRole('button', { name: `Open ${routeName}` });
+  expect(openRouteButton).toBeVisible();
+
+  await fireEvent.click(openRouteButton);
+
+  expect(openExternalMock).toHaveBeenCalledWith(`http://${routeHost}`);
+});
+
+test('Expect kubernetes route to be displayed but disabled', async () => {
+  render(PodActions, { pod: pod });
+
+  const openRouteButton = await screen.findByRole('button', { name: `Open Browser` });
+  expect(openRouteButton).toBeVisible();
+  expect(openRouteButton).toBeDisabled();
+});
+
+test('Expect kubernetes routes kebab menu to be displayed', async () => {
+  vi.mocked(window.kubernetesListRoutes).mockResolvedValue([
+    { metadata: { labels: { app: 'foo' }, name: 'route1.name' }, spec: { host: 'host1.local' } } as unknown as V1Route,
+    { metadata: { labels: { app: 'foo' }, name: 'route2.name' }, spec: { host: 'host2.local' } } as unknown as V1Route,
+  ]);
+
+  render(PodActions, { pod: pod });
+
+  const openRouteButton = await screen.findByRole('button', { name: 'Open Kubernetes Routes' });
+  expect(openRouteButton).toBeVisible();
+
+  await fireEvent.click(openRouteButton);
+
+  const routesDropDownMenu = await screen.findByTitle('Drop Down Menu Items');
+  expect(routesDropDownMenu).toBeVisible();
+});

--- a/packages/renderer/src/lib/kube/pods/PodActions.svelte
+++ b/packages/renderer/src/lib/kube/pods/PodActions.svelte
@@ -1,0 +1,114 @@
+<script lang="ts">
+import { faArrowsRotate, faExternalLinkSquareAlt, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { DropdownMenu } from '@podman-desktop/ui-svelte';
+import { createEventDispatcher, onMount } from 'svelte';
+
+import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
+
+import FlatMenu from '../../ui/FlatMenu.svelte';
+import ListItemButtonIcon from '../../ui/ListItemButtonIcon.svelte';
+import type { PodUI } from './PodUI';
+
+export let pod: PodUI;
+export let dropdownMenu = false;
+export let detailed = false;
+
+const dispatch = createEventDispatcher<{ update: PodUI }>();
+export let onUpdate: (update: PodUI) => void = update => {
+  dispatch('update', update);
+};
+
+$: openingKubernetesUrls = new Map();
+
+onMount(async () => {
+  const ns = await window.kubernetesGetCurrentNamespace();
+  if (ns) {
+    const kubepod = await window.kubernetesReadNamespacedPod(pod.name, ns);
+    if (kubepod?.metadata?.labels?.app) {
+      const appName = kubepod.metadata.labels.app;
+      const routes = await window.kubernetesListRoutes();
+      const appRoutes = routes.filter(r => r.metadata.labels && r.metadata.labels['app'] === appName);
+      appRoutes.forEach(route => {
+        openingKubernetesUrls = openingKubernetesUrls.set(
+          route.metadata.name,
+          route.spec.tls ? `https://${route.spec.host}` : `http://${route.spec.host}`,
+        );
+      });
+    }
+  }
+});
+
+async function restartPod(): Promise<void> {
+  pod.status = 'RESTARTING';
+  onUpdate(pod);
+
+  await window.restartKubernetesPod(pod.name);
+}
+
+async function deletePod(): Promise<void> {
+  pod.status = 'DELETING';
+  onUpdate(pod);
+
+  await window.kubernetesDeletePod(pod.name);
+}
+
+// If dropdownMenu = true, we'll change style to the imported dropdownMenu style
+// otherwise, leave blank.
+let actionsStyle: typeof DropdownMenu | typeof FlatMenu;
+if (dropdownMenu) {
+  actionsStyle = DropdownMenu;
+} else {
+  actionsStyle = FlatMenu;
+}
+</script>
+
+<ListItemButtonIcon
+  title="Delete Pod"
+  onClick={():void => withConfirmation(deletePod, `delete pod ${pod.name}`)}
+  icon={faTrash}
+  detailed={detailed}/>
+
+<!-- If dropdownMenu is true, use it, otherwise just show the regular buttons -->
+<svelte:component this={actionsStyle}>
+  <ListItemButtonIcon
+    title="Restart Pod"
+    onClick={restartPod}
+    menu={dropdownMenu}
+    detailed={detailed}
+    icon={faArrowsRotate} />
+    {#if openingKubernetesUrls.size === 0}
+      <ListItemButtonIcon
+        title="Open Browser"
+        menu={dropdownMenu}
+        enabled={false}
+        hidden={dropdownMenu}
+        detailed={detailed}
+        icon={faExternalLinkSquareAlt} />
+    {:else if openingKubernetesUrls.size === 1}
+      <ListItemButtonIcon
+        title="Open {[...openingKubernetesUrls][0][0]}"
+        onClick={(): Promise<void> => window.openExternal([...openingKubernetesUrls][0][1])}
+        menu={dropdownMenu}
+        enabled={pod.status === 'RUNNING'}
+        hidden={dropdownMenu}
+        detailed={detailed}
+        icon={faExternalLinkSquareAlt} />
+    {:else if openingKubernetesUrls.size > 1}
+      <DropdownMenu
+        title="Open Kubernetes Routes"
+        icon={faExternalLinkSquareAlt}
+        hidden={dropdownMenu}
+        shownAsMenuActionItem={true}>
+        {#each Array.from(openingKubernetesUrls) as [routeName, routeHost]}
+          <ListItemButtonIcon
+            title="Open {routeName}"
+            onClick={(): Promise<void>  => window.openExternal(routeHost)}
+            menu={!dropdownMenu}
+            enabled={pod.status === 'RUNNING'}
+            hidden={dropdownMenu}
+            detailed={detailed}
+            icon={faExternalLinkSquareAlt} />
+        {/each}
+      </DropdownMenu>
+    {/if}
+</svelte:component>

--- a/packages/renderer/src/lib/kube/pods/PodColumnActions.spec.ts
+++ b/packages/renderer/src/lib/kube/pods/PodColumnActions.spec.ts
@@ -1,0 +1,40 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import PodColumnActions from './PodColumnActions.svelte';
+import type { PodUI } from './PodUI';
+
+test('Expect action buttons', async () => {
+  const pod: PodUI = {
+    name: '',
+    status: '',
+    selected: false,
+    containers: [],
+    namespace: '',
+  };
+
+  render(PodColumnActions, { object: pod });
+
+  const buttons = await screen.findAllByRole('button');
+  expect(buttons).toHaveLength(2);
+});

--- a/packages/renderer/src/lib/kube/pods/PodColumnActions.svelte
+++ b/packages/renderer/src/lib/kube/pods/PodColumnActions.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+import PodActions from './PodActions.svelte';
+import type { PodUI } from './PodUI';
+
+let {
+  object,
+}: {
+  object: PodUI;
+} = $props();
+</script>
+
+<PodActions pod={object} dropdownMenu={true} on:update />

--- a/packages/renderer/src/lib/kube/pods/PodColumnContainers.spec.ts
+++ b/packages/renderer/src/lib/kube/pods/PodColumnContainers.spec.ts
@@ -1,0 +1,47 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import PodColumnContainers from './PodColumnContainers.svelte';
+import type { PodUI } from './PodUI';
+
+const pod: PodUI = {
+  name: '',
+  status: '',
+  selected: false,
+  containers: [
+    {
+      Id: 'container1',
+      Names: 'container1',
+      Status: 'RUNNING',
+    },
+  ],
+  namespace: '',
+};
+
+test('Expect simple column styling', async () => {
+  render(PodColumnContainers, { object: pod });
+
+  const dot = screen.getByTestId('status-dot');
+  expect(dot).toBeInTheDocument();
+  expect(dot).toHaveClass('bg-[var(--pd-status-running)]');
+});

--- a/packages/renderer/src/lib/kube/pods/PodColumnContainers.svelte
+++ b/packages/renderer/src/lib/kube/pods/PodColumnContainers.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+import Dots from '../../ui/Dots.svelte';
+import type { PodUI } from './PodUI';
+
+let {
+  object,
+}: {
+  object: PodUI;
+} = $props();
+</script>
+
+<Dots containers={object.containers} />

--- a/packages/renderer/src/lib/kube/pods/PodColumnName.spec.ts
+++ b/packages/renderer/src/lib/kube/pods/PodColumnName.spec.ts
@@ -1,0 +1,46 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import PodColumnName from './PodColumnName.svelte';
+import type { PodUI } from './PodUI';
+
+const pod: PodUI = {
+  name: 'my-pod',
+  status: '',
+  selected: false,
+  containers: [],
+  node: 'node1',
+  namespace: 'default',
+};
+
+test('Expect simple column styling', async () => {
+  render(PodColumnName, { object: pod });
+
+  const text = screen.getByText(pod.name);
+  expect(text).toBeInTheDocument();
+  expect(text).toHaveClass('text-[var(--pd-table-body-text-highlight)]');
+
+  const id = screen.getByText(pod.namespace);
+  expect(id).toBeInTheDocument();
+  expect(id).toHaveClass('text-[var(--pd-table-body-text)]');
+});

--- a/packages/renderer/src/lib/kube/pods/PodColumnName.svelte
+++ b/packages/renderer/src/lib/kube/pods/PodColumnName.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import type { PodUI } from './PodUI';
+
+let {
+  object,
+}: {
+  object: PodUI;
+} = $props();
+</script>
+
+<div class="flex flex-col max-w-full">
+  <div class="text-[var(--pd-table-body-text-highlight)] max-w-full overflow-hidden text-ellipsis">
+    {object.name}
+  </div>
+  <div class="flex flex-row text-sm gap-1">
+    {#if object.namespace}
+      <div class="font-extra-light text-[var(--pd-table-body-text)]">{object.namespace}</div>
+    {/if}
+  </div>
+</div>

--- a/packages/renderer/src/lib/kube/pods/PodColumnStatus.spec.ts
+++ b/packages/renderer/src/lib/kube/pods/PodColumnStatus.spec.ts
@@ -1,0 +1,41 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import PodColumnStatus from './PodColumnStatus.svelte';
+import type { PodUI } from './PodUI';
+
+const pod: PodUI = {
+  name: '',
+  status: 'RUNNING',
+  selected: false,
+  containers: [],
+  namespace: '',
+};
+
+test('Expect simple column styling', async () => {
+  render(PodColumnStatus, { object: pod });
+
+  const status = screen.getByRole('status');
+  expect(status).toBeInTheDocument();
+  expect(status).toHaveClass('bg-[var(--pd-status-running)]');
+});

--- a/packages/renderer/src/lib/kube/pods/PodColumnStatus.svelte
+++ b/packages/renderer/src/lib/kube/pods/PodColumnStatus.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+import { StatusIcon } from '@podman-desktop/ui-svelte';
+
+import PodIcon from '../../images/PodIcon.svelte';
+import type { PodUI } from './PodUI';
+
+let {
+  object,
+}: {
+  object: PodUI;
+} = $props();
+</script>
+
+<StatusIcon icon={PodIcon} status={object.status} />

--- a/packages/renderer/src/lib/kube/pods/PodUI.ts
+++ b/packages/renderer/src/lib/kube/pods/PodUI.ts
@@ -1,0 +1,29 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { PodInfoContainerUI } from '../../pod/PodInfoUI';
+
+export interface PodUI {
+  name: string;
+  status: string;
+  namespace: string;
+  created?: Date;
+  selected: boolean;
+  node?: string;
+  containers: PodInfoContainerUI[];
+}

--- a/packages/renderer/src/lib/kube/pods/PodsList.spec.ts
+++ b/packages/renderer/src/lib/kube/pods/PodsList.spec.ts
@@ -1,0 +1,236 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import type { KubernetesObject, V1Pod } from '@kubernetes/client-node';
+import { fireEvent, render, screen, within } from '@testing-library/svelte';
+import { writable } from 'svelte/store';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import * as states from '/@/stores/kubernetes-contexts-state';
+
+import PodsList from './PodsList.svelte';
+
+vi.mock('/@/stores/kubernetes-contexts-state');
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.clearAllMocks();
+  vi.mocked(states).podSearchPattern = writable<string>('');
+  vi.mocked(states).kubernetesContextsCheckingStateDelayed = writable();
+  vi.mocked(states).kubernetesCurrentContextState = writable();
+});
+
+test('Expect pod empty screen', async () => {
+  vi.mocked(states).kubernetesCurrentContextPodsFiltered = writable<KubernetesObject[]>([]);
+  render(PodsList);
+  const noPods = screen.getByRole('heading', { name: 'No pods' });
+  expect(noPods).toBeInTheDocument();
+});
+
+test('Expect pods list', async () => {
+  const pod: V1Pod = {
+    apiVersion: 'v1',
+    kind: 'Pod',
+    metadata: { name: 'my-pod', namespace: 'default' },
+    spec: {
+      containers: [
+        {
+          name: 'test-container',
+          ports: [{ name: 'http', containerPort: 8080 }],
+        },
+      ],
+    },
+  };
+  vi.mocked(states).kubernetesCurrentContextPodsFiltered = writable<KubernetesObject[]>([pod]);
+
+  render(PodsList);
+  const podName = screen.getByRole('cell', { name: 'my-pod default' });
+  expect(podName).toBeInTheDocument();
+});
+
+test('Expect correct column overflow', async () => {
+  const pod: V1Pod = {
+    apiVersion: 'v1',
+    kind: 'Pod',
+    metadata: { name: 'my-pod', namespace: 'default' },
+    spec: {
+      containers: [
+        {
+          name: 'test-container',
+          ports: [{ name: 'http', containerPort: 8080 }],
+        },
+      ],
+    },
+  };
+  vi.mocked(states).kubernetesCurrentContextPodsFiltered = writable<KubernetesObject[]>([pod]);
+
+  render(PodsList);
+  const rows = await screen.findAllByRole('row');
+  expect(rows).toBeDefined();
+  expect(rows.length).toBe(2);
+
+  const cells = await within(rows[1]).findAllByRole('cell');
+  expect(cells).toBeDefined();
+  expect(cells.length).toBe(7);
+
+  expect(cells[2]).toHaveClass('overflow-hidden');
+  expect(cells[3]).toHaveClass('overflow-hidden');
+  expect(cells[4]).not.toHaveClass('overflow-hidden');
+  expect(cells[5]).toHaveClass('overflow-hidden');
+});
+
+test('Expect filter empty screen', async () => {
+  vi.mocked(states).kubernetesCurrentContextPodsFiltered = writable<KubernetesObject[]>([]);
+
+  render(PodsList, { searchTerm: 'No match' });
+  const filterButton = screen.getByRole('button', { name: 'Clear filter' });
+  expect(filterButton).toBeInTheDocument();
+});
+
+test('Expect user confirmation to pop up when preferences require', async () => {
+  const pod: V1Pod = {
+    apiVersion: 'v1',
+    kind: 'Pod',
+    metadata: { name: 'my-pod', namespace: 'default' },
+    spec: {
+      containers: [
+        {
+          name: 'test-container',
+          ports: [{ name: 'http', containerPort: 8080 }],
+        },
+      ],
+    },
+  };
+  vi.mocked(states).kubernetesCurrentContextPodsFiltered = writable<KubernetesObject[]>([pod]);
+
+  render(PodsList);
+
+  const checkboxes = screen.getAllByRole('checkbox', { name: 'Toggle pod' });
+  await fireEvent.click(checkboxes[0]);
+
+  vi.mocked(window.getConfigurationValue).mockResolvedValue(true);
+
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 1 });
+
+  const deleteButton = screen.getByRole('button', { name: 'Delete 1 selected items' });
+  await fireEvent.click(deleteButton);
+
+  expect(window.showMessageBox).toHaveBeenCalledOnce();
+
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  await fireEvent.click(deleteButton);
+  expect(window.showMessageBox).toHaveBeenCalledTimes(2);
+  await vi.waitFor(() => expect(window.kubernetesDeletePod).toHaveBeenCalled());
+});
+
+test('pods list is updated when kubernetesCurrentContextPodsFiltered changes', async () => {
+  const pod1: V1Pod = {
+    apiVersion: 'v1',
+    kind: 'Pod',
+    metadata: { name: 'my-pod-1', namespace: 'test-namespace' },
+    spec: {
+      containers: [
+        {
+          name: 'test-container',
+          ports: [{ name: 'http', containerPort: 8080 }],
+        },
+      ],
+    },
+  };
+  const pod2: V1Pod = {
+    apiVersion: 'v1',
+    kind: 'Pod',
+    metadata: { name: 'my-pod-2', namespace: 'test-namespace' },
+    spec: {
+      containers: [
+        {
+          name: 'test-container',
+          ports: [{ name: 'http', containerPort: 8080 }],
+        },
+      ],
+    },
+  };
+  const filtered = writable<KubernetesObject[]>([pod1, pod2]);
+  vi.mocked(states).kubernetesCurrentContextPodsFiltered = filtered;
+
+  const component = render(PodsList);
+  const podName1 = screen.getByRole('cell', { name: 'my-pod-1 test-namespace' });
+  expect(podName1).toBeInTheDocument();
+  const podName2 = screen.getByRole('cell', { name: 'my-pod-2 test-namespace' });
+  expect(podName2).toBeInTheDocument();
+
+  filtered.set([pod2]);
+  await component.rerender({});
+
+  const podName1after = screen.queryByRole('cell', { name: 'my-pod-1 test-namespace' });
+  expect(podName1after).not.toBeInTheDocument();
+  const podName2after = screen.getByRole('cell', { name: 'my-pod-2 test-namespace' });
+  expect(podName2after).toBeInTheDocument();
+});
+
+test('Expect the pod1 row to have 3 status dots with the correct colors and the pod2 row to have 1 status dot', async () => {
+  const pod: V1Pod = {
+    apiVersion: 'v1',
+    kind: 'Pod',
+    metadata: { name: 'my-pod-1', namespace: 'test-namespace' },
+    status: {
+      containerStatuses: [
+        {
+          containerID: 'container-1',
+          name: 'container-1-name',
+          state: {
+            waiting: {},
+          },
+        },
+        {
+          containerID: 'container-2',
+          name: 'container-2-name',
+          state: {
+            terminated: {},
+          },
+        },
+        {
+          containerID: 'container-3',
+          name: 'container-3-name',
+          state: {
+            running: {},
+          },
+        },
+      ],
+    },
+  } as unknown as V1Pod;
+  const filtered = writable<KubernetesObject[]>([pod]);
+  vi.mocked(states).kubernetesCurrentContextPodsFiltered = filtered;
+
+  render(PodsList);
+
+  // Should render 3 status dots, reordered
+  const statusDots = screen.getAllByTestId('status-dot');
+  expect(statusDots.length).toBe(3);
+
+  expect(statusDots[0].title).toBe('container-3-name: Running');
+  expect(statusDots[0]).toHaveClass('bg-[var(--pd-status-running)]');
+
+  expect(statusDots[1].title).toBe('container-1-name: Waiting');
+  expect(statusDots[1]).toHaveClass('bg-[var(--pd-status-waiting)]');
+
+  expect(statusDots[2].title).toBe('container-2-name: Terminated');
+  expect(statusDots[2]).toHaveClass('bg-[var(--pd-status-terminated)]');
+});

--- a/packages/renderer/src/lib/kube/pods/PodsList.svelte
+++ b/packages/renderer/src/lib/kube/pods/PodsList.svelte
@@ -1,0 +1,151 @@
+<script lang="ts">
+import { faTrash } from '@fortawesome/free-solid-svg-icons';
+import {
+  Button,
+  FilteredEmptyScreen,
+  NavPage,
+  Table,
+  TableColumn,
+  TableDurationColumn,
+  TableRow,
+} from '@podman-desktop/ui-svelte';
+import moment from 'moment';
+
+import KubernetesCurrentContextConnectionBadge from '/@/lib/ui/KubernetesCurrentContextConnectionBadge.svelte';
+import { kubernetesCurrentContextPodsFiltered, podSearchPattern } from '/@/stores/kubernetes-contexts-state';
+
+import { withBulkConfirmation } from '../../actions/BulkActions';
+import PodIcon from '../../images/PodIcon.svelte';
+import PodEmptyScreen from '../../pod/PodEmptyScreen.svelte';
+import KubeApplyYamlButton from '../KubeApplyYAMLButton.svelte';
+import { PodUtils } from './pod-utils';
+import PodColumnActions from './PodColumnActions.svelte';
+import PodColumnContainers from './PodColumnContainers.svelte';
+import PodColumnName from './PodColumnName.svelte';
+import PodColumnStatus from './PodColumnStatus.svelte';
+import type { PodUI } from './PodUI';
+
+let {
+  searchTerm = '',
+}: {
+  searchTerm?: string;
+} = $props();
+
+$effect(() => {
+  podSearchPattern.set(searchTerm);
+});
+
+const podUtils = new PodUtils();
+const pods = $derived($kubernetesCurrentContextPodsFiltered.map(pod => podUtils.getPodUI(pod)));
+
+// delete the items selected in the list
+let bulkDeleteInProgress = $state<boolean>(false);
+async function deleteSelectedPods(): Promise<void> {
+  const selectedPods = pods.filter(pod => pod.selected);
+  if (selectedPods.length === 0) {
+    return;
+  }
+
+  // mark pods for deletion
+  bulkDeleteInProgress = true;
+  selectedPods.forEach(pod => (pod.status = 'DELETING'));
+
+  await Promise.all(
+    selectedPods.map(async pod => {
+      try {
+        await window.kubernetesDeletePod(pod.name);
+      } catch (e) {
+        console.error('error while deleting pod', e);
+      }
+    }),
+  );
+  bulkDeleteInProgress = false;
+}
+
+let selectedItemsNumber = $state<number>(0);
+let table: Table;
+
+let statusColumn = new TableColumn<PodUI>('Status', {
+  align: 'center',
+  width: '70px',
+  renderer: PodColumnStatus,
+  comparator: (a, b): number => b.status.localeCompare(a.status),
+});
+
+let nameColumn = new TableColumn<PodUI>('Name', {
+  width: '2fr',
+  renderer: PodColumnName,
+  comparator: (a, b): number => a.name.localeCompare(b.name),
+});
+
+let containersColumn = new TableColumn<PodUI>('Containers', {
+  renderer: PodColumnContainers,
+  comparator: (a, b): number => a.containers.length - b.containers.length,
+  initialOrder: 'descending',
+  overflow: true,
+});
+
+let ageColumn = new TableColumn<PodUI, Date | undefined>('Age', {
+  renderMapping: (pod): Date | undefined => pod.created,
+  renderer: TableDurationColumn,
+  comparator: (a, b): number => moment(b.created).diff(moment(a.created)),
+});
+
+const columns = [
+  statusColumn,
+  nameColumn,
+  containersColumn,
+  ageColumn,
+  new TableColumn<PodUI>('Actions', { align: 'right', width: '150px', renderer: PodColumnActions, overflow: true }),
+];
+
+const row = new TableRow<PodUI>({ selectable: (_pod): boolean => true });
+</script>
+
+<NavPage bind:searchTerm={searchTerm} title="pods">
+  <svelte:fragment slot="additional-actions">
+    <KubeApplyYamlButton />
+  </svelte:fragment>
+
+  <svelte:fragment slot="bottom-additional-actions">
+    {#if selectedItemsNumber > 0}
+      <Button
+        on:click={(): void =>
+          withBulkConfirmation(
+            deleteSelectedPods,
+            `delete ${selectedItemsNumber} pod${selectedItemsNumber > 1 ? 's' : ''}`,
+          )}
+        title="Delete {selectedItemsNumber} selected items"
+        inProgress={bulkDeleteInProgress}
+        icon={faTrash} />
+      <span>On {selectedItemsNumber} selected items.</span>
+    {/if}
+    <div class="flex grow justify-end">
+      <KubernetesCurrentContextConnectionBadge />
+    </div>
+  </svelte:fragment>
+
+  <div class="flex min-w-full h-full" slot="content">
+    <Table
+      kind="pod"
+      bind:this={table}
+      bind:selectedItemsNumber={selectedItemsNumber}
+      data={pods}
+      columns={columns}
+      row={row}
+      defaultSortColumn="Name">
+    </Table>
+
+    {#if $kubernetesCurrentContextPodsFiltered.length === 0}
+      {#if searchTerm}
+        <FilteredEmptyScreen
+          icon={PodIcon}
+          kind="pods"
+          searchTerm={searchTerm}
+          on:resetFilter={(): string => (searchTerm = '')} />
+      {:else}
+        <PodEmptyScreen />
+      {/if}
+    {/if}
+  </div>
+</NavPage>

--- a/packages/renderer/src/lib/kube/pods/pod-utils.spec.ts
+++ b/packages/renderer/src/lib/kube/pods/pod-utils.spec.ts
@@ -1,0 +1,83 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1Pod } from '@kubernetes/client-node';
+import { expect, test } from 'vitest';
+
+import { PodUtils } from './pod-utils';
+
+const podUtils = new PodUtils();
+const podInfo = {
+  apiVersion: 'v1',
+  kind: 'Pod',
+  metadata: { name: 'my-pod', namespace: 'test-namespace' },
+  status: {
+    containerStatuses: [
+      {
+        containerID: 'container-1',
+        name: 'container-1-name',
+        state: {
+          running: {},
+        },
+      },
+      {
+        containerID: 'container-2',
+        name: 'container-2-name',
+        state: {
+          terminated: {},
+        },
+      },
+      {
+        containerID: 'container-3',
+        name: 'container-3-name',
+        state: {
+          waiting: {},
+        },
+      },
+    ],
+  },
+  spec: {
+    nodeName: 'test-node',
+  },
+} as unknown as V1Pod;
+
+test('Expect to get node and namespace from pod info', () => {
+  const pod = podUtils.getPodUI(podInfo);
+
+  expect(pod.name).toBe('my-pod');
+  expect(pod.node).toBe('test-node');
+  expect(pod.namespace).toBe('test-namespace');
+});
+
+test('Expect to get container status from pod info', () => {
+  const pod = podUtils.getPodUI(podInfo);
+
+  expect(pod.containers).toHaveLength(3);
+
+  expect(pod.containers[0].Id).toBe('container-1');
+  expect(pod.containers[0].Names).toBe('container-1-name');
+  expect(pod.containers[0].Status).toBe('running');
+
+  expect(pod.containers[1].Id).toBe('container-2');
+  expect(pod.containers[1].Names).toBe('container-2-name');
+  expect(pod.containers[1].Status).toBe('terminated');
+
+  expect(pod.containers[2].Id).toBe('container-3');
+  expect(pod.containers[2].Names).toBe('container-3-name');
+  expect(pod.containers[2].Status).toBe('waiting');
+});

--- a/packages/renderer/src/lib/kube/pods/pod-utils.ts
+++ b/packages/renderer/src/lib/kube/pods/pod-utils.ts
@@ -1,0 +1,61 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1ContainerState, V1Pod } from '@kubernetes/client-node';
+
+import type { PodUI } from './PodUI';
+
+export class PodUtils {
+  getStatus(status: string | undefined): string {
+    return (status ?? '').toUpperCase();
+  }
+
+  toContainerStatus(state: V1ContainerState | undefined): string {
+    if (state) {
+      if (state.running) {
+        return 'running';
+      } else if (state.terminated) {
+        return 'terminated';
+      } else if (state.waiting) {
+        return 'waiting';
+      }
+    }
+    return 'unknown';
+  }
+
+  getPodUI(pod: V1Pod): PodUI {
+    const containers =
+      pod.status?.containerStatuses?.map(status => {
+        return {
+          Id: status.containerID ?? '',
+          Names: status.name,
+          Status: this.toContainerStatus(status.state),
+        };
+      }) ?? [];
+
+    return {
+      name: pod.metadata?.name ?? '',
+      status: this.getStatus(pod.metadata?.deletionTimestamp ? 'DELETING' : (pod.status?.phase ?? '')),
+      created: pod.metadata?.creationTimestamp,
+      containers: containers,
+      selected: false,
+      node: pod.spec?.nodeName,
+      namespace: pod.metadata?.namespace ?? '',
+    };
+  }
+}

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-pods.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-pods.svelte.spec.ts
@@ -17,44 +17,35 @@
  ***********************************************************************/
 
 import type { KubernetesObject } from '@kubernetes/client-node';
-import { beforeEach, expect, test, vi } from 'vitest';
+import { expect, test, vi } from 'vitest';
 
-import { createNavigationKubernetesDeploymentsEntry } from './navigation-registry-k8s-deployments.svelte';
-
-beforeEach(() => {
-  vi.resetAllMocks();
-  Object.defineProperty(window, 'kubernetesRegisterGetCurrentContextResources', {
-    value: kubernetesRegisterGetCurrentContextResourcesMock,
-  });
-});
-
-const kubernetesRegisterGetCurrentContextResourcesMock = vi.fn();
+import { createNavigationKubernetesPodsEntry } from './navigation-registry-k8s-pods.svelte';
 
 test('createNavigationKubernetesDeploymentsEntry', async () => {
-  const nodes: KubernetesObject[] = [
+  const pods: KubernetesObject[] = [
     {
       apiVersion: 'v1',
-      kind: 'Node',
+      kind: 'Pod',
       metadata: {
-        name: 'node1',
+        name: 'pod1',
       },
     },
     {
       apiVersion: 'v1',
-      kind: 'Node',
+      kind: 'Pod',
       metadata: {
-        name: 'node2',
+        name: 'pod2',
       },
     },
   ];
-  kubernetesRegisterGetCurrentContextResourcesMock.mockResolvedValue(nodes);
+  vi.mocked(window.kubernetesRegisterGetCurrentContextResources).mockResolvedValue(pods);
 
-  const entry = createNavigationKubernetesDeploymentsEntry();
+  const entry = createNavigationKubernetesPodsEntry();
 
   expect(entry).toBeDefined();
-  expect(entry.name).toBe('Deployments');
-  expect(entry.link).toBe('/kubernetes/deployments');
-  expect(entry.tooltip).toBe('Deployments');
+  expect(entry.name).toBe('Pods');
+  expect(entry.link).toBe('/kubernetes/pods');
+  expect(entry.tooltip).toBe('Pods');
   await vi.waitFor(() => {
     expect(entry.counter).toBe(2);
   });

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-pods.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-pods.svelte.spec.ts
@@ -1,0 +1,61 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject } from '@kubernetes/client-node';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { createNavigationKubernetesDeploymentsEntry } from './navigation-registry-k8s-deployments.svelte';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  Object.defineProperty(window, 'kubernetesRegisterGetCurrentContextResources', {
+    value: kubernetesRegisterGetCurrentContextResourcesMock,
+  });
+});
+
+const kubernetesRegisterGetCurrentContextResourcesMock = vi.fn();
+
+test('createNavigationKubernetesDeploymentsEntry', async () => {
+  const nodes: KubernetesObject[] = [
+    {
+      apiVersion: 'v1',
+      kind: 'Node',
+      metadata: {
+        name: 'node1',
+      },
+    },
+    {
+      apiVersion: 'v1',
+      kind: 'Node',
+      metadata: {
+        name: 'node2',
+      },
+    },
+  ];
+  kubernetesRegisterGetCurrentContextResourcesMock.mockResolvedValue(nodes);
+
+  const entry = createNavigationKubernetesDeploymentsEntry();
+
+  expect(entry).toBeDefined();
+  expect(entry.name).toBe('Deployments');
+  expect(entry.link).toBe('/kubernetes/deployments');
+  expect(entry.tooltip).toBe('Deployments');
+  await vi.waitFor(() => {
+    expect(entry.counter).toBe(2);
+  });
+});

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-pods.svelte.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-pods.svelte.ts
@@ -1,0 +1,41 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import PodIcon from '/@/lib/images/PodIcon.svelte';
+
+import { kubernetesCurrentContextPods } from '../../kubernetes-contexts-state';
+import type { NavigationRegistryEntry } from '../navigation-registry';
+
+let count = $state(0);
+
+export function createNavigationKubernetesPodsEntry(): NavigationRegistryEntry {
+  kubernetesCurrentContextPods.subscribe(pods => {
+    count = pods.length;
+  });
+  const registry: NavigationRegistryEntry = {
+    name: 'Pods',
+    icon: { iconComponent: PodIcon },
+    link: '/kubernetes/pods',
+    tooltip: 'Pods',
+    type: 'entry',
+    get counter() {
+      return count;
+    },
+  };
+  return registry;
+}

--- a/packages/renderer/src/stores/navigation/navigation-registry-kubernetes.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-kubernetes.svelte.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,6 +55,7 @@ test('createNavigationImageEntry with current context', async () => {
   vi.mocked(kubeContextStore).kubernetesCurrentContextState = readable<ContextGeneralState>({} as ContextGeneralState);
   vi.mocked(kubeContextStore).kubernetesCurrentContextNodes = readable<KubernetesObject[]>(nodes);
   vi.mocked(kubeContextStore).kubernetesCurrentContextDeployments = readable<KubernetesObject[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextPods = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextServices = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextIngresses = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextRoutes = readable<KubernetesObject[]>([]);
@@ -69,9 +70,9 @@ test('createNavigationImageEntry with current context', async () => {
   expect(entry.name).toBe('Kubernetes');
   expect(entry.icon.iconComponent).toBe(KubeIcon);
 
-  // should have 8 items
+  // should have 9 items
   await vi.waitFor(() => {
-    expect(entry.items?.length).toBe(8);
+    expect(entry.items?.length).toBe(9);
   });
 });
 
@@ -81,6 +82,7 @@ test('createNavigationImageEntry without current context', async () => {
   } as ContextGeneralState);
   vi.mocked(kubeContextStore).kubernetesCurrentContextNodes = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextDeployments = readable<KubernetesObject[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextPods = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextServices = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextIngresses = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextRoutes = readable<KubernetesObject[]>([]);

--- a/packages/renderer/src/stores/navigation/navigation-registry-kubernetes.svelte.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-kubernetes.svelte.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import { createNavigationKubernetesDeploymentsEntry } from './kubernetes/navigat
 import { createNavigationKubernetesIngressesRoutesEntry } from './kubernetes/navigation-registry-k8s-ingresses-routes.svelte';
 import { createNavigationKubernetesNodesEntry } from './kubernetes/navigation-registry-k8s-nodes.svelte';
 import { createNavigationKubernetesPersistentVolumeEntry } from './kubernetes/navigation-registry-k8s-persistent-volume.svelte';
+import { createNavigationKubernetesPodsEntry } from './kubernetes/navigation-registry-k8s-pods.svelte';
 import { createNavigationKubernetesServicesEntry } from './kubernetes/navigation-registry-k8s-services.svelte';
 import type { NavigationRegistryEntry } from './navigation-registry';
 
@@ -42,6 +43,7 @@ export function createNavigationKubernetesGroup(): NavigationRegistryEntry {
   newItems.push(createNavigationKubernetesDashboardEntry());
   newItems.push(createNavigationKubernetesNodesEntry());
   newItems.push(createNavigationKubernetesDeploymentsEntry());
+  newItems.push(createNavigationKubernetesPodsEntry());
   newItems.push(createNavigationKubernetesServicesEntry());
   newItems.push(createNavigationKubernetesIngressesRoutesEntry());
   newItems.push(createNavigationKubernetesPersistentVolumeEntry());


### PR DESCRIPTION
### What does this PR do?

Adds a Kubernetes Pods page, similar to Deployments/Services/etc, but with the same columns and actions as the Kubernetes pods in the current Pods page.

Given the number of files just to add the page, this commit intentionally does not include a details page. That would come in following PRs.

Since we already have a PodsList in src/lib/pod, I've put this in /src/lib/kube/pods, not sure if there is a better location or we should start organizing Kube folders differently.

### Screenshot / video of UI

<img width="887" alt="Screenshot 2025-01-27 at 4 39 47 PM" src="https://github.com/user-attachments/assets/a19083bd-8c17-4861-b1a5-59d38e34fcc9" />
<img width="706" alt="Screenshot 2025-01-27 at 4 40 18 PM" src="https://github.com/user-attachments/assets/5a3878ae-110c-4f4f-863d-b23cc5d4acb9" />

### What issues does this PR fix or reference?

Part of #8818.

### How to test this PR?

Connect to a Kube cluster and work with Pods; compare to other pages.

- [x] Tests are covering the bug fix or the new feature