### PR TITLE
chore: bump svelte 5.19.5 and weird reactivity fix

### DIFF
--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -37,7 +37,7 @@
     "monaco-editor": "^0.52.2",
     "postcss": "^8.5.1",
     "postcss-load-config": "^6.0.1",
-    "svelte": "5.19.4",
+    "svelte": "5.19.5",
     "svelte-check": "^4.1.4",
     "svelte-eslint-parser": "^0.43.0",
     "svelte-fa": "^4.0.3",

--- a/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.svelte
@@ -12,10 +12,12 @@ interface Props {
 
 let { onCloseForm, category = 'bug', contentChange }: Props = $props();
 
-let issueTitle = $state('');
-let issueDescription = $state('');
+let issueTitle: string = $state('');
+let issueDescription: string = $state('');
 let includeSystemInfo: boolean = $state(true); // default to true
 let includeExtensionInfo: boolean = $state(true); // default to true
+
+const disabled: boolean = $derived(!issueTitle || !issueDescription);
 
 let issueValidationError = $derived.by(() => {
   if (!issueTitle) {
@@ -108,12 +110,12 @@ async function previewOnGitHub(): Promise<void> {
     {/if}
   </svelte:fragment>
   <svelte:fragment slot="validation">
-    {#if !issueTitle || !issueDescription}
+    {#if disabled}
       <ErrorMessage class="text-xs" error={issueValidationError}/>
     {/if}
   </svelte:fragment>
   <svelte:fragment slot="buttons">
     <Button class="underline" type="link" aria-label="Cancel" on:click={(): void => onCloseForm(true)}>Cancel</Button>
-    <Button aria-label="Preview on GitHub" on:click={previewOnGitHub} disabled={!issueTitle || !issueDescription}>Preview on GitHub</Button>
+    <Button aria-label="Preview on GitHub" on:click={previewOnGitHub} disabled={disabled}>Preview on GitHub</Button>
   </svelte:fragment>
 </FeedbackForm>

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -157,7 +157,7 @@
     "jsdom": "^26.0.0",
     "postcss": "^8.5.1",
     "postcss-load-config": "^6.0.1",
-    "svelte": "5.19.4",
+    "svelte": "5.19.5",
     "svelte-check": "^4.1.4",
     "svelte-eslint-parser": "^0.43.0",
     "tailwindcss": "^3.4.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -559,7 +559,7 @@ importers:
         version: link:../ui
       '@zerodevx/svelte-toast':
         specifier: ^0.9.6
-        version: 0.9.6(svelte@5.19.4)
+        version: 0.9.6(svelte@5.19.5)
       electron-context-menu:
         specifier: 4.0.4
         version: 4.0.4
@@ -587,7 +587,7 @@ importers:
         version: 6.7.2
       '@sveltejs/vite-plugin-svelte':
         specifier: 5.0.3
-        version: 5.0.3(svelte@5.19.4)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0))
+        version: 5.0.3(svelte@5.19.5)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0))
       '@testing-library/dom':
         specifier: ^10.4.0
         version: 10.4.0
@@ -596,7 +596,7 @@ importers:
         version: 6.6.3
       '@testing-library/svelte':
         specifier: ^5.2.6
-        version: 5.2.6(svelte@5.19.4)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0))(vitest@2.1.6(@types/node@22.12.0)(jiti@2.4.1)(jsdom@26.0.0)(msw@2.7.0(@types/node@22.12.0)(typescript@5.6.3))(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0))
+        version: 5.2.6(svelte@5.19.5)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0))(vitest@2.1.6(@types/node@22.12.0)(jiti@2.4.1)(jsdom@26.0.0)(msw@2.7.0(@types/node@22.12.0)(typescript@5.6.3))(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0))
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.0)
@@ -629,7 +629,7 @@ importers:
         version: 10.4.20(postcss@8.5.1)
       eslint-plugin-svelte:
         specifier: ^2.46.1
-        version: 2.46.1(eslint@9.19.0(jiti@2.4.1))(svelte@5.19.4)
+        version: 2.46.1(eslint@9.19.0(jiti@2.4.1))(svelte@5.19.5)
       filesize:
         specifier: ^10.1.6
         version: 10.1.6
@@ -658,17 +658,17 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1(jiti@2.4.1)(postcss@8.5.1)(tsx@4.19.2)(yaml@2.7.0)
       svelte:
