### PR TITLE
chore: postinstall should only install chromium

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "storybook:dev": "npm run storybook:css && cd storybook && pnpm run dev",
     "storybook:build": "npm run build:ui && npm run storybook:css && cd storybook && pnpm run build",
     "prepare": "husky install",
-    "postinstall": "playwright install"
+    "postinstall": "playwright install chromium"
   },
   "lint-staged": {
     "*.{js,ts,tsx,svelte}": [


### PR DESCRIPTION
### What does this PR do?

Question: do we need to have all browser installed when running playwright install?

I noticed while working on https://github.com/podman-desktop/extension-podman-quadlet/pull/236 that we download every browser in existence, which take some time and resources.

Since electron is only using chromium, we may be able to limit the browser download (might be wrong?)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
