### PR TITLE
chore: remove @typescript-eslint/no-explicit-any usage from featured, feedback, and kube

### DIFF
--- a/packages/renderer/src/lib/featured/FeaturedExtensionDownload.spec.ts
+++ b/packages/renderer/src/lib/featured/FeaturedExtensionDownload.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/renderer/src/lib/featured/FeaturedExtensionDownload.spec.ts
+++ b/packages/renderer/src/lib/featured/FeaturedExtensionDownload.spec.ts
@@ -16,8 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen } from '@testing-library/svelte';
@@ -26,13 +24,10 @@ import { beforeAll, expect, test, vi } from 'vitest';
 import type { FeaturedExtension } from '../../../../main/src/plugin/featured/featured-api';
 import FeaturedExtensionDownload from './FeaturedExtensionDownload.svelte';
 
-const extensionInstallFromImageMock = vi.fn();
-
 // fake the window.events object
 beforeAll(() => {
-  (window as any).extensionInstallFromImage = extensionInstallFromImageMock;
   (window.events as unknown) = {
-    receive: (_channel: string, func: any): void => {
+    receive: (_channel: string, func: () => void): void => {
       func();
     },
   };
@@ -80,7 +75,7 @@ test('Expect that we can see the button and click on the install', async () => {
   expect(installButton).toBeInTheDocument();
 
   // mock the install function
-  extensionInstallFromImageMock.mockImplementation(async () => {
+  vi.mocked(window.extensionInstallFromImage).mockImplementation(async () => {
     featuredExtension.installed = true;
     featuredExtension.fetchable = false;
     featuredExtension = { ...featuredExtension };
@@ -91,7 +86,7 @@ test('Expect that we can see the button and click on the install', async () => {
   await fireEvent.click(installButton);
 
   // install should have been called
-  expect(extensionInstallFromImageMock).toHaveBeenCalled();
+  expect(vi.mocked(window.extensionInstallFromImage)).toHaveBeenCalled();
 
   // now, expect the button to be gone
   // expect the button to be there

--- a/packages/renderer/src/lib/featured/FeaturedExtensions.spec.ts
+++ b/packages/renderer/src/lib/featured/FeaturedExtensions.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/renderer/src/lib/featured/FeaturedExtensions.spec.ts
+++ b/packages/renderer/src/lib/featured/FeaturedExtensions.spec.ts
@@ -16,8 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import '@testing-library/jest-dom/vitest';
 
 import { render, screen } from '@testing-library/svelte';
@@ -29,13 +27,10 @@ import { featuredExtensionInfos } from '/@/stores/featuredExtensions';
 import type { FeaturedExtension } from '../../../../main/src/plugin/featured/featured-api';
 import FeaturedExtensions from './FeaturedExtensions.svelte';
 
-const getFeaturedExtensionsMock = vi.fn();
-
 // fake the window.events object
 beforeAll(() => {
-  (window as any).getFeaturedExtensions = getFeaturedExtensionsMock;
   (window.events as unknown) = {
-    receive: (_channel: string, func: any): void => {
+    receive: (_channel: string, func: () => void): void => {
       func();
     },
   };
@@ -77,7 +72,11 @@ test('Expect that featured extensions are displayed', async () => {
     installed: false,
   };
 
-  getFeaturedExtensionsMock.mockResolvedValue([featuredExtension1, featuredExtension2, featuredExtension3]);
+  vi.mocked(window.getFeaturedExtensions).mockResolvedValue([
+    featuredExtension1,
+    featuredExtension2,
+    featuredExtension3,
+  ]);
 
   // ask to update the featured Extensions store
   window.dispatchEvent(new CustomEvent('system-ready'));

--- a/packages/renderer/src/lib/feedback/SendFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/SendFeedback.spec.ts
@@ -36,8 +36,7 @@ vi.mock('./feedbackForms/DevelopersFeedback.svelte', () => ({
 
 beforeAll(() => {
   (window.events as unknown) = {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    receive: (_channel: string, func: any): void => {
+    receive: (_channel: string, func: () => void): void => {
       func();
     },
   };

--- a/packages/renderer/src/lib/kube/KubePlayYAML.svelte
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.svelte
@@ -37,8 +37,7 @@ let currentNamespace: string | undefined;
 let allNamespaces: V1NamespaceList;
 
 let playKubeResultRaw: string;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let playKubeResultJSON: any;
+let playKubeResultJSON: unknown;
 
 let userChoice: 'podman' | 'kubernetes' = 'podman';
 
@@ -89,19 +88,32 @@ async function playKubeFile(): Promise<void> {
         // If there are container errors, that means that it was *able* to create the container
         // but if failed to start. We will add this to the "warning" section as we were able to create the
         // We add this with comma deliminated errors
-        if (playKubeResultJSON.Pods.length > 0) {
-          // Filter out the pods that have container errors, but check to see that container errors exists first
-          const containerErrors = playKubeResultJSON.Pods.filter(
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (pod: any) => pod.ContainerErrors && pod.ContainerErrors.length > 0,
-          );
+        if (playKubeResultJSON && typeof playKubeResultJSON === 'object' && 'Pods' in playKubeResultJSON) {
+          if (
+            playKubeResultJSON.Pods !== undefined &&
+            Array.isArray(playKubeResultJSON.Pods) &&
+            playKubeResultJSON.Pods.length > 0
+          ) {
+            // Filter out the pods that have container errors, but check to see that container errors exists first
+            const containerErrors = playKubeResultJSON.Pods.filter(
+              (pod: unknown) =>
+                pod &&
+                typeof pod === 'object' &&
+                'ContainerErrors' in pod &&
+                Array.isArray(pod.ContainerErrors) &&
+                pod.ContainerErrors.length > 0,
+            );
 
-          // For each Pod that has container errors, we will add the container errors to the warning message
-          if (containerErrors.length > 0) {
-            runWarning = `The following pods were created but failed to start: ${containerErrors
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              .map((pod: any) => pod.ContainerErrors.join(', '))
-              .join(', ')}`;
+            // For each Pod that has container errors, we will add the container errors to the warning message
+            if (containerErrors.length > 0) {
+              runWarning = `The following pods were created but failed to start: ${containerErrors
+                .map((pod: unknown) =>
+                  pod && typeof pod === 'object' && 'ContainerErrors' in pod && Array.isArray(pod.ContainerErrors)
+                    ? pod.ContainerErrors.join(', ')
+                    : '',
+                )
+                .join(', ')}`;
+            }
           }
         }
 
@@ -334,12 +346,12 @@ function goBackToPodsPage(): void {
         <ErrorMessage class="text-sm" error={runError} />
       {/if}
 
-      {#if playKubeResultJSON}
+      {#if playKubeResultJSON && typeof playKubeResultJSON === 'object'}
         <!-- Output area similar to DeployPodToKube.svelte -->
         <div class="bg-[var(--pd--content-card-bg)] p-5 my-4 text-[var(--pd-content-card-text)]">
           <div class="flex flex-row items-center">
             <div>
-              {#if playKubeResultJSON?.Pods.length > 1}
+              {#if 'Pods' in playKubeResultJSON && Array.isArray(playKubeResultJSON?.Pods) && playKubeResultJSON?.Pods.length > 1}
                 Created pods:
               {:else}
                 Created pod:

--- a/packages/renderer/src/lib/kube/KubePlayYAML.svelte
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.svelte
@@ -38,6 +38,7 @@ let allNamespaces: V1NamespaceList;
 
 let playKubeResultRaw: string;
 let playKubeResultJSON: unknown;
+let playKubeResult: { Pods?: unknown[] } | undefined = undefined;
 
 let userChoice: 'podman' | 'kubernetes' = 'podman';
 
@@ -88,12 +89,15 @@ async function playKubeFile(): Promise<void> {
         // If there are container errors, that means that it was *able* to create the container
         // but if failed to start. We will add this to the "warning" section as we were able to create the
         // We add this with comma deliminated errors
-        if (playKubeResultJSON && typeof playKubeResultJSON === 'object' && 'Pods' in playKubeResultJSON) {
+        if (playKubeResultJSON && typeof playKubeResultJSON === 'object') {
+          playKubeResult = {};
           if (
+            'Pods' in playKubeResultJSON &&
             playKubeResultJSON.Pods !== undefined &&
             Array.isArray(playKubeResultJSON.Pods) &&
             playKubeResultJSON.Pods.length > 0
           ) {
+            playKubeResult.Pods = playKubeResultJSON.Pods;
             // Filter out the pods that have container errors, but check to see that container errors exists first
             const containerErrors = playKubeResultJSON.Pods.filter(
               (pod: unknown) =>
@@ -346,12 +350,12 @@ function goBackToPodsPage(): void {
         <ErrorMessage class="text-sm" error={runError} />
       {/if}
 
-      {#if playKubeResultJSON && typeof playKubeResultJSON === 'object'}
+      {#if playKubeResult}
         <!-- Output area similar to DeployPodToKube.svelte -->
         <div class="bg-[var(--pd--content-card-bg)] p-5 my-4 text-[var(--pd-content-card-text)]">
           <div class="flex flex-row items-center">
             <div>
-              {#if 'Pods' in playKubeResultJSON && Array.isArray(playKubeResultJSON?.Pods) && playKubeResultJSON?.Pods.length > 1}
+              {#if playKubeResult.Pods && playKubeResult.Pods.length > 1}
                 Created pods:
               {:else}
                 Created pod:


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR removes @typescript-eslint/no-explicit-any usage from featured, feedback, and kube in renderer

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/10604

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
