### PR TITLE
fix: autostarted connection fires onDidUpdateContainerConnection

### DIFF
--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -1456,7 +1456,10 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
     extensionContext.subscriptions.push(command);
   }
 
-  const doAutoStart = async (logger: extensionApi.Logger): Promise<void> => {
+  const doAutoStart = async (
+    logger: extensionApi.Logger,
+    autostartContext: extensionApi.AutostartContext,
+  ): Promise<void> => {
     autostartInProgress = true;
     // If autostart has been enabled for the machine, try to start it.
     try {
@@ -1490,6 +1493,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
             containerProviderConnection,
           );
           await startMachine(provider, podmanConfiguration, machineInfo, context, logger, undefined, true);
+          autostartContext.updateContainerConnection(containerProviderConnection);
           autoMachineStarted = true;
           autoMachineName = machineName;
         }
@@ -1498,10 +1502,10 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   };
 
   provider.registerAutostart({
-    start: async (logger: extensionApi.Logger) => {
+    start: async (logger: extensionApi.Logger, autostartContext: extensionApi.AutostartContext) => {
       try {
         autostartInProgress = true;
-        await doAutoStart(logger);
+        await doAutoStart(logger, autostartContext);
       } finally {
         autostartInProgress = false;
       }

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -607,13 +607,17 @@ declare module '@podman-desktop/api' {
     preflightChecks?(): InstallCheck[];
   }
 
+  export interface AutostartContext {
+    updateContainerConnection(containerProviderConnection: ContainerProviderConnection): void;
+  }
+
   /**
    * By providing this interface, when Podman Desktop is starting
    * It'll start the provider through this interface.
    * It can be turned off/on by the user.
    */
   export interface ProviderAutostart {
-    start(logger: Logger): Promise<void>;
+    start(logger: Logger, context?: AutostartContext): Promise<void>;
   }
 
   /**

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -608,6 +608,9 @@ declare module '@podman-desktop/api' {
   }
 
   export interface AutostartContext {
+    /**
+     * updateContainerConnection must be called by the provider when a connection status is updated
+     */
     updateContainerConnection(containerProviderConnection: ContainerProviderConnection): void;
   }
 
@@ -615,6 +618,8 @@ declare module '@podman-desktop/api' {
    * By providing this interface, when Podman Desktop is starting
    * It'll start the provider through this interface.
    * It can be turned off/on by the user.
+   *
+   * `context` contains helper functions to be called by the provider during startup (see {@link AutostartContext})
    */
   export interface ProviderAutostart {
     start(logger: Logger, context?: AutostartContext): Promise<void>;

--- a/packages/main/src/plugin/provider-registry.spec.ts
+++ b/packages/main/src/plugin/provider-registry.spec.ts
@@ -540,33 +540,82 @@ describe('when auto-starting a container connection', async () => {
     test('should send events when api is directly attached', async () => {
       vi.mocked(containerRegistry.isApiAttached).mockReturnValue(true);
 
-      let onBeforeDidUpdateContainerConnectionCalled = 0;
-      providerRegistry.onBeforeDidUpdateContainerConnection(event => {
-        expect(event.connection.name).toBe(connection.name);
-        expect(event.connection.type).toBe(connection.type);
-        expect(event.status).toBe(onBeforeDidUpdateContainerConnectionCalled ? 'started' : 'starting');
-        onBeforeDidUpdateContainerConnectionCalled++;
-      });
-      let onDidUpdateContainerConnectionCalled = 0;
-      providerRegistry.onDidUpdateContainerConnection(event => {
-        expect(event.connection.name).toBe(connection.name);
-        expect(event.connection.type).toBe(connection.type);
-        expect(event.status).toBe(onDidUpdateContainerConnectionCalled ? 'started' : 'starting');
-        onDidUpdateContainerConnectionCalled++;
-      });
-      let onAfterDidUpdateContainerConnectionCalled = 0;
-      providerRegistry.onAfterDidUpdateContainerConnection(event => {
-        expect(event.connection.name).toBe(connection.name);
-        expect(event.connection.type).toBe(connection.type);
-        expect(event.status).toBe(onAfterDidUpdateContainerConnectionCalled ? 'started' : 'starting');
-        onAfterDidUpdateContainerConnectionCalled++;
-      });
+      const onBeforeDidUpdateContainerConnectionListenerMock = vi.fn();
+      providerRegistry.onBeforeDidUpdateContainerConnection(onBeforeDidUpdateContainerConnectionListenerMock);
+
+      const onDidUpdateContainerConnectionListenerMock = vi.fn();
+      providerRegistry.onDidUpdateContainerConnection(onDidUpdateContainerConnectionListenerMock);
+
+      const onAfterDidUpdateContainerConnectionListenerMock = vi.fn();
+      providerRegistry.onAfterDidUpdateContainerConnection(onAfterDidUpdateContainerConnectionListenerMock);
 
       await providerRegistry.runAutostart('0');
 
-      expect(onBeforeDidUpdateContainerConnectionCalled).toBe(2);
-      expect(onDidUpdateContainerConnectionCalled).toBe(2);
-      expect(onAfterDidUpdateContainerConnectionCalled).toBe(2);
+      expect(onBeforeDidUpdateContainerConnectionListenerMock).toHaveBeenCalledTimes(2);
+      expect(onBeforeDidUpdateContainerConnectionListenerMock).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          connection: expect.objectContaining({
+            name: connection.name,
+            type: connection.type,
+          }),
+          status: 'starting',
+        }),
+      );
+      expect(onBeforeDidUpdateContainerConnectionListenerMock).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          connection: expect.objectContaining({
+            name: connection.name,
+            type: connection.type,
+          }),
+          status: 'started',
+        }),
+      );
+
+      expect(onDidUpdateContainerConnectionListenerMock).toHaveBeenCalledTimes(2);
+      expect(onDidUpdateContainerConnectionListenerMock).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          connection: expect.objectContaining({
+            name: connection.name,
+            type: connection.type,
+          }),
+          status: 'starting',
+        }),
+      );
+      expect(onDidUpdateContainerConnectionListenerMock).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          connection: expect.objectContaining({
+            name: connection.name,
+            type: connection.type,
+          }),
+          status: 'started',
+        }),
+      );
+
+      expect(onAfterDidUpdateContainerConnectionListenerMock).toHaveBeenCalledTimes(2);
+      expect(onAfterDidUpdateContainerConnectionListenerMock).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          connection: expect.objectContaining({
+            name: connection.name,
+            type: connection.type,
+          }),
+          status: 'starting',
+        }),
+      );
+      expect(onAfterDidUpdateContainerConnectionListenerMock).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          connection: expect.objectContaining({
+            name: connection.name,
+            type: connection.type,
+          }),
+          status: 'started',
+        }),
+      );
     });
 
     test('should send events when api is eventually attached', async () => {

--- a/packages/main/src/plugin/provider-registry.spec.ts
+++ b/packages/main/src/plugin/provider-registry.spec.ts
@@ -19,13 +19,17 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 
 import type {
+  AutostartContext,
   CheckResult,
   ContainerProviderConnection,
   InstallCheck,
   KubernetesProviderConnection,
+  Logger,
+  Provider,
   ProviderCleanup,
   ProviderConnectionShellAccess,
   ProviderConnectionShellAccessSession,
+  ProviderConnectionStatus,
   ProviderInstallation,
   ProviderLifecycle,
   ProviderUpdate,
@@ -58,6 +62,7 @@ let containerRegistry: ContainerProviderRegistry;
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.restoreAllMocks();
   telemetryTrackMock.mockImplementation(() => Promise.resolve());
   const telemetry: Telemetry = {
     track: telemetryTrackMock,
@@ -440,6 +445,172 @@ describe('should send events when starting a container connection', async () => 
       expect(onBeforeDidUpdateContainerConnectionCalled).toBe(2);
       expect(onDidUpdateContainerConnectionCalled).toBe(2);
       expect(onAfterDidUpdateContainerConnectionCalled).toBe(2);
+    });
+  });
+});
+
+describe('when auto-starting a container connection', async () => {
+  let connection: ProviderContainerConnectionInfo;
+  let provider: Provider;
+  let containerProviderConnection: ContainerProviderConnection;
+
+  beforeEach(() => {
+    provider = providerRegistry.createProvider('id', 'name', {
+      id: 'internal',
+      name: 'internal',
+      status: 'installed',
+    });
+    connection = {
+      name: 'connection',
+      displayName: 'connection',
+      type: 'docker',
+      endpoint: {
+        socketPath: '/endpoint1.sock',
+      },
+      status: 'started',
+      vmType: {
+        id: 'libkrun',
+        name: 'libkrun',
+      },
+    };
+
+    containerProviderConnection = {
+      name: 'connection',
+      displayName: 'connection',
+      type: 'docker',
+      lifecycle: {
+        start: vi.fn(),
+        stop: vi.fn(),
+      },
+      endpoint: {
+        socketPath: '/endpoint1.sock',
+      },
+      status(): ProviderConnectionStatus {
+        return 'started';
+      },
+      vmType: 'libkrun',
+    };
+
+    providerRegistry.registerAutostartEngine(autostartEngine);
+  });
+
+  describe('when provider does not call updateContainerConnection', () => {
+    beforeEach(() => {
+      provider.registerAutostart({
+        start: async (_logger: Logger, _context?: AutostartContext) => {},
+      });
+    });
+
+    test('a warn should be displayed', async () => {
+      vi.spyOn(console, 'warn');
+      await providerRegistry.runAutostart('0');
+      expect(console.warn).toHaveBeenCalledWith(
+        `autostart called for provider internal but provider never called updateContainerConnection. Provider needs to call this method or UpdateContainerConnection events won't be propagated`,
+      );
+    });
+  });
+
+  describe('when provider calls updateContainerConnection with non-registered connection', () => {
+    beforeEach(() => {
+      provider.registerAutostart({
+        start: async (_logger: Logger, context?: AutostartContext) => {
+          context?.updateContainerConnection(containerProviderConnection);
+        },
+      });
+    });
+
+    test('an error should be thrown', async () => {
+      await expect(() => providerRegistry.runAutostart('0')).rejects.toThrowError(
+        'container connection connection is not registered by provider internal',
+      );
+    });
+  });
+
+  describe('when provider calls updateContainerConnection with registered connection', () => {
+    beforeEach(() => {
+      provider.registerContainerProviderConnection(containerProviderConnection);
+
+      provider.registerAutostart({
+        start: async (_logger: Logger, context?: AutostartContext) => {
+          context?.updateContainerConnection(containerProviderConnection);
+        },
+      });
+    });
+
+    test('should send events when api is directly attached', async () => {
+      vi.mocked(containerRegistry.isApiAttached).mockReturnValue(true);
+
+      let onBeforeDidUpdateContainerConnectionCalled = 0;
+      providerRegistry.onBeforeDidUpdateContainerConnection(event => {
+        expect(event.connection.name).toBe(connection.name);
+        expect(event.connection.type).toBe(connection.type);
+        expect(event.status).toBe(onBeforeDidUpdateContainerConnectionCalled ? 'started' : 'starting');
+        onBeforeDidUpdateContainerConnectionCalled++;
+      });
+      let onDidUpdateContainerConnectionCalled = 0;
+      providerRegistry.onDidUpdateContainerConnection(event => {
+        expect(event.connection.name).toBe(connection.name);
+        expect(event.connection.type).toBe(connection.type);
+        expect(event.status).toBe(onDidUpdateContainerConnectionCalled ? 'started' : 'starting');
+        onDidUpdateContainerConnectionCalled++;
+      });
+      let onAfterDidUpdateContainerConnectionCalled = 0;
+      providerRegistry.onAfterDidUpdateContainerConnection(event => {
+        expect(event.connection.name).toBe(connection.name);
+        expect(event.connection.type).toBe(connection.type);
+        expect(event.status).toBe(onAfterDidUpdateContainerConnectionCalled ? 'started' : 'starting');
+        onAfterDidUpdateContainerConnectionCalled++;
+      });
+
+      await providerRegistry.runAutostart('0');
+
+      expect(onBeforeDidUpdateContainerConnectionCalled).toBe(2);
+      expect(onDidUpdateContainerConnectionCalled).toBe(2);
+      expect(onAfterDidUpdateContainerConnectionCalled).toBe(2);
+    });
+
+    test('should send events when api is eventually attached', async () => {
+      vi.mocked(containerRegistry.isApiAttached).mockReturnValue(false);
+      vi.mocked(containerRegistry.onApiAttached).mockImplementation(c => {
+        setTimeout(() => {
+          c('internal.connection');
+        }, 10);
+        return Disposable.noop();
+      });
+
+      let onBeforeDidUpdateContainerConnectionCalled = 0;
+      providerRegistry.onBeforeDidUpdateContainerConnection(event => {
+        expect(event.connection.name).toBe(connection.name);
+        expect(event.connection.type).toBe(connection.type);
+        expect(event.status).toBe(onBeforeDidUpdateContainerConnectionCalled ? 'started' : 'starting');
+        onBeforeDidUpdateContainerConnectionCalled++;
+      });
+      let onDidUpdateContainerConnectionCalled = 0;
+      providerRegistry.onDidUpdateContainerConnection(event => {
+        expect(event.connection.name).toBe(connection.name);
+        expect(event.connection.type).toBe(connection.type);
+        expect(event.status).toBe(onDidUpdateContainerConnectionCalled ? 'started' : 'starting');
+        onDidUpdateContainerConnectionCalled++;
+      });
+      let onAfterDidUpdateContainerConnectionCalled = 0;
+      providerRegistry.onAfterDidUpdateContainerConnection(event => {
+        expect(event.connection.name).toBe(connection.name);
+        expect(event.connection.type).toBe(connection.type);
+        expect(event.status).toBe(onAfterDidUpdateContainerConnectionCalled ? 'started' : 'starting');
+        onAfterDidUpdateContainerConnectionCalled++;
+      });
+
+      await providerRegistry.runAutostart('0');
+
+      expect(onBeforeDidUpdateContainerConnectionCalled).toBe(1);
+      expect(onDidUpdateContainerConnectionCalled).toBe(1);
+      expect(onAfterDidUpdateContainerConnectionCalled).toBe(1);
+
+      await vi.waitFor(() => {
+        expect(onBeforeDidUpdateContainerConnectionCalled).toBe(2);
+        expect(onDidUpdateContainerConnectionCalled).toBe(2);
+        expect(onAfterDidUpdateContainerConnectionCalled).toBe(2);
+      });
     });
   });
 });

