### PR TITLE
chore(test,ci): add option to install all extensions before update

### DIFF
--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -51,7 +51,7 @@ on:
         - podman 
         required: false
       update_with_extensions: 
-        description: 'Installation Type For Update Test'
+        description: 'Installation extensions before update'
         type: choice
         options:
         - 'false'

--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -50,6 +50,13 @@ on:
         - docker
         - podman 
         required: false
+      update_with_extensions: 
+        description: 'Installation Type For Update Test'
+        type: choice
+        options:
+        - 'false'
+        - 'true'
+        required: false
 
 jobs:
   e2e-tests:
@@ -156,11 +163,17 @@ jobs:
             !./tests/**/traces/raw
 
   win-update-e2e-test:
-    name: win update e2e tests
+    name: win update e2e tests - ${{ matrix.installation }}
     runs-on: windows-2022
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        installation: ['vanilla', 'custom-extensions']
+        exclude:
+        - installation: ${{ (github.event.inputs.update_with_extensions && github.event.inputs.update_with_extensions == 'true') && 'N/A' || 'custom-extensions' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -186,7 +199,7 @@ jobs:
 
       - name: Adjust/Downgrade local podman desktop version Windows
         run: |
-          $version="1.0.0"
+          $version="1.15.0"
           jq --arg version "$version" '.version = $version' package.json | Out-File -FilePath package.json_tmp
           Move-Item -Path package.json_tmp -Destination package.json -Force
 
@@ -200,8 +213,11 @@ jobs:
           echo ("PODMAN_DESKTOP_BINARY=" + $path) >> $env:GITHUB_ENV
 
       - name: Run E2E Update test
+        env:
+          INSTALLATION_TYPE: ${{ matrix.installation }}
         run: |
           echo "${{ env.PODMAN_DESKTOP_BINARY }}"
+          echo "${{ env.INSTALLATION_TYPE }}"
           pnpm test:e2e:update:run
 
       - name: Publish Test Report
@@ -218,7 +234,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: update-e2e-test
+          name: update-e2e-test-${{ matrix.installation }}
           path: |
             ./tests/**/output/
             !./tests/**/traces/raw
@@ -254,7 +270,7 @@ jobs:
 
       - name: Adjust/Downgrade local podman desktop version
         run: |
-          version="1.13.0"
+          version="1.15.0"
           jq --arg version "$version" '.version = $version' package.json > package.json_tmp
           mv package.json_tmp package.json
 

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -427,7 +427,7 @@ jobs:
 
       - name: Adjust/Downgrade local podman desktop version Windows
         run: |
-          $version="1.0.0"
+          $version="1.15.0"
           jq --arg version "$version" '.version = $version' package.json | Out-File -FilePath package.json_tmp
           Move-Item -Path package.json_tmp -Destination package.json -Force
 
@@ -491,7 +491,7 @@ jobs:
 
       - name: Adjust/Downgrade local podman desktop version
         run: |
-          version="1.13.0"
+          version="1.15.0"
           jq --arg version "$version" '.version = $version' package.json > package.json_tmp
           mv package.json_tmp package.json
 
@@ -504,7 +504,7 @@ jobs:
           echo "DMG Path: $dmgPath"
           # extract the dmg
           hdiutil attach $dmgPath
-          pdVolumePath=$(find /Volumes -name *1.13.0*)
+          pdVolumePath=$(find /Volumes -name *1.15.0*)
           echo "PD Volume path: $pdVolumePath"
           sudo cp -R "$pdVolumePath/Podman Desktop.app" /Applications
           # codesign the extracted app

--- a/tests/playwright/src/index.ts
+++ b/tests/playwright/src/index.ts
@@ -28,6 +28,7 @@ export * from './utility/platform';
 export * from './utility/wait';
 
 // exports Podman Desktop Page Object Module
+export * from './model/core/extensions';
 export * from './model/core/operations';
 export * from './model/core/platforms';
 export * from './model/core/states';

--- a/tests/playwright/src/model/core/extensions.ts
+++ b/tests/playwright/src/model/core/extensions.ts
@@ -1,0 +1,184 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+// Extension locators definition
+export interface ExtensionType {
+  extensionName: string;
+  extensionFullName: string;
+  extensionLabel: string;
+  extensionFullLabel: string;
+}
+
+// Catalog/External extensions
+export const minikubeExtension: ExtensionType = {
+  extensionName: 'minikube',
+  extensionFullName: 'minikube extension',
+  extensionLabel: 'minikube',
+  extensionFullLabel: 'podman-desktop.minikube',
+};
+
+export const podmanAILabExtension: ExtensionType = {
+  extensionName: 'Podman AI Lab',
+  extensionFullName: 'Podman AI Lab extension',
+  extensionLabel: 'ai-lab',
+  extensionFullLabel: 'redhat.ai-lab',
+};
+
+export const extensionsPackExtension: ExtensionType = {
+  extensionName: 'Red Hat Extension Pack',
+  extensionFullName: 'Red Hat Extension Pack extension',
+  extensionLabel: 'redhat-pack',
+  extensionFullLabel: 'redhat.redhat-pack',
+};
+
+export const bootcExtension: ExtensionType = {
+  extensionName: 'Bootable Container',
+  extensionFullName: 'Bootable Container extension',
+  extensionLabel: 'bootc',
+  extensionFullLabel: 'redhat.bootc',
+};
+
+export const developerSandboxExtension: ExtensionType = {
+  extensionName: 'Developer Sandbox',
+  extensionFullName: 'Developer Sandbox extension',
+  extensionLabel: 'redhat-sandbox',
+  extensionFullLabel: 'redhat.redhat-sandbox',
+};
+
+export const imageLayersExplorerExtension: ExtensionType = {
+  extensionName: 'Image Layers Explorer',
+  extensionFullName: 'Image Layers Explorer extension',
+  extensionLabel: 'layers-explorer',
+  extensionFullLabel: 'podman-desktop.layers-explorer',
+};
+
+export const podmanQuadletExtension: ExtensionType = {
+  extensionName: 'Podman Quadlet',
+  extensionFullName: 'Podman Quadlet extension',
+  extensionLabel: 'quadlet',
+  extensionFullLabel: 'podman-desktop.quadlet',
+};
+
+export const ssoExtension: ExtensionType = {
+  extensionName: 'Red Hat Authentication',
+  extensionFullName: 'Red Hat Authentication extension',
+  extensionLabel: 'redhat-authentication',
+  extensionFullLabel: 'redhat.redhat-authentication',
+};
+
+export const openshiftCheckerExtension: ExtensionType = {
+  extensionName: 'Red Hat OpenShift Checker',
+  extensionFullName: 'Red Hat OpenShift Checker extension',
+  extensionLabel: 'openshift-checker',
+  extensionFullLabel: 'redhat.openshift-checker',
+};
+
+export const openshiftLocalExtension: ExtensionType = {
+  extensionName: 'Red Hat OpenShift Local',
+  extensionFullName: 'Red Hat OpenShift Local extension',
+  extensionLabel: 'openshift-local',
+  extensionFullLabel: 'redhat.openshift-local',
+};
+
+// external contributor
+export const headlampExtension: ExtensionType = {
+  extensionName: 'Headlamp',
+  extensionFullName: 'Headlamp extension',
+  extensionLabel: 'Headlamp',
+  extensionFullLabel: 'Headlamp',
+};
+
+// Built-in extensions
+export const composeExtension: ExtensionType = {
+  extensionName: 'Compose',
+  extensionFullName: 'Compose extension',
+  extensionLabel: 'compose',
+  extensionFullLabel: 'podman-desktop.compose',
+};
+
+export const dockerExtension: ExtensionType = {
+  extensionName: 'Docker',
+  extensionFullName: 'Docker extension',
+  extensionLabel: 'docker',
+  extensionFullLabel: 'podman-desktop.docker',
+};
+
+export const kindExtension: ExtensionType = {
+  extensionName: 'Kind',
+  extensionFullName: 'Kind extension',
+  extensionLabel: 'kind',
+  extensionFullLabel: 'podman-desktop.kind',
+};
+
+export const kubeContextExtension: ExtensionType = {
+  extensionName: 'Kube Context',
+  extensionFullName: 'Kube Context extension',
+  extensionLabel: 'kube-context',
+  extensionFullLabel: 'podman-desktop.kube-context',
+};
+
+export const kubectlCLIExtension: ExtensionType = {
+  extensionName: 'kubectl CLI',
+  extensionFullName: 'kubectl CLI extension',
+  extensionLabel: 'podman-desktop.kubectl-cli',
+  extensionFullLabel: 'podman-desktop.kubectl-cli',
+};
+
+export const limaExtension: ExtensionType = {
+  extensionName: 'Lima',
+  extensionFullName: 'Lima extension',
+  extensionLabel: 'lima',
+  extensionFullLabel: 'podman-desktop.lima',
+};
+
+export const podmanExtension: ExtensionType = {
+  extensionName: 'Podman',
+  extensionFullName: 'Podman extension',
+  extensionLabel: 'podman',
+  extensionFullLabel: 'podman-desktop.podman',
+};
+
+export const registriesExtension: ExtensionType = {
+  extensionName: 'Registries',
+  extensionFullName: 'Registries extension',
+  extensionLabel: 'registries',
+  extensionFullLabel: 'podman-desktop.registries',
+};
+
+export const extensionsBuiltInList = [
+  composeExtension,
+  dockerExtension,
+  kindExtension,
+  kubeContextExtension,
+  kubectlCLIExtension,
+  podmanAILabExtension,
+  registriesExtension,
+];
+export const extensionsExternalList = [
+  minikubeExtension,
+  podmanAILabExtension,
+  extensionsPackExtension,
+  bootcExtension,
+  developerSandboxExtension,
+  imageLayersExplorerExtension,
+  podmanQuadletExtension,
+  ssoExtension,
+  openshiftCheckerExtension,
+  openshiftLocalExtension,
+];
+export const extensionsAllExternalList = [...extensionsExternalList, headlampExtension];

--- a/tests/playwright/src/model/pages/extensions-page.ts
+++ b/tests/playwright/src/model/pages/extensions-page.ts
@@ -41,7 +41,7 @@ export class ExtensionsPage {
       name: 'additionalActions',
     });
     this.installedTab = this.page.getByRole('button', { name: 'Installed' });
-    this.catalogTab = this.page.getByRole('button', { name: 'Catalog' });
+    this.catalogTab = this.page.getByRole('button', { name: 'Catalog', exact: true });
     this.installExtensionFromOCIImageButton = this.additionalActions.getByLabel('Install custom');
   }
 

