### PR TITLE
fix: changed color of text on kubernetes empty page to have better visibility

### DIFF
--- a/packages/renderer/src/lib/kube/KubernetesEmptyPage.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesEmptyPage.svelte
@@ -62,7 +62,7 @@ async function ondetails(extensionId: string): Promise<void> {
           {provider.kubernetesProviderConnectionCreationDisplayName ?? provider.name}
         </h1>
     
-        <p class="text-sm text-gray-300 mb-6">
+        <p class="text-sm text-[var(--pd-content-text)] mb-6">
         <Markdown markdown={provider.emptyConnectionMarkdownDescription} />
         </p>
     


### PR DESCRIPTION
### What does this PR do?
Changes the text color to make text more visible on kubernetes empty page
The banners on top have now same color of text as those extension suggestions below

### Screenshot / video of UI
After:
![Screenshot 2025-01-30 092337](https://github.com/user-attachments/assets/1641d199-484b-4557-93c4-ab829b4aa175)
![Screenshot 2025-01-30 092354](https://github.com/user-attachments/assets/aa297c88-8ae1-41eb-8ac7-708e19cbfb2b)

Before: 
![Image](https://github.com/user-attachments/assets/e229f3a9-a633-4102-90bb-95a1213cc1bf)

### What issues does this PR fix or reference?
Closes #10634 

### How to test this PR?
Remove contexts

- [x] Tests are covering the bug fix or the new feature
