### PR TITLE
chore: remove gradient styling from tailwindcss

### DIFF
--- a/website/src/pages/extensions/ai-lab/index.tsx
+++ b/website/src/pages/extensions/ai-lab/index.tsx
@@ -128,7 +128,7 @@ export default function Home(): JSX.Element {
             <div className="w-full grid grid-cols-2 gap-2 lg:grid-cols-2">
               {RECIPES.map(recipe => (
                 <div
-                  className="px-8 py-4 rounded-xl from-purple-500 from-70% bg-gradient-to-t to-white flex flex-col grow items-center text-black text-center"
+                  className="px-8 py-4 rounded-xl flex flex-col grow items-center text-black text-center"
                   style={{
                     background: getGradient(recipe.colorFrom, recipe.colorTo),
                     border: `1px solid ${recipe.colorFrom}`,


### PR DESCRIPTION
### What does this PR do?
there are two gradients colliding (tailwindcss rules and the style getGradient)
only the style one should be kept as if tailwind is considered as more important the rendering is failing

### Screenshot / video of UI

should not see a difference

### What issues does this PR fix or reference?

https://github.com/podman-desktop/podman-desktop/pull/10901#issuecomment-2624865662

### How to test this PR?

check the `/extensions/ai-lab` page of the website (and look at the 4 boxes with gradients)

expected : 4 different colors


- [ ] Tests are covering the bug fix or the new feature
