### PR TITLE
feat: kube pod details

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -43,6 +43,7 @@ import IngressesRoutesList from './lib/ingresses-routes/IngressesRoutesList.svel
 import RouteDetails from './lib/ingresses-routes/RouteDetails.svelte';
 import KubePlayYAML from './lib/kube/KubePlayYAML.svelte';
 import KubernetesDashboard from './lib/kube/KubernetesDashboard.svelte';
+import KubePodDetails from './lib/kube/pods/PodDetails.svelte';
 import KubePodsList from './lib/kube/pods/PodsList.svelte';
 import PortForwardingList from './lib/kubernetes-port-forward/PortForwardingList.svelte';
 import ManifestDetails from './lib/manifest/ManifestDetails.svelte';
@@ -260,6 +261,13 @@ window.events?.receive('navigate', (navigationRequest: unknown) => {
           </Route>
           <Route path="/kubernetes/pods" breadcrumb="Pods" navigationHint="root">
             <KubePodsList />
+          </Route>
+          <Route
+            path="/kubernetes/pods/:name/:namespace/*"
+            breadcrumb="Pod Details"
+            let:meta
+            navigationHint="details">
+            <KubePodDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
           </Route>
           <Route path="/kubernetes/persistentvolumeclaims" breadcrumb="Persistent Volume Claims" navigationHint="root">
             <PVCList />

--- a/packages/renderer/src/lib/kube/pods/KubernetesTerminalBrowser.spec.ts
+++ b/packages/renderer/src/lib/kube/pods/KubernetesTerminalBrowser.spec.ts
@@ -20,9 +20,7 @@ import '@testing-library/jest-dom/vitest';
 
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
-import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
-
-import { podsInfos } from '/@/stores/pods';
+import { beforeAll, expect, test, vi } from 'vitest';
 
 import { terminalService } from '../../pod/KubernetesTerminalService';
 import KubernetesTerminalBrowser from './KubernetesTerminalBrowser.svelte';
@@ -60,11 +58,6 @@ beforeAll(() => {
       getComputedStyle: vi.fn(),
       addEventListener: vi.fn(),
       removeEventListener: vi.fn(),
-      matchMedia: vi.fn().mockReturnValue({
-        matches: false,
-        addEventListener: vi.fn(),
-        removeEventListener: vi.fn(),
-      }),
     },
   });
   vi.mocked(window.getComputedStyle).mockReturnValue({
@@ -91,10 +84,6 @@ const pod: PodUI = {
     },
   ],
 } as unknown as PodUI;
-
-beforeEach(() => {
-  vi.clearAllMocks();
-});
 
 test('Expect switch of terminal clicking on the item', async () => {
   render(KubernetesTerminalBrowser, { pod: pod });

--- a/packages/renderer/src/lib/kube/pods/KubernetesTerminalBrowser.spec.ts
+++ b/packages/renderer/src/lib/kube/pods/KubernetesTerminalBrowser.spec.ts
@@ -1,0 +1,154 @@
+/**********************************************************************
+ * Copyright (C) 2024-2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
+
+import { podsInfos } from '/@/stores/pods';
+
+import { terminalService } from '../../pod/KubernetesTerminalService';
+import KubernetesTerminalBrowser from './KubernetesTerminalBrowser.svelte';
+import type { PodUI } from './PodUI';
+
+vi.mock('@xterm/xterm', () => {
+  return {
+    Terminal: vi
+      .fn()
+      .mockReturnValue({ loadAddon: vi.fn(), open: vi.fn(), write: vi.fn(), dispose: vi.fn(), onData: vi.fn() }),
+  };
+});
+
+vi.mock('@xterm/addon-serialize');
+
+// dummy event emitter
+const eventEmitter = {
+  receive: (): void => {},
+};
+
+beforeAll(() => {
+  Object.defineProperty(global, 'window', {
+    value: {
+      events: {
+        receive: eventEmitter.receive,
+      },
+      navigator: {
+        clipboard: {
+          writeText: vi.fn(),
+        },
+      },
+      getConfigurationValue: vi.fn(),
+      kubernetesExec: vi.fn(),
+      kubernetesExecResize: vi.fn(),
+      getComputedStyle: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      matchMedia: vi.fn().mockReturnValue({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      }),
+    },
+  });
+  vi.mocked(window.getComputedStyle).mockReturnValue({
+    getPropertyValue: vi.fn().mockReturnValue(''),
+  } as unknown as CSSStyleDeclaration);
+});
+
+const podName = 'My Pod';
+
+// create a pod with 2 containers
+const pod: PodUI = {
+  name: podName,
+  selected: true,
+  containers: [
+    {
+      Id: '1234',
+      Names: 'container1',
+      Status: 'running',
+    },
+    {
+      Id: '5678',
+      Names: 'container2',
+      Status: 'running',
+    },
+  ],
+} as unknown as PodUI;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test('Expect switch of terminal clicking on the item', async () => {
+  render(KubernetesTerminalBrowser, { pod: pod });
+
+  // get the dropdown button
+  const dropdown = screen.getByRole('button', { name: 'Connected to:' });
+  expect(dropdown).toBeInTheDocument();
+
+  // assert we see only container1 which is the default being selected
+  expect(screen.getByText('container1')).toBeInTheDocument();
+  expect(screen.queryByText('container2')).not.toBeInTheDocument();
+
+  // click on the dropdown
+  await userEvent.click(dropdown);
+
+  // select the button with container2
+  const container2 = screen.getByText('container2');
+  expect(container2).toBeInTheDocument();
+  await userEvent.click(container2);
+
+  // now expect that the we did the switch to container 2
+  // and container1 is no longer present
+  expect(screen.getByText('container2')).toBeInTheDocument();
+  expect(screen.queryByText('container1')).not.toBeInTheDocument();
+});
+
+test('Expect switch of terminal using keyboard switch with arrow keys', async () => {
+  // spyon terminal Service
+  const spyOnTerminalServiceSpy = vi.spyOn(terminalService, 'ensureTerminalExists');
+
+  render(KubernetesTerminalBrowser, { pod: pod });
+
+  // get the dropdown button
+  const dropdown = screen.getByRole('button', { name: 'Connected to:' });
+  expect(dropdown).toBeInTheDocument();
+
+  // assert we see only container1 which is the default being selected
+  expect(screen.getByText('container1')).toBeInTheDocument();
+  expect(screen.queryByText('container2')).not.toBeInTheDocument();
+
+  // click on the dropdown
+  await userEvent.click(dropdown);
+
+  // clear the mock of the spy
+  spyOnTerminalServiceSpy.mockClear();
+  // send the arrow down key
+  await userEvent.keyboard('{arrowdown}');
+  // send the enter key
+  await userEvent.keyboard('{enter}');
+
+  // check that the terminal service was called with the right arguments
+  await vi.waitFor(() => expect(spyOnTerminalServiceSpy).toHaveBeenCalledWith('My Pod', 'container2'));
+
+  // should have container2
+  const container2 = screen.getByText('container2');
+  expect(container2).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/kube/pods/KubernetesTerminalBrowser.svelte
+++ b/packages/renderer/src/lib/kube/pods/KubernetesTerminalBrowser.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+import { Dropdown, EmptyScreen } from '@podman-desktop/ui-svelte';
+import { onMount } from 'svelte';
+
+import NoLogIcon from '/@/lib/ui/NoLogIcon.svelte';
+
+import { terminalService } from '../../pod/KubernetesTerminalService';
+import type { PodUI } from './PodUI';
+
+interface Props {
+  pod: PodUI;
+}
+let { pod }: Props = $props();
+
+let key = $state(0);
+
+let currentContainerStatus = $state(
+  pod.containers.reduce((acc, c) => {
+    acc.set(c.Names, c.Status);
+    return acc;
+  }, new Map<string, string>()) ?? new Map<string, string>(),
+);
+
+let currentContainerName = $state('');
+
+onMount(() => {
+  if (pod.containers.length > 0) {
+    currentContainerName = pod.containers[0].Names;
+    terminalService.ensureTerminalExists(pod.name, currentContainerName);
+  }
+  key++;
+});
+
+function handleSelectionChange(value: unknown): void {
+  currentContainerName = String(value);
+  terminalService.ensureTerminalExists(pod.name, currentContainerName);
+  key++;
+}
+</script>
+  
+<div class="flex flex-col h-full">
+  <div class="flex py-2 h-[40px]">
+    <label
+      for="input-standard-{pod.name}"
+      class="block w-auto text-sm font-medium whitespace-nowrap leading-6 text-[var(--pd-content-text)] pl-2 pr-2">
+      {#key key}
+        {#if terminalService.hasTerminal(pod.name, currentContainerName) && currentContainerStatus.get(currentContainerName) === 'running'}
+          Connected to:
+        {:else}
+          Connecting to:
+        {/if}
+      {/key}
+    </label>
+    <div class="w-full">
+      {#if pod.containers.length > 1}
+        <Dropdown
+          onChange={handleSelectionChange}
+          class="w-48"
+          name={pod.name}
+          id="input-standard-{pod.name}"
+          options={pod.containers.map(container => ({
+            label: container.Names,
+            value: container.Names,
+          }))}>
+        </Dropdown>
+      {:else}
+        <span
+          id="input-standard-{pod.name}"
+          class="block text-sm font-bold leading-6 text-[var(--pd-content-text)]"
+          aria-labelledby="listbox-label">{currentContainerName}</span>
+      {/if}
+    </div>
+  </div>
+
+  <div class="flex grow w-full min-h-0">
+    {#key key}
+      {#if terminalService.hasTerminal(pod.name, currentContainerName) && currentContainerStatus.get(currentContainerName) === 'running'}
+        <!-- svelte-ignore svelte_component_deprecated -->
+        <svelte:component
+          this={terminalService.getTerminal(pod.name, currentContainerName).component}
+          {...terminalService.getTerminal(pod.name, currentContainerName).props} />
+      {/if}
+    {/key}
+  </div>
+</div>
+
+<EmptyScreen
+  hidden={!currentContainerStatus.get(currentContainerName)}
+  icon={NoLogIcon}
+  title="No Terminal"
+  message="Container is not running" />

--- a/packages/renderer/src/lib/kube/pods/PodColumnName.spec.ts
+++ b/packages/renderer/src/lib/kube/pods/PodColumnName.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,10 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import { fireEvent } from '@testing-library/dom';
 import { render, screen } from '@testing-library/svelte';
-import { expect, test } from 'vitest';
+import { router } from 'tinro';
+import { expect, test, vi } from 'vitest';
 
 import PodColumnName from './PodColumnName.svelte';
 import type { PodUI } from './PodUI';
@@ -43,4 +45,37 @@ test('Expect simple column styling', async () => {
   const id = screen.getByText(pod.namespace);
   expect(id).toBeInTheDocument();
   expect(id).toHaveClass('text-[var(--pd-table-body-text)]');
+});
+
+test('Expect clicking works', async () => {
+  render(PodColumnName, { object: pod });
+
+  const text = screen.getByText(pod.name);
+  expect(text).toBeInTheDocument();
+
+  // test click
+  const routerGotoSpy = vi.spyOn(router, 'goto');
+
+  fireEvent.click(text);
+
+  expect(routerGotoSpy).toBeCalledWith('/kubernetes/pods/my-pod/default/summary');
+});
+
+test('Expect Kubernetes pod information', async () => {
+  const pod: PodUI = {
+    name: 'my-pod',
+    status: '',
+    selected: false,
+    containers: [],
+    node: 'node1',
+    namespace: 'customnamespace',
+  };
+
+  render(PodColumnName, { object: pod });
+
+  const name = screen.getByText('my-pod');
+  expect(name).toBeInTheDocument();
+
+  const namespace = screen.getByText('customnamespace');
+  expect(namespace).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/kube/pods/PodColumnName.svelte
+++ b/packages/renderer/src/lib/kube/pods/PodColumnName.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+import { router } from 'tinro';
+
 import type { PodUI } from './PodUI';
 
 let {
@@ -6,9 +8,13 @@ let {
 }: {
   object: PodUI;
 } = $props();
+
+function openDetails(): void {
+  router.goto(`/kubernetes/pods/${encodeURI(object.name)}/${encodeURI(object.namespace)}/summary`);
+}
 </script>
 
-<div class="flex flex-col max-w-full">
+<button class="hover:cursor-pointer flex flex-col max-w-full" onclick={openDetails}>
   <div class="text-[var(--pd-table-body-text-highlight)] max-w-full overflow-hidden text-ellipsis">
     {object.name}
   </div>
@@ -17,4 +23,4 @@ let {
       <div class="font-extra-light text-[var(--pd-table-body-text)]">{object.namespace}</div>
     {/if}
   </div>
-</div>
+</button>

--- a/packages/renderer/src/lib/kube/pods/PodDetails.spec.ts
+++ b/packages/renderer/src/lib/kube/pods/PodDetails.spec.ts
@@ -1,0 +1,137 @@
+/**********************************************************************
+ * Copyright (C) 2023-2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import type { CoreV1Event, KubernetesObject, V1Pod } from '@kubernetes/client-node';
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { writable } from 'svelte/store';
+import { router } from 'tinro';
+import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
+
+import { lastPage } from '/@/stores/breadcrumb';
+import * as kubeContextStore from '/@/stores/kubernetes-contexts-state';
+
+import PodDetails from './PodDetails.svelte';
+
+const mocks = vi.hoisted(() => ({
+  TerminalMock: vi.fn(),
+}));
+vi.mock('@xterm/xterm', () => ({
+  Terminal: mocks.TerminalMock,
+}));
+vi.mock('@xterm/addon-search');
+
+vi.mock('/@/stores/kubernetes-contexts-state', async () => {
+  return {
+    kubernetesCurrentContextPods: vi.fn(),
+    kubernetesCurrentContextEvents: vi.fn(),
+  };
+});
+
+const myPod: V1Pod = {
+  apiVersion: 'v1',
+  kind: 'Pod',
+  metadata: { name: 'my-pod', namespace: 'default' },
+  spec: {
+    containers: [
+      {
+        name: 'test-container',
+        ports: [{ name: 'http', containerPort: 8080 }],
+      },
+    ],
+  },
+};
+
+const showMessageBoxMock = vi.fn();
+const kubernetesDeletePodMock = vi.fn();
+
+beforeAll(() => {
+  mocks.TerminalMock.mockReturnValue({
+    loadAddon: vi.fn(),
+    open: vi.fn(),
+    write: vi.fn(),
+    dispose: vi.fn(),
+  });
+  global.ResizeObserver = vi.fn().mockReturnValue({
+    observe: vi.fn(),
+    unobserve: vi.fn(),
+    disconnect: vi.fn(),
+  });
+  Object.defineProperty(window, 'showMessageBox', { value: showMessageBoxMock });
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  vi.mocked(window.kubernetesListRoutes).mockResolvedValue([]);
+  //vi.mocked(window.showMessageBox).mockImplementation(showMessageBoxMock);
+  vi.mocked(window.kubernetesGetCurrentNamespace).mockResolvedValue('ns');
+  vi.mocked(window.kubernetesReadNamespacedPod).mockResolvedValue({ metadata: { labels: { app: 'foo' } } });
+  vi.mocked(window.kubernetesDeletePod).mockImplementation(kubernetesDeletePodMock);
+});
+
+test('Expect redirect to previous page if pod is deleted', async () => {
+  showMessageBoxMock.mockResolvedValue({ response: 0 });
+
+  const routerGotoSpy = vi.spyOn(router, 'goto');
+
+  // mock object stores
+  const pods = writable<KubernetesObject[]>([myPod]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextPods = pods;
+  const events = writable<CoreV1Event[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextEvents = events;
+
+  // remove deployment from the store when we call delete
+  kubernetesDeletePodMock.mockImplementation(() => {
+    pods.set([]);
+  });
+
+  // defines a fake lastPage so we can check where we will be redirected
+  lastPage.set({ name: 'Fake Previous', path: '/last' });
+
+  // render the component
+  render(PodDetails, { name: 'my-pod', namespace: 'default' });
+  expect(screen.getByText('my-pod')).toBeInTheDocument();
+
+  // grab current route
+  const currentRoute = window.location;
+  expect(currentRoute.href).toBe('http://localhost:3000/');
+
+  // click on delete pod button
+  const deleteButton = screen.getByRole('button', { name: 'Delete Pod' });
+  expect(deleteButton).toBeInTheDocument();
+  expect(deleteButton).toBeEnabled();
+
+  await fireEvent.click(deleteButton);
+  expect(showMessageBoxMock).toHaveBeenCalledOnce();
+
+  // Wait for confirmation modal to disappear after clicking on delete
+  await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+
+  // check that delete method has been called
+  expect(kubernetesDeletePodMock).toHaveBeenCalled();
+
+  // expect that we have called the router when page has been removed
+  // to jump to the previous page
+  expect(routerGotoSpy).toBeCalledWith('/last');
+
+  // grab updated route
+  const afterRoute = window.location;
+  expect(afterRoute.href).toBe('http://localhost:3000/last');
+});

--- a/packages/renderer/src/lib/kube/pods/PodDetails.spec.ts
+++ b/packages/renderer/src/lib/kube/pods/PodDetails.spec.ts
@@ -29,12 +29,7 @@ import * as kubeContextStore from '/@/stores/kubernetes-contexts-state';
 
 import PodDetails from './PodDetails.svelte';
 
-const mocks = vi.hoisted(() => ({
-  TerminalMock: vi.fn(),
-}));
-vi.mock('@xterm/xterm', () => ({
-  Terminal: mocks.TerminalMock,
-}));
+vi.mock('@xterm/xterm');
 vi.mock('@xterm/addon-search');
 
 vi.mock('/@/stores/kubernetes-contexts-state', async () => {
@@ -62,12 +57,6 @@ const showMessageBoxMock = vi.fn();
 const kubernetesDeletePodMock = vi.fn();
 
 beforeAll(() => {
-  mocks.TerminalMock.mockReturnValue({
-    loadAddon: vi.fn(),
-    open: vi.fn(),
-    write: vi.fn(),
-    dispose: vi.fn(),
-  });
   global.ResizeObserver = vi.fn().mockReturnValue({
     observe: vi.fn(),
     unobserve: vi.fn(),
@@ -80,7 +69,6 @@ beforeEach(() => {
   vi.resetAllMocks();
 
   vi.mocked(window.kubernetesListRoutes).mockResolvedValue([]);
-  //vi.mocked(window.showMessageBox).mockImplementation(showMessageBoxMock);
   vi.mocked(window.kubernetesGetCurrentNamespace).mockResolvedValue('ns');
   vi.mocked(window.kubernetesReadNamespacedPod).mockResolvedValue({ metadata: { labels: { app: 'foo' } } });
   vi.mocked(window.kubernetesDeletePod).mockImplementation(kubernetesDeletePodMock);

--- a/packages/renderer/src/lib/kube/pods/PodDetails.svelte
+++ b/packages/renderer/src/lib/kube/pods/PodDetails.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+import type { V1Pod } from '@kubernetes/client-node';
+import { StatusIcon, Tab } from '@podman-desktop/ui-svelte';
+import { onMount } from 'svelte';
+import { router } from 'tinro';
+import { stringify } from 'yaml';
+
+import { kubernetesCurrentContextPods } from '/@/stores/kubernetes-contexts-state';
+
+import Route from '../../../Route.svelte';
+import MonacoEditor from '../../editor/MonacoEditor.svelte';
+import PodIcon from '../../images/PodIcon.svelte';
+import DetailsPage from '../../ui/DetailsPage.svelte';
+import StateChange from '../../ui/StateChange.svelte';
+import { getTabUrl, isTabSelected } from '../../ui/Util';
+import KubeEditYaml from '../KubeEditYAML.svelte';
+import KubernetesTerminalBrowser from './KubernetesTerminalBrowser.svelte';
+import { PodUtils } from './pod-utils';
+import PodActions from './PodActions.svelte';
+import PodDetailsLogs from './PodDetailsLogs.svelte';
+import PodDetailsSummary from './PodDetailsSummary.svelte';
+import type { PodUI } from './PodUI';
+
+interface Props {
+  name: string;
+  namespace: string;
+}
+let { name, namespace }: Props = $props();
+
+let pod = $state<PodUI>();
+let detailsPage = $state<DetailsPage>();
+let kubePod = $state<V1Pod | undefined>();
+let kubeError = $state<string>();
+
+onMount(() => {
+  const podUtils = new PodUtils();
+  // loading pod info
+  return kubernetesCurrentContextPods.subscribe(pods => {
+    const matchingPod = pods.find(pod => pod.metadata?.name === name && pod.metadata?.namespace === namespace);
+    if (matchingPod) {
+      try {
+        pod = podUtils.getPodUI(matchingPod);
+        loadDetails().catch((err: unknown) => console.error(`Error getting pod details ${pod?.name}`, err));
+      } catch (err) {
+        console.error(err);
+      }
+    } else if (detailsPage) {
+      // the pod has been deleted
+      detailsPage.close();
+    }
+  });
+});
+
+async function loadDetails(): Promise<void> {
+  const getKubePod = await window.kubernetesReadNamespacedPod(name, namespace);
+  if (getKubePod) {
+    kubePod = getKubePod;
+  } else {
+    kubeError = `Unable to retrieve Kubernetes details for ${pod?.name}`;
+  }
+}
+</script>
+
+{#if pod}
+  <DetailsPage title={pod.name} subtitle={pod.namespace} bind:this={detailsPage}>
+    <StatusIcon slot="icon" icon={PodIcon} size={24} status={pod.status} />
+    <svelte:fragment slot="actions">
+      <PodActions pod={pod} detailed={true} />
+    </svelte:fragment>
+    <div slot="detail" class="flex py-2 w-full justify-end text-sm text-[var(--pd-content-text)]">
+      <StateChange state={pod.status} />
+    </div>
+    <svelte:fragment slot="tabs">
+      <Tab title="Summary" selected={isTabSelected($router.path, 'summary')} url={getTabUrl($router.path, 'summary')} />
+      <Tab title="Logs" selected={isTabSelected($router.path, 'logs')} url={getTabUrl($router.path, 'logs')} />
+      <Tab title="Inspect" selected={isTabSelected($router.path, 'inspect')} url={getTabUrl($router.path, 'inspect')} />
+      <Tab title="Kube" selected={isTabSelected($router.path, 'kube')} url={getTabUrl($router.path, 'kube')} />
+      <Tab
+          title="Terminal"
+          selected={isTabSelected($router.path, 'k8s-terminal')}
+          url={getTabUrl($router.path, 'k8s-terminal')} />
+    </svelte:fragment>
+    <svelte:fragment slot="content">
+      <Route path="/summary" breadcrumb="Summary" navigationHint="tab">
+        <PodDetailsSummary pod={kubePod} kubeError={kubeError} />
+      </Route>
+      <Route path="/logs" breadcrumb="Logs" navigationHint="tab">
+        <PodDetailsLogs pod={pod} />
+      </Route>
+      <Route path="/inspect" breadcrumb="Inspect" navigationHint="tab">
+        <MonacoEditor content={JSON.stringify(kubePod, undefined, 2)} language="json" />
+      </Route>
+      <Route path="/kube" breadcrumb="Kube" navigationHint="tab">
+        <KubeEditYaml content={stringify(kubePod)} />
+      </Route>
+      <Route path="/k8s-terminal" breadcrumb="Terminal" navigationHint="tab">
+        <KubernetesTerminalBrowser pod={pod} />
+      </Route>
+    </svelte:fragment>
+  </DetailsPage>
+{/if}

--- a/packages/renderer/src/lib/kube/pods/PodDetails.svelte
+++ b/packages/renderer/src/lib/kube/pods/PodDetails.svelte
@@ -27,10 +27,10 @@ interface Props {
 }
 let { name, namespace }: Props = $props();
 
-let pod = $state<PodUI | undefined>();
-let detailsPage = $state<DetailsPage | undefined>();
-let kubePod = $state<V1Pod | undefined>();
-let kubeError = $state<string | undefined>();
+let pod = $state<PodUI>();
+let detailsPage = $state<DetailsPage>();
+let kubePod = $state<V1Pod>();
+let kubeError = $state<string>();
 
 onMount(() => {
   const podUtils = new PodUtils();

--- a/packages/renderer/src/lib/kube/pods/PodDetails.svelte
+++ b/packages/renderer/src/lib/kube/pods/PodDetails.svelte
@@ -27,10 +27,10 @@ interface Props {
 }
 let { name, namespace }: Props = $props();
 
-let pod = $state<PodUI>();
-let detailsPage = $state<DetailsPage>();
+let pod = $state<PodUI | undefined>();
+let detailsPage = $state<DetailsPage | undefined>();
 let kubePod = $state<V1Pod | undefined>();
-let kubeError = $state<string>();
+let kubeError = $state<string | undefined>();
 
 onMount(() => {
   const podUtils = new PodUtils();
@@ -46,7 +46,7 @@ onMount(() => {
       }
     } else if (detailsPage) {
       // the pod has been deleted
-      detailsPage.close();
+      detailsPage?.close();
     }
   });
 });

--- a/packages/renderer/src/lib/kube/pods/PodDetailsLogs.svelte
+++ b/packages/renderer/src/lib/kube/pods/PodDetailsLogs.svelte
@@ -1,0 +1,108 @@
+<script lang="ts">
+import '@xterm/xterm/css/xterm.css';
+
+import { EmptyScreen } from '@podman-desktop/ui-svelte';
+import type { Terminal } from '@xterm/xterm';
+import { onMount } from 'svelte';
+
+import { ansi256Colours, colourizedANSIContainerName } from '../../editor/editor-utils';
+import { isMultiplexedLog } from '../../stream/stream-utils';
+import NoLogIcon from '../../ui/NoLogIcon.svelte';
+import TerminalWindow from '../../ui/TerminalWindow.svelte';
+import type { PodUI } from './PodUI';
+
+interface Props {
+  pod: PodUI;
+}
+let { pod }: Props = $props();
+
+// Log
+let refPod: PodUI;
+// Logs has been initialized
+let noLogs = $state(true);
+let logsTerminal = $state<Terminal>();
+
+// need to refresh logs when pod is switched or state changes
+$effect(() => {
+  if (refPod && (refPod.name !== pod.name || (refPod.status !== pod.status && pod.status !== 'EXITED'))) {
+    logsTerminal?.clear();
+    fetchPodLogs().catch((err: unknown) => console.error(`Error fetching logs for pod ${pod.name}`, err));
+  }
+  refPod = pod;
+});
+
+// Create a map that will store the ANSI 256 colour for each container name
+// if we run out of colours, we'll start from the beginning.
+const colourizedContainerName = new Map<string, string>();
+pod.containers.forEach((container, index) => {
+  const colour = ansi256Colours[index % ansi256Colours.length];
+  colourizedContainerName.set(container.Names, colourizedANSIContainerName(container.Names, colour));
+});
+
+// Callback for logs which will output the logs to the terminal
+function callback(name: string, data: string): void {
+  if (name === 'first-message') {
+    noLogs = false;
+  } else if (name === 'data') {
+    noLogs = false;
+    // 1: STDOUT
+    // 2: STDERR
+    logsTerminal?.write(data + '\r');
+  }
+  if (!noLogs) {
+    window.dispatchEvent(new Event('resize'));
+  }
+}
+
+// Fetches the logs for each container in the pod and outputs to the terminal
+async function fetchPodLogs(): Promise<void> {
+  // Go through each name of pod.containers array and determine
+  // how much spacing is required for each name to be printed.
+  let maxNameLength = 0;
+  pod.containers.forEach(container => {
+    if (container.Names.length > maxNameLength) {
+      maxNameLength = container.Names.length;
+    }
+  });
+
+  // Go through the array of containers from pod.containers and
+  // call window.logsContainer for each container with a logs callback.
+  // We use a custom logsCallback since we are adding the container name and padding
+  // before each log output.
+  //
+  // NOTE: Podman API returns 'Names' despite being a singular name for the container.
+  for (let container of pod.containers) {
+    // Set a customer callback that will add the container name and padding
+    const logsCallback = (name: string, data: string): void => {
+      const padding = ' '.repeat(maxNameLength - container.Names.length);
+      const colouredName = colourizedContainerName.get(container.Names);
+
+      let content;
+      if (isMultiplexedLog(data)) {
+        content = data.substring(8);
+      } else {
+        content = data;
+      }
+
+      callback(name, `${colouredName} ${padding} | ${content}`);
+    };
+
+    // Get the logs for the container
+    await window.kubernetesReadPodLog(pod.name, container.Names, logsCallback);
+  }
+}
+
+onMount(async () => {
+  await fetchPodLogs();
+});
+</script>
+
+<EmptyScreen icon={NoLogIcon} title="No Log" message="Log output of Pod {pod.name}" hidden={noLogs === false} />
+
+<div
+  class="min-w-full flex flex-col"
+  class:invisible={noLogs === true}
+  class:h-0={noLogs === true}
+  class:h-full={noLogs === false}>
+  <TerminalWindow class="h-full" bind:terminal={logsTerminal} convertEol disableStdIn />
+</div>

--- a/packages/renderer/src/lib/kube/pods/PodDetailsSummary.spec.ts
+++ b/packages/renderer/src/lib/kube/pods/PodDetailsSummary.spec.ts
@@ -1,0 +1,119 @@
+/**********************************************************************
+ * Copyright (C) 2023-2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import type {
+  V1ConfigMapVolumeSource,
+  V1Container,
+  V1PersistentVolumeClaimVolumeSource,
+  V1Pod,
+  V1PodSpec,
+  V1PodStatus,
+  V1SecretVolumeSource,
+  V1Volume,
+} from '@kubernetes/client-node';
+import { render, screen, waitFor } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import PodDetailsSummary from './PodDetailsSummary.svelte';
+
+const fakePod: V1Pod = {
+  apiVersion: 'v1',
+  kind: 'Pod',
+  metadata: {
+    name: 'fakepod',
+    annotations: {
+      'example.com/annotation1': 'annotation-value1',
+      'example.com/annotation2': 'annotation-value2',
+    },
+    // Use Date object to avoid timezone issues
+    creationTimestamp: new Date('2021-01-01T00:00:00Z'),
+  },
+  spec: {
+    serviceAccountName: 'fake-service-account',
+    restartPolicy: 'Always',
+    containers: [
+      {
+        name: 'fake-container',
+        image: 'fake-image',
+        env: [
+          {
+            name: 'ENV_VAR1',
+            value: 'value1',
+          },
+          {
+            name: 'ENV_VAR2',
+            value: 'value2',
+          },
+        ],
+        volumeMounts: [
+          {
+            name: 'secret-volume',
+            mountPath: '/etc/secret',
+          },
+          {
+            name: 'configmap-volume',
+            mountPath: '/etc/config',
+          },
+          {
+            name: 'pvc-volume',
+            mountPath: '/data',
+          },
+        ],
+      } as V1Container,
+    ],
+    volumes: [
+      {
+        name: 'secret-volume',
+        secret: {
+          secretName: 'fake-secret',
+        } as V1SecretVolumeSource,
+      },
+      {
+        name: 'configmap-volume',
+        configMap: {
+          name: 'fake-configmap',
+        } as V1ConfigMapVolumeSource,
+      },
+      {
+        name: 'pvc-volume',
+        persistentVolumeClaim: {
+          claimName: 'fake-pvc',
+        } as V1PersistentVolumeClaimVolumeSource,
+      },
+    ] as V1Volume[],
+  } as V1PodSpec,
+  status: {
+    phase: 'Running',
+  } as V1PodStatus,
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(window.kubernetesGetCurrentNamespace).mockResolvedValue('default');
+});
+
+test('Render with a kubernetes object', async () => {
+  vi.mocked(window.kubernetesReadNamespacedPod).mockResolvedValue(fakePod);
+
+  render(PodDetailsSummary, { pod: fakePod });
+
+  // wait for the text to show as it sometimes takes a few ms
+  await waitFor(() => expect(screen.getByText('fake-secret')).toBeInTheDocument());
+});

--- a/packages/renderer/src/lib/kube/pods/PodDetailsSummary.svelte
+++ b/packages/renderer/src/lib/kube/pods/PodDetailsSummary.svelte
@@ -3,7 +3,9 @@ import type { V1Pod } from '@kubernetes/client-node';
 import { ErrorMessage } from '@podman-desktop/ui-svelte';
 
 import Table from '/@/lib/details/DetailsTable.svelte';
+import { kubernetesCurrentContextEvents } from '/@/stores/kubernetes-contexts-state';
 
+import KubeEventsArtifact from '../details/KubeEventsArtifact.svelte';
 import KubeObjectMetaArtifact from '../details/KubeObjectMetaArtifact.svelte';
 import KubePodSpecArtifact from '../details/KubePodSpecArtifact.svelte';
 import KubePodStatusArtifact from '../details/KubePodStatusArtifact.svelte';
@@ -13,6 +15,8 @@ interface Props {
   kubeError: string | undefined;
 }
 let { pod, kubeError = undefined }: Props = $props();
+
+let events = $derived($kubernetesCurrentContextEvents.filter(ev => ev.involvedObject.uid === pod?.metadata?.uid));
 </script>
 
 <!-- Show the kube error if we're unable to retrieve the data correctly, but we still want to show the
@@ -26,6 +30,8 @@ basic information -->
     <KubeObjectMetaArtifact artifact={pod.metadata} />
     <KubePodStatusArtifact artifact={pod.status} />
     <KubePodSpecArtifact artifact={pod.spec} />
+    <KubePodSpecArtifact artifact={pod.spec} podName={pod.metadata?.name} namespace={pod.metadata?.namespace} />
+    <KubeEventsArtifact events={events} />
   {:else}
     <p class="text-[var(--pd-state-info)] font-medium">Loading ...</p>
   {/if}

--- a/packages/renderer/src/lib/kube/pods/PodDetailsSummary.svelte
+++ b/packages/renderer/src/lib/kube/pods/PodDetailsSummary.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+import type { V1Pod } from '@kubernetes/client-node';
+import { ErrorMessage } from '@podman-desktop/ui-svelte';
+
+import Table from '/@/lib/details/DetailsTable.svelte';
+
+import KubeObjectMetaArtifact from '../details/KubeObjectMetaArtifact.svelte';
+import KubePodSpecArtifact from '../details/KubePodSpecArtifact.svelte';
+import KubePodStatusArtifact from '../details/KubePodStatusArtifact.svelte';
+
+interface Props {
+  pod: V1Pod | undefined;
+  kubeError: string | undefined;
+}
+let { pod, kubeError = undefined }: Props = $props();
+</script>
+
+<!-- Show the kube error if we're unable to retrieve the data correctly, but we still want to show the
+basic information -->
+{#if kubeError}
+  <ErrorMessage error={kubeError} />
+{/if}
+
+<Table>
+  {#if pod}
+    <KubeObjectMetaArtifact artifact={pod.metadata} />
+    <KubePodStatusArtifact artifact={pod.status} />
+    <KubePodSpecArtifact artifact={pod.spec} />
+  {:else}
+    <p class="text-[var(--pd-state-info)] font-medium">Loading ...</p>
+  {/if}
+</Table>

--- a/packages/renderer/src/lib/kube/pods/PodDetailsSummary.svelte
+++ b/packages/renderer/src/lib/kube/pods/PodDetailsSummary.svelte
@@ -12,7 +12,7 @@ import KubePodStatusArtifact from '../details/KubePodStatusArtifact.svelte';
 
 interface Props {
   pod: V1Pod | undefined;
-  kubeError: string | undefined;
+  kubeError?: string;
 }
 let { pod, kubeError = undefined }: Props = $props();
 
@@ -29,7 +29,6 @@ basic information -->
   {#if pod}
     <KubeObjectMetaArtifact artifact={pod.metadata} />
     <KubePodStatusArtifact artifact={pod.status} />
-    <KubePodSpecArtifact artifact={pod.spec} />
     <KubePodSpecArtifact artifact={pod.spec} podName={pod.metadata?.name} namespace={pod.metadata?.namespace} />
     <KubeEventsArtifact events={events} />
   {:else}


### PR DESCRIPTION
### What does this PR do?

Adds Kubernetes pod details page with summary, logs, inspect, kube, and terminal tabs. (same as today in general Pods page, or equivalent Kube pages)

Some files (especially KubernetesTerminalBrowser) are near-direct copies of the equivalent pods terminal, etc., but with different types/cleaner because they're Kubernetes-only.

### Screenshot / video of UI

<img width="770" alt="Screenshot 2025-02-04 at 8 21 02 AM" src="https://github.com/user-attachments/assets/9b0d3a18-dbf8-4655-a01f-7fb24c543470" />

### What issues does this PR fix or reference?

Fixes #8818.

### How to test this PR?

Test with a Kube cluster.

- [x] Tests are covering the bug fix or the new feature