### PR TITLE
feat: expose navigateToCliTools to 3rd party extensions

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -4775,6 +4775,9 @@ declare module '@podman-desktop/api' {
     // Navigate to a specific pod referenced by kind, name and engineId
     export function navigateToPod(kind: string, name: string, engineId: string): Promise<void>;
 
+    // Navigate to the CliTools page
+    export function navigateToCliTools(): Promise<void>;
+
     // Navigate to a specific contribution (aka extension page) referenced by name
     export function navigateToContribution(name: string): Promise<void>;
 

--- a/packages/main/src/plugin/extension/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension/extension-loader.spec.ts
@@ -1615,6 +1615,16 @@ describe('Navigation', async () => {
     // checked on onboarding registry
     expect(vi.mocked(onboardingRegistry.getOnboarding)).toHaveBeenCalledWith('do.not-exists');
   });
+
+  test('navigateToCliTools', async () => {
+    const api = createApi();
+
+    // Spy send method
+    const sendMock = vi.spyOn(apiSender, 'send');
+
+    await api.navigation.navigateToCliTools();
+    expect(sendMock).toBeCalledWith('navigate', { page: NavigationPage.CLI_TOOLS });
+  });
 });
 
 test('check listWebviews', async () => {

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -1411,6 +1411,9 @@ export class ExtensionLoader {
       navigateToResources: async (): Promise<void> => {
         await this.navigationManager.navigateToResources();
       },
+      navigateToCliTools: async (): Promise<void> => {
+        await this.navigationManager.navigateToCliTools();
+      },
       navigateToEditProviderContainerConnection: async (
         connection: containerDesktopAPI.ProviderContainerConnection,
       ): Promise<void> => {


### PR DESCRIPTION
### What does this PR do?
expose internal method `navigateToCliTools` to the extensions

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/podman-desktop/podman-desktop/issues/10922

### How to test this PR?

unit test provided

- [x] Tests are covering the bug fix or the new feature
