### PR TITLE
chore: include electron.d.ts for podman extension

### DIFF
--- a/extensions/podman/packages/extension/src/util.ts
+++ b/extensions/podman/packages/extension/src/util.ts
@@ -47,12 +47,10 @@ export interface RunOptions {
 }
 
 export function getAssetsFolder(): string {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   if (isDev()) {
     return path.resolve(__dirname, '..', 'assets');
   } else {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return path.resolve((process as any).resourcesPath, 'extensions', 'podman', 'packages', 'extension', 'assets');
+    return path.resolve(process.resourcesPath, 'extensions', 'podman', 'packages', 'extension', 'assets');
   }
 }
 

--- a/extensions/podman/packages/extension/tsconfig.json
+++ b/extensions/podman/packages/extension/tsconfig.json
@@ -12,5 +12,5 @@
     "allowSyntheticDefaultImports": true,
     "types": ["node"]
   },
-  "include": ["src"]
+  "include": ["src", "../../../../node_modules/electron/electron.d.ts"]
 }


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Include electron.d.ts for podman extension, so process type comes from electron.d.ts, not node types.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of #10598 

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
