### PR TITLE
fix: show error message dialog in case compose download error

### DIFF
--- a/extensions/compose/src/extension.spec.ts
+++ b/extensions/compose/src/extension.spec.ts
@@ -59,6 +59,9 @@ vi.mock('@podman-desktop/api', async () => {
     cli: {
       createCliTool: vi.fn(),
     },
+    window: {
+      showErrorMessage: vi.fn(),
+    },
   };
 });
 
@@ -515,5 +518,14 @@ describe('registerCLITool', () => {
       installationSource: 'extension',
       version: '1.0.0',
     });
+  });
+
+  test('onboarding download command shows error message if version list cannot be obtained', async () => {
+    await activate(extensionContextMock);
+    const downloadCommandHandler = vi.mocked(extensionApi.commands.registerCommand).mock.calls[2][1];
+    vi.mocked(composeDownloadMock.getLatestVersionAsset).mockRejectedValue(new Error('API call error'));
+    vi.mocked(extensionApi.window.showErrorMessage).mockResolvedValue(undefined);
+    await downloadCommandHandler();
+    expect(extensionApi.window.showErrorMessage).toHaveBeenCalledOnce();
   });
 });

--- a/extensions/compose/src/extension.ts
+++ b/extensions/compose/src/extension.ts
@@ -123,12 +123,11 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
     async () => {
       // If the version is undefined (checks weren't run, or the user didn't select a version)
       // we will just download the latest version
-      if (composeVersionMetadata === undefined) {
-        composeVersionMetadata = await composeDownload.getLatestVersionAsset();
-      }
-
       let downloaded: boolean = false;
       try {
+        if (composeVersionMetadata === undefined) {
+          composeVersionMetadata = await composeDownload.getLatestVersionAsset();
+        }
         // Download
         await composeDownload.download(composeVersionMetadata);
 
@@ -140,9 +139,11 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
         if (!composeCliTool) {
           await registerCLITool(composeDownload, detect, extensionContext);
         }
+      } catch (error) {
+        await extensionApi.window.showErrorMessage(`Unable to download docker-compose binary: ${error}`);
       } finally {
         // Make sure we log the telemetry even if we encounter an error
-        // If we have downloaded the binary, we can log it as being succcessfully downloaded
+        // If we have downloaded the binary, we can log it as being successfully downloaded
         telemetryLogger?.logUsage('compose.onboarding.downloadCommand', {
           successful: downloaded,
           version: composeVersionMetadata?.tag,


### PR DESCRIPTION
### What does this PR do?

This PR add error message in case download issues, so user does not have to check electron or troubleshooting log for the reason download failed.

### Screenshot / video of UI

https://github.com/user-attachments/assets/47f45dfa-cbd6-43d5-a377-3855687fc098

### What issues does this PR fix or reference?

Fix #10530.

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
