### PR TITLE
feat: display deployments from experimental informers

### DIFF
--- a/packages/renderer/src/lib/deployments/DeploymentsList.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentsList.spec.ts
@@ -21,13 +21,16 @@ import '@testing-library/jest-dom/vitest';
 import type { KubernetesObject, V1Deployment } from '@kubernetes/client-node';
 import { fireEvent, render, screen, within } from '@testing-library/svelte';
 import { writable } from 'svelte/store';
-import { beforeEach, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import * as states from '/@/stores/kubernetes-contexts-state';
+import type { KubernetesContextResources } from '/@api/kubernetes-resources';
 
+import * as resourcesListen from '../kube/resources-listen';
 import DeploymentsList from './DeploymentsList.svelte';
 
 vi.mock('/@/stores/kubernetes-contexts-state');
+vi.mock('../kube/resources-listen');
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -37,152 +40,230 @@ beforeEach(() => {
   vi.mocked(states).kubernetesCurrentContextState = writable();
 });
 
-test('Expect deployment empty screen', async () => {
-  vi.mocked(states).kubernetesCurrentContextDeploymentsFiltered = writable<KubernetesObject[]>([]);
-  render(DeploymentsList);
-  const noDeployments = screen.getByRole('heading', { name: 'No deployments' });
-  expect(noDeployments).toBeInTheDocument();
-});
-
-test('Expect deployments list', async () => {
-  const deployment: V1Deployment = {
-    apiVersion: 'apps/v1',
-    kind: 'Deployment',
-    metadata: {
-      name: 'my-deployment',
-      namespace: 'test-namespace',
+describe.each<{
+  experimental: boolean;
+  initMocks: () => void;
+  initObjectsList: (objects: KubernetesObject[]) => { update: (objects: KubernetesObject[]) => void };
+}>([
+  {
+    experimental: true,
+    initMocks: (): void => {
+      vi.mocked(states).kubernetesCurrentContextDeploymentsFiltered = writable([]);
     },
-    spec: {
-      replicas: 2,
-      selector: {},
-      template: {},
+    initObjectsList: (objects: KubernetesObject[]): { update: (objects: KubernetesObject[]) => void } => {
+      let callback: (resoures: KubernetesContextResources[]) => void;
+      vi.mocked(resourcesListen.listenResources).mockImplementation(
+        async (_resources, cb): Promise<resourcesListen.ResourceListener> => {
+          callback = cb;
+          return {
+            setSearchTerm: async (): Promise<void> => {
+              callback([
+                {
+                  contextName: 'ctx1',
+                  items: objects,
+                },
+              ]);
+            },
+            updateContexts: async (): Promise<void> => {
+              callback([
+                {
+                  contextName: 'ctx1',
+                  items: objects,
+                },
+              ]);
+            },
+            dispose: vi.fn(),
+          };
+        },
+      );
+      return {
+        update: (objects: KubernetesObject[]): void => {
+          callback([
+            {
+              contextName: 'ctx1',
+              items: objects,
+            },
+          ]);
+        },
+      };
     },
-  };
-  vi.mocked(states).kubernetesCurrentContextDeploymentsFiltered = writable<KubernetesObject[]>([deployment]);
-
-  render(DeploymentsList);
-  const deploymentName = screen.getByRole('cell', { name: 'my-deployment test-namespace' });
-  expect(deploymentName).toBeInTheDocument();
-});
-
-test('Expect correct column overflow', async () => {
-  const deployment: V1Deployment = {
-    apiVersion: 'apps/v1',
-    kind: 'Deployment',
-    metadata: {
-      name: 'my-deployment',
-      namespace: 'test-namespace',
+  },
+  {
+    experimental: false,
+    initMocks: (): void => {
+      vi.mocked(resourcesListen.listenResources).mockResolvedValue(undefined);
     },
-    spec: {
-      replicas: 2,
-      selector: {},
-      template: {},
+    initObjectsList: (objects: KubernetesObject[]): { update: (objects: KubernetesObject[]) => void } => {
+      const store = writable<KubernetesObject[]>(objects);
+      vi.mocked(states).kubernetesCurrentContextDeploymentsFiltered = store;
+      return {
+        update: (objects: KubernetesObject[]): void => {
+          store.set(objects);
+        },
+      };
     },
-  };
-  vi.mocked(states).kubernetesCurrentContextDeploymentsFiltered = writable<KubernetesObject[]>([deployment]);
+  },
+])('kubernetes experimental is %s', ({ experimental: _experimental, initObjectsList, initMocks }) => {
+  beforeEach(() => {
+    initMocks();
+  });
 
-  render(DeploymentsList);
-  const rows = await screen.findAllByRole('row');
-  expect(rows).toBeDefined();
-  expect(rows.length).toBe(2);
+  test('Expect deployment empty screen', async () => {
+    initObjectsList([]);
+    render(DeploymentsList);
+    const noDeployments = screen.getByRole('heading', { name: 'No deployments' });
+    expect(noDeployments).toBeInTheDocument();
+  });
 
-  const cells = await within(rows[1]).findAllByRole('cell');
-  expect(cells).toBeDefined();
-  expect(cells.length).toBe(8);
+  test('Expect deployments list', async () => {
+    const deployment: V1Deployment = {
+      apiVersion: 'apps/v1',
+      kind: 'Deployment',
+      metadata: {
+        name: 'my-deployment',
+        namespace: 'test-namespace',
+      },
+      spec: {
+        replicas: 2,
+        selector: {},
+        template: {},
+      },
+    };
+    initObjectsList([deployment]);
 
-  expect(cells[2]).toHaveClass('overflow-hidden');
-  expect(cells[3]).toHaveClass('overflow-hidden');
-  expect(cells[4]).not.toHaveClass('overflow-hidden');
-  expect(cells[5]).toHaveClass('overflow-hidden');
-  expect(cells[6]).toHaveClass('overflow-hidden');
-  expect(cells[7]).toHaveClass('overflow-hidden');
-});
+    render(DeploymentsList);
+    await vi.waitFor(() => {
+      const deploymentName = screen.getByRole('cell', { name: 'my-deployment test-namespace' });
+      expect(deploymentName).toBeInTheDocument();
+    });
+  });
 
-test('Expect filter empty screen', async () => {
-  vi.mocked(states).kubernetesCurrentContextDeploymentsFiltered = writable<KubernetesObject[]>([]);
+  test('Expect correct column overflow', async () => {
+    const deployment: V1Deployment = {
+      apiVersion: 'apps/v1',
+      kind: 'Deployment',
+      metadata: {
+        name: 'my-deployment',
+        namespace: 'test-namespace',
+      },
+      spec: {
+        replicas: 2,
+        selector: {},
+        template: {},
+      },
+    };
+    initObjectsList([deployment]);
 
-  render(DeploymentsList, { searchTerm: 'No match' });
-  const filterButton = screen.getByRole('button', { name: 'Clear filter' });
-  expect(filterButton).toBeInTheDocument();
-});
+    render(DeploymentsList);
 
-test('Expect user confirmation to pop up when preferences require', async () => {
-  const deployment: V1Deployment = {
-    apiVersion: 'apps/v1',
-    kind: 'Deployment',
-    metadata: {
-      name: 'my-deployment',
-      namespace: 'test-namespace',
-    },
-    spec: {
-      replicas: 2,
-      selector: {},
-      template: {},
-    },
-  };
-  vi.mocked(states).kubernetesCurrentContextDeploymentsFiltered = writable<KubernetesObject[]>([deployment]);
+    await vi.waitFor(async () => {
+      const rows = await screen.findAllByRole('row');
+      expect(rows).toBeDefined();
+      expect(rows.length).toBe(2);
 
-  render(DeploymentsList);
+      const cells = await within(rows[1]).findAllByRole('cell');
+      expect(cells).toBeDefined();
+      expect(cells.length).toBe(8);
 
-  const checkboxes = screen.getAllByRole('checkbox', { name: 'Toggle deployment' });
-  await fireEvent.click(checkboxes[0]);
+      expect(cells[2]).toHaveClass('overflow-hidden');
+      expect(cells[3]).toHaveClass('overflow-hidden');
+      expect(cells[4]).not.toHaveClass('overflow-hidden');
+      expect(cells[5]).toHaveClass('overflow-hidden');
+      expect(cells[6]).toHaveClass('overflow-hidden');
+      expect(cells[7]).toHaveClass('overflow-hidden');
+    });
+  });
 
-  vi.mocked(window.getConfigurationValue).mockResolvedValue(true);
+  test('Expect filter empty screen', async () => {
+    initObjectsList([]);
 
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 1 });
+    render(DeploymentsList, { searchTerm: 'No match' });
+    const filterButton = screen.getByRole('button', { name: 'Clear filter' });
+    expect(filterButton).toBeInTheDocument();
+  });
 
-  const deleteButton = screen.getByRole('button', { name: 'Delete 1 selected items' });
-  await fireEvent.click(deleteButton);
+  test('Expect user confirmation to pop up when preferences require', async () => {
+    const deployment: V1Deployment = {
+      apiVersion: 'apps/v1',
+      kind: 'Deployment',
+      metadata: {
+        name: 'my-deployment',
+        namespace: 'test-namespace',
+      },
+      spec: {
+        replicas: 2,
+        selector: {},
+        template: {},
+      },
+    };
+    initObjectsList([deployment]);
 
-  expect(window.showMessageBox).toHaveBeenCalledOnce();
+    render(DeploymentsList);
 
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
-  await fireEvent.click(deleteButton);
-  expect(window.showMessageBox).toHaveBeenCalledTimes(2);
-  await vi.waitFor(() => expect(window.kubernetesDeleteDeployment).toHaveBeenCalled());
-});
+    await vi.waitFor(async () => {
+      const checkboxes = screen.getAllByRole('checkbox', { name: 'Toggle deployment' });
+      await fireEvent.click(checkboxes[0]);
+    });
 
-test('deployemnts list is updated when kubernetesCurrentContextDeploymentsFiltered changes', async () => {
-  const deployment1: V1Deployment = {
-    apiVersion: 'apps/v1',
-    kind: 'Deployment',
-    metadata: {
-      name: 'my-deployment-1',
-      namespace: 'test-namespace',
-    },
-    spec: {
-      replicas: 2,
-      selector: {},
-      template: {},
-    },
-  };
-  const deployment2: V1Deployment = {
-    apiVersion: 'apps/v1',
-    kind: 'Deployment',
-    metadata: {
-      name: 'my-deployment-2',
-      namespace: 'test-namespace',
-    },
-    spec: {
-      replicas: 2,
-      selector: {},
-      template: {},
-    },
-  };
-  const filtered = writable<KubernetesObject[]>([deployment1, deployment2]);
-  vi.mocked(states).kubernetesCurrentContextDeploymentsFiltered = filtered;
+    vi.mocked(window.getConfigurationValue).mockResolvedValue(true);
 
-  const component = render(DeploymentsList);
-  const deploymentName1 = screen.getByRole('cell', { name: 'my-deployment-1 test-namespace' });
-  expect(deploymentName1).toBeInTheDocument();
-  const deploymentName2 = screen.getByRole('cell', { name: 'my-deployment-2 test-namespace' });
-  expect(deploymentName2).toBeInTheDocument();
+    vi.mocked(window.showMessageBox).mockResolvedValue({ response: 1 });
 
-  filtered.set([deployment2]);
-  await component.rerender({});
+    const deleteButton = screen.getByRole('button', { name: 'Delete 1 selected items' });
+    await fireEvent.click(deleteButton);
 
-  const deploymentName1after = screen.queryByRole('cell', { name: 'my-deployment-1 test-namespace' });
-  expect(deploymentName1after).not.toBeInTheDocument();
-  const deploymentName2after = screen.getByRole('cell', { name: 'my-deployment-2 test-namespace' });
-  expect(deploymentName2after).toBeInTheDocument();
+    expect(window.showMessageBox).toHaveBeenCalledOnce();
+
+    vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+    await fireEvent.click(deleteButton);
+    expect(window.showMessageBox).toHaveBeenCalledTimes(2);
+    await vi.waitFor(() => expect(window.kubernetesDeleteDeployment).toHaveBeenCalled());
+  });
+
+  test('deployemnts list is updated when resources change', async () => {
+    const deployment1: V1Deployment = {
+      apiVersion: 'apps/v1',
+      kind: 'Deployment',
+      metadata: {
+        name: 'my-deployment-1',
+        namespace: 'test-namespace',
+      },
+      spec: {
+        replicas: 2,
+        selector: {},
+        template: {},
+      },
+    };
+    const deployment2: V1Deployment = {
+      apiVersion: 'apps/v1',
+      kind: 'Deployment',
+      metadata: {
+        name: 'my-deployment-2',
+        namespace: 'test-namespace',
+      },
+      spec: {
+        replicas: 2,
+        selector: {},
+        template: {},
+      },
+    };
+    const list = initObjectsList([deployment1, deployment2]);
+
+    const component = render(DeploymentsList);
+
+    await vi.waitFor(async () => {
+      const deploymentName1 = screen.getByRole('cell', { name: 'my-deployment-1 test-namespace' });
+      expect(deploymentName1).toBeInTheDocument();
+      const deploymentName2 = screen.getByRole('cell', { name: 'my-deployment-2 test-namespace' });
+      expect(deploymentName2).toBeInTheDocument();
+    });
+
+    list.update([deployment2]);
+    await component.rerender({});
+
+    const deploymentName1after = screen.queryByRole('cell', { name: 'my-deployment-1 test-namespace' });
+    expect(deploymentName1after).not.toBeInTheDocument();
+    const deploymentName2after = screen.getByRole('cell', { name: 'my-deployment-2 test-namespace' });
+    expect(deploymentName2after).toBeInTheDocument();
+  });
 });

--- a/packages/renderer/src/lib/kube/resources-listen.spec.ts
+++ b/packages/renderer/src/lib/kube/resources-listen.spec.ts
@@ -1,0 +1,160 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject } from '@kubernetes/client-node';
+import { beforeAll, expect, type Mock, test, vi } from 'vitest';
+
+import type { KubernetesContextResources } from '/@api/kubernetes-resources';
+
+import { Disposable } from '../../../../main/src/plugin/types/disposable';
+import { listenResources } from './resources-listen';
+
+const callbacks = new Map<string, () => void>();
+
+const eventEmitter = {
+  receive: (message: string, callback: () => void): void => {
+    callbacks.set(message, callback);
+  },
+};
+
+beforeAll(() => {
+  Object.defineProperty(window, 'events', {
+    value: {
+      receive: (message: string, callback: () => void) => {
+        eventEmitter.receive(message, callback);
+        return new Disposable(() => {});
+      },
+    },
+  });
+  vi.mocked(window.getConfigurationValue<boolean>).mockResolvedValue(true);
+});
+
+test('non filtered resources', async () => {
+  const resource1: KubernetesObject = {
+    metadata: {
+      name: 'res1',
+    },
+  };
+  const contextResource: KubernetesContextResources = {
+    contextName: 'ctx1',
+    items: [resource1],
+  };
+
+  const callbackSpy: Mock<(resoures: KubernetesContextResources[]) => void> = vi.fn();
+  vi.mocked(window.kubernetesGetResources).mockResolvedValue([contextResource]);
+  const listener = await listenResources('resource1', callbackSpy);
+  expect(listener).not.toBeUndefined();
+  await listener!.updateContexts(['ctx1']);
+
+  callbackSpy.mockClear();
+  const callback = callbacks.get('kubernetes-update-resource1');
+  expect(callback).toBeDefined();
+  expect(callbackSpy).not.toHaveBeenCalled();
+
+  callbackSpy.mockClear();
+  vi.mocked(window.kubernetesGetResources).mockClear();
+  callback!();
+  expect(window.kubernetesGetResources).toHaveBeenCalledWith(['ctx1'], 'resource1');
+  await vi.waitFor(() => {
+    expect(callbackSpy).toHaveBeenCalledWith([contextResource]);
+  });
+});
+
+test('filtered resources', async () => {
+  const resource1: KubernetesObject = {
+    metadata: {
+      name: 'res1',
+    },
+  };
+  const resource2: KubernetesObject = {
+    metadata: {
+      name: 'res2',
+    },
+  };
+  let contextResource: KubernetesContextResources = {
+    contextName: 'ctx1',
+    items: [resource1, resource2],
+  };
+
+  const callbackSpy: Mock<(resoures: KubernetesContextResources[]) => void> = vi.fn();
+  vi.mocked(window.kubernetesGetResources).mockResolvedValue([contextResource]);
+  const listener = await listenResources('resource1', callbackSpy);
+  expect(listener).not.toBeUndefined();
+
+  callbackSpy.mockClear();
+  await listener!.setSearchTerm('res2');
+  await vi.waitFor(() => {
+    expect(callbackSpy).toHaveBeenCalledWith([
+      {
+        contextName: 'ctx1',
+        items: [resource2],
+      },
+    ]);
+  });
+
+  callbackSpy.mockClear();
+  await listener!.setSearchTerm('notfound');
+  await vi.waitFor(() => {
+    expect(callbackSpy).toHaveBeenCalledWith([
+      {
+        contextName: 'ctx1',
+        items: [],
+      },
+    ]);
+  });
+
+  callbackSpy.mockClear();
+  await listener!.setSearchTerm('res1');
+  await vi.waitFor(() => {
+    expect(callbackSpy).toHaveBeenCalledWith([
+      {
+        contextName: 'ctx1',
+        items: [resource1],
+      },
+    ]);
+  });
+
+  // filter is still active when resources change
+  // here, resource1 appears in the result, but resource2 is still filtered
+  callbackSpy.mockClear();
+
+  const resource1bis: KubernetesObject = {
+    metadata: {
+      name: 'res1bis',
+    },
+  };
+  contextResource = {
+    contextName: 'ctx1',
+    items: [resource1, resource2, resource1bis],
+  };
+
+  vi.mocked(window.kubernetesGetResources).mockResolvedValue([contextResource]);
+
+  const callback = callbacks.get('kubernetes-update-resource1');
+  expect(callback).toBeDefined();
+  expect(callbackSpy).not.toHaveBeenCalled();
+  callback!();
+  await vi.waitFor(() => {
+    expect(callbackSpy).toHaveBeenCalledWith([
+      {
+        contextName: 'ctx1',
+        items: [resource1, resource1bis],
+      },
+    ]);
+  });
+});

--- a/packages/renderer/src/lib/kube/resources-listen.ts
+++ b/packages/renderer/src/lib/kube/resources-listen.ts
@@ -1,0 +1,123 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject } from '@kubernetes/client-node';
+import type { Unsubscriber, Writable } from 'svelte/store';
+
+import { kubernetesContexts } from '/@/stores/kubernetes-contexts';
+import { findMatchInLeaves } from '/@/stores/search-util';
+
+import type { IDisposable } from '../../../../main/src/plugin/types/disposable';
+
+export interface ListenResourcesOptions {
+  searchTermStore?: Writable<string>;
+}
+
+// listenResources returns undefined and does nothing when `kubernetes.statesExperimental` setting is not set to true
+//
+// In experimental mode:
+// - watches kubernetes-update-${resourceName} events
+// - watches changes of current context
+// - watches changes of searchTerm
+// and on each event, fetch resources from the backend (informers) filter them on searchTerm and send them through the callback
+export async function listenResources(
+  resourceName: string,
+  options: ListenResourcesOptions,
+  callback: (resoures: KubernetesObject[]) => void,
+): Promise<IDisposable | undefined> {
+  if (!(await isKubernetesExperimentalMode())) {
+    return;
+  }
+  let searchTerm: string = '';
+  let contextName: string | undefined;
+  let searchTermStoreUnsubscribe: Unsubscriber | undefined;
+
+  const disposable = window.events.receive(`kubernetes-update-${resourceName}`, () => {
+    if (!contextName) {
+      return;
+    }
+    collectAndSendFilteredResources(callback, contextName, resourceName, searchTerm);
+  });
+
+  const kubernetesContextsUnsubscribe = kubernetesContexts.subscribe(contexts => {
+    const currentContext = contexts.find(c => c.currentContext)?.name;
+    if (currentContext === contextName) {
+      return;
+    }
+    contextName = currentContext;
+    if (!contextName) {
+      callback([]);
+      return;
+    }
+    collectAndSendFilteredResources(callback, contextName, resourceName, searchTerm);
+  });
+
+  if (options.searchTermStore) {
+    searchTermStoreUnsubscribe = options.searchTermStore.subscribe(newSearchTerm => {
+      searchTerm = newSearchTerm;
+      if (!contextName) {
+        return;
+      }
+      collectAndSendFilteredResources(callback, contextName, resourceName, searchTerm);
+    });
+  }
+
+  return {
+    dispose: (): void => {
+      disposable.dispose();
+      kubernetesContextsUnsubscribe();
+      searchTermStoreUnsubscribe?.();
+    },
+  };
+}
+
+function collectAndSendFilteredResources(
+  callback: (resoures: KubernetesObject[]) => void,
+  contextName: string,
+  resourceName: string,
+  searchTerm: string,
+): void {
+  window
+    .kubernetesGetResources([contextName], resourceName)
+    .then(result => {
+      callback(
+        filter(
+          result.flatMap(r => r.items),
+          searchTerm,
+        ),
+      );
+    })
+    .catch(() => {
+      console.log(`error getting ${resourceName}`);
+    });
+}
+
+function filter(resources: KubernetesObject[], searchTerm: string): KubernetesObject[] {
+  if (!searchTerm) {
+    return resources;
+  }
+  return resources.filter(resource => findMatchInLeaves(resource, searchTerm.toLowerCase()));
+}
+
+async function isKubernetesExperimentalMode(): Promise<boolean> {
+  try {
+    return (await window.getConfigurationValue<boolean>('kubernetes.statesExperimental')) ?? false;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Display deployments in experimental mode

### Screenshot / video of UI

![deployments-experimental](https://github.com/user-attachments/assets/80a3b776-415c-4e51-9454-1dedc4619745)


### What issues does this PR fix or reference?

Part of #10657 

### How to test this PR?

Set the Kubernetes experimental mode in `$HOME/.local/share/containers/podman-desktop/configuration/settings.json`:

```
"kubernetes.statesExperimental": true
```

Also check that it is still working in non experimental mode

- [x] Tests are covering the bug fix or the new feature
