### PR TITLE
chore: use podman desktop colors rather than theme colors

### DIFF
--- a/packages/renderer/src/lib/markdown/Markdown.svelte
+++ b/packages/renderer/src/lib/markdown/Markdown.svelte
@@ -35,12 +35,13 @@ UI guidelines -->
   line-height: normal;
 }
 .markdown :global(a) {
-  color: theme(colors.purple.500);
+  color: var(--pd-link);
   text-decoration: none;
+  border-radius: 4px;
+  padding: 0.125rem;
 }
 .markdown :global(a):hover {
-  color: theme(colors.purple.400);
-  text-decoration: underline;
+  background-color: var(--pd-link-hover-bg);
 }
 </style>
 

--- a/packages/renderer/src/lib/ui/Steps.svelte
+++ b/packages/renderer/src/lib/ui/Steps.svelte
@@ -1,6 +1,6 @@
 <style>
 .bootstrap-color {
-  --bs-primary: theme(colors.purple.500);
+  --bs-primary: var(--pd-button-primary-bg);
 }
 </style>
 


### PR DESCRIPTION
### What does this PR do?
while updating to tailwindcss v4, there are changes on the theming colors, so it would not work anymore.
But then, now that Podman Desktop is exporting some css variables for colors, it should match the one from the components rather than the theme colors

So apply same style for the links that 'our' Link item

### Screenshot / video of UI
before
![image](https://github.com/user-attachments/assets/7459115f-5193-4cfd-ab50-e0ade5cf7fd8)


after:
![image](https://github.com/user-attachments/assets/c72e8711-e3c4-4980-b0b3-19602207573f)


### What issues does this PR fix or reference?

related to #10795 
### How to test this PR?

check links in the settings/resources for example and the steps (remove all podman machines and click on 'init and start' button on the podman provider card, see the bgcolor of the step.

- [ ] Tests are covering the bug fix or the new feature
