### PR TITLE
chore: remove @typescript-eslint/no-explicit-any usage in renderer

### DIFF
--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteEmptyScreen.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteEmptyScreen.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-
-/* eslint-disable @typescript-eslint/no-explicit-any */
 
 import '@testing-library/jest-dom/vitest';
 

--- a/packages/renderer/src/lib/learning-center/GuideCard.spec.ts
+++ b/packages/renderer/src/lib/learning-center/GuideCard.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen } from '@testing-library/svelte';
@@ -25,10 +23,6 @@ import { afterEach, beforeEach, expect, suite, test, vi } from 'vitest';
 
 import GuideCard from './GuideCard.svelte';
 
-beforeEach(() => {
-  (window as any).openExternal = vi.fn();
-  (window as any).telemetryTrack = vi.fn();
-});
 afterEach(() => {
   vi.resetAllMocks();
 });

--- a/packages/renderer/src/lib/learning-center/LearningCenter.spec.ts
+++ b/packages/renderer/src/lib/learning-center/LearningCenter.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-
-/* eslint-disable @typescript-eslint/no-explicit-any */
 
 import '@testing-library/jest-dom/vitest';
 

--- a/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
@@ -24,7 +24,7 @@ import '@testing-library/jest-dom/vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import * as jsYaml from 'js-yaml';
-import { tick } from 'svelte';
+import { type ComponentProps, tick } from 'svelte';
 import { router } from 'tinro';
 import { beforeEach, expect, test, vi } from 'vitest';
 
@@ -164,7 +164,7 @@ beforeEach(() => {
   listSimpleContainersByLabelMock.mockResolvedValue([simpleContainerInfo]);
 });
 
-async function waitRender(customProperties: object): Promise<void> {
+async function waitRender(customProperties: Partial<ComponentProps<DeployPodToKube>>): Promise<void> {
   render(DeployPodToKube, { resourceId: 'foo', engineId: 'bar', type: 'unknown', ...customProperties });
   await tick();
   await tick();

--- a/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2024 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-empty-function */
 
@@ -165,7 +164,7 @@ beforeEach(() => {
   listSimpleContainersByLabelMock.mockResolvedValue([simpleContainerInfo]);
 });
 
-async function waitRender(customProperties: any): Promise<void> {
+async function waitRender(customProperties: object): Promise<void> {
   render(DeployPodToKube, { resourceId: 'foo', engineId: 'bar', type: 'unknown', ...customProperties });
   await tick();
   await tick();


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR removes @typescript-eslint/no-explicit-any usage from ingresses-routes, learning-center, node, and pod in renderer

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/10604

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