-        specifier: 5.19.4
-        version: 5.19.4
+        specifier: 5.19.5
+        version: 5.19.5
       svelte-check:
         specifier: ^4.1.4
-        version: 4.1.4(picomatch@4.0.2)(svelte@5.19.4)(typescript@5.6.3)
+        version: 4.1.4(picomatch@4.0.2)(svelte@5.19.5)(typescript@5.6.3)
       svelte-eslint-parser:
         specifier: ^0.43.0
-        version: 0.43.0(svelte@5.19.4)
+        version: 0.43.0(svelte@5.19.5)
       svelte-fa:
         specifier: ^4.0.3
-        version: 4.0.3(svelte@5.19.4)
+        version: 4.0.3(svelte@5.19.5)
       svelte-steps:
         specifier: 2.4.1
         version: 2.4.1
@@ -716,14 +716,14 @@ importers:
         version: 2.30.1
       svelte-fa:
         specifier: ^4.0.3
-        version: 4.0.3(svelte@5.19.4)
+        version: 4.0.3(svelte@5.19.5)
     devDependencies:
       '@sveltejs/package':
         specifier: ^2.3.9
-        version: 2.3.9(svelte@5.19.4)(typescript@5.6.3)
+        version: 2.3.9(svelte@5.19.5)(typescript@5.6.3)
       '@sveltejs/vite-plugin-svelte':
         specifier: 5.0.3
-        version: 5.0.3(svelte@5.19.4)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0))
+        version: 5.0.3(svelte@5.19.5)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0))
       '@testing-library/dom':
         specifier: ^10.4.0
         version: 10.4.0
@@ -732,7 +732,7 @@ importers:
         version: 6.6.3
       '@testing-library/svelte':
         specifier: ^5.2.6
-        version: 5.2.6(svelte@5.19.4)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0))(vitest@2.1.6(@types/node@22.12.0)(jiti@2.4.1)(jsdom@26.0.0)(msw@2.7.0(@types/node@22.12.0)(typescript@5.6.3))(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0))
+        version: 5.2.6(svelte@5.19.5)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0))(vitest@2.1.6(@types/node@22.12.0)(jiti@2.4.1)(jsdom@26.0.0)(msw@2.7.0(@types/node@22.12.0)(typescript@5.6.3))(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0))
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.0)
@@ -747,7 +747,7 @@ importers:
         version: 10.4.20(postcss@8.5.1)
       eslint-plugin-svelte:
         specifier: ^2.46.1
-        version: 2.46.1(eslint@9.19.0(jiti@2.4.1))(svelte@5.19.4)
+        version: 2.46.1(eslint@9.19.0(jiti@2.4.1))(svelte@5.19.5)
       jsdom:
         specifier: ^26.0.0
         version: 26.0.0
@@ -758,14 +758,14 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1(jiti@2.4.1)(postcss@8.5.1)(tsx@4.19.2)(yaml@2.7.0)
       svelte:
-        specifier: 5.19.4
-        version: 5.19.4
+        specifier: 5.19.5
+        version: 5.19.5
       svelte-check:
         specifier: ^4.1.4
-        version: 4.1.4(picomatch@4.0.2)(svelte@5.19.4)(typescript@5.6.3)
+        version: 4.1.4(picomatch@4.0.2)(svelte@5.19.5)(typescript@5.6.3)
       svelte-eslint-parser:
         specifier: ^0.43.0
-        version: 0.43.0(svelte@5.19.4)
+        version: 0.43.0(svelte@5.19.5)
       tailwindcss:
         specifier: ^3.4.17
         version: 3.4.17
@@ -806,7 +806,7 @@ importers:
         version: 9.19.0(jiti@2.4.1)
       svelte-fa:
         specifier: ^4.0.3
-        version: 4.0.3(svelte@5.19.4)
+        version: 4.0.3(svelte@5.19.5)
     devDependencies:
       '@storybook/addon-essentials':
         specifier: ^8.5.2
@@ -819,25 +819,25 @@ importers:
         version: 8.5.2(react@18.2.0)(storybook@8.5.0(prettier@3.4.2))
       '@storybook/addon-svelte-csf':
         specifier: 5.0.0-next.11