--- a/tests/playwright/src/special-specs/installation/update-install.spec.ts
+++ b/tests/playwright/src/special-specs/installation/update-install.spec.ts
@@ -26,7 +26,7 @@ import { expect as playExpect, test } from '../../utility/fixtures';
 import { handleConfirmationDialog } from '../../utility/operations';
 import { isLinux, isMac } from '../../utility/platform';
 
-const installExtensions = process.env.INSTALLATION_TYPE !== 'vanilla' ? true : false;
+const installExtensions = process.env.INSTALLATION_TYPE === 'custom-extensions' ? true : false;
 const activeExtensionStatus = 'ACTIVE';
 let sBar: StatusBar;
 let updateAvailableDialog: Locator;

--- a/tests/playwright/src/special-specs/installation/update-install.spec.ts
+++ b/tests/playwright/src/special-specs/installation/update-install.spec.ts
@@ -18,11 +18,16 @@
 
 import type { Locator } from '@playwright/test';
 
+import { extensionsExternalList, podmanExtension } from '/@/model/core/extensions';
+
+import { ExtensionCardPage, ExtensionCatalogCardPage } from '../..';
 import type { StatusBar } from '../../model/workbench/status-bar';
 import { expect as playExpect, test } from '../../utility/fixtures';
 import { handleConfirmationDialog } from '../../utility/operations';
