### PR TITLE
chore: kubernetes navigation store mocking

### DIFF
--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-configmap-secrets.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-configmap-secrets.svelte.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,21 +17,12 @@
  ***********************************************************************/
 
 import type { KubernetesObject } from '@kubernetes/client-node';
-import { beforeEach, expect, test, vi } from 'vitest';
+import { expect, test, vi } from 'vitest';
 
 import { createNavigationKubernetesConfigMapSecretsEntry } from './navigation-registry-k8s-configmap-secrets.svelte';
 
-beforeEach(() => {
-  vi.resetAllMocks();
-  Object.defineProperty(window, 'kubernetesRegisterGetCurrentContextResources', {
-    value: kubernetesRegisterGetCurrentContextResourcesMock,
-  });
-});
-
-const kubernetesRegisterGetCurrentContextResourcesMock = vi.fn();
-
 test('createNavigationKubernetesConfigMapSecretsEntry', async () => {
-  const nodes: KubernetesObject[] = [
+  const configMap: KubernetesObject[] = [
     {
       apiVersion: 'v1',
       kind: 'Node',
@@ -47,7 +38,7 @@ test('createNavigationKubernetesConfigMapSecretsEntry', async () => {
       },
     },
   ];
-  kubernetesRegisterGetCurrentContextResourcesMock.mockResolvedValue(nodes);
+  vi.mocked(window.kubernetesRegisterGetCurrentContextResources).mockResolvedValue(configMap);
 
   const entry = createNavigationKubernetesConfigMapSecretsEntry();
 

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-deployments.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-deployments.svelte.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,37 +17,28 @@
  ***********************************************************************/
 
 import type { KubernetesObject } from '@kubernetes/client-node';
-import { beforeEach, expect, test, vi } from 'vitest';
+import { expect, test, vi } from 'vitest';
 
 import { createNavigationKubernetesDeploymentsEntry } from './navigation-registry-k8s-deployments.svelte';
 
-beforeEach(() => {
-  vi.resetAllMocks();
-  Object.defineProperty(window, 'kubernetesRegisterGetCurrentContextResources', {
-    value: kubernetesRegisterGetCurrentContextResourcesMock,
-  });
-});
-
-const kubernetesRegisterGetCurrentContextResourcesMock = vi.fn();
-
 test('createNavigationKubernetesDeploymentsEntry', async () => {
-  const nodes: KubernetesObject[] = [
+  const deployments: KubernetesObject[] = [
     {
       apiVersion: 'v1',
-      kind: 'Node',
+      kind: 'Deployment',
       metadata: {
-        name: 'node1',
+        name: 'deployment1',
       },
     },
     {
       apiVersion: 'v1',
-      kind: 'Node',
+      kind: 'Deployment',
       metadata: {
-        name: 'node2',
+        name: 'deployment2',
       },
     },
   ];
-  kubernetesRegisterGetCurrentContextResourcesMock.mockResolvedValue(nodes);
+  vi.mocked(window.kubernetesRegisterGetCurrentContextResources).mockResolvedValue(deployments);
 
   const entry = createNavigationKubernetesDeploymentsEntry();
 

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-ingresses-routes.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-ingresses-routes.svelte.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,37 +17,28 @@
  ***********************************************************************/
 
 import type { KubernetesObject } from '@kubernetes/client-node';
-import { beforeEach, expect, test, vi } from 'vitest';
+import { expect, test, vi } from 'vitest';
 
 import { createNavigationKubernetesIngressesRoutesEntry } from './navigation-registry-k8s-ingresses-routes.svelte';
 
-beforeEach(() => {
-  vi.resetAllMocks();
-  Object.defineProperty(window, 'kubernetesRegisterGetCurrentContextResources', {
-    value: kubernetesRegisterGetCurrentContextResourcesMock,
-  });
-});
-
-const kubernetesRegisterGetCurrentContextResourcesMock = vi.fn();
-
 test('createNavigationKubernetesIngressesRoutesEntry', async () => {
-  const nodes: KubernetesObject[] = [
+  const ingressRoutes: KubernetesObject[] = [
     {
       apiVersion: 'v1',
-      kind: 'Node',
+      kind: 'Ingress',
       metadata: {
-        name: 'node1',
+        name: 'ingress1',
       },
     },
     {
       apiVersion: 'v1',
-      kind: 'Node',
+      kind: 'Ingress',
       metadata: {
-        name: 'node2',
+        name: 'ingress2',
       },
     },
   ];
-  kubernetesRegisterGetCurrentContextResourcesMock.mockResolvedValue(nodes);
+  vi.mocked(window.kubernetesRegisterGetCurrentContextResources).mockResolvedValue(ingressRoutes);
 
   const entry = createNavigationKubernetesIngressesRoutesEntry();
 

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-nodes.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-nodes.svelte.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,18 +17,9 @@
  ***********************************************************************/
 
 import type { KubernetesObject } from '@kubernetes/client-node';
-import { beforeEach, expect, test, vi } from 'vitest';
+import { expect, test, vi } from 'vitest';
 
 import { createNavigationKubernetesNodesEntry } from './navigation-registry-k8s-nodes.svelte';
-
-beforeEach(() => {
-  vi.resetAllMocks();
-  Object.defineProperty(window, 'kubernetesRegisterGetCurrentContextResources', {
-    value: kubernetesRegisterGetCurrentContextResourcesMock,
-  });
-});
-
-const kubernetesRegisterGetCurrentContextResourcesMock = vi.fn();
 
 test('createNavigationKubernetesNodesEntry', async () => {
   const nodes: KubernetesObject[] = [
@@ -47,7 +38,7 @@ test('createNavigationKubernetesNodesEntry', async () => {
       },
     },
   ];
-  kubernetesRegisterGetCurrentContextResourcesMock.mockResolvedValue(nodes);
+  vi.mocked(window.kubernetesRegisterGetCurrentContextResources).mockResolvedValue(nodes);
 
   const entry = createNavigationKubernetesNodesEntry();
 

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-persistent-volume.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-persistent-volume.svelte.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,38 +17,29 @@
  ***********************************************************************/
 
 import type { KubernetesObject } from '@kubernetes/client-node';
-import { beforeEach, expect, test, vi } from 'vitest';
+import { expect, test, vi } from 'vitest';
 
 import { createNavigationKubernetesPersistentVolumeEntry } from './navigation-registry-k8s-persistent-volume.svelte';
 
-beforeEach(() => {
-  vi.resetAllMocks();
-  Object.defineProperty(window, 'kubernetesRegisterGetCurrentContextResources', {
-    value: kubernetesRegisterGetCurrentContextResourcesMock,
-  });
-});
-
-const kubernetesRegisterGetCurrentContextResourcesMock = vi.fn();
-
 test('createNavigationKubernetesPersistentVolumeEntry', async () => {
-  const nodes: KubernetesObject[] = [
+  const pvcs: KubernetesObject[] = [
     {
       apiVersion: 'v1',
-      kind: 'Node',
+      kind: 'PersistentVolumeClaim',
       metadata: {
-        name: 'node1',
+        name: 'pvc1',
       },
     },
     {
       apiVersion: 'v1',
-      kind: 'Node',
+      kind: 'PersistentVolumeClaim',
       metadata: {
-        name: 'node2',
+        name: 'pvc2',
       },
     },
   ];
 
-  kubernetesRegisterGetCurrentContextResourcesMock.mockResolvedValue(nodes);
+  vi.mocked(window.kubernetesRegisterGetCurrentContextResources).mockResolvedValue(pvcs);
 
   const entry = createNavigationKubernetesPersistentVolumeEntry();
 

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-services.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-services.svelte.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,39 +17,29 @@
  ***********************************************************************/
 
 import type { KubernetesObject } from '@kubernetes/client-node';
-import { beforeEach, expect, test, vi } from 'vitest';
+import { expect, test, vi } from 'vitest';
 
 import { createNavigationKubernetesServicesEntry } from './navigation-registry-k8s-services.svelte';
 
-beforeEach(() => {
-  vi.resetAllMocks();
-  vi.clearAllMocks();
-  Object.defineProperty(window, 'kubernetesRegisterGetCurrentContextResources', {
-    value: kubernetesRegisterGetCurrentContextResourcesMock,
-  });
-});
-
-const kubernetesRegisterGetCurrentContextResourcesMock = vi.fn();
-
 test('createNavigationKubernetesServicesEntry', async () => {
-  const nodes: KubernetesObject[] = [
+  const services: KubernetesObject[] = [
     {
       apiVersion: 'v1',
-      kind: 'Node',
+      kind: 'Service',
       metadata: {
-        name: 'node1',
+        name: 'service1',
       },
     },
     {
       apiVersion: 'v1',
-      kind: 'Node',
+      kind: 'Service',
       metadata: {
-        name: 'node2',
+        name: 'service2',
       },
     },
   ];
 
-  kubernetesRegisterGetCurrentContextResourcesMock.mockResolvedValue(nodes);
+  vi.mocked(window.kubernetesRegisterGetCurrentContextResources).mockResolvedValue(services);
 
   const entry = createNavigationKubernetesServicesEntry();
 


### PR DESCRIPTION
### What does this PR do?

When we added Pods to the Kubernetes navigation, we used the newer vi.mocking. This just updates the existing tests to use the same mocking.

Note: the actual objects being mocked are irrelevant for the tests, they would still pass if they used [{},{}]. Instead of switching to that I've cleaned up the objects and array name in case we ever change kubernetesRegisterGetCurrentContextResources such that the tests rely on the correct type of resource.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of #10903.

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature