### PR TITLE
feat: add cronjobs to kubernetes

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -2462,6 +2462,10 @@ export class PluginSystem {
       return kubernetesClient.deleteConfigMap(name);
     });
 
+    this.ipcHandle('kubernetes-client:deleteCronJob', async (_listener, name: string): Promise<void> => {
+      return kubernetesClient.deleteCronJob(name);
+    });
+
     this.ipcHandle('kubernetes-client:deleteSecret', async (_listener, name: string): Promise<void> => {
       return kubernetesClient.deleteSecret(name);
     });

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -18,6 +18,7 @@ import ContainerDetails from './lib/container/ContainerDetails.svelte';
 import ContainerExport from './lib/container/ContainerExport.svelte';
 import ContainerList from './lib/container/ContainerList.svelte';
 import ContextKey from './lib/context/ContextKey.svelte';
+import CronJobList from './lib/cronjob/CronJobList.svelte';
 import DashboardPage from './lib/dashboard/DashboardPage.svelte';
 import DeploymentDetails from './lib/deployments/DeploymentDetails.svelte';
 import DeploymentsList from './lib/deployments/DeploymentsList.svelte';
@@ -301,6 +302,9 @@ window.events?.receive('navigate', (navigationRequest: unknown) => {
           </Route>
           <Route path="/kubernetes/ingressesRoutes" breadcrumb="Ingresses & Routes" navigationHint="root">
             <IngressesRoutesList />
+          </Route>
+          <Route path="/kubernetes/cronjobs" breadcrumb="CronJobs" navigationHint="root">
+            <CronJobList />
           </Route>
           <Route
             path="/kubernetes/ingressesRoutes/ingress/:name/:namespace/*"

--- a/packages/renderer/src/AppNavigation.spec.ts
+++ b/packages/renderer/src/AppNavigation.spec.ts
@@ -71,6 +71,7 @@ test('Test rendering of the navigation bar with empty items', async (_arg: unkno
   vi.mocked(kubeContextStore).kubernetesCurrentContextPersistentVolumeClaims = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextPortForwards = readable<ForwardConfig[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextState = readable<ContextGeneralState>({} as ContextGeneralState);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextCronJobs = readable<KubernetesObject[]>([]);
 
   // init navigation registry
   await fetchNavigationRegistries();

--- a/packages/renderer/src/lib/cronjob/CronJobActions.spec.ts
+++ b/packages/renderer/src/lib/cronjob/CronJobActions.spec.ts
@@ -1,0 +1,65 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+
+import CronJobActions from './CronJobActions.svelte';
+import type { CronJobUI } from './CronJobUI';
+
+const updateMock = vi.fn();
+const deleteMock = vi.fn();
+const showMessageBoxMock = vi.fn();
+
+const cronjob: CronJobUI = {
+  uid: '123',
+  name: 'my-cronjob',
+  status: 'RUNNING',
+  namespace: '',
+  selected: false,
+  schedule: '',
+  suspended: false,
+  lastScheduleTime: new Date(),
+  active: 1,
+};
+
+beforeEach(() => {
+  Object.defineProperty(window, 'showMessageBox', { value: showMessageBoxMock });
+  Object.defineProperty(window, 'kubernetesDeleteCronJob', { value: deleteMock });
+});
+
+afterEach(() => {
+  vi.resetAllMocks();
+  vi.clearAllMocks();
+});
+
+test('Expect no error and status deleting cronjob', async () => {
+  // Mock the showMessageBox to return 0 (yes)
+  showMessageBoxMock.mockResolvedValue({ response: 0 });
+  render(CronJobActions, { cronjob, onUpdate: updateMock });
+
+  // click on delete button
+  const deleteButton = screen.getByRole('button', { name: 'Delete CronJob' });
+  await fireEvent.click(deleteButton);
+
+  expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  expect(updateMock).toHaveBeenCalled();
+  expect(deleteMock).toHaveBeenCalled();
+});

--- a/packages/renderer/src/lib/cronjob/CronJobActions.spec.ts
+++ b/packages/renderer/src/lib/cronjob/CronJobActions.spec.ts
@@ -41,8 +41,8 @@ const cronjob: CronJobUI = {
 };
 
 beforeEach(() => {
-  Object.defineProperty(window, 'showMessageBox', { value: showMessageBoxMock });
-  Object.defineProperty(window, 'kubernetesDeleteCronJob', { value: deleteMock });
+  vi.mocked(window.showMessageBox).mockImplementation(showMessageBoxMock);
+  vi.mocked(window.kubernetesDeleteCronJob).mockImplementation(deleteMock);
 });
 
 afterEach(() => {

--- a/packages/renderer/src/lib/cronjob/CronJobActions.spec.ts
+++ b/packages/renderer/src/lib/cronjob/CronJobActions.spec.ts
@@ -19,7 +19,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen } from '@testing-library/svelte';
-import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
 
 import CronJobActions from './CronJobActions.svelte';
 import type { CronJobUI } from './CronJobUI';
@@ -40,13 +40,9 @@ const cronjob: CronJobUI = {
 };
 
 beforeEach(() => {
+  vi.resetAllMocks();
   vi.mocked(window.showMessageBox).mockImplementation(showMessageBoxMock);
   vi.mocked(window.kubernetesDeleteCronJob).mockImplementation(deleteMock);
-});
-
-afterEach(() => {
-  vi.resetAllMocks();
-  vi.clearAllMocks();
 });
 
 test('Expect no error and status deleting cronjob', async () => {

--- a/packages/renderer/src/lib/cronjob/CronJobActions.spec.ts
+++ b/packages/renderer/src/lib/cronjob/CronJobActions.spec.ts
@@ -24,7 +24,6 @@ import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import CronJobActions from './CronJobActions.svelte';
 import type { CronJobUI } from './CronJobUI';
 
-const updateMock = vi.fn();
 const deleteMock = vi.fn();
 const showMessageBoxMock = vi.fn();
 
@@ -53,13 +52,12 @@ afterEach(() => {
 test('Expect no error and status deleting cronjob', async () => {
   // Mock the showMessageBox to return 0 (yes)
   showMessageBoxMock.mockResolvedValue({ response: 0 });
-  render(CronJobActions, { cronjob, onUpdate: updateMock });
+  render(CronJobActions, { cronjob, detailed: false });
 
   // click on delete button
   const deleteButton = screen.getByRole('button', { name: 'Delete CronJob' });
   await fireEvent.click(deleteButton);
 
   expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-  expect(updateMock).toHaveBeenCalled();
   expect(deleteMock).toHaveBeenCalled();
 });

--- a/packages/renderer/src/lib/cronjob/CronJobActions.svelte
+++ b/packages/renderer/src/lib/cronjob/CronJobActions.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+import { faTrash } from '@fortawesome/free-solid-svg-icons';
+import { createEventDispatcher } from 'svelte';
+
+import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
+
+import ListItemButtonIcon from '../ui/ListItemButtonIcon.svelte';
+import type { CronJobUI } from './CronJobUI';
+
+export let cronjob: CronJobUI;
+export let detailed = false;
+
+const dispatch = createEventDispatcher<{ update: CronJobUI }>();
+
+export let onUpdate: (cronjob: CronJobUI) => void = cronjob => {
+  dispatch('update', cronjob);
+};
+
+async function deleteCronJob(): Promise<void> {
+  cronjob.status = 'DELETING';
+  onUpdate(cronjob);
+
+  await window.kubernetesDeleteCronJob(cronjob.name);
+}
+</script>
+
+<ListItemButtonIcon
+  title="Delete CronJob"
+  onClick={(): void => withConfirmation(deleteCronJob, `delete cronjob ${cronjob.name}`)}
+  detailed={detailed}
+  icon={faTrash} />

--- a/packages/renderer/src/lib/cronjob/CronJobActions.svelte
+++ b/packages/renderer/src/lib/cronjob/CronJobActions.svelte
@@ -1,24 +1,21 @@
 <script lang="ts">
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
-import { createEventDispatcher } from 'svelte';
 
 import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
 
 import ListItemButtonIcon from '../ui/ListItemButtonIcon.svelte';
 import type { CronJobUI } from './CronJobUI';
 
-export let cronjob: CronJobUI;
-export let detailed = false;
-
-const dispatch = createEventDispatcher<{ update: CronJobUI }>();
-
-export let onUpdate: (cronjob: CronJobUI) => void = cronjob => {
-  dispatch('update', cronjob);
-};
+let {
+  cronjob,
+  detailed = false,
+}: {
+  cronjob: CronJobUI;
+  detailed: boolean;
+} = $props();
 
 async function deleteCronJob(): Promise<void> {
   cronjob.status = 'DELETING';
-  onUpdate(cronjob);
 
   await window.kubernetesDeleteCronJob(cronjob.name);
 }

--- a/packages/renderer/src/lib/cronjob/CronJobActions.svelte
+++ b/packages/renderer/src/lib/cronjob/CronJobActions.svelte
@@ -11,7 +11,7 @@ let {
   detailed = false,
 }: {
   cronjob: CronJobUI;
-  detailed: boolean;
+  detailed?: boolean;
 } = $props();
 
 async function deleteCronJob(): Promise<void> {

--- a/packages/renderer/src/lib/cronjob/CronJobColumnActions.spec.ts
+++ b/packages/renderer/src/lib/cronjob/CronJobColumnActions.spec.ts
@@ -1,0 +1,44 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import CronJobColumnActions from './CronJobColumnActions.svelte';
+import type { CronJobUI } from './CronJobUI';
+
+test('Expect cronjob buttons', async () => {
+  const cronjob: CronJobUI = {
+    uid: '123',
+    name: 'my-cronjob',
+    status: 'RUNNING',
+    namespace: '',
+    selected: false,
+    schedule: '',
+    suspended: false,
+    lastScheduleTime: new Date(),
+    active: 1,
+  };
+
+  render(CronJobColumnActions, { object: cronjob });
+
+  const buttons = await screen.findAllByRole('button');
+  expect(buttons).toHaveLength(1);
+});

--- a/packages/renderer/src/lib/cronjob/CronJobColumnActions.svelte
+++ b/packages/renderer/src/lib/cronjob/CronJobColumnActions.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 import CronJobActions from './CronJobActions.svelte';
-import type { CronJobUI } from './CronJobUI';
 
-export let object: CronJobUI;
+let { object } = $props();
 </script>
 
 <CronJobActions cronjob={object} on:update />

--- a/packages/renderer/src/lib/cronjob/CronJobColumnActions.svelte
+++ b/packages/renderer/src/lib/cronjob/CronJobColumnActions.svelte
@@ -4,4 +4,4 @@ import CronJobActions from './CronJobActions.svelte';
 let { object } = $props();
 </script>
 
-<CronJobActions cronjob={object} on:update />
+<CronJobActions cronjob={object} />

--- a/packages/renderer/src/lib/cronjob/CronJobColumnActions.svelte
+++ b/packages/renderer/src/lib/cronjob/CronJobColumnActions.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+import CronJobActions from './CronJobActions.svelte';
+import type { CronJobUI } from './CronJobUI';
+
+export let object: CronJobUI;
+</script>
+
+<CronJobActions cronjob={object} on:update />

--- a/packages/renderer/src/lib/cronjob/CronJobColumnActions.svelte
+++ b/packages/renderer/src/lib/cronjob/CronJobColumnActions.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
 import CronJobActions from './CronJobActions.svelte';
+import type { CronJobUI } from './CronJobUI';
 
-let { object } = $props();
+interface Props {
+  object: CronJobUI;
+}
+
+let { object }: Props = $props();
 </script>
 
 <CronJobActions cronjob={object} />

--- a/packages/renderer/src/lib/cronjob/CronJobColumnName.spec.ts
+++ b/packages/renderer/src/lib/cronjob/CronJobColumnName.spec.ts
@@ -37,7 +37,7 @@ const cronjob: CronJobUI = {
 };
 
 test('Expect simple column styling', async () => {
-  render(CronJobColumnName, { object: JSON.parse(JSON.stringify(cronjob)) });
+  render(CronJobColumnName, { object: cronjob });
 
   const text = screen.getByText(cronjob.name);
   expect(text).toBeInTheDocument();
@@ -45,7 +45,7 @@ test('Expect simple column styling', async () => {
 });
 
 test('Expect to show namespace in column', async () => {
-  render(CronJobColumnName, { object: JSON.parse(JSON.stringify(cronjob)) });
+  render(CronJobColumnName, { object: cronjob });
 
   const text = screen.getByText(cronjob.namespace);
   expect(text).toBeInTheDocument();

--- a/packages/renderer/src/lib/cronjob/CronJobColumnName.spec.ts
+++ b/packages/renderer/src/lib/cronjob/CronJobColumnName.spec.ts
@@ -1,0 +1,52 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import CronJobColumnName from './CronJobColumnName.svelte';
+import type { CronJobUI } from './CronJobUI';
+
+const cronjob: CronJobUI = {
+  uid: '123',
+  name: 'my-cronjob',
+  status: 'RUNNING',
+  namespace: 'foobar',
+  selected: false,
+  schedule: '',
+  suspended: false,
+  lastScheduleTime: new Date(),
+  active: 1,
+};
+
+test('Expect simple column styling', async () => {
+  render(CronJobColumnName, { object: JSON.parse(JSON.stringify(cronjob)) });
+
+  const text = screen.getByText(cronjob.name);
+  expect(text).toBeInTheDocument();
+  expect(text).toHaveClass('text-[var(--pd-table-body-text-highlight)]');
+});
+
+test('Expect to show namespace in column', async () => {
+  render(CronJobColumnName, { object: JSON.parse(JSON.stringify(cronjob)) });
+
+  const text = screen.getByText(cronjob.namespace);
+  expect(text).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/cronjob/CronJobColumnName.svelte
+++ b/packages/renderer/src/lib/cronjob/CronJobColumnName.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
-import type { CronJobUI } from './CronJobUI';
-
-export let object: CronJobUI;
+let { object } = $props();
 </script>
 
 <!-- Add the summary in the future, keep hover:cursor-pointer so we do not forget! -->

--- a/packages/renderer/src/lib/cronjob/CronJobColumnName.svelte
+++ b/packages/renderer/src/lib/cronjob/CronJobColumnName.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+import type { CronJobUI } from './CronJobUI';
+
+export let object: CronJobUI;
+</script>
+
+<!-- Add the summary in the future, keep hover:cursor-pointer so we do not forget! -->
+<button class="hover:cursor-pointer flex flex-col max-w-full">
+  <div class="text-[var(--pd-table-body-text-highlight)] max-w-full overflow-hidden text-ellipsis">
+    {object.name}
+  </div>
+  <div class="flex flex-row text-sm gap-1">
+    {#if object.namespace}
+      <div class="font-extra-light text-[var(--pd-table-body-text)]">{object.namespace}</div>
+    {/if}
+  </div>
+</button>

--- a/packages/renderer/src/lib/cronjob/CronJobColumnName.svelte
+++ b/packages/renderer/src/lib/cronjob/CronJobColumnName.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
-let { object } = $props();
+import type { CronJobUI } from './CronJobUI';
+
+let {
+  object,
+}: {
+  object: CronJobUI;
+} = $props();
 </script>
 
 <!-- Add the summary in the future, keep hover:cursor-pointer so we do not forget! -->

--- a/packages/renderer/src/lib/cronjob/CronJobColumnName.svelte
+++ b/packages/renderer/src/lib/cronjob/CronJobColumnName.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
 import type { CronJobUI } from './CronJobUI';
 
-let {
-  object,
-}: {
+interface Props {
   object: CronJobUI;
-} = $props();
+}
+let { object }: Props = $props();
 </script>
 
 <!-- Add the summary in the future, keep hover:cursor-pointer so we do not forget! -->

--- a/packages/renderer/src/lib/cronjob/CronJobColumnStatus.spec.ts
+++ b/packages/renderer/src/lib/cronjob/CronJobColumnStatus.spec.ts
@@ -1,0 +1,44 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import CronJobColumnStatus from './CronJobColumnStatus.svelte';
+import type { CronJobUI } from './CronJobUI';
+
+test('Expect cronjob status to be shown', async () => {
+  const cronjob: CronJobUI = {
+    uid: '123',
+    name: 'my-cronjob',
+    status: 'RUNNING',
+    namespace: '',
+    selected: false,
+    schedule: '',
+    suspended: false,
+    lastScheduleTime: new Date(),
+    active: 1,
+  };
+  render(CronJobColumnStatus, { object: cronjob });
+
+  const text = screen.getByRole('status');
+  expect(text).toBeInTheDocument();
+  expect(text).toHaveClass('bg-[var(--pd-status-running)]');
+});

--- a/packages/renderer/src/lib/cronjob/CronJobColumnStatus.svelte
+++ b/packages/renderer/src/lib/cronjob/CronJobColumnStatus.svelte
@@ -2,8 +2,13 @@
 import { StatusIcon } from '@podman-desktop/ui-svelte';
 
 import CronJobIcon from '../images/CronJobIcon.svelte';
+import type { CronJobUI } from './CronJobUI';
 
-let { object } = $props();
+let {
+  object,
+}: {
+  object: CronJobUI;
+} = $props();
 </script>
 
 <StatusIcon icon={CronJobIcon} status={object.status} />

--- a/packages/renderer/src/lib/cronjob/CronJobColumnStatus.svelte
+++ b/packages/renderer/src/lib/cronjob/CronJobColumnStatus.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+import { StatusIcon } from '@podman-desktop/ui-svelte';
+
+import CronJobIcon from '../images/CronJobIcon.svelte';
+import type { CronJobUI } from './CronJobUI';
+
+export let object: CronJobUI;
+</script>
+
+<StatusIcon icon={CronJobIcon} status={object.status} />

--- a/packages/renderer/src/lib/cronjob/CronJobColumnStatus.svelte
+++ b/packages/renderer/src/lib/cronjob/CronJobColumnStatus.svelte
@@ -4,11 +4,11 @@ import { StatusIcon } from '@podman-desktop/ui-svelte';
 import CronJobIcon from '../images/CronJobIcon.svelte';
 import type { CronJobUI } from './CronJobUI';
 
-let {
-  object,
-}: {
+interface Props {
   object: CronJobUI;
-} = $props();
+}
+
+let { object }: Props = $props();
 </script>
 
 <StatusIcon icon={CronJobIcon} status={object.status} />

--- a/packages/renderer/src/lib/cronjob/CronJobColumnStatus.svelte
+++ b/packages/renderer/src/lib/cronjob/CronJobColumnStatus.svelte
@@ -2,9 +2,8 @@
 import { StatusIcon } from '@podman-desktop/ui-svelte';
 
 import CronJobIcon from '../images/CronJobIcon.svelte';
-import type { CronJobUI } from './CronJobUI';
 
-export let object: CronJobUI;
+let { object } = $props();
 </script>
 
 <StatusIcon icon={CronJobIcon} status={object.status} />

--- a/packages/renderer/src/lib/cronjob/CronJobEmptyScreen.svelte
+++ b/packages/renderer/src/lib/cronjob/CronJobEmptyScreen.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+import CronJobIcon from '../images/CronJobIcon.svelte';
+import KubernetesEmptyScreen from '../kube/KubernetesEmptyScreen.svelte';
+</script>
+
+<KubernetesEmptyScreen icon={CronJobIcon} title="No cronjobs" message="Try switching to a different context or namespace" />

--- a/packages/renderer/src/lib/cronjob/CronJobList.spec.ts
+++ b/packages/renderer/src/lib/cronjob/CronJobList.spec.ts
@@ -1,0 +1,146 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import type { KubernetesObject, V1CronJob } from '@kubernetes/client-node';
+import { render, screen } from '@testing-library/svelte';
+import { writable } from 'svelte/store';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import * as states from '/@/stores/kubernetes-contexts-state';
+
+import CronJobList from './CronJobList.svelte';
+
+vi.mock('/@/stores/kubernetes-contexts-state');
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.clearAllMocks();
+  vi.mocked(states).cronJobSearchPattern = writable<string>('');
+  vi.mocked(states).kubernetesContextsCheckingStateDelayed = writable();
+  vi.mocked(states).kubernetesCurrentContextState = writable();
+});
+
+test('Expect cronjob empty screen', async () => {
+  vi.mocked(states).kubernetesCurrentContextCronJobsFiltered = writable<KubernetesObject[]>([]);
+  render(CronJobList);
+  const noCronJobs = screen.getByRole('heading', { name: 'No cronjobs' });
+  expect(noCronJobs).toBeInTheDocument();
+});
+
+test('Expect cronjobs list', async () => {
+  const cronjob: V1CronJob = {
+    apiVersion: 'v1',
+    kind: 'CronJob',
+    metadata: {
+      name: 'my-cronjob',
+      namespace: 'test-namespace',
+    },
+    spec: {
+      schedule: '*/1 * * * *',
+      suspend: false,
+      jobTemplate: {
+        spec: {
+          template: {
+            spec: {
+              containers: [],
+            },
+          },
+        },
+      },
+    },
+  };
+  vi.mocked(states).kubernetesCurrentContextCronJobsFiltered = writable<KubernetesObject[]>([cronjob]);
+
+  render(CronJobList);
+
+  const cronjobName = screen.getByRole('cell', { name: 'my-cronjob test-namespace' });
+  expect(cronjobName).toBeInTheDocument();
+});
+
+test('Expect filter empty screen', async () => {
+  vi.mocked(states).kubernetesCurrentContextCronJobsFiltered = writable<KubernetesObject[]>([]);
+
+  render(CronJobList, { searchTerm: 'No match' });
+
+  const filterButton = screen.getByRole('button', { name: 'Clear filter' });
+  expect(filterButton).toBeInTheDocument();
+});
+
+test('Expect cronjob list is updated when kubernetesCurrentContextCronJobsFiltered changes', async () => {
+  const cronjob1: V1CronJob = {
+    apiVersion: 'v1',
+    kind: 'CronJob',
+    metadata: {
+      name: 'my-cronjob-1',
+      namespace: 'test-namespace',
+    },
+    spec: {
+      schedule: '*/1 * * * *',
+      suspend: false,
+      jobTemplate: {
+        spec: {
+          template: {
+            spec: {
+              containers: [],
+            },
+          },
+        },
+      },
+    },
+  };
+  const cronjob2: V1CronJob = {
+    apiVersion: 'v1',
+    kind: 'CronJob',
+    metadata: {
+      name: 'my-cronjob-2',
+      namespace: 'test-namespace',
+    },
+    spec: {
+      schedule: '*/1 * * * *',
+      suspend: false,
+      jobTemplate: {
+        spec: {
+          template: {
+            spec: {
+              containers: [],
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const filtered = writable<KubernetesObject[]>([cronjob1, cronjob2]);
+  vi.mocked(states).kubernetesCurrentContextCronJobsFiltered = filtered;
+
+  const component = render(CronJobList);
+  const cronjobName1 = screen.getByRole('cell', { name: 'my-cronjob-1 test-namespace' });
+  expect(cronjobName1).toBeInTheDocument();
+  const cronjobName2 = screen.getByRole('cell', { name: 'my-cronjob-2 test-namespace' });
+  expect(cronjobName2).toBeInTheDocument();
+
+  filtered.set([cronjob2]);
+  await component.rerender({});
+
+  const cronjobName1after = screen.queryByRole('cell', { name: 'my-cronjob-1 test-namespace' });
+  expect(cronjobName1after).not.toBeInTheDocument();
+  const cronjobName2after = screen.getByRole('cell', { name: 'my-cronjob-2 test-namespace' });
+  expect(cronjobName2after).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/cronjob/CronJobList.spec.ts
+++ b/packages/renderer/src/lib/cronjob/CronJobList.spec.ts
@@ -68,9 +68,10 @@ test('Expect cronjobs list', async () => {
   vi.mocked(states).kubernetesCurrentContextCronJobsFiltered = writable<KubernetesObject[]>([cronjob]);
 
   render(CronJobList);
-
-  const cronjobName = screen.getByRole('cell', { name: 'my-cronjob test-namespace' });
-  expect(cronjobName).toBeInTheDocument();
+  await vi.waitFor(() => {
+    const cronjobName = screen.getByRole('cell', { name: 'my-cronjob test-namespace' });
+    expect(cronjobName).toBeInTheDocument();
+  });
 });
 
 test('Expect filter empty screen', async () => {
@@ -130,16 +131,20 @@ test('Expect cronjob list is updated when kubernetesCurrentContextCronJobsFilter
   vi.mocked(states).kubernetesCurrentContextCronJobsFiltered = filtered;
 
   const component = render(CronJobList);
-  const cronjobName1 = screen.getByRole('cell', { name: 'my-cronjob-1 test-namespace' });
-  expect(cronjobName1).toBeInTheDocument();
-  const cronjobName2 = screen.getByRole('cell', { name: 'my-cronjob-2 test-namespace' });
-  expect(cronjobName2).toBeInTheDocument();
+  await vi.waitFor(() => {
+    const cronjobName1 = screen.getByRole('cell', { name: 'my-cronjob-1 test-namespace' });
+    expect(cronjobName1).toBeInTheDocument();
+    const cronjobName2 = screen.getByRole('cell', { name: 'my-cronjob-2 test-namespace' });
+    expect(cronjobName2).toBeInTheDocument();
+  });
 
   filtered.set([cronjob2]);
   await component.rerender({});
 
-  const cronjobName1after = screen.queryByRole('cell', { name: 'my-cronjob-1 test-namespace' });
-  expect(cronjobName1after).not.toBeInTheDocument();
-  const cronjobName2after = screen.getByRole('cell', { name: 'my-cronjob-2 test-namespace' });
-  expect(cronjobName2after).toBeInTheDocument();
+  await vi.waitFor(() => {
+    const cronjobName1after = screen.queryByRole('cell', { name: 'my-cronjob-1 test-namespace' });
+    expect(cronjobName1after).not.toBeInTheDocument();
+    const cronjobName2after = screen.getByRole('cell', { name: 'my-cronjob-2 test-namespace' });
+    expect(cronjobName2after).toBeInTheDocument();
+  });
 });

--- a/packages/renderer/src/lib/cronjob/CronJobList.spec.ts
+++ b/packages/renderer/src/lib/cronjob/CronJobList.spec.ts
@@ -31,7 +31,6 @@ vi.mock('/@/stores/kubernetes-contexts-state');
 
 beforeEach(() => {
   vi.resetAllMocks();
-  vi.clearAllMocks();
   vi.mocked(states).cronJobSearchPattern = writable<string>('');
   vi.mocked(states).kubernetesContextsCheckingStateDelayed = writable();
   vi.mocked(states).kubernetesCurrentContextState = writable();

--- a/packages/renderer/src/lib/cronjob/CronJobList.svelte
+++ b/packages/renderer/src/lib/cronjob/CronJobList.svelte
@@ -1,23 +1,11 @@
 <script lang="ts">
-import { faTrash } from '@fortawesome/free-solid-svg-icons';
-import {
-  Button,
-  FilteredEmptyScreen,
-  NavPage,
-  Table,
-  TableColumn,
-  TableDurationColumn,
-  TableRow,
-  TableSimpleColumn,
-} from '@podman-desktop/ui-svelte';
+import { TableColumn, TableDurationColumn, TableRow, TableSimpleColumn } from '@podman-desktop/ui-svelte';
 import moment from 'moment';
 
-import KubeActions from '/@/lib/kube/KubeActions.svelte';
-import KubernetesCurrentContextConnectionBadge from '/@/lib/ui/KubernetesCurrentContextConnectionBadge.svelte';
 import { cronJobSearchPattern, kubernetesCurrentContextCronJobsFiltered } from '/@/stores/kubernetes-contexts-state';
 
-import { withBulkConfirmation } from '../actions/BulkActions';
 import CronJobIcon from '../images/CronJobIcon.svelte';
+import KubernetesObjectsList from '../objects/KubernetesObjectsList.svelte';
 import { capitalize } from '../ui/Util';
 import { CronJobUtils } from './cronjob-utils';
 import CronJobColumnActions from './CronJobColumnActions.svelte';
@@ -35,34 +23,7 @@ $effect(() => {
   cronJobSearchPattern.set(searchTerm);
 });
 const cronjobUtils = new CronJobUtils();
-const cronjobs = $derived($kubernetesCurrentContextCronJobsFiltered.map(cronjob => cronjobUtils.getCronJobUI(cronjob)));
 
-// Bulk deletion progress for cronjobs
-let bulkDeleteInProgress = $state<boolean>(false);
-let selectedItemsNumber = $state<number>(0);
-async function deleteSelectedCronJobs(): Promise<void> {
-  const selectedCronJobs = cronjobs.filter(cronjob => cronjob.selected);
-  if (selectedCronJobs.length === 0) {
-    return;
-  }
-
-  bulkDeleteInProgress = true;
-  selectedCronJobs.forEach(cronjob => (cronjob.status = 'DELETING'));
-
-  await Promise.all(
-    selectedCronJobs.map(async cronjob => {
-      try {
-        await window.kubernetesDeleteCronJob(cronjob.name);
-      } catch (e) {
-        console.error('error while deleting cronjob', e);
-      }
-    }),
-  );
-  bulkDeleteInProgress = false;
-}
-
-// Columns / information
-let table: Table;
 let statusColumn = new TableColumn<CronJobUI>('Status', {
   align: 'center',
   width: '70px',
@@ -121,46 +82,24 @@ const columns = [
 const row = new TableRow<CronJobUI>({ selectable: (_cronjob): boolean => true });
 </script>
 
-<NavPage bind:searchTerm={searchTerm} title="cronjobs">
-  <svelte:fragment slot="additional-actions">
-    <KubeActions />
-  </svelte:fragment>
-
-  <svelte:fragment slot="bottom-additional-actions">
-    {#if selectedItemsNumber > 0}
-      <Button
-        on:click={(): void =>
-          withBulkConfirmation(
-            deleteSelectedCronJobs,
-            `delete ${selectedItemsNumber} cronjob${selectedItemsNumber > 1 ? 's' : ''}`,
-          )}
-        title="Delete {selectedItemsNumber} selected items"
-        inProgress={bulkDeleteInProgress}
-        icon={faTrash} />
-      <span>On {selectedItemsNumber} selected items.</span>
-    {/if}
-    <div class="flex grow justify-end">
-      <KubernetesCurrentContextConnectionBadge />
-    </div>
-  </svelte:fragment>
-
-  <div class="flex min-w-full h-full" slot="content">
-    <Table
-      kind="cronjob"
-      bind:this={table}
-      bind:selectedItemsNumber={selectedItemsNumber}
-      data={cronjobs}
-      columns={columns}
-      row={row}
-      defaultSortColumn="Name">
-    </Table>
-
-    {#if $kubernetesCurrentContextCronJobsFiltered.length === 0}
-      {#if searchTerm}
-        <FilteredEmptyScreen icon={CronJobIcon} kind="cronjobs" bind:searchTerm={searchTerm} />
-      {:else}
-        <CronJobEmptyScreen />
-      {/if}
-    {/if}
-  </div>
-</NavPage>
+<KubernetesObjectsList
+  kinds={[{
+    resource: 'cronjobs',
+    transformer: cronjobUtils.getCronJobUI,
+    delete: window.kubernetesDeleteCronJob,
+    isResource: (): boolean => true,
+    legacySearchPatternStore: cronJobSearchPattern,
+    legacyObjectStore: kubernetesCurrentContextCronJobsFiltered,
+  }]}
+  singular="CronJob"
+  plural="CronJobs"
+  icon={CronJobIcon}
+  searchTerm={searchTerm}
+  columns={columns}
+  row={row}
+  >
+  <!-- eslint-disable-next-line sonarjs/no-unused-vars -->
+  {#snippet emptySnippet()}
+    <CronJobEmptyScreen />
+  {/snippet}
+</KubernetesObjectsList>

--- a/packages/renderer/src/lib/cronjob/CronJobList.svelte
+++ b/packages/renderer/src/lib/cronjob/CronJobList.svelte
@@ -1,0 +1,166 @@
+<script lang="ts">
+import { faTrash } from '@fortawesome/free-solid-svg-icons';
+import {
+  Button,
+  FilteredEmptyScreen,
+  NavPage,
+  Table,
+  TableColumn,
+  TableDurationColumn,
+  TableRow,
+  TableSimpleColumn,
+} from '@podman-desktop/ui-svelte';
+import moment from 'moment';
+
+import KubeActions from '/@/lib/kube/KubeActions.svelte';
+import KubernetesCurrentContextConnectionBadge from '/@/lib/ui/KubernetesCurrentContextConnectionBadge.svelte';
+import { cronJobSearchPattern, kubernetesCurrentContextCronJobsFiltered } from '/@/stores/kubernetes-contexts-state';
+
+import { withBulkConfirmation } from '../actions/BulkActions';
+import CronJobIcon from '../images/CronJobIcon.svelte';
+import { capitalize } from '../ui/Util';
+import { CronJobUtils } from './cronjob-utils';
+import CronJobColumnActions from './CronJobColumnActions.svelte';
+import CronJobColumnName from './CronJobColumnName.svelte';
+import CronJobColumnStatus from './CronJobColumnStatus.svelte';
+import CronJobEmptyScreen from './CronJobEmptyScreen.svelte';
+import type { CronJobUI } from './CronJobUI';
+
+// Search and "utility" functions for CronJob
+interface Props {
+  searchTerm?: string;
+}
+let { searchTerm = '' }: Props = $props();
+$effect(() => {
+  cronJobSearchPattern.set(searchTerm);
+});
+const cronjobUtils = new CronJobUtils();
+const cronjobs = $derived($kubernetesCurrentContextCronJobsFiltered.map(cronjob => cronjobUtils.getCronJobUI(cronjob)));
+
+// Bulk deletion progress for cronjobs
+let bulkDeleteInProgress = $state<boolean>(false);
+let selectedItemsNumber = $state<number>(0);
+async function deleteSelectedCronJobs(): Promise<void> {
+  const selectedCronJobs = cronjobs.filter(cronjob => cronjob.selected);
+  if (selectedCronJobs.length === 0) {
+    return;
+  }
+
+  bulkDeleteInProgress = true;
+  selectedCronJobs.forEach(cronjob => (cronjob.status = 'DELETING'));
+
+  await Promise.all(
+    selectedCronJobs.map(async cronjob => {
+      try {
+        await window.kubernetesDeleteCronJob(cronjob.name);
+      } catch (e) {
+        console.error('error while deleting cronjob', e);
+      }
+    }),
+  );
+  bulkDeleteInProgress = false;
+}
+
+// Columns / information
+let table: Table;
+let statusColumn = new TableColumn<CronJobUI>('Status', {
+  align: 'center',
+  width: '70px',
+  renderer: CronJobColumnStatus,
+  comparator: (a, b): number => a.status.localeCompare(b.status),
+});
+
+let nameColumn = new TableColumn<CronJobUI>('Name', {
+  width: '1.3fr',
+  renderer: CronJobColumnName,
+  comparator: (a, b): number => a.name.localeCompare(b.name),
+});
+
+let ageColumn = new TableColumn<CronJobUI, Date | undefined>('Age', {
+  renderMapping: (cronjob): Date | undefined => cronjob.created,
+  renderer: TableDurationColumn,
+  comparator: (a, b): number => moment(b.created).diff(moment(a.created)),
+});
+
+let scheduleColumn = new TableColumn<CronJobUI, string>('Schedule', {
+  renderMapping: (cronjob): string => cronjob.schedule,
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.schedule.localeCompare(b.schedule),
+});
+
+let suspendColumn = new TableColumn<CronJobUI, string>('Suspended', {
+  renderMapping: (cronjob): string => capitalize(cronjob.suspended.toString()),
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => a.suspended.toString().localeCompare(b.suspended.toString()),
+});
+
+// This column just lists the number of active jobs at the moment, we do not link to the pods, etc (yet).. maybe in the future
+let activeColumn = new TableColumn<CronJobUI, string>('Active', {
+  renderMapping: (cronjob): string => cronjob.active?.toString() ?? '',
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => (a.active?.toString() ?? '').localeCompare(b.active?.toString() ?? ''),
+});
+
+let lastScheduleColumn = new TableColumn<CronJobUI, Date | undefined>('Last scheduled', {
+  renderMapping: (cronjob): Date | undefined => cronjob.lastScheduleTime,
+  renderer: TableDurationColumn,
+  comparator: (a, b): number => moment(b.lastScheduleTime).diff(moment(a.lastScheduleTime)),
+});
+
+const columns = [
+  statusColumn,
+  nameColumn,
+  scheduleColumn,
+  lastScheduleColumn,
+  suspendColumn,
+  activeColumn,
+  ageColumn,
+  new TableColumn<CronJobUI>('Actions', { align: 'right', renderer: CronJobColumnActions }),
+];
+
+const row = new TableRow<CronJobUI>({ selectable: (_cronjob): boolean => true });
+</script>
+
+<NavPage bind:searchTerm={searchTerm} title="cronjobs">
+  <svelte:fragment slot="additional-actions">
+    <KubeActions />
+  </svelte:fragment>
+
+  <svelte:fragment slot="bottom-additional-actions">
+    {#if selectedItemsNumber > 0}
+      <Button
+        on:click={(): void =>
+          withBulkConfirmation(
+            deleteSelectedCronJobs,
+            `delete ${selectedItemsNumber} cronjob${selectedItemsNumber > 1 ? 's' : ''}`,
+          )}
+        title="Delete {selectedItemsNumber} selected items"
+        inProgress={bulkDeleteInProgress}
+        icon={faTrash} />
+      <span>On {selectedItemsNumber} selected items.</span>
+    {/if}
+    <div class="flex grow justify-end">
+      <KubernetesCurrentContextConnectionBadge />
+    </div>
+  </svelte:fragment>
+
+  <div class="flex min-w-full h-full" slot="content">
+    <Table
+      kind="cronjob"
+      bind:this={table}
+      bind:selectedItemsNumber={selectedItemsNumber}
+      data={cronjobs}
+      columns={columns}
+      row={row}
+      defaultSortColumn="Name">
+    </Table>
+
+    {#if $kubernetesCurrentContextCronJobsFiltered.length === 0}
+      {#if searchTerm}
+        <FilteredEmptyScreen icon={CronJobIcon} kind="cronjobs" bind:searchTerm={searchTerm} />
+      {:else}
+        <CronJobEmptyScreen />
+      {/if}
+    {/if}
+  </div>
+</NavPage>

--- a/packages/renderer/src/lib/cronjob/CronJobUI.ts
+++ b/packages/renderer/src/lib/cronjob/CronJobUI.ts
@@ -1,0 +1,38 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export interface CronJobUI {
+  uid: string;
+  name: string;
+  status: string;
+  namespace: string;
+  created?: Date;
+  selected: boolean;
+
+  // The "schedule" in cron format. See: https://en.wikipedia.org/wiki/Cron
+  schedule: string;
+
+  // If suspended or not, as cronjobs can be suspended / turned on and off.
+  suspended: boolean;
+
+  // Last scheduled run time
+  lastScheduleTime?: Date;
+
+  // Number of "active" jobs
+  active?: number;
+}

--- a/packages/renderer/src/lib/cronjob/cronjob-utils.spec.ts
+++ b/packages/renderer/src/lib/cronjob/cronjob-utils.spec.ts
@@ -24,7 +24,7 @@ import { CronJobUtils } from './cronjob-utils';
 let cronjobUtils: CronJobUtils;
 
 beforeEach(() => {
-  vi.clearAllMocks();
+  vi.resetAllMocks();
   cronjobUtils = new CronJobUtils();
 });
 

--- a/packages/renderer/src/lib/cronjob/cronjob-utils.spec.ts
+++ b/packages/renderer/src/lib/cronjob/cronjob-utils.spec.ts
@@ -1,0 +1,42 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1CronJob } from '@kubernetes/client-node';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { CronJobUtils } from './cronjob-utils';
+
+let cronjobUtils: CronJobUtils;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  cronjobUtils = new CronJobUtils();
+});
+
+test('expect basic UI conversion', async () => {
+  const cronjob = {
+    metadata: {
+      name: 'my-cronjob',
+      namespace: 'test-namespace',
+    },
+    status: {},
+  } as V1CronJob;
+  const cronjobUI = cronjobUtils.getCronJobUI(cronjob);
+  expect(cronjobUI.name).toEqual('my-cronjob');
+  expect(cronjobUI.namespace).toEqual('test-namespace');
+});

--- a/packages/renderer/src/lib/cronjob/cronjob-utils.ts
+++ b/packages/renderer/src/lib/cronjob/cronjob-utils.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/renderer/src/lib/cronjob/cronjob-utils.ts
+++ b/packages/renderer/src/lib/cronjob/cronjob-utils.ts
@@ -1,0 +1,39 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1CronJob } from '@kubernetes/client-node';
+
+import type { CronJobUI } from './CronJobUI';
+
+export class CronJobUtils {
+  getCronJobUI(cronjob: V1CronJob): CronJobUI {
+    return {
+      uid: cronjob.metadata?.uid ?? '',
+      name: cronjob.metadata?.name ?? '',
+      status: 'RUNNING',
+      namespace: cronjob.metadata?.namespace ?? '',
+      created: cronjob.metadata?.creationTimestamp,
+      selected: false,
+      schedule: cronjob.spec?.schedule ?? '',
+      suspended: cronjob.spec?.suspend ?? false,
+      lastScheduleTime: cronjob.status?.lastScheduleTime,
+      // Get the number of "active" jobs, we just get the length of the array
+      active: cronjob.status?.active?.length ?? 0,
+    };
+  }
+}

--- a/packages/renderer/src/lib/kube/KubernetesDashboard.spec.ts
+++ b/packages/renderer/src/lib/kube/KubernetesDashboard.spec.ts
@@ -60,6 +60,7 @@ test('Verify basic page', async () => {
   vi.mocked(kubeContextStore).kubernetesCurrentContextIngresses = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextRoutes = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextNodes = readable<KubernetesObject[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextCronJobs = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextConfigMaps = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextSecrets = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextPersistentVolumeClaims = readable<KubernetesObject[]>([]);
@@ -90,6 +91,7 @@ test('Verify basic page with cluster', async () => {
   vi.mocked(kubeContextStore).kubernetesCurrentContextIngresses = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextRoutes = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextNodes = readable<KubernetesObject[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextCronJobs = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextConfigMaps = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextSecrets = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextPersistentVolumeClaims = readable<KubernetesObject[]>([]);
@@ -114,7 +116,7 @@ test('Verify basic page with cluster', async () => {
 
   const metrics = screen.getByText('Metrics');
   expect(metrics).toBeInTheDocument();
-  expect(metrics.nextElementSibling?.childElementCount).toBe(7);
+  expect(metrics.nextElementSibling?.childElementCount).toBe(8);
 
   const guides = screen.getByText('Explore articles and blog posts');
   expect(guides).toBeInTheDocument();

--- a/packages/renderer/src/lib/kube/KubernetesDashboard.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesDashboard.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
 import type { KubernetesObject } from '@kubernetes/client-node';
 import { Link } from '@podman-desktop/ui-svelte';
+import type { Component } from 'svelte';
 
 import KubernetesCurrentContextConnectionBadge from '/@/lib/ui/KubernetesCurrentContextConnectionBadge.svelte';
 import { containersInfos } from '/@/stores/containers';
 import {
   kubernetesCurrentContextConfigMaps,
+  kubernetesCurrentContextCronJobs,
   kubernetesCurrentContextDeployments,
   kubernetesCurrentContextIngresses,
   kubernetesCurrentContextNodes,
@@ -20,6 +22,7 @@ import { NO_CURRENT_CONTEXT_ERROR } from '/@api/kubernetes-contexts-states';
 
 import { kubernetesContexts } from '../../stores/kubernetes-contexts';
 import ConfigMapSecretIcon from '../images/ConfigMapSecretIcon.svelte';
+import CronJobIcon from '../images/CronJobIcon.svelte';
 import DeploymentIcon from '../images/DeploymentIcon.svelte';
 import IngressRouteIcon from '../images/IngressRouteIcon.svelte';
 import NodeIcon from '../images/NodeIcon.svelte';
@@ -63,6 +66,7 @@ let pvcCount = $derived($kubernetesCurrentContextPersistentVolumeClaims.length);
 let configMapSecretCount = $derived(
   $kubernetesCurrentContextConfigMaps.length + $kubernetesCurrentContextSecrets.length,
 );
+let cronjobCount = $derived($kubernetesCurrentContextCronJobs.length);
 let expandedDetails: boolean = $state(true);
 let expandedGuide: boolean = $state(true);
 
@@ -126,6 +130,7 @@ async function openKubernetesDocumentation(): Promise<void> {
                     <KubernetesDashboardResourceCard type='Ingresses & Routes' Icon={IngressRouteIcon} count={ingressRouteCount} link='/kubernetes/ingressesRoutes'/>
                     <KubernetesDashboardResourceCard type='Persistent Volume Claims' Icon={PvcIcon} count={pvcCount} link='/kubernetes/persistentvolumeclaims'/>
                     <KubernetesDashboardResourceCard type='ConfigMaps & Secrets' Icon={ConfigMapSecretIcon} count={configMapSecretCount} link='/kubernetes/configmapsSecrets'/>
+                    <KubernetesDashboardResourceCard type='CronJobs' Icon={CronJobIcon as Component} count={cronjobCount} link='/kubernetes/cronjobs'/>
                 </div>
                 <!-- Graphs -->
                 

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-cronjobs.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-cronjobs.svelte.spec.ts
@@ -1,0 +1,53 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { KubernetesObject } from '@kubernetes/client-node';
+import { expect, test, vi } from 'vitest';
+
+import { createNavigationKubernetesCronJobsEntry } from './navigation-registry-k8s-cronjobs.svelte';
+
+test('createNavigationKubernetesCronJobsEntry', async () => {
+  const cronJobs: KubernetesObject[] = [
+    {
+      apiVersion: 'v1',
+      kind: 'CronJob',
+      metadata: {
+        name: 'cronjob1',
+      },
+    },
+    {
+      apiVersion: 'v1',
+      kind: 'CronJob',
+      metadata: {
+        name: 'cronjob2',
+      },
+    },
+  ];
+
+  vi.mocked(window.kubernetesRegisterGetCurrentContextResources).mockResolvedValue(cronJobs);
+
+  const entry = createNavigationKubernetesCronJobsEntry();
+
+  expect(entry).toBeDefined();
+  expect(entry.name).toBe('CronJobs');
+  expect(entry.link).toBe('/kubernetes/cronjobs');
+  expect(entry.tooltip).toBe('CronJobs');
+  await vi.waitFor(() => {
+    expect(entry.counter).toBe(2);
+  });
+});

--- a/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-cronjobs.svelte.ts
+++ b/packages/renderer/src/stores/navigation/kubernetes/navigation-registry-k8s-cronjobs.svelte.ts
@@ -1,0 +1,45 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Component } from 'svelte';
+
+import CronJobIcon from '/@/lib/images/CronJobIcon.svelte';
+
+import { kubernetesCurrentContextCronJobs } from '../../kubernetes-contexts-state';
+import type { NavigationRegistryEntry } from '../navigation-registry';
+
+let count = $state(0);
+
+export function createNavigationKubernetesCronJobsEntry(): NavigationRegistryEntry {
+  kubernetesCurrentContextCronJobs.subscribe(cronjobs => {
+    count = cronjobs.length;
+  });
+  const registry: NavigationRegistryEntry = {
+    name: 'CronJobs',
+    icon: {
+      iconComponent: CronJobIcon as Component,
+    },
+    link: '/kubernetes/cronjobs',
+    tooltip: 'CronJobs',
+    type: 'entry',
+    get counter() {
+      return count;
+    },
+  };
+  return registry;
+}

--- a/packages/renderer/src/stores/navigation/navigation-registry-kubernetes.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-kubernetes.svelte.spec.ts
@@ -54,6 +54,7 @@ test('createNavigationImageEntry with current context', async () => {
   ];
   vi.mocked(kubeContextStore).kubernetesCurrentContextState = readable<ContextGeneralState>({} as ContextGeneralState);
   vi.mocked(kubeContextStore).kubernetesCurrentContextNodes = readable<KubernetesObject[]>(nodes);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextCronJobs = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextDeployments = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextPods = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextServices = readable<KubernetesObject[]>([]);
@@ -70,9 +71,9 @@ test('createNavigationImageEntry with current context', async () => {
   expect(entry.name).toBe('Kubernetes');
   expect(entry.icon.iconComponent).toBe(KubeIcon);
 
-  // should have 9 items
+  // should have 10 items
   await vi.waitFor(() => {
-    expect(entry.items?.length).toBe(9);
+    expect(entry.items?.length).toBe(10);
   });
 });
 
@@ -81,6 +82,7 @@ test('createNavigationImageEntry without current context', async () => {
     error: NO_CURRENT_CONTEXT_ERROR,
   } as ContextGeneralState);
   vi.mocked(kubeContextStore).kubernetesCurrentContextNodes = readable<KubernetesObject[]>([]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextCronJobs = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextDeployments = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextPods = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextServices = readable<KubernetesObject[]>([]);

--- a/packages/renderer/src/stores/navigation/navigation-registry-kubernetes.svelte.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-kubernetes.svelte.ts
@@ -22,6 +22,7 @@ import { NO_CURRENT_CONTEXT_ERROR } from '/@api/kubernetes-contexts-states';
 
 import { kubernetesCurrentContextState } from '../kubernetes-contexts-state';
 import { createNavigationKubernetesConfigMapSecretsEntry } from './kubernetes/navigation-registry-k8s-configmap-secrets.svelte';
+import { createNavigationKubernetesCronJobsEntry } from './kubernetes/navigation-registry-k8s-cronjobs.svelte';
 import { createNavigationKubernetesDashboardEntry } from './kubernetes/navigation-registry-k8s-dashboard.svelte';
 import { createNavigationKubernetesDeploymentsEntry } from './kubernetes/navigation-registry-k8s-deployments.svelte';
 import { createNavigationKubernetesIngressesRoutesEntry } from './kubernetes/navigation-registry-k8s-ingresses-routes.svelte';
@@ -48,6 +49,7 @@ export function createNavigationKubernetesGroup(): NavigationRegistryEntry {
   newItems.push(createNavigationKubernetesIngressesRoutesEntry());
   newItems.push(createNavigationKubernetesPersistentVolumeEntry());
   newItems.push(createNavigationKubernetesConfigMapSecretsEntry());
+  newItems.push(createNavigationKubernetesCronJobsEntry());
   newItems.push(createNavigationKubernetesPortForwardEntry());
   kubernetesNavigationGroupItems = newItems;
 


### PR DESCRIPTION
feat: add cronjobs to kubernetes

### What does this PR do?

* Adds CronJobs to Kubernetes
* Does NOT include "summary" page (separate PR)
* Includes scheduling information, suspension information, ability to
  delete, scheduling.
* Tests added

### Screenshot / video of UI

![Screenshot 2025-02-04 at 2 43 31 PM](https://github.com/user-attachments/assets/e94e6aae-d0d1-4001-bf2e-670d1b65aeda)

https://github.com/user-attachments/assets/aed88aeb-2ca1-45be-a687-2cfff97d724d



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Part of https://github.com/podman-desktop/podman-desktop/issues/10560

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

1. Deploy an example CronJob such as:

```yaml
apiVersion: batch/v1
kind: CronJob
metadata:
  name: infinite-cronjob
spec:
  schedule: "*/5 * * * *"  # Runs every 5 minutes
  concurrencyPolicy: Forbid
  successfulJobsHistoryLimit: 1
  failedJobsHistoryLimit: 1
  jobTemplate:
    spec:
      template:
        spec:
          restartPolicy: Never
          containers:
          - name: infinite-loop
            image: busybox
            command: ["/bin/sh", "-c", "while true; do echo 'Running...'; sleep 30; done"]
```

2. See it has been deployed / interact with it within the Kubernetes
   section of Podman Desktop.
