### PR TITLE
chore: remove @typescript-eslint/no-explicit-any usage from image

### DIFF
--- a/packages/renderer/src/lib/image/ActionsMenu.spec.ts
+++ b/packages/renderer/src/lib/image/ActionsMenu.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-
-/* eslint-disable @typescript-eslint/no-explicit-any */
 
 import '@testing-library/jest-dom/vitest';
 

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2024 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-
-/* eslint-disable @typescript-eslint/no-explicit-any */
 
 import '@testing-library/jest-dom/vitest';
 
@@ -43,27 +41,16 @@ vi.mock('@xterm/xterm', () => {
 // fake the window.events object
 beforeAll(() => {
   (window.events as unknown) = {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    receive: (_channel: string, func: any): void => {
+    receive: (_channel: string, func: () => void): void => {
       func();
     },
   };
-  (window as any).dispatchEvent = vi.fn();
-  (window as any).getConfigurationValue = vi.fn();
-  (window as any).matchMedia = vi.fn().mockReturnValue({
+  vi.mocked(window.matchMedia).mockReturnValue({
     addListener: vi.fn(),
-  });
-  (window as any).openDialog = vi.fn().mockResolvedValue(['Containerfile']);
-  (window as any).telemetryPage = vi.fn().mockResolvedValue(undefined);
-  // Mock the getOsArch function to return 'linux/amd64' by default for the form
-  (window as any).getOsArch = vi.fn();
-  (window as any).buildImage = vi.fn();
-  (window as any).createManifest = vi.fn();
-  (window as any).getImageCheckerProviders = vi.fn();
-  (window as any).getCancellableTokenSource = vi.fn().mockReturnValue({
-    cancel: vi.fn(),
-  });
-  (window as any).pathRelative = vi.fn();
+  } as unknown as MediaQueryList);
+  vi.mocked(window.openDialog).mockResolvedValue(['Containerfile']);
+  vi.mocked(window.telemetryPage).mockResolvedValue(undefined);
+  vi.mocked(window.getCancellableTokenSource).mockResolvedValue(1234);
 });
 
 beforeEach(() => {

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
@@ -45,9 +45,14 @@ beforeAll(() => {
       func();
     },
   };
-  vi.mocked(window.matchMedia).mockReturnValue({
-    addListener: vi.fn(),
-  } as unknown as MediaQueryList);
+  Object.defineProperty(window, 'matchMedia', {
+    value: () => {
+      return {
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+      };
+    },
+  });
   vi.mocked(window.openDialog).mockResolvedValue(['Containerfile']);
   vi.mocked(window.telemetryPage).mockResolvedValue(undefined);
   vi.mocked(window.getCancellableTokenSource).mockResolvedValue(1234);

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
@@ -45,16 +45,7 @@ beforeAll(() => {
       func();
     },
   };
-  Object.defineProperty(window, 'matchMedia', {
-    value: () => {
-      return {
-        addListener: vi.fn(),
-        removeListener: vi.fn(),
-      };
-    },
-  });
   vi.mocked(window.openDialog).mockResolvedValue(['Containerfile']);
-  vi.mocked(window.telemetryPage).mockResolvedValue(undefined);
   vi.mocked(window.getCancellableTokenSource).mockResolvedValue(1234);
 });
 

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfileCard.spec.ts
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfileCard.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-
-/* eslint-disable @typescript-eslint/no-explicit-any */
 
 import '@testing-library/jest-dom/vitest';
 

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfileCard.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfileCard.svelte
@@ -125,10 +125,12 @@ onMount(() => {
       {/if}
     </div>
     <div class="flex grow justify-end">
-      {#if iconType === 'fontAwesome'}
-        <Fa class="text-[var(--pd-content-card-icon)] cursor-pointer" icon={icon as IconDefinition} size="1.5x" />
-      {:else if iconType === 'unknown'}
-        <svelte:component this={icon as Component} class="text-[var(--pd-content-card-icon)] cursor-pointer" size="24" />
+      {#if icon}
+        {#if iconType === 'fontAwesome'}
+          <Fa class="text-[var(--pd-content-card-icon)] cursor-pointer" icon={icon as IconDefinition} size="1.5x" />
+        {:else if iconType === 'unknown'}
+          <svelte:component this={icon as Component} class="text-[var(--pd-content-card-icon)] cursor-pointer" size="24" />
+        {/if}
       {/if}
     </div>
   </div>

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfileCard.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfileCard.svelte
@@ -10,7 +10,7 @@ export let badge: string = '';
 export let isDefault: boolean = false;
 export let checked: boolean = false;
 export let value: string = '';
-export let icon: unknown | undefined = undefined;
+export let icon: IconDefinition | Component | undefined = undefined;
 let iconType: 'fontAwesome' | 'unknown' | undefined = undefined;
 
 export let additionalItem: boolean = false;

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfileCard.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfileCard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-import { faCircle, faPlusCircle } from '@fortawesome/free-solid-svg-icons';
+import { faCircle, faPlusCircle, type IconDefinition } from '@fortawesome/free-solid-svg-icons';
 import { Checkbox, isFontAwesomeIcon, Tooltip } from '@podman-desktop/ui-svelte';
+import type { Component } from 'svelte';
 import { createEventDispatcher, onMount, tick } from 'svelte';
 import Fa from 'svelte-fa';
 
@@ -9,8 +10,7 @@ export let badge: string = '';
 export let isDefault: boolean = false;
 export let checked: boolean = false;
 export let value: string = '';
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export let icon: any | undefined = '';
+export let icon: unknown | undefined = undefined;
 let iconType: 'fontAwesome' | 'unknown' | undefined = undefined;
 
 export let additionalItem: boolean = false;
@@ -126,9 +126,9 @@ onMount(() => {
     </div>
     <div class="flex grow justify-end">
       {#if iconType === 'fontAwesome'}
-        <Fa class="text-[var(--pd-content-card-icon)] cursor-pointer" icon={icon} size="1.5x" />
+        <Fa class="text-[var(--pd-content-card-icon)] cursor-pointer" icon={icon as IconDefinition} size="1.5x" />
       {:else if iconType === 'unknown'}
-        <svelte:component this={icon} class="text-[var(--pd-content-card-icon)] cursor-pointer" size="24" />
+        <svelte:component this={icon as Component} class="text-[var(--pd-content-card-icon)] cursor-pointer" size="24" />
       {/if}
     </div>
   </div>

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfileCards.spec.ts
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfileCards.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import '@testing-library/jest-dom/vitest';
 
 import { render, screen } from '@testing-library/svelte';
@@ -29,12 +27,10 @@ import BuildImageFromContainerfileCards from './BuildImageFromContainerfileCards
 // fake the window.events object
 beforeAll(() => {
   (window.events as unknown) = {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    receive: (_channel: string, func: any): void => {
+    receive: (_channel: string, func: () => void): void => {
       func();
     },
   };
-  (window as any).getOsArch = vi.fn();
 });
 
 test('check default on arm64', async () => {

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfileCards.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfileCards.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
 import { faLinux } from '@fortawesome/free-brands-svg-icons';
-import { faChevronCircleDown, faChevronRight, faLayerGroup } from '@fortawesome/free-solid-svg-icons';
-import { onMount } from 'svelte';
+import {
+  faChevronCircleDown,
+  faChevronRight,
+  faLayerGroup,
+  type IconDefinition,
+} from '@fortawesome/free-solid-svg-icons';
+import { type Component, onMount } from 'svelte';
 import Fa from 'svelte-fa';
 
 import WebAssemblyIcon from '../images/WebAssemblyIcon.svelte';
@@ -16,7 +21,7 @@ interface CardInfo {
   isDefault: boolean;
   checked: boolean;
   value: string;
-  icon: unknown;
+  icon: IconDefinition | Component | undefined;
 }
 
 const DEFAULT_CARDS: CardInfo[] = [

--- a/packages/renderer/src/lib/image/ImagesList.spec.ts
+++ b/packages/renderer/src/lib/image/ImagesList.spec.ts
@@ -41,7 +41,6 @@ beforeEach(() => {
   providerInfos.set([]);
   imagesInfos.set([]);
   viewsContributions.set([]);
-  vi.mocked(window.onDidUpdateProviderStatus).mockResolvedValue(undefined);
   vi.mocked(window.hasAuthconfigForImage).mockResolvedValue(false);
   vi.mocked(window.listViewsContributions).mockResolvedValue([]);
   vi.mocked(window.getConfigurationProperties).mockResolvedValue({});
@@ -52,7 +51,6 @@ beforeEach(() => {
       func();
     },
   };
-  vi.mocked(window.deleteImage).mockResolvedValue(undefined);
 });
 
 async function waitRender(customProperties: object): Promise<void> {

--- a/packages/renderer/src/lib/image/ImagesList.spec.ts
+++ b/packages/renderer/src/lib/image/ImagesList.spec.ts
@@ -41,8 +41,8 @@ beforeEach(() => {
   providerInfos.set([]);
   imagesInfos.set([]);
   viewsContributions.set([]);
-  vi.mocked(window.onDidUpdateProviderStatus).mockImplementation(() => Promise.resolve());
-  vi.mocked(window.hasAuthconfigForImage).mockImplementation(() => Promise.resolve(false));
+  vi.mocked(window.onDidUpdateProviderStatus).mockResolvedValue(undefined);
+  vi.mocked(window.hasAuthconfigForImage).mockResolvedValue(false);
   vi.mocked(window.listViewsContributions).mockResolvedValue([]);
   vi.mocked(window.getConfigurationProperties).mockResolvedValue({});
   vi.mocked(window.getConfigurationValue).mockResolvedValue(false);
@@ -90,7 +90,7 @@ test('Expect images being ordered by newest first', async () => {
       Status: 'Running',
       engineId: 'podman',
       engineName: 'podman',
-    } as unknown as ImageInfo,
+    },
     {
       Id: 'sha256:456456456456456',
       RepoTags: ['veryold:image'],
@@ -99,7 +99,7 @@ test('Expect images being ordered by newest first', async () => {
       Status: 'Running',
       engineId: 'podman',
       engineName: 'podman',
-    } as unknown as ImageInfo,
+    },
     {
       Id: 'sha256:7897891234567890123',
       RepoTags: ['fedora:recent'],
@@ -108,8 +108,8 @@ test('Expect images being ordered by newest first', async () => {
       Status: 'Running',
       engineId: 'podman',
       engineName: 'podman',
-    } as unknown as ImageInfo,
-  ]);
+    },
+  ] as unknown as ImageInfo[]);
 
   window.dispatchEvent(new CustomEvent('extensions-already-started'));
   window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
@@ -161,8 +161,8 @@ test('Expect filter empty screen', async () => {
       Status: 'Running',
       engineId: 'podman',
       engineName: 'podman',
-    } as unknown as ImageInfo,
-  ]);
+    },
+  ] as unknown as ImageInfo[]);
 
   window.dispatchEvent(new CustomEvent('extensions-already-started'));
   window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
@@ -206,7 +206,7 @@ test('Expect two images in list given image id and engine id', async () => {
       Status: 'Running',
       engineId: 'podman',
       engineName: 'podman',
-    } as unknown as ImageInfo,
+    },
     {
       Id: 'sha256:1234567890123',
       RepoTags: ['fedora:1'],
@@ -215,7 +215,7 @@ test('Expect two images in list given image id and engine id', async () => {
       Status: 'Running',
       engineId: 'docker',
       engineName: 'docker',
-    } as unknown as ImageInfo,
+    },
     {
       Id: 'sha256:1234567890123',
       RepoTags: ['fedora:2'],
@@ -224,7 +224,7 @@ test('Expect two images in list given image id and engine id', async () => {
       Status: 'Running',
       engineId: 'podman',
       engineName: 'podman',
-    } as unknown as ImageInfo,
+    },
     {
       Id: 'sha256:2345678901234',
       RepoTags: ['fedora:3'],
@@ -233,7 +233,7 @@ test('Expect two images in list given image id and engine id', async () => {
       Status: 'Running',
       engineId: 'podman',
       engineName: 'podman',
-    } as unknown as ImageInfo,
+    },
     {
       Id: 'sha256:3456789012345',
       RepoTags: ['fedora:4'],
@@ -242,8 +242,8 @@ test('Expect two images in list given image id and engine id', async () => {
       Status: 'Running',
       engineId: 'podman',
       engineName: 'podman',
-    } as unknown as ImageInfo,
-  ]);
+    },
+  ] as unknown as ImageInfo[]);
 
   window.dispatchEvent(new CustomEvent('extensions-already-started'));
   window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
@@ -303,8 +303,8 @@ describe('Contributions', () => {
           engineId: 'podman',
           engineName: 'podman',
           Labels: labels,
-        } as unknown as ImageInfo,
-      ]);
+        },
+      ] as unknown as ImageInfo[]);
 
       window.dispatchEvent(new CustomEvent('extensions-already-started'));
       window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
@@ -381,8 +381,8 @@ describe('Contributions', () => {
           engineId: 'podman',
           engineName: 'podman',
           Labels: labels,
-        } as unknown as ImageInfo,
-      ]);
+        },
+      ] as unknown as ImageInfo[]);
 
       window.dispatchEvent(new CustomEvent('extensions-already-started'));
       window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
@@ -465,7 +465,7 @@ test('expect redirect to saveImage page when at least one image is selected and 
       Status: 'Running',
       engineId: 'podman',
       engineName: 'podman',
-    } as unknown as ImageInfo,
+    },
     {
       Id: 'sha256:456456456456456',
       RepoTags: ['veryold:image'],
@@ -474,7 +474,7 @@ test('expect redirect to saveImage page when at least one image is selected and 
       Status: 'Running',
       engineId: 'podman',
       engineName: 'podman',
-    } as unknown as ImageInfo,
+    },
     {
       Id: 'sha256:7897891234567890123',
       RepoTags: ['fedora:recent'],
@@ -483,8 +483,8 @@ test('expect redirect to saveImage page when at least one image is selected and 
       Status: 'Running',
       engineId: 'podman',
       engineName: 'podman',
-    } as unknown as ImageInfo,
-  ]);
+    },
+  ] as unknown as ImageInfo[]);
 
   const goToMock = vi.spyOn(router, 'goto');
 
@@ -546,7 +546,7 @@ test('Manifest images display without actions', async () => {
       Status: 'Running',
       engineId: 'podman',
       engineName: 'podman',
-    } as unknown as ImageInfo,
+    },
     {
       Id: 'sha256:7897891234567890123',
       RepoTags: ['manifestimage:latest'],
@@ -556,8 +556,8 @@ test('Manifest images display without actions', async () => {
       engineId: 'podman',
       engineName: 'podman',
       isManifest: true,
-    } as unknown as ImageInfo,
-  ]);
+    },
+  ] as unknown as ImageInfo[]);
 
   // dispatch events
   window.dispatchEvent(new CustomEvent('extensions-already-started'));
@@ -622,8 +622,8 @@ test('Expect user confirmation to pop up when preferences require', async () => 
       Status: 'Running',
       engineId: 'podman',
       engineName: 'podman',
-    } as unknown as ImageInfo,
-  ]);
+    },
+  ] as unknown as ImageInfo[]);
 
   // dispatch events
   window.dispatchEvent(new CustomEvent('extensions-already-started'));


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR removes @typescript-eslint/no-explicit-any usage from image in renderer

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/10604
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