-import { isLinux } from '../../utility/platform';
+import { isLinux, isMac } from '../../utility/platform';
 
+const installExtensions = process.env.INSTALLATION_TYPE !== 'vanilla' ? true : false;
+const activeExtensionStatus = 'ACTIVE';
 let sBar: StatusBar;
 let updateAvailableDialog: Locator;
 let updateDialog: Locator;
@@ -57,6 +62,51 @@ test.describe.serial('Podman Desktop Update installation', { tag: '@update-insta
     // handle welcome page now
     await welcomePage.handleWelcomePage(true);
   });
+
+  test.describe
+    .serial('External Extensions installation', () => {
+      test.skip(!installExtensions || isMac, 'Skipping extension installation, testing fresh/vanilla update');
+
+      test('Podman Extension is activated', async ({ navigationBar, page }) => {
+        const extensions = await navigationBar.openExtensions();
+        await playExpect(async () => {
+          await extensions.openInstalledTab();
+          const podmanExtensionCard = new ExtensionCardPage(
+            page,
+            podmanExtension.extensionName,
+            podmanExtension.extensionFullLabel,
+          );
+          await podmanExtensionCard.card.scrollIntoViewIfNeeded();
+          await playExpect(podmanExtensionCard.status).toHaveText(activeExtensionStatus);
+        }).toPass({ timeout: 30_000 });
+      });
+
+      extensionsExternalList.forEach(extension => {
+        test(`Installation of ${extension.extensionFullName}`, async ({ navigationBar, page }) => {
+          test.setTimeout(200_000);
+          const extensionsPage = await navigationBar.openExtensions();
+          await extensionsPage.openCatalogTab();
+          const extensionCatalogCard = new ExtensionCatalogCardPage(page, extension.extensionName);
+          await playExpect(extensionCatalogCard.parent).toBeVisible();
+          await extensionCatalogCard.install(180_000);
+          await test.step('Extension is installed', async () => {
+            await extensionsPage.openInstalledTab();
+            await playExpect
+              .poll(async () => await extensionsPage.extensionIsInstalled(extension.extensionLabel))
+              .toBeTruthy();
+            const extensionDetailsPage = await extensionsPage.openExtensionDetails(
+              extension.extensionLabel,
+              extension.extensionFullLabel,
+              extension.extensionFullName,
+            );
+            await playExpect(extensionDetailsPage.heading).toBeVisible();
+            await test.step.skip('Extension is active - unstable on windows now', async () => {
+              await playExpect.soft(extensionDetailsPage.status).toHaveText(activeExtensionStatus, { timeout: 20_000 });
+            });
+          });
+        });
+      });
+    });
 
   test('Version button is visible', async () => {
     await playExpect(sBar.content).toBeVisible();


### PR DESCRIPTION
### What does this PR do?
Includes am option to install all extensions before performing an update of podman-desktop. Now the two path of update should be checked - fresh installation and with all external extensions.
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#10881 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
Will run in my fork.
<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
