### PR TITLE
chore: set tailwind framework as being the 'winner of the CSS'

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -179,31 +179,39 @@ a {
 }
 
 /* headings */
-.theme-doc-markdown.markdown h1 {
+
+article .markdown h1 {
   font-size: 1.5rem;
   font-weight: bolder;
 }
 
-.theme-doc-markdown.markdown h2 {
+nav h2,
+article .markdown h2 {
   font-size: 1.2rem;
   font-weight: bolder;
 }
 
+nav h3,
+article .markdown h3 {
+  font-size: 1.1rem;
+  font-weight: bolder;
+}
+
 /* lists */
-.theme-doc-markdown.markdown ul,
-.theme-doc-markdown.markdown ol {
+article .markdown ul,
+article .markdown ol {
   margin-block-start: 1em;
   margin-block-end: 1em;
   margin-inline-start: 0px;
   margin-inline-end: 0px;
   padding-inline-start: 40px;
 }
-.theme-doc-markdown.markdown ul {
+article .markdown ul {
   list-style-type: disc;
 }
-.theme-doc-markdown.markdown ol {
+article .markdown ol {
   list-style-type: decimal;
 }
-.theme-doc-markdown.markdown ol ol {
+article .markdown ol ol {
   list-style-type: lower-roman;
 }

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -16,37 +16,15 @@
   src: url('../../static/fonts/manrope.ttf') format('truetype');
 }
 
-/* Apply default style for markdown*/
-@layer base {
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6 {
-    font-size: revert;
-    font-weight: revert;
-  }
-  ol,
-  ul {
-    list-style: revert;
-    margin: revert;
-    padding: revert;
-  }
-  a {
-    color: revert;
-  }
-}
-
 /*
 Apply style on documentation
 */
 [data-theme='dark'].docs-doc-page .main-wrapper a {
-  @apply text-purple-200;
+  color: text-purple-200;
 }
 
 .docs-doc-page .main-wrapper a {
-  @apply text-purple-600;
+  color: text-purple-600;
 }
 
 /* You can override the default Infima variables here. */

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -177,3 +177,33 @@ li.footer__item a svg {
 a {
   color: var(--ifm-link-color);
 }
+
+/* headings */
+.theme-doc-markdown.markdown h1 {
+  font-size: 1.5rem;
+  font-weight: bolder;
+}
+
+.theme-doc-markdown.markdown h2 {
+  font-size: 1.2rem;
+  font-weight: bolder;
+}
+
+/* lists */
+.theme-doc-markdown.markdown ul,
+.theme-doc-markdown.markdown ol {
+  margin-block-start: 1em;
+  margin-block-end: 1em;
+  margin-inline-start: 0px;
+  margin-inline-end: 0px;
+  padding-inline-start: 40px;
+}
+.theme-doc-markdown.markdown ul {
+  list-style-type: disc;
+}
+.theme-doc-markdown.markdown ol {
+  list-style-type: decimal;
+}
+.theme-doc-markdown.markdown ol ol {
+  list-style-type: lower-roman;
+}

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -16,17 +16,6 @@
   src: url('../../static/fonts/manrope.ttf') format('truetype');
 }
 
-/*
-Apply style on documentation
-*/
-[data-theme='dark'].docs-doc-page .main-wrapper a {
-  color: text-purple-200;
-}
-
-.docs-doc-page .main-wrapper a {
-  color: text-purple-600;
-}
-
 /* You can override the default Infima variables here. */
 :root {
   --ifm-font-family-base: 'Manrope', sans-serif;
@@ -185,6 +174,6 @@ li.footer__item a svg {
   align-items: center;
 }
 
-.footer a {
+a {
   color: var(--ifm-link-color);
 }

--- a/website/tailwind.config.js
+++ b/website/tailwind.config.js
@@ -4,6 +4,7 @@ const rootTailWindConfig = require('../tailwind.config.cjs');
 module.exports = {
   content: ['./docusaurus.config.js', './src/**/*.{js,jsx,ts,tsx}'],
   darkMode: 'class',
+  important: true,
   theme: {
     extend: {
       // share same color palette of Podman Desktop UI


### PR DESCRIPTION
### What does this PR do?
instead of trying to revert some styles from docusaurus, tell tailwindcss to behave with important styling so it is always winning the rendering style

will make easier to move to tailwindcss v4 as the layers rendering is changing

note: there are some small UI changes but I think it's better to stick to tailwindcss rules over any docusaurus styling.

### Screenshot / video of UI

Check using netlify or argos-ci

### What issues does this PR fix or reference?

#10795 

### How to test this PR?

Check using netlify or argos-ci

- [ ] Tests are covering the bug fix or the new feature
