### PR TITLE
fix: add kubeconfig flag to create a Kind cluster

### DIFF
--- a/extensions/kind/src/create-cluster.spec.ts
+++ b/extensions/kind/src/create-cluster.spec.ts
@@ -29,6 +29,7 @@ vi.mock('@podman-desktop/api', async () => {
     Logger: {},
     kubernetes: {
       createResources: vi.fn(),
+      getKubeconfig: vi.fn().mockReturnValue({ path: '/some/path' }),
     },
     provider: {
       getContainerConnections: vi

--- a/extensions/kind/src/create-cluster.ts
+++ b/extensions/kind/src/create-cluster.ts
@@ -183,14 +183,19 @@ export async function createCluster(
     ingressController,
   };
 
+  const kubeConfigPath = extensionApi.kubernetes.getKubeconfig().path;
   // now execute the command to create the cluster
   const startTime = performance.now();
   try {
-    await extensionApi.process.exec(kindCli, ['create', 'cluster', '--config', configFile ?? tmpFilePath], {
-      env,
-      logger,
-      token,
-    });
+    await extensionApi.process.exec(
+      kindCli,
+      ['create', 'cluster', '--config', configFile ?? tmpFilePath, '--kubeconfig', kubeConfigPath],
+      {
+        env,
+        logger,
+        token,
+      },
+    );
     if (ingressController) {
       logger?.log('Creating ingress controller resources');
       await setupIngressController(clusterName);

--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -183,7 +183,12 @@ async function updateClusters(
           }
           env.PATH = getKindPath() ?? '';
           if (kindPath) {
-            await extensionApi.process.exec(kindPath, ['delete', 'cluster', '--name', cluster.name], { env, logger });
+            const kubeConfigPath = extensionApi.kubernetes.getKubeconfig().path;
+            await extensionApi.process.exec(
+              kindPath,
+              ['delete', 'cluster', '--name', cluster.name, '--kubeconfig', kubeConfigPath],
+              { env, logger },
+            );
           }
         },
       };


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR adds a `--kubeconfig` flag to the `create cluster` and `delete cluster` Kind operations.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Fixes https://github.com/podman-desktop/podman-desktop/issues/10367

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