-        version: 5.0.0-next.11(@storybook/svelte@8.5.2(storybook@8.5.0(prettier@3.4.2))(svelte@5.19.4))(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.4)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0)))(storybook@8.5.0(prettier@3.4.2))(svelte@5.19.4)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0))
+        version: 5.0.0-next.11(@storybook/svelte@8.5.2(storybook@8.5.0(prettier@3.4.2))(svelte@5.19.5))(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.5)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0)))(storybook@8.5.0(prettier@3.4.2))(svelte@5.19.5)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0))
       '@storybook/blocks':
         specifier: ^8.5.2
         version: 8.5.2(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(storybook@8.5.0(prettier@3.4.2))
       '@storybook/svelte':
         specifier: ^8.5.2
-        version: 8.5.2(storybook@8.5.0(prettier@3.4.2))(svelte@5.19.4)
+        version: 8.5.2(storybook@8.5.0(prettier@3.4.2))(svelte@5.19.5)
       '@storybook/svelte-vite':
         specifier: ^8.5.2
-        version: 8.5.2(@babel/core@7.26.0)(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.4)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0)))(postcss-load-config@6.0.1(jiti@2.4.1)(postcss@8.5.1)(tsx@4.19.2)(yaml@2.7.0))(postcss@8.5.1)(storybook@8.5.0(prettier@3.4.2))(svelte@5.19.4)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0))
+        version: 8.5.2(@babel/core@7.26.0)(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.5)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0)))(postcss-load-config@6.0.1(jiti@2.4.1)(postcss@8.5.1)(tsx@4.19.2)(yaml@2.7.0))(postcss@8.5.1)(storybook@8.5.0(prettier@3.4.2))(svelte@5.19.5)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0))
       '@storybook/test':
         specifier: ^8.5.2
         version: 8.5.2(storybook@8.5.0(prettier@3.4.2))
       '@sveltejs/package':
         specifier: ^2.3.9
-        version: 2.3.9(svelte@5.19.4)(typescript@5.6.3)
+        version: 2.3.9(svelte@5.19.5)(typescript@5.6.3)
       '@sveltejs/vite-plugin-svelte':
         specifier: 5.0.3
-        version: 5.0.3(svelte@5.19.4)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0))
+        version: 5.0.3(svelte@5.19.5)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0))
       '@tsconfig/svelte':
         specifier: ^5.0.2
         version: 5.0.4
@@ -852,7 +852,7 @@ importers:
         version: 7.0.3
       eslint-plugin-svelte:
         specifier: ^2.46.1
-        version: 2.46.1(eslint@9.19.0(jiti@2.4.1))(svelte@5.19.4)
+        version: 2.46.1(eslint@9.19.0(jiti@2.4.1))(svelte@5.19.5)
       postcss:
         specifier: ^8.5.1
         version: 8.5.1
@@ -872,11 +872,11 @@ importers:
         specifier: ^4.0.2
         version: 4.0.2(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(storybook@8.5.0(prettier@3.4.2))
       svelte:
-        specifier: 5.19.4
-        version: 5.19.4
+        specifier: 5.19.5
+        version: 5.19.5
       svelte-check:
         specifier: ^4.1.4
-        version: 4.1.4(picomatch@4.0.2)(svelte@5.19.4)(typescript@5.6.3)
+        version: 4.1.4(picomatch@4.0.2)(svelte@5.19.5)(typescript@5.6.3)
       tailwindcss:
         specifier: ^3.4.17
         version: 3.4.17
@@ -10421,8 +10421,8 @@ packages:
       svelte: ^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0
       typescript: ^4.9.4 || ^5.0.0
 
-  svelte@5.19.4:
-    resolution: {integrity: sha512-pzWvFQdvfEfT4Ll/JriAtcG7qmWjcL+x/NSl9Q+FPje5SXukYNp9kcufZ27ydauLLE/dwYMz9XRC8kiwTZmfDA==}
+  svelte@5.19.5:
+    resolution: {integrity: sha512-vVAntseegJX80sgbY8CxQISSE/VoDSfP7VZHoQaf2+z+2XOPOz/N+k455HJmO9O0g8oxTtuE0TBhC/5LAP4lPg==}
     engines: {node: '>=18'}
 
   sveltedoc-parser@4.2.1:
@@ -14716,20 +14716,20 @@ snapshots:
       storybook: 8.5.0(prettier@3.4.2)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-svelte-csf@5.0.0-next.11(@storybook/svelte@8.5.2(storybook@8.5.0(prettier@3.4.2))(svelte@5.19.4))(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.4)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0)))(storybook@8.5.0(prettier@3.4.2))(svelte@5.19.4)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0))':
