### PR TITLE
chore: svelte 5 kubernetes columns

### DIFF
--- a/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretColumnActions.svelte
+++ b/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretColumnActions.svelte
@@ -2,7 +2,10 @@
 import ConfigmapSecretActions from './ConfigMapSecretActions.svelte';
 import type { ConfigMapSecretUI } from './ConfigMapSecretUI';
 
-export let object: ConfigMapSecretUI;
+interface Props {
+  object: ConfigMapSecretUI;
+}
+let { object }: Props = $props();
 </script>
 
 <ConfigmapSecretActions configMapSecret={object} on:update />

--- a/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretColumnName.svelte
+++ b/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretColumnName.svelte
@@ -4,7 +4,10 @@ import { router } from 'tinro';
 import { ConfigMapSecretUtils } from './configmap-secret-utils';
 import type { ConfigMapSecretUI } from './ConfigMapSecretUI';
 
-export let object: ConfigMapSecretUI;
+interface Props {
+  object: ConfigMapSecretUI;
+}
+let { object }: Props = $props();
 
 function openDetails(): void {
   const configmapSecretUtils = new ConfigMapSecretUtils();
@@ -22,7 +25,7 @@ function openDetails(): void {
 }
 </script>
 
-<button class="hover:cursor-pointer flex flex-col max-w-full" on:click={openDetails}>
+<button class="hover:cursor-pointer flex flex-col max-w-full" onclick={openDetails}>
   <div class="text-sm text-[var(--pd-table-body-text-highlight)] max-w-full overflow-hidden text-ellipsis">
     {object.name}
   </div>

--- a/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretColumnStatus.svelte
+++ b/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretColumnStatus.svelte
@@ -4,7 +4,10 @@ import { StatusIcon } from '@podman-desktop/ui-svelte';
 import ConfigMapSecretIcon from '../images/ConfigMapSecretIcon.svelte';
 import type { ConfigMapSecretUI } from './ConfigMapSecretUI';
 
-export let object: ConfigMapSecretUI;
+interface Props {
+  object: ConfigMapSecretUI;
+}
+let { object }: Props = $props();
 </script>
 
 <StatusIcon icon={ConfigMapSecretIcon} status={object.status} />

--- a/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretColumnType.svelte
+++ b/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretColumnType.svelte
@@ -5,7 +5,10 @@ import Fa from 'svelte-fa';
 import Label from '../ui/Label.svelte';
 import type { ConfigMapSecretUI } from './ConfigMapSecretUI';
 
-export let object: ConfigMapSecretUI;
+interface Props {
+  object: ConfigMapSecretUI;
+}
+let { object }: Props = $props();
 
 // Determine the icon and color based on the type
 function getTypeAttributes(type: string): { color: string; icon: IconDefinition } {

--- a/packages/renderer/src/lib/deployments/DeploymentColumnActions.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnActions.svelte
@@ -2,7 +2,10 @@
 import DeploymentActions from './DeploymentActions.svelte';
 import type { DeploymentUI } from './DeploymentUI';
 
-export let object: DeploymentUI;
+interface Props {
+  object: DeploymentUI;
+}
+let { object }: Props = $props();
 </script>
 
 <DeploymentActions deployment={object} on:update />

--- a/packages/renderer/src/lib/deployments/DeploymentColumnConditions.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnConditions.svelte
@@ -14,7 +14,10 @@ import Fa from 'svelte-fa';
 import Label from '../ui/Label.svelte';
 import type { DeploymentCondition, DeploymentUI } from './DeploymentUI';
 
-export let object: DeploymentUI;
+interface Props {
+  object: DeploymentUI;
+}
+let { object }: Props = $props();
 
 // Determine both the icon and color based on the deployment condition
 function getConditionAttributes(condition: DeploymentCondition): { name: string; color: string; icon: IconDefinition } {

--- a/packages/renderer/src/lib/deployments/DeploymentColumnName.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnName.svelte
@@ -3,14 +3,17 @@ import { router } from 'tinro';
 
 import type { DeploymentUI } from './DeploymentUI';
 
-export let object: DeploymentUI;
+interface Props {
+  object: DeploymentUI;
+}
+let { object }: Props = $props();
 
 function openDetails(): void {
   router.goto(`/kubernetes/deployments/${encodeURI(object.name)}/${encodeURI(object.namespace)}/summary`);
 }
 </script>
 
-<button class="hover:cursor-pointer flex flex-col max-w-full" on:click={openDetails}>
+<button class="hover:cursor-pointer flex flex-col max-w-full" onclick={openDetails}>
   <div class="text-[var(--pd-table-body-text-highlight)] max-w-full overflow-hidden text-ellipsis">
     {object.name}
   </div>

--- a/packages/renderer/src/lib/deployments/DeploymentColumnPods.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnPods.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
 import type { DeploymentUI } from './DeploymentUI';
 
-export let object: DeploymentUI;
+interface Props {
+  object: DeploymentUI;
+}
+let { object }: Props = $props();
 </script>
 
 <div class="text-[var(--pd-table-body-text)]">

--- a/packages/renderer/src/lib/deployments/DeploymentColumnStatus.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnStatus.svelte
@@ -4,7 +4,10 @@ import { StatusIcon } from '@podman-desktop/ui-svelte';
 import DeploymentIcon from '../images/DeploymentIcon.svelte';
 import type { DeploymentUI } from './DeploymentUI';
 
-export let object: DeploymentUI;
+interface Props {
+  object: DeploymentUI;
+}
+let { object }: Props = $props();
 </script>
 
 <StatusIcon icon={DeploymentIcon} status={object.status} />

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnActions.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnActions.svelte
@@ -3,7 +3,10 @@ import IngressRouteActions from './IngressRouteActions.svelte';
 import type { IngressUI } from './IngressUI';
 import type { RouteUI } from './RouteUI';
 
-export let object: IngressUI | RouteUI;
+interface Props {
+  object: IngressUI | RouteUI;
+}
+let { object }: Props = $props();
 </script>
 
 <IngressRouteActions ingressRoute={object} on:update />

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnBackend.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnBackend.svelte
@@ -3,7 +3,10 @@ import { IngressRouteUtils } from './ingress-route-utils';
 import type { IngressUI } from './IngressUI';
 import type { RouteUI } from './RouteUI';
 
-export let object: IngressUI | RouteUI;
+interface Props {
+  object: IngressUI | RouteUI;
+}
+let { object }: Props = $props();
 
 const ingressRouteUtils = new IngressRouteUtils();
 </script>

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnHostPath.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnHostPath.svelte
@@ -5,7 +5,10 @@ import { IngressRouteUtils } from './ingress-route-utils';
 import type { IngressUI } from './IngressUI';
 import type { RouteUI } from './RouteUI';
 
-export let object: IngressUI | RouteUI;
+interface Props {
+  object: IngressUI | RouteUI;
+}
+let { object }: Props = $props();
 
 const ingressRouteUtils = new IngressRouteUtils();
 </script>

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnName.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnName.svelte
@@ -5,7 +5,10 @@ import { IngressRouteUtils } from './ingress-route-utils';
 import type { IngressUI } from './IngressUI';
 import type { RouteUI } from './RouteUI';
 
-export let object: IngressUI | RouteUI;
+interface Props {
+  object: IngressUI | RouteUI;
+}
+let { object }: Props = $props();
 
 function openDetails(): void {
   const ingressRouteUtils = new IngressRouteUtils();
@@ -17,7 +20,7 @@ function openDetails(): void {
 }
 </script>
 
-<button class="hover:cursor-pointer flex flex-col max-w-full" on:click={openDetails}>
+<button class="hover:cursor-pointer flex flex-col max-w-full" onclick={openDetails}>
   <div class="text-[var(--pd-table-body-text-highlight)] max-w-full overflow-hidden text-ellipsis">
     {object.name}
   </div>

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnStatus.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnStatus.svelte
@@ -5,7 +5,10 @@ import IngressRouteIcon from '../images/IngressRouteIcon.svelte';
 import type { IngressUI } from './IngressUI';
 import type { RouteUI } from './RouteUI';
 
-export let object: IngressUI | RouteUI;
+interface Props {
+  object: IngressUI | RouteUI;
+}
+let { object }: Props = $props();
 </script>
 
 <StatusIcon icon={IngressRouteIcon} status={object.status} />

--- a/packages/renderer/src/lib/kube/pods/PodColumnActions.svelte
+++ b/packages/renderer/src/lib/kube/pods/PodColumnActions.svelte
@@ -2,11 +2,10 @@
 import PodActions from './PodActions.svelte';
 import type { PodUI } from './PodUI';
 
-let {
-  object,
-}: {
+interface Props {
   object: PodUI;
-} = $props();
+}
+let { object }: Props = $props();
 </script>
 
 <PodActions pod={object} dropdownMenu={true} on:update />

--- a/packages/renderer/src/lib/kube/pods/PodColumnContainers.svelte
+++ b/packages/renderer/src/lib/kube/pods/PodColumnContainers.svelte
@@ -2,11 +2,10 @@
 import Dots from '../../ui/Dots.svelte';
 import type { PodUI } from './PodUI';
 
-let {
-  object,
-}: {
+interface Props {
   object: PodUI;
-} = $props();
+}
+let { object }: Props = $props();
 </script>
 
 <Dots containers={object.containers} />

--- a/packages/renderer/src/lib/kube/pods/PodColumnName.svelte
+++ b/packages/renderer/src/lib/kube/pods/PodColumnName.svelte
@@ -3,11 +3,10 @@ import { router } from 'tinro';
 
 import type { PodUI } from './PodUI';
 
-let {
-  object,
-}: {
+interface Props {
   object: PodUI;
-} = $props();
+}
+let { object }: Props = $props();
 
 function openDetails(): void {
   router.goto(`/kubernetes/pods/${encodeURI(object.name)}/${encodeURI(object.namespace)}/summary`);

--- a/packages/renderer/src/lib/kube/pods/PodColumnStatus.svelte
+++ b/packages/renderer/src/lib/kube/pods/PodColumnStatus.svelte
@@ -4,11 +4,10 @@ import { StatusIcon } from '@podman-desktop/ui-svelte';
 import PodIcon from '../../images/PodIcon.svelte';
 import type { PodUI } from './PodUI';
 
-let {
-  object,
-}: {
+interface Props {
   object: PodUI;
-} = $props();
+}
+let { object }: Props = $props();
 </script>
 
 <StatusIcon icon={PodIcon} status={object.status} />

--- a/packages/renderer/src/lib/node/NodeColumnName.svelte
+++ b/packages/renderer/src/lib/node/NodeColumnName.svelte
@@ -3,14 +3,17 @@ import { router } from 'tinro';
 
 import type { NodeUI } from './NodeUI';
 
-export let object: NodeUI;
+interface Props {
+  object: NodeUI;
+}
+let { object }: Props = $props();
 
 function openDetails(): void {
   router.goto(`/kubernetes/nodes/${encodeURI(object.name)}/summary`);
 }
 </script>
 
-<button class="hover:cursor-pointer flex flex-col max-w-full" on:click={openDetails}>
+<button class="hover:cursor-pointer flex flex-col max-w-full" onclick={openDetails}>
   <div class="text-[var(--pd-table-body-text-highlight)] max-w-full overflow-hidden text-ellipsis">
     {object.name}
   </div>

--- a/packages/renderer/src/lib/node/NodeColumnRoles.svelte
+++ b/packages/renderer/src/lib/node/NodeColumnRoles.svelte
@@ -6,30 +6,36 @@ import Fa from 'svelte-fa';
 import Label from '../ui/Label.svelte';
 import type { NodeUI } from './NodeUI';
 
-export let object: NodeUI;
+interface Props {
+  object: NodeUI;
+}
+let { object }: Props = $props();
 
-let roleName: string;
-let roleIcon: IconDefinition;
+let roleName = $state<string>();
+let roleIcon = $state<IconDefinition>(faServer);
+let roleClass = $state<string>();
 
-function getConditionColour(role: 'control-plane' | 'node'): string {
-  switch (role) {
+$effect(() => {
+  switch (object.role) {
     case 'control-plane':
       roleName = 'Control Plane';
       // faSatelliteDish: Represents a satellite dish, suitable for the control plane role
       roleIcon = faSatelliteDish;
-      return 'text-[var(--pd-status-running)]';
+      roleClass = 'text-[var(--pd-status-running)]';
+      break;
     case 'node':
       roleName = 'Node';
       // faServer: Better represents a "node" / server rack
       roleIcon = faServer;
-      return 'text-[var(--pd-status-updated)]';
+      roleClass = 'text-[var(--pd-status-updated)]';
+      break;
   }
-}
+});
 </script>
 
 <div class="flex flex-row gap-1">
   <Label name={roleName}>
-    <Fa size="1x" icon={roleIcon} class={getConditionColour(object.role)} />
+    <Fa size="1x" icon={roleIcon} class={roleClass} />
   </Label>
   {#if object.hasGpu}
     <Label name="GPU">

--- a/packages/renderer/src/lib/node/NodeColumnStatus.svelte
+++ b/packages/renderer/src/lib/node/NodeColumnStatus.svelte
@@ -4,7 +4,10 @@ import { StatusIcon } from '@podman-desktop/ui-svelte';
 import NodeIcon from '../images/NodeIcon.svelte';
 import type { NodeUI } from './NodeUI';
 
-export let object: NodeUI;
+interface Props {
+  object: NodeUI;
+}
+let { object }: Props = $props();
 </script>
 
 <StatusIcon icon={NodeIcon} status={object.status} />

--- a/packages/renderer/src/lib/pvc/PVCColumnActions.svelte
+++ b/packages/renderer/src/lib/pvc/PVCColumnActions.svelte
@@ -2,7 +2,10 @@
 import PVCActions from './PVCActions.svelte';
 import type { PVCUI } from './PVCUI';
 
-export let object: PVCUI;
+interface Props {
+  object: PVCUI;
+}
+let { object }: Props = $props();
 </script>
 
 <PVCActions pvc={object} on:update />

--- a/packages/renderer/src/lib/pvc/PVCColumnMode.svelte
+++ b/packages/renderer/src/lib/pvc/PVCColumnMode.svelte
@@ -5,7 +5,10 @@ import Fa from 'svelte-fa';
 import Label from '../ui/Label.svelte';
 import type { PVCUI } from './PVCUI';
 
-export let object: PVCUI;
+interface Props {
+  object: PVCUI;
+}
+let { object }: Props = $props();
 
 // Determine the icon and color based on the access mode, with comments explaining each icon choice
 // Many = multiple access points, so should be green

--- a/packages/renderer/src/lib/pvc/PVCColumnName.svelte
+++ b/packages/renderer/src/lib/pvc/PVCColumnName.svelte
@@ -3,14 +3,17 @@ import { router } from 'tinro';
 
 import type { PVCUI } from './PVCUI';
 
-export let object: PVCUI;
+interface Props {
+  object: PVCUI;
+}
+let { object }: Props = $props();
 
 function openDetails(): void {
   router.goto(`/kubernetes/persistentvolumeclaims/${encodeURI(object.name)}/${encodeURI(object.namespace)}/summary`);
 }
 </script>
 
-<button class="hover:cursor-pointer flex flex-col max-w-full" on:click={openDetails}>
+<button class="hover:cursor-pointer flex flex-col max-w-full" onclick={openDetails}>
   <div class="max-w-full overflow-hidden text-ellipsis text-[var(--pd-table-body-text-highlight)]">
     {object.name}
   </div>

--- a/packages/renderer/src/lib/pvc/PVCColumnStatus.svelte
+++ b/packages/renderer/src/lib/pvc/PVCColumnStatus.svelte
@@ -4,7 +4,10 @@ import { StatusIcon } from '@podman-desktop/ui-svelte';
 import PVCIcon from '../images/PVCIcon.svelte';
 import type { PVCUI } from './PVCUI';
 
-export let object: PVCUI;
+interface Props {
+  object: PVCUI;
+}
+let { object }: Props = $props();
 </script>
 
 <StatusIcon icon={PVCIcon} status={object.status} />

--- a/packages/renderer/src/lib/service/ServiceColumnActions.svelte
+++ b/packages/renderer/src/lib/service/ServiceColumnActions.svelte
@@ -2,7 +2,10 @@
 import ServiceActions from './ServiceActions.svelte';
 import type { ServiceUI } from './ServiceUI';
 
-export let object: ServiceUI;
+interface Props {
+  object: ServiceUI;
+}
+let { object }: Props = $props();
 </script>
 
 <ServiceActions service={object} on:update />

--- a/packages/renderer/src/lib/service/ServiceColumnName.svelte
+++ b/packages/renderer/src/lib/service/ServiceColumnName.svelte
@@ -3,14 +3,17 @@ import { router } from 'tinro';
 
 import type { ServiceUI } from './ServiceUI';
 
-export let object: ServiceUI;
+interface Props {
+  object: ServiceUI;
+}
+let { object }: Props = $props();
 
 function openDetails(): void {
   router.goto(`/kubernetes/services/${encodeURI(object.name)}/${encodeURI(object.namespace)}/summary`);
 }
 </script>
 
-<button class="hover:cursor-pointer flex flex-col max-w-full" on:click={openDetails}>
+<button class="hover:cursor-pointer flex flex-col max-w-full" onclick={openDetails}>
   <div class="text-[var(--pd-table-body-text-highlight)] max-w-full overflow-hidden text-ellipsis">
     {object.name}
   </div>

--- a/packages/renderer/src/lib/service/ServiceColumnStatus.svelte
+++ b/packages/renderer/src/lib/service/ServiceColumnStatus.svelte
@@ -4,7 +4,10 @@ import { StatusIcon } from '@podman-desktop/ui-svelte';
 import ServiceIcon from '../images/ServiceIcon.svelte';
 import type { ServiceUI } from './ServiceUI';
 
-export let object: ServiceUI;
+interface Props {
+  object: ServiceUI;
+}
+let { object }: Props = $props();
 </script>
 
 <StatusIcon icon={ServiceIcon} status={object.status} />

--- a/packages/renderer/src/lib/service/ServiceColumnType.svelte
+++ b/packages/renderer/src/lib/service/ServiceColumnType.svelte
@@ -11,7 +11,10 @@ import { Fa } from 'svelte-fa';
 import Label from '../ui/Label.svelte';
 import type { ServiceUI } from './ServiceUI';
 
-export let object: ServiceUI;
+interface Props {
+  object: ServiceUI;
+}
+let { object }: Props = $props();
 
 // Determine both the icon and color based on the service type
 function getTypeAttributes(type: string): { color: string; icon: IconDefinition } {


### PR DESCRIPTION
### What does this PR do?

Update all the Kubernetes columns to svelte 5: $props, $state, and onclick

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of #10903.

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature