### PR TITLE
chore(test): validate that dialog disappears after dismissal

### DIFF
--- a/tests/playwright/src/utility/operations.ts
+++ b/tests/playwright/src/utility/operations.ts
@@ -184,6 +184,7 @@ export async function handleConfirmationDialog(
       : dialog.getByRole('button', { name: cancelButton });
     await playExpect(button).toBeEnabled();
     await button.click();
+    await waitUntil(async () => !(await dialog.isVisible(), { timeout: 10_000 }));
   });
 }
 

--- a/tests/playwright/src/utility/operations.ts
+++ b/tests/playwright/src/utility/operations.ts
@@ -184,7 +184,7 @@ export async function handleConfirmationDialog(
       : dialog.getByRole('button', { name: cancelButton });
     await playExpect(button).toBeEnabled();
     await button.click();
-    await waitUntil(async () => !(await dialog.isVisible(), { timeout: 10_000 }));
+    await waitUntil(async () => !(await dialog.isVisible()), { timeout: 10_000 });
   });
 }
 


### PR DESCRIPTION
### What does this PR do?
Validates that popup dialog disappears after button press.

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/10968