+  '@storybook/addon-svelte-csf@5.0.0-next.11(@storybook/svelte@8.5.2(storybook@8.5.0(prettier@3.4.2))(svelte@5.19.5))(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.5)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0)))(storybook@8.5.0(prettier@3.4.2))(svelte@5.19.5)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0))':
     dependencies:
       '@storybook/csf': 0.1.11
       '@storybook/docs-tools': 8.4.4(storybook@8.5.0(prettier@3.4.2))
       '@storybook/node-logger': 8.4.4(storybook@8.5.0(prettier@3.4.2))
-      '@storybook/svelte': 8.5.2(storybook@8.5.0(prettier@3.4.2))(svelte@5.19.4)
+      '@storybook/svelte': 8.5.2(storybook@8.5.0(prettier@3.4.2))(svelte@5.19.5)
       '@storybook/types': 8.4.4(storybook@8.5.0(prettier@3.4.2))
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.19.4)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0))
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.19.5)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0))
       dedent: 1.5.3
       es-toolkit: 1.27.0
       esrap: 1.2.2
       magic-string: 0.30.13
-      svelte: 5.19.4
-      svelte-ast-print: 0.4.2(svelte@5.19.4)
+      svelte: 5.19.5
+      svelte-ast-print: 0.4.2(svelte@5.19.5)
       vite: 6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0)
       zimmerframe: 1.1.2
     transitivePeerDependencies:
@@ -14852,16 +14852,16 @@ snapshots:
       react-dom: 18.3.1(react@18.2.0)
       storybook: 8.5.0(prettier@3.4.2)
 
-  '@storybook/svelte-vite@8.5.2(@babel/core@7.26.0)(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.4)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0)))(postcss-load-config@6.0.1(jiti@2.4.1)(postcss@8.5.1)(tsx@4.19.2)(yaml@2.7.0))(postcss@8.5.1)(storybook@8.5.0(prettier@3.4.2))(svelte@5.19.4)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0))':
+  '@storybook/svelte-vite@8.5.2(@babel/core@7.26.0)(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.5)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0)))(postcss-load-config@6.0.1(jiti@2.4.1)(postcss@8.5.1)(tsx@4.19.2)(yaml@2.7.0))(postcss@8.5.1)(storybook@8.5.0(prettier@3.4.2))(svelte@5.19.5)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0))':
     dependencies:
       '@storybook/builder-vite': 8.5.2(storybook@8.5.0(prettier@3.4.2))(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0))
-      '@storybook/svelte': 8.5.2(storybook@8.5.0(prettier@3.4.2))(svelte@5.19.4)
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.19.4)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0))
+      '@storybook/svelte': 8.5.2(storybook@8.5.0(prettier@3.4.2))(svelte@5.19.5)
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.19.5)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0))
       magic-string: 0.30.17
       storybook: 8.5.0(prettier@3.4.2)
-      svelte: 5.19.4
-      svelte-preprocess: 5.1.4(@babel/core@7.26.0)(postcss-load-config@6.0.1(jiti@2.4.1)(postcss@8.5.1)(tsx@4.19.2)(yaml@2.7.0))(postcss@8.5.1)(svelte@5.19.4)(typescript@5.6.3)
-      svelte2tsx: 0.7.34(svelte@5.19.4)(typescript@5.6.3)
+      svelte: 5.19.5
+      svelte-preprocess: 5.1.4(@babel/core@7.26.0)(postcss-load-config@6.0.1(jiti@2.4.1)(postcss@8.5.1)(tsx@4.19.2)(yaml@2.7.0))(postcss@8.5.1)(svelte@5.19.5)(typescript@5.6.3)
+      svelte2tsx: 0.7.34(svelte@5.19.5)(typescript@5.6.3)
       sveltedoc-parser: 4.2.1
       ts-dedent: 2.2.0
       typescript: 5.6.3
@@ -14878,7 +14878,7 @@ snapshots:
       - sugarss
       - supports-color
 
-  '@storybook/svelte@8.5.2(storybook@8.5.0(prettier@3.4.2))(svelte@5.19.4)':
+  '@storybook/svelte@8.5.2(storybook@8.5.0(prettier@3.4.2))(svelte@5.19.5)':
     dependencies:
       '@storybook/components': 8.5.2(storybook@8.5.0(prettier@3.4.2))
       '@storybook/global': 5.0.0
