### PR TITLE
chore: cronjob use native functions rather than custom API call

### DIFF
--- a/packages/main/src/plugin/kubernetes/contexts-manager.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager.ts
@@ -45,6 +45,7 @@ import type {
 } from '@kubernetes/client-node';
 import {
   AppsV1Api,
+  BatchV1Api,
   CoreV1Api,
   CustomObjectsApi,
   KubeConfig,
@@ -479,14 +480,8 @@ export class ContextsManager {
   }
 
   public createCronJobInformer(kc: KubeConfig, namespace: string, context: KubeContext): CancellableInformer {
-    const customObjectsApi = kc.makeApiClient(CustomObjectsApi);
-    const listFn = (): Promise<KubernetesListObject<V1CronJob>> =>
-      customObjectsApi.listNamespacedCustomObject({
-        group: 'batch',
-        version: 'v1',
-        namespace,
-        plural: 'cronjobs',
-      }) as Promise<KubernetesListObject<V1CronJob>>;
+    const batchV1Api = kc.makeApiClient(BatchV1Api);
+    const listFn = (): Promise<KubernetesListObject<V1CronJob>> => batchV1Api.listNamespacedCronJob({ namespace });
     const path = `/apis/batch/v1/namespaces/${namespace}/cronjobs`;
     let timer: NodeJS.Timeout | undefined;
     let connectionDelay: NodeJS.Timeout | undefined;


### PR DESCRIPTION
chore: cronjob use native functions rather than custom API call

### What does this PR do?

Slight refactor, cronjobs can be called natively using batchV1Api rather
than using a custom call.

Does the same function as the previous one, but instead uses the native
call.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Part of https://github.com/podman-desktop/podman-desktop/issues/10560

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
