### PR TITLE
chore: remove @typescript-eslint/no-explicit-any usage from image

### DIFF
--- a/packages/renderer/src/lib/image/PullImage.spec.ts
+++ b/packages/renderer/src/lib/image/PullImage.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2024 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import '@testing-library/jest-dom/vitest';
 
 import { render, screen } from '@testing-library/svelte';
@@ -32,26 +30,15 @@ import type { ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provid
 
 import PullImage from './PullImage.svelte';
 
-const pullImageMock = vi.fn();
-const resolveShortnameImageMock = vi.fn();
-const listImageTagsInRegistryMock = vi.fn();
-
-// fake the window.events object
 beforeAll(() => {
   (window.events as unknown) = {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    receive: (_channel: string, func: any): void => {
+    receive: (_channel: string, func: () => void): void => {
       func();
     },
   };
-  (window as any).telemetryPage = vi.fn().mockResolvedValue(undefined);
-  (window as any).getConfigurationValue = vi.fn().mockResolvedValue(undefined);
-  (window as any).matchMedia = vi.fn().mockReturnValue({
-    addListener: vi.fn(),
-  });
-  (window as any).pullImage = pullImageMock;
-  (window as any).resolveShortnameImage = resolveShortnameImageMock.mockResolvedValue(['docker.io/test1']);
-  (window as any).listImageTagsInRegistry = listImageTagsInRegistryMock;
+  vi.mocked(window.telemetryPage).mockResolvedValue(undefined);
+  vi.mocked(window.getConfigurationValue).mockResolvedValue(undefined);
+  vi.mocked(window.resolveShortnameImage).mockResolvedValue(['docker.io/test1']);
 
   Object.defineProperty(window, 'matchMedia', {
     value: () => {
@@ -150,7 +137,7 @@ describe('PullImage', () => {
     render(PullImage, { imageToPull: 'image-does-not-exist' });
 
     // first call to pull image throw an error
-    pullImageMock.mockRejectedValueOnce(new Error('Image does not exists'));
+    vi.mocked(window.pullImage).mockRejectedValueOnce(new Error('Image does not exists'));
 
     const pullImagebutton = screen.getByRole('button', { name: 'Pull image' });
     await userEvent.click(pullImagebutton);
@@ -172,7 +159,7 @@ describe('PullImage', () => {
     render(PullImage);
 
     // first call to pull image throw an error
-    pullImageMock.mockRejectedValueOnce(new Error('Image does not exists'));
+    vi.mocked(window.pullImage).mockRejectedValueOnce(new Error('Image does not exists'));
 
     await userEvent.keyboard('image-does-not-exist[Enter]');
 
@@ -188,10 +175,10 @@ describe('PullImage', () => {
     const renderResult = render(PullImage, { imageToPull: 'image-does-not-exist' });
 
     // first call to pull image throw an error
-    pullImageMock.mockRejectedValueOnce(new Error('Image does not exists'));
+    vi.mocked(window.pullImage).mockRejectedValueOnce(new Error('Image does not exists'));
 
     // next one are ok
-    pullImageMock.mockResolvedValueOnce({});
+    vi.mocked(window.pullImage).mockResolvedValueOnce();
 
     const pullImagebutton = screen.getByRole('button', { name: 'Pull image' });
     await userEvent.click(pullImagebutton);
@@ -234,10 +221,10 @@ describe('PullImage', () => {
     render(PullImage, { imageToPull: 'my.registry.com/image-to-pull' });
 
     // first call to pull image throw an error
-    pullImageMock.mockRejectedValueOnce(new Error('Image does not exists'));
+    vi.mocked(window.pullImage).mockRejectedValueOnce(new Error('Image does not exists'));
 
     // next one are ok
-    pullImageMock.mockResolvedValueOnce({});
+    vi.mocked(window.pullImage).mockResolvedValueOnce();
 
     const pullImagebutton = screen.getByRole('button', { name: 'Pull image' });
     await userEvent.click(pullImagebutton);
@@ -250,14 +237,14 @@ describe('PullImage', () => {
 });
 
 test('Expect if no docker.io shortname to use Podman FQN', async () => {
-  resolveShortnameImageMock.mockResolvedValue(['someregistry/test1']);
+  vi.mocked(window.resolveShortnameImage).mockResolvedValue(['someregistry/test1']);
   render(PullImage);
 
   const textbox = screen.getByRole('textbox', { name: 'Image to Pull' });
   await userEvent.click(textbox);
   await userEvent.paste('test1');
 
-  expect(resolveShortnameImageMock).toBeCalled();
+  expect(vi.mocked(window.resolveShortnameImage)).toBeCalled();
   await tick();
   const FQNButton = screen.getByRole('checkbox', { name: 'Use Podman FQN' });
 
@@ -265,44 +252,44 @@ test('Expect if no docker.io shortname to use Podman FQN', async () => {
   const pullImagebutton = screen.getByRole('button', { name: 'Pull image' });
   await userEvent.click(pullImagebutton);
 
-  const imageName = pullImageMock.mock.calls[0][1];
+  const imageName = vi.mocked(window.pullImage).mock.calls[0][1];
   expect(imageName).toBe('someregistry/test1');
 });
 
 test('Expect if no docker.io shortname but checkbox not checked to use docker hub', async () => {
-  resolveShortnameImageMock.mockResolvedValue(['someregistry/test1']);
+  vi.mocked(window.resolveShortnameImage).mockResolvedValue(['someregistry/test1']);
   render(PullImage);
 
   const textbox = screen.getByRole('textbox', { name: 'Image to Pull' });
   await userEvent.click(textbox);
   await userEvent.paste('test1');
 
-  expect(resolveShortnameImageMock).toBeCalled();
+  expect(vi.mocked(window.resolveShortnameImage)).toBeCalled();
   await tick();
 
   const pullImagebutton = screen.getByRole('button', { name: 'Pull image' });
   await userEvent.click(pullImagebutton);
 
-  const imageName = pullImageMock.mock.calls[0][1];
+  const imageName = vi.mocked(window.pullImage).mock.calls[0][1];
   expect(imageName).toBe('docker.io/test1');
 });
 
 test('Expect if docker.io shortname exists to not use Podman FQN', async () => {
-  resolveShortnameImageMock.mockResolvedValue(['someregistry/test1', 'docker.io/test1']);
+  vi.mocked(window.resolveShortnameImage).mockResolvedValue(['someregistry/test1', 'docker.io/test1']);
   render(PullImage);
 
   const textbox = screen.getByRole('textbox', { name: 'Image to Pull' });
   await userEvent.click(textbox);
   await userEvent.paste('test1');
 
-  expect(resolveShortnameImageMock).toBeCalled();
+  expect(vi.mocked(window.resolveShortnameImage)).toBeCalled();
   await tick();
   expect(screen.queryByRole('checkbox', { name: 'Use Podman FQN' })).not.toBeInTheDocument();
 
   const pullImagebutton = screen.getByRole('button', { name: 'Pull image' });
   await userEvent.click(pullImagebutton);
 
-  const imageName = pullImageMock.mock.calls[0][1];
+  const imageName = vi.mocked(window.pullImage).mock.calls[0][1];
   expect(imageName).toBe('test1');
 });
 
@@ -313,13 +300,13 @@ test('Expect not to check not shortname images', async () => {
   await userEvent.click(textbox);
   await userEvent.paste('test1/');
 
-  expect(resolveShortnameImageMock).not.toBeCalled();
+  expect(vi.mocked(window.resolveShortnameImage)).not.toBeCalled();
 });
 
 test('Expect latest tag warning is displayed when the image does not have latest tag', async () => {
   render(PullImage);
 
-  listImageTagsInRegistryMock.mockResolvedValue(['other']);
+  vi.mocked(window.listImageTagsInRegistry).mockResolvedValue(['other']);
   await userEvent.keyboard('my-registry/image-without-latest[Enter]');
 
   // expect that the warning message is displayed
@@ -331,7 +318,7 @@ test('Expect latest tag warning is displayed when the image does not have latest
 test('Expect latest tag warning is not displayed when the image has latest tag', async () => {
   render(PullImage);
 
-  listImageTagsInRegistryMock.mockResolvedValue(['latest', 'other']);
+  vi.mocked(window.listImageTagsInRegistry).mockResolvedValue(['latest', 'other']);
   await userEvent.keyboard('my-registry/image-without-latest[Enter]');
 
   // expect that the warning message is not displayed
@@ -342,7 +329,7 @@ test('Expect latest tag warning is not displayed when the image has latest tag',
 test('input component should not raise an error when the input is valid', async () => {
   const pullImage = render(PullImage);
 
-  listImageTagsInRegistryMock.mockResolvedValue(['latest', 'other']);
+  vi.mocked(window.listImageTagsInRegistry).mockResolvedValue(['latest', 'other']);
   await userEvent.keyboard('my-registry/image');
 
   const cellOutsideInput = pullImage.getAllByRole('textbox');
@@ -355,7 +342,7 @@ test('input component should not raise an error when the input is valid', async 
 test('input component should raise an error when the input is not valid', async () => {
   const pullImage = render(PullImage);
 
-  listImageTagsInRegistryMock.mockResolvedValue({});
+  vi.mocked(window.listImageTagsInRegistry).mockResolvedValue([]);
   await userEvent.keyboard('my-registry/image');
 
   const cellOutsideInput = pullImage.getAllByRole('textbox');
@@ -368,7 +355,7 @@ test('input component should raise an error when the input is not valid', async 
 test('input component should raise an error when the input is not valid - error', async () => {
   const pullImage = render(PullImage);
 
-  listImageTagsInRegistryMock.mockImplementation(() => {
+  vi.mocked(window.listImageTagsInRegistry).mockImplementation(() => {
     throw Error('Error msg');
   });
   await userEvent.keyboard('my-registry/image');

--- a/packages/renderer/src/lib/image/PullImage.spec.ts
+++ b/packages/renderer/src/lib/image/PullImage.spec.ts
@@ -36,8 +36,6 @@ beforeAll(() => {
       func();
     },
   };
-  vi.mocked(window.telemetryPage).mockResolvedValue(undefined);
-  vi.mocked(window.getConfigurationValue).mockResolvedValue(undefined);
   vi.mocked(window.resolveShortnameImage).mockResolvedValue(['docker.io/test1']);
 
   Object.defineProperty(window, 'matchMedia', {

--- a/packages/renderer/src/lib/image/PushImageModal.spec.ts
+++ b/packages/renderer/src/lib/image/PushImageModal.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,8 +47,7 @@ const pushImageMock = vi.fn();
 
 beforeAll(() => {
   (window.events as unknown) = {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    receive: (_channel: string, func: any): void => {
+    receive: (_channel: string, func: () => void): void => {
       func();
     },
   };

--- a/packages/renderer/src/lib/image/RecommendedRegistry.spec.ts
+++ b/packages/renderer/src/lib/image/RecommendedRegistry.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import '@testing-library/jest-dom/vitest';
 
 import { render, screen } from '@testing-library/svelte';
@@ -30,16 +28,11 @@ import RecommendedRegistry from './RecommendedRegistry.svelte';
 // fake the window.events object
 beforeAll(() => {
   (window.events as unknown) = {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    receive: (_channel: string, func: any): void => {
+    receive: (_channel: string, func: () => void): void => {
       func();
     },
   };
-  (window as any).getConfigurationValue = vi.fn().mockResolvedValue(undefined);
-  (window as any).matchMedia = vi.fn().mockReturnValue({
-    addListener: vi.fn(),
-  });
-
+  vi.mocked(window.getConfigurationValue).mockResolvedValue(undefined);
   Object.defineProperty(window, 'matchMedia', {
     value: () => {
       return {

--- a/packages/renderer/src/lib/image/RecommendedRegistry.spec.ts
+++ b/packages/renderer/src/lib/image/RecommendedRegistry.spec.ts
@@ -32,16 +32,6 @@ beforeAll(() => {
       func();
     },
   };
-  vi.mocked(window.getConfigurationValue).mockResolvedValue(undefined);
-  Object.defineProperty(window, 'matchMedia', {
-    value: () => {
-      return {
-        matches: false,
-        addListener: (): void => {},
-        removeListener: (): void => {},
-      };
-    },
-  });
 });
 
 beforeEach(() => {

--- a/packages/renderer/src/lib/image/RunImage.spec.ts
+++ b/packages/renderer/src/lib/image/RunImage.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2024 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-
-/* eslint-disable @typescript-eslint/no-explicit-any */
 
 import '@testing-library/jest-dom/vitest';
 
@@ -38,17 +36,13 @@ const originalConsoleDebug = console.debug;
 // fake the window.events object
 beforeAll(() => {
   (window.events as unknown) = {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    receive: (_channel: string, func: any): void => {
+    receive: (_channel: string, func: () => void): void => {
       func();
     },
   };
-  (window as any).getImageInspect = vi.fn();
-  (window as any).listNetworks = vi.fn().mockResolvedValue([]);
-  (window as any).listContainers = vi.fn().mockResolvedValue([]);
-  (window as any).createAndStartContainer = vi.fn().mockResolvedValue({ id: '1234' });
-  (window as any).getFreePort = vi.fn();
-  (window as any).isFreePort = vi.fn();
+  vi.mocked(window.listNetworks).mockResolvedValue([]);
+  vi.mocked(window.listContainers).mockResolvedValue([]);
+  vi.mocked(window.createAndStartContainer).mockResolvedValue({ id: '1234' });
 
   mockBreadcrumb();
 });

--- a/packages/renderer/src/lib/image/SaveImages.spec.ts
+++ b/packages/renderer/src/lib/image/SaveImages.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import '@testing-library/jest-dom/vitest';
 
 import type { Uri } from '@podman-desktop/api';
@@ -25,7 +23,7 @@ import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { tick } from 'svelte';
 import { router } from 'tinro';
-import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
 
 import { saveImagesInfo } from '/@/stores/save-images-store';
 
@@ -47,15 +45,6 @@ const imageInfo2: ImageInfoUI = {
   tag: '',
   engineId: 'engine',
 } as ImageInfoUI;
-
-const saveDialogMock = vi.fn();
-const saveImagesMock = vi.fn();
-
-// fake the window.events object
-beforeAll(() => {
-  (window as any).saveDialog = saveDialogMock;
-  (window as any).saveImages = saveImagesMock;
-});
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -101,8 +90,8 @@ test('Expect deleteImage is visible if page has been opened with multiple item',
 });
 
 test('Expect save button to be enabled if output target is selected and saveImages function called', async () => {
-  saveDialogMock.mockResolvedValue({ scheme: 'file', path: '/tmp/my/path' } as Uri);
-  saveImagesMock.mockResolvedValue('');
+  vi.mocked(window.saveDialog).mockResolvedValue({ scheme: 'file', path: '/tmp/my/path' } as Uri);
+  vi.mocked(window.saveImages).mockResolvedValue();
   const goToMock = vi.spyOn(router, 'goto');
 
   saveImagesInfo.set([imageInfo]);
@@ -123,7 +112,7 @@ test('Expect save button to be enabled if output target is selected and saveImag
 
   await userEvent.click(saveButtonAfterSelection);
 
-  expect(saveImagesMock).toBeCalledWith({
+  expect(vi.mocked(window.saveImages)).toBeCalledWith({
     images: [
       {
         id: 'id',
@@ -136,8 +125,8 @@ test('Expect save button to be enabled if output target is selected and saveImag
 });
 
 test('Expect saveImages function called with tagged images', async () => {
-  saveDialogMock.mockResolvedValue({ scheme: 'file', path: '/tmp/my/path' } as Uri);
-  saveImagesMock.mockResolvedValue('');
+  vi.mocked(window.saveDialog).mockResolvedValue({ scheme: 'file', path: '/tmp/my/path' } as Uri);
+  vi.mocked(window.saveImages).mockResolvedValue();
   const goToMock = vi.spyOn(router, 'goto');
 
   // default tag (latest)
@@ -180,7 +169,7 @@ test('Expect saveImages function called with tagged images', async () => {
 
   await userEvent.click(saveButton);
 
-  expect(saveImagesMock).toBeCalledWith({
+  expect(vi.mocked(window.saveImages)).toBeCalledWith({
     images: [
       {
         id: 'quay.io/podman/hello:latest',
@@ -201,8 +190,8 @@ test('Expect saveImages function called with tagged images', async () => {
 });
 
 test('Expect error message dispayed if saveImages fails', async () => {
-  saveDialogMock.mockResolvedValue({ scheme: 'file', path: '/tmp/my/path' } as Uri);
-  saveImagesMock.mockRejectedValue('error while saving');
+  vi.mocked(window.saveDialog).mockResolvedValue({ scheme: 'file', path: '/tmp/my/path' } as Uri);
+  vi.mocked(window.saveImages).mockRejectedValue('error while saving');
   const goToMock = vi.spyOn(router, 'goto');
 
   saveImagesInfo.set([imageInfo]);
@@ -221,7 +210,7 @@ test('Expect error message dispayed if saveImages fails', async () => {
 
   const errorDiv = screen.getByLabelText('Error Message Content');
 
-  expect(saveImagesMock).toBeCalledWith({
+  expect(vi.mocked(window.saveImages)).toBeCalledWith({
     images: [
       {
         id: 'id',


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR removes @typescript-eslint/no-explicit-any usage from image in renderer

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/10604

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
