### PR TITLE
chore: update release notes banner to not show for first time users of PD

### DIFF
--- a/packages/renderer/src/lib/welcome/WelcomePage.spec.ts
+++ b/packages/renderer/src/lib/welcome/WelcomePage.spec.ts
@@ -16,8 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen } from '@testing-library/svelte';
@@ -37,7 +35,7 @@ import WelcomePage from './WelcomePage.svelte';
 beforeEach(() => {
   vi.mocked(window.getPodmanDesktopVersion).mockResolvedValue('1.0.0');
   (window.events as unknown) = {
-    receive: (_channel: string, func: any): void => {
+    receive: (_channel: string, func: () => void): void => {
       func();
     },
   };

--- a/packages/renderer/src/lib/welcome/WelcomePage.spec.ts
+++ b/packages/renderer/src/lib/welcome/WelcomePage.spec.ts
@@ -33,13 +33,13 @@ import WelcomePage from './WelcomePage.svelte';
 
 // fake the window.events object
 beforeEach(() => {
+  vi.resetAllMocks();
   vi.mocked(window.getPodmanDesktopVersion).mockResolvedValue('1.0.0');
   (window.events as unknown) = {
     receive: (_channel: string, func: () => void): void => {
       func();
     },
   };
-  vi.clearAllMocks();
 });
 
 async function waitRender(customProperties: object): Promise<void> {

--- a/packages/renderer/src/lib/welcome/WelcomePage.spec.ts
+++ b/packages/renderer/src/lib/welcome/WelcomePage.spec.ts
@@ -33,17 +33,9 @@ import type { ProviderInfo } from '/@api/provider-info';
 
 import WelcomePage from './WelcomePage.svelte';
 
-const getFeaturedExtensionsMock = vi.fn();
-const getProviderInfosMock = vi.fn();
-
 // fake the window.events object
 beforeEach(() => {
-  (window as any).getConfigurationValue = vi.fn();
-  (window as any).updateConfigurationValue = vi.fn();
-  (window as any).getPodmanDesktopVersion = vi.fn().mockResolvedValue('1.0.0');
-  (window as any).telemetryConfigure = vi.fn();
-  (window as any).getFeaturedExtensions = getFeaturedExtensionsMock;
-  (window as any).getProviderInfos = getProviderInfosMock;
+  vi.mocked(window.getPodmanDesktopVersion).mockResolvedValue('1.0.0');
   (window.events as unknown) = {
     receive: (_channel: string, func: any): void => {
       func();

--- a/packages/renderer/src/lib/welcome/WelcomePage.svelte
+++ b/packages/renderer/src/lib/welcome/WelcomePage.svelte
@@ -61,6 +61,10 @@ onMount(async () => {
     showTelemetry = true;
   }
   podmanDesktopVersion = await window.getPodmanDesktopVersion();
+
+  if (showWelcome) {
+    await window.updateConfigurationValue(`releaseNotesBanner.show`, podmanDesktopVersion);
+  }
 });
 
 async function closeWelcome(): Promise<void> {


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR  makes it so that the release notes will not be visible to first time user (based on if the welcome screen is shown or not), unless they choose to show the banner by clicking on the version button or after their first update.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/podman-desktop/issues/10330

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->
1. To simulate a new user for this PR, go to `$HOME/.local/share/containers/podman-desktop/configuration` and remove the `settings.json` file.
2. Assert that the release notes banner is not visible when opening PD

- [X] Tests are covering the bug fix or the new feature