@@ -14886,7 +14886,7 @@ snapshots:
       '@storybook/preview-api': 8.5.2(storybook@8.5.0(prettier@3.4.2))
       '@storybook/theming': 8.5.2(storybook@8.5.0(prettier@3.4.2))
       storybook: 8.5.0(prettier@3.4.2)
-      svelte: 5.19.4
+      svelte: 5.19.5
       sveltedoc-parser: 4.2.1
       ts-dedent: 2.2.0
       type-fest: 2.19.0
@@ -14917,34 +14917,34 @@ snapshots:
     dependencies:
       storybook: 8.5.0(prettier@3.4.2)
 
-  '@sveltejs/package@2.3.9(svelte@5.19.4)(typescript@5.6.3)':
+  '@sveltejs/package@2.3.9(svelte@5.19.5)(typescript@5.6.3)':
     dependencies:
       chokidar: 4.0.3
       kleur: 4.1.5
       sade: 1.8.1
       semver: 7.7.0
-      svelte: 5.19.4
-      svelte2tsx: 0.7.34(svelte@5.19.4)(typescript@5.6.3)
+      svelte: 5.19.5
+      svelte2tsx: 0.7.34(svelte@5.19.5)(typescript@5.6.3)
     transitivePeerDependencies:
       - typescript
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.4)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0)))(svelte@5.19.4)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0))':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.5)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0)))(svelte@5.19.5)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.19.4)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0))
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.19.5)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0))
       debug: 4.4.0
-      svelte: 5.19.4
+      svelte: 5.19.5
       vite: 6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.4)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0))':
+  '@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.5)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.4)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0)))(svelte@5.19.4)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0))
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.19.5)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0)))(svelte@5.19.5)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0))
       debug: 4.4.0
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.15
-      svelte: 5.19.4
+      svelte: 5.19.5
       vite: 6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0)
       vitefu: 1.0.4(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0))
     transitivePeerDependencies:
@@ -15082,10 +15082,10 @@ snapshots:
       lodash: 4.17.21
       redent: 3.0.0
 
-  '@testing-library/svelte@5.2.6(svelte@5.19.4)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0))(vitest@2.1.6(@types/node@22.12.0)(jiti@2.4.1)(jsdom@26.0.0)(msw@2.7.0(@types/node@22.12.0)(typescript@5.6.3))(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0))':
+  '@testing-library/svelte@5.2.6(svelte@5.19.5)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0))(vitest@2.1.6(@types/node@22.12.0)(jiti@2.4.1)(jsdom@26.0.0)(msw@2.7.0(@types/node@22.12.0)(typescript@5.6.3))(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0))':
     dependencies:
       '@testing-library/dom': 10.4.0
-      svelte: 5.19.4
+      svelte: 5.19.5
     optionalDependencies:
       vite: 6.0.11(@types/node@22.12.0)(jiti@2.4.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0)
       vitest: 2.1.6(@types/node@22.12.0)(jiti@2.4.1)(jsdom@26.0.0)(msw@2.7.0(@types/node@22.12.0)(typescript@5.6.3))(terser@5.36.0)(tsx@4.19.2)(yaml@2.7.0)
@@ -15840,9 +15840,9 @@ snapshots:
 
   '@xtuc/long@4.2.2': {}
 
-  '@zerodevx/svelte-toast@0.9.6(svelte@5.19.4)':
+  '@zerodevx/svelte-toast@0.9.6(svelte@5.19.5)':
     dependencies:
-      svelte: 5.19.4
+      svelte: 5.19.5
 
   JSONStream@1.3.5:
     dependencies:
@@ -18090,7 +18090,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-svelte@2.46.1(eslint@9.19.0(jiti@2.4.1))(svelte@5.19.4):
+  eslint-plugin-svelte@2.46.1(eslint@9.19.0(jiti@2.4.1))(svelte@5.19.5):
     dependencies:
       '@eslint-community/eslint-utils': 4.4.1(eslint@9.19.0(jiti@2.4.1))
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -18103,9 +18103,9 @@ snapshots:
       postcss-safe-parser: 6.0.0(postcss@8.5.1)
       postcss-selector-parser: 6.1.2
       semver: 7.7.0
