### PR TITLE
fix: handling of proxy bypass values from system under macOS

### DIFF
--- a/packages/main/src/plugin/proxy-system.spec.ts
+++ b/packages/main/src/plugin/proxy-system.spec.ts
@@ -296,7 +296,7 @@ describe('MacOS platform tests', () => {
       } else if (args?.[0] === '-getsecurewebproxy') {
         return { stdout: 'Server:\nPort: 0\nEnabled: No' } as RunResult;
       } else if (args?.[0] === '-getproxybypassdomains') {
-        return { stdout: '*.internal' } as RunResult;
+        return { stdout: 'localhost\n127.0.0.1\n*.internal\nfoobar.example.com' } as RunResult;
       }
       throw new Error('Unsupported call');
     });
@@ -304,6 +304,6 @@ describe('MacOS platform tests', () => {
     expect(settings).toBeDefined();
     expect(settings?.httpProxy).toBeUndefined();
     expect(settings?.httpsProxy).toBeUndefined();
-    expect(settings?.noProxy).toBe('*.internal');
+    expect(settings?.noProxy).toBe('localhost,127.0.0.1,internal,foobar.example.com');
   });
 });

--- a/packages/main/src/plugin/proxy-system.ts
+++ b/packages/main/src/plugin/proxy-system.ts
@@ -108,7 +108,7 @@ async function getMacOSConnectionProxyByPass(exec: Exec, connection: string): Pr
   try {
     const result = await exec.exec('networksetup', ['-getproxybypassdomains', connection]);
     const lines = result.stdout.split(/\r?\n/);
-    const line = lines.join(';');
+    const line = lines.map(entry => entry.replace(/^\*\./, '')).join(',');
     return line.length > 0 ? line : undefined;
   } catch (err) {
     console.warn(`Error while getting MacOS proxy settings for connection ${connection}`, err);


### PR DESCRIPTION
Ensures a noProxy syntax compatible with Podman VM:
- concatenate multiple entries with comma instead of semicolon
- remove subdomain wildcard

Fixes #10949.
Signed-off-by: Gregor Dschung <gregor@chkpnt.de>

### What does this PR do?

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