--- a/packages/main/src/plugin/provider-registry.spec.ts
+++ b/packages/main/src/plugin/provider-registry.spec.ts
@@ -452,7 +452,22 @@ describe('should send events when starting a container connection', async () => 
 describe('when auto-starting a container connection', async () => {
   let connection: ProviderContainerConnectionInfo;
   let provider: Provider;
-  let containerProviderConnection: ContainerProviderConnection;
+  const containerProviderConnection: ContainerProviderConnection = {
+    name: 'connection',
+    displayName: 'connection',
+    type: 'docker',
+    lifecycle: {
+      start: vi.fn(),
+      stop: vi.fn(),
+    },
+    endpoint: {
+      socketPath: '/endpoint1.sock',
+    },
+    status(): ProviderConnectionStatus {
+      return 'started';
+    },
+    vmType: 'libkrun',
+  };
 
   beforeEach(() => {
     provider = providerRegistry.createProvider('id', 'name', {
@@ -472,23 +487,6 @@ describe('when auto-starting a container connection', async () => {
         id: 'libkrun',
         name: 'libkrun',
       },
-    };
-
-    containerProviderConnection = {
-      name: 'connection',
-      displayName: 'connection',
-      type: 'docker',
-      lifecycle: {
-        start: vi.fn(),
-        stop: vi.fn(),
-      },
-      endpoint: {
-        socketPath: '/endpoint1.sock',
-      },
-      status(): ProviderConnectionStatus {
-        return 'started';
-      },
-      vmType: 'libkrun',
     };
 
     providerRegistry.registerAutostartEngine(autostartEngine);

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -400,15 +400,20 @@ export class ProviderRegistry {
     const provider = this.getMatchingProvider(internalId);
 
     let updateContainerConnectionCalled: boolean = false;
-    const context = {
+    const context = Object.freeze({
       updateContainerConnection: (containerProviderConnection: ContainerProviderConnection): void => {
+        if (!this.isContainerProviderConnectionRegistered(provider, containerProviderConnection)) {
+          throw new Error(
+            `container connection ${containerProviderConnection.name} is not registered by provider ${provider.name}`,
+          );
+        }
         updateContainerConnectionCalled = true;
         const providerConnectionInfo = this.getProviderConnectionInfo(containerProviderConnection);
         if (this.isProviderContainerConnection(providerConnectionInfo)) {
           this.fireUpdateContainerConnectionEvents(provider.id, providerConnectionInfo);
         }
       },
-    };
+    });
     await autoStart.start(new LoggerImpl(), context);
     if (!updateContainerConnectionCalled) {
       console.warn(
@@ -1371,5 +1376,18 @@ export class ProviderRegistry {
     };
     sendEvents('starting');
     this.onProviderConnectionApiAttached(`${providerId}.${providerConnectionInfo.name}`, () => sendEvents('started'));
+  }
+
+  isContainerProviderConnectionRegistered(
+    provider: ProviderImpl,
+    containerProviderConnection: ContainerProviderConnection,
+  ): boolean {
+    const connections = provider.containerConnections;
+    for (const connection of connections) {
+      if (connection.name === containerProviderConnection.name) {
+        return true;
+      }
+    }
+    return false;
   }
 }


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

- When a provider's connection is auto-started, wait for api to be attached before to send onDidUpdateProvider event

- On Kind extension, search kind clusters when onDidUpdateProvider event is received

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #9929 

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