-      svelte-eslint-parser: 0.43.0(svelte@5.19.4)
+      svelte-eslint-parser: 0.43.0(svelte@5.19.5)
     optionalDependencies:
-      svelte: 5.19.4
+      svelte: 5.19.5
     transitivePeerDependencies:
       - ts-node
 
@@ -23140,25 +23140,25 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-ast-print@0.4.2(svelte@5.19.4):
+  svelte-ast-print@0.4.2(svelte@5.19.5):
     dependencies:
       esrap: 1.2.2
-      svelte: 5.19.4
+      svelte: 5.19.5
       zimmerframe: 1.1.2
 
-  svelte-check@4.1.4(picomatch@4.0.2)(svelte@5.19.4)(typescript@5.6.3):
+  svelte-check@4.1.4(picomatch@4.0.2)(svelte@5.19.5)(typescript@5.6.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       chokidar: 4.0.1
       fdir: 6.4.2(picomatch@4.0.2)
       picocolors: 1.1.1
       sade: 1.8.1
-      svelte: 5.19.4
+      svelte: 5.19.5
       typescript: 5.6.3
     transitivePeerDependencies:
       - picomatch
 
-  svelte-eslint-parser@0.43.0(svelte@5.19.4):
+  svelte-eslint-parser@0.43.0(svelte@5.19.5):
     dependencies:
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
@@ -23166,20 +23166,20 @@ snapshots:
       postcss: 8.5.1
       postcss-scss: 4.0.9(postcss@8.5.1)
     optionalDependencies:
-      svelte: 5.19.4
+      svelte: 5.19.5
 
-  svelte-fa@4.0.3(svelte@5.19.4):
+  svelte-fa@4.0.3(svelte@5.19.5):
     dependencies:
-      svelte: 5.19.4
+      svelte: 5.19.5
 
-  svelte-preprocess@5.1.4(@babel/core@7.26.0)(postcss-load-config@6.0.1(jiti@2.4.1)(postcss@8.5.1)(tsx@4.19.2)(yaml@2.7.0))(postcss@8.5.1)(svelte@5.19.4)(typescript@5.6.3):
+  svelte-preprocess@5.1.4(@babel/core@7.26.0)(postcss-load-config@6.0.1(jiti@2.4.1)(postcss@8.5.1)(tsx@4.19.2)(yaml@2.7.0))(postcss@8.5.1)(svelte@5.19.5)(typescript@5.6.3):
     dependencies:
       '@types/pug': 2.0.10
       detect-indent: 6.1.0
       magic-string: 0.30.17
       sorcery: 0.11.1
       strip-indent: 3.0.0
-      svelte: 5.19.4
+      svelte: 5.19.5
     optionalDependencies:
       '@babel/core': 7.26.0
       postcss: 8.5.1
@@ -23188,14 +23188,14 @@ snapshots:
 
   svelte-steps@2.4.1: {}
 
-  svelte2tsx@0.7.34(svelte@5.19.4)(typescript@5.6.3):
+  svelte2tsx@0.7.34(svelte@5.19.5)(typescript@5.6.3):
     dependencies:
       dedent-js: 1.0.1
       pascal-case: 3.1.2
-      svelte: 5.19.4
+      svelte: 5.19.5
       typescript: 5.6.3
 
-  svelte@5.19.4:
+  svelte@5.19.5:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@jridgewell/sourcemap-codec': 1.5.0

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -42,7 +42,7 @@
     "react-dom": "18.3.1",
     "storybook": "^8.5.0",
     "storybook-dark-mode": "^4.0.2",
-    "svelte": "5.19.4",
+    "svelte": "5.19.5",
     "svelte-check": "^4.1.4",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.6.3",


### PR DESCRIPTION
### What does this PR do?

Very strange bug... the following button is having some issues when it is supposed to be enabled

https://github.com/podman-desktop/podman-desktop/blob/8321e0b7ad10eb87c6fa24a0833a794eb4bb7f0c/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.svelte#L117

the condition `disabled={!issueTitle || !issueDescription}` is failing, here is the button (when failing)

```svelte
<button
  aria-label="Preview on GitHub"
  class="[...] bg-[var(--pd-button-disabled)] text-[var(--pd-button-disabled-text)]"
  disabled=""
  type="button"
/>
```

The disabled is `""` but might be considered to true if not explicit to false ? very weird... I don't understand why it had this empty string...

I really don't understand, creating a derived state fixed it :/

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
