### PR TITLE
refactor(kind): cleaning extension tests

### DIFF
--- a/extensions/kind/src/extension.spec.ts
+++ b/extensions/kind/src/extension.spec.ts
@@ -27,7 +27,9 @@ import type { KindGithubReleaseArtifactMetadata } from './kind-installer';
 import { KindInstaller } from './kind-installer';
 import * as util from './util';
 
-vi.mock('./image-handler', async () => {
+vi.mock('node:fs');
+vi.mock('./util');
+vi.mock('./image-handler', () => {
   return {
     ImageHandler: vi.fn().mockImplementation(() => {
       return {
@@ -37,68 +39,78 @@ vi.mock('./image-handler', async () => {
   };
 });
 
-vi.mock('@podman-desktop/api', async () => {
-  return {
-    window: {
-      withProgress: vi.fn(),
-      createStatusBarItem: vi.fn(),
-    },
-    cli: {
-      createCliTool: vi.fn(),
-    },
-    ProgressLocation: {
-      TASK_WIDGET: 'TASK_WIDGET',
-    },
-    provider: {
-      onDidRegisterContainerConnection: vi.fn(),
-      onDidUnregisterContainerConnection: vi.fn(),
-      onDidUpdateProvider: vi.fn(),
-      onDidUpdateContainerConnection: vi.fn(),
-      createProvider: vi.fn(),
-    },
-    containerEngine: {
-      listContainers: vi.fn(),
-      onEvent: vi.fn(),
-    },
-    commands: {
-      registerCommand: vi.fn(),
-    },
-    context: {
-      setValue: vi.fn(),
-    },
-    env: {
-      isWindows: false,
-      isMac: false,
-      isLinux: true,
-      createTelemetryLogger: vi.fn().mockReturnValue({
-        logUsage: vi.fn(),
-      } as unknown as extensionApi.TelemetryLogger),
-    },
-    process: {
-      exec: vi.fn(),
-    },
-  };
-});
+vi.mock('./kind-installer', () => ({
+  KindInstaller: vi.fn(),
+}));
 
-const kindInstallerMock = {
+vi.mock('@podman-desktop/api', () => ({
+  window: {
+    withProgress: vi.fn(),
+    createStatusBarItem: vi.fn(),
+  },
+  cli: {
+    createCliTool: vi.fn(),
+  },
+  ProgressLocation: {
+    TASK_WIDGET: 'TASK_WIDGET',
+  },
+  provider: {
+    onDidRegisterContainerConnection: vi.fn(),
+    onDidUnregisterContainerConnection: vi.fn(),
+    onDidUpdateProvider: vi.fn(),
+    onDidUpdateContainerConnection: vi.fn(),
+    createProvider: vi.fn(),
+  },
+  containerEngine: {
+    listContainers: vi.fn(),
+    onEvent: vi.fn(),
+  },
+  commands: {
+    registerCommand: vi.fn(),
+  },
+  context: {
+    setValue: vi.fn(),
+  },
+  env: {
+    isWindows: false,
+    isMac: false,
+    isLinux: true,
+    createTelemetryLogger: vi.fn(),
+  },
+  process: {
+    exec: vi.fn(),
+  },
+}));
+
+const KIND_INSTALLER_MOCK: KindInstaller = {
   getLatestVersionAsset: vi.fn(),
   getKindCliStoragePath: vi.fn(),
   download: vi.fn(),
   promptUserForVersion: vi.fn(),
 } as unknown as KindInstaller;
 
-vi.mock('./kind-installer', () => ({
-  KindInstaller: vi.fn(),
-}));
+const CLI_TOOL_MOCK: extensionApi.CliTool = {
+  displayName: 'test',
+  dispose: vi.fn(),
+  registerUpdate: vi.fn(),
+  registerInstaller: vi.fn(),
+  updateVersion: vi.fn(),
+} as unknown as extensionApi.CliTool;
 
 beforeEach(() => {
-  vi.clearAllMocks();
+  vi.resetAllMocks();
+
+  vi.mocked(KIND_INSTALLER_MOCK.getKindCliStoragePath).mockReturnValue('storage-path');
+
+  vi.mocked(podmanDesktopApi.env.createTelemetryLogger).mockReturnValue({
+    logUsage: vi.fn(),
+  } as unknown as extensionApi.TelemetryLogger);
+
   vi.spyOn(console, 'log').mockImplementation(vi.fn());
   vi.spyOn(console, 'error').mockImplementation(vi.fn());
-  vi.mocked(podmanDesktopApi.cli.createCliTool).mockReturnValue({
-    displayName: 'test',
-    dispose: vi.fn(),
-  } as unknown as extensionApi.CliTool);
+
+  // mock create cli tool
+  vi.mocked(podmanDesktopApi.cli.createCliTool).mockReturnValue(CLI_TOOL_MOCK);
 
   vi.mocked(podmanDesktopApi.provider.createProvider).mockResolvedValue({
     setKubernetesProviderConnectionFactory: vi.fn(),
@@ -109,8 +121,23 @@ beforeEach(() => {
   createProviderMock.mockImplementation(() => ({ setKubernetesProviderConnectionFactory: vi.fn() }));
 
   vi.mocked(podmanDesktopApi.containerEngine.listContainers).mockResolvedValue([]);
-  vi.mocked(KindInstaller).mockReturnValue(kindInstallerMock);
+  vi.mocked(KindInstaller).mockReturnValue(KIND_INSTALLER_MOCK);
+
+  vi.mocked(util.removeVersionPrefix).mockReturnValue('1.0.0');
+  vi.mocked(util.getSystemBinaryPath).mockReturnValue('test-storage-path/kind');
 });
+
+function activate(options?: Partial<extensionApi.ExtensionContext>): Promise<void> {
+  return extension.activate(
+    vi.mocked<extensionApi.ExtensionContext>({
+      storagePath: 'test-storage-path',
+      subscriptions: {
+        push: vi.fn(),
+      },
+      ...options,
+    } as unknown as extensionApi.ExtensionContext),
+  );
+}
 
 test('check we received notifications ', async () => {
   const onDidUpdateContainerConnectionMock = vi.fn();
@@ -135,26 +162,16 @@ test('check we received notifications ', async () => {
 });
 
 describe('cli tool', () => {
-  test('activation should register cli tool when available, installed by desktop', async () => {
-    vi.spyOn(util, 'getKindBinaryInfo').mockResolvedValue({
+  beforeEach(() => {
+    vi.mocked(util.getKindBinaryInfo).mockResolvedValue({
       path: 'kind',
       version: '0.0.1',
     });
-    vi.spyOn(util, 'getSystemBinaryPath').mockReturnValue('kind');
-    vi.spyOn(podmanDesktopApi.cli, 'createCliTool').mockReturnValue({
-      registerUpdate: vi.fn(),
-      registerInstaller: vi.fn(),
-      updateVersion: vi.fn(),
-    } as unknown as extensionApi.CliTool);
+    vi.mocked(util.getSystemBinaryPath).mockReturnValue('kind');
+  });
 
-    await extension.activate(
-      vi.mocked<extensionApi.ExtensionContext>({
-        storagePath: 'test-storage-path',
-        subscriptions: {
-          push: vi.fn(),
-        },
-      } as unknown as extensionApi.ExtensionContext),
-    );
+  test('activation should register cli tool when available, installed by desktop', async () => {
+    await activate();
 
     expect(podmanDesktopApi.cli.createCliTool).toHaveBeenCalledWith({
       displayName: 'Kind',
@@ -168,25 +185,9 @@ describe('cli tool', () => {
   });
 
   test('activation should register cli tool when available, installed by user', async () => {
-    vi.spyOn(util, 'getKindBinaryInfo').mockResolvedValue({
-      path: 'kind',
-      version: '0.0.1',
-    });
-    vi.spyOn(util, 'getSystemBinaryPath').mockReturnValue('user-kind');
-    vi.spyOn(podmanDesktopApi.cli, 'createCliTool').mockReturnValue({
-      registerUpdate: vi.fn(),
-      registerInstaller: vi.fn(),
-      updateVersion: vi.fn(),
-    } as unknown as extensionApi.CliTool);
+    vi.mocked(util.getSystemBinaryPath).mockReturnValue('user-kind');
 
-    await extension.activate(
-      vi.mocked<extensionApi.ExtensionContext>({
-        storagePath: 'test-storage-path',
-        subscriptions: {
-          push: vi.fn(),
-        },
-      } as unknown as extensionApi.ExtensionContext),
-    );
+    await activate();
 
     expect(podmanDesktopApi.cli.createCliTool).toHaveBeenCalledWith({
       displayName: 'Kind',
@@ -200,24 +201,12 @@ describe('cli tool', () => {
   });
 
   test('activation should register cli tool when does not exist', async () => {
-    vi.spyOn(util, 'getKindBinaryInfo').mockRejectedValue(new Error('does not exist'));
-    vi.spyOn(podmanDesktopApi.window, 'createStatusBarItem').mockReturnValue({
+    vi.mocked(util.getKindBinaryInfo).mockRejectedValue(new Error('does not exist'));
+    vi.mocked(podmanDesktopApi.window.createStatusBarItem).mockReturnValue({
       show: vi.fn(),
     } as unknown as extensionApi.StatusBarItem);
-    vi.spyOn(podmanDesktopApi.cli, 'createCliTool').mockReturnValue({
-      registerUpdate: vi.fn(),
-      registerInstaller: vi.fn(),
-      updateVersion: vi.fn(),
-    } as unknown as extensionApi.CliTool);
 
-    await extension.activate(
-      vi.mocked<extensionApi.ExtensionContext>({
-        storagePath: 'test-storage-path',
-        subscriptions: {
-          push: vi.fn(),
-        },
-      } as unknown as extensionApi.ExtensionContext),
-    );
+    await activate();
 
     expect(podmanDesktopApi.cli.createCliTool).toHaveBeenCalledWith({
       name: 'kind',
@@ -230,26 +219,14 @@ describe('cli tool', () => {
   });
 
   test('activation should register cli tool when available in storage path', async () => {
-    vi.spyOn(util, 'getKindBinaryInfo').mockRejectedValueOnce(new Error('does not exist')).mockResolvedValue({
+    // mock twice
+    vi.mocked(util.getKindBinaryInfo).mockRejectedValueOnce(new Error('does not exist')).mockResolvedValue({
       version: '0.0.1',
       path: 'test-storage-path/kind',
     });
 
-    vi.spyOn(util, 'getSystemBinaryPath').mockReturnValue('test-storage-path/kind');
-    vi.spyOn(podmanDesktopApi.cli, 'createCliTool').mockReturnValue({
-      registerUpdate: vi.fn(),
-      registerInstaller: vi.fn(),
-      updateVersion: vi.fn(),
-    } as unknown as extensionApi.CliTool);
-
-    await extension.activate(
-      vi.mocked<extensionApi.ExtensionContext>({
-        storagePath: 'test-storage-path',
-        subscriptions: {
-          push: vi.fn(),
-        },
-      } as unknown as extensionApi.ExtensionContext),
-    );
+    vi.mocked(util.getSystemBinaryPath).mockReturnValue('test-storage-path/kind');
+    await activate();
 
     expect(util.getKindBinaryInfo).toHaveBeenCalledTimes(2);
     expect(podmanDesktopApi.cli.createCliTool).toHaveBeenCalledWith({
@@ -292,24 +269,13 @@ test('Ensuring a progress task is created when calling kind.image.move command',
 
   const contextSetValueMock = vi.fn();
   podmanDesktopApi.context.setValue = contextSetValueMock;
-  vi.spyOn(podmanDesktopApi.cli, 'createCliTool').mockReturnValue({
-    registerUpdate: vi.fn(),
-    registerInstaller: vi.fn(),
-    updateVersion: vi.fn(),
-  } as unknown as extensionApi.CliTool);
 
-  vi.spyOn(util, 'getKindBinaryInfo').mockResolvedValue({
+  vi.mocked(util.getKindBinaryInfo).mockResolvedValue({
     path: 'kind',
     version: '0.0.1',
   });
 
-  await extension.activate(
-    vi.mocked<extensionApi.ExtensionContext>({
-      subscriptions: {
-        push: vi.fn(),
-      },
-    } as unknown as extensionApi.ExtensionContext),
-  );
+  await activate();
 
   // ensure the command has been registered
   expect(commandRegistry['kind.image.move']).toBeDefined();
@@ -323,288 +289,194 @@ test('Ensuring a progress task is created when calling kind.image.move command',
   expect(contextSetValueMock).toHaveBeenNthCalledWith(2, 'imagesPushInProgressToKind', []);
 });
 
-const cliToolMock = {
-  registerUpdate: vi.fn(),
-  registerInstaller: vi.fn(),
-  updateVersion: vi.fn(),
-} as unknown as extensionApi.CliTool;
+describe('cli#update', () => {
+  /**
+   * Utility method to get the {@link extensionApi.CliToolSelectUpdate} object registered by kind
+   */
+  async function getCliToolUpdate(): Promise<extensionApi.CliToolSelectUpdate> {
+    await activate();
 
-async function getCliToolUpdate(): Promise<extensionApi.CliToolSelectUpdate> {
-  vi.spyOn(util, 'getKindBinaryInfo').mockRejectedValueOnce(new Error('does not exist')).mockResolvedValue({
-    version: '0.0.1',
-    path: 'test-storage-path/kind',
+    return await vi.waitFor<extensionApi.CliToolSelectUpdate>(() => {
+      expect(CLI_TOOL_MOCK.registerUpdate).toHaveBeenCalled();
+      const listener = vi.mocked(CLI_TOOL_MOCK.registerUpdate).mock.calls[0][0];
+      if (!('selectVersion' in listener)) throw new Error('kind should register update of type CliToolSelectUpdate');
+      return listener;
+    });
+  }
+
+  beforeEach(() => {
+    // mock existing cli object (otherwise we can't update)
+    vi.mocked(util.getKindBinaryInfo).mockResolvedValue({
+      path: 'test-storage-path/kind',
+      version: '0.0.1',
+    });
   });
 
-  vi.spyOn(util, 'getSystemBinaryPath').mockReturnValue('test-storage-path/kind');
-  vi.mocked(cliToolMock.registerUpdate).mockImplementation(mUpdate => {
-    if ('selectVersion' in mUpdate) {
-      update = mUpdate;
-    }
-    return { dispose: vi.fn() };
-  });
-  vi.spyOn(podmanDesktopApi.cli, 'createCliTool').mockReturnValue(cliToolMock);
-  let update: extensionApi.CliToolSelectUpdate | undefined;
-  await extension.activate(
-    vi.mocked<extensionApi.ExtensionContext>({
-      subscriptions: {
-        push: vi.fn(),
-      },
-    } as unknown as extensionApi.ExtensionContext),
-  );
-
-  await vi.waitFor(() => {
-    expect(update).toBeDefined();
+  test('try to update before selecting cli tool version should throw an error', async () => {
+    const update: extensionApi.CliToolSelectUpdate = await getCliToolUpdate();
+    await expect(() => update?.doUpdate({} as unknown as extensionApi.Logger)).rejects.toThrowError(
+      'Cannot update test-storage-path/kind version 0.0.1. No release selected.',
+    );
   });
 
-  if (!update) throw new Error('undefined update');
-  return update;
+  test('update updatable version should update version', async () => {
+    vi.mocked(util.installBinaryToSystem).mockResolvedValue('path');
+
+    vi.mocked(KIND_INSTALLER_MOCK.getKindCliStoragePath).mockReturnValue('storage-path');
+    vi.mocked(KIND_INSTALLER_MOCK.promptUserForVersion).mockResolvedValue({
+      tag: 'v1.0.0',
+    } as unknown as KindGithubReleaseArtifactMetadata);
+    const update: extensionApi.CliToolSelectUpdate = await getCliToolUpdate();
+    await update?.selectVersion();
+    await update.doUpdate({} as unknown as extensionApi.Logger);
+
+    expect(KIND_INSTALLER_MOCK.download).toHaveBeenCalledWith({
+      tag: 'v1.0.0',
+    });
+    expect(KIND_INSTALLER_MOCK.getKindCliStoragePath).toHaveBeenCalled();
+
+    expect(util.installBinaryToSystem).toHaveBeenCalledWith('storage-path', 'kind');
+    expect(CLI_TOOL_MOCK.updateVersion).toHaveBeenCalledWith({
+      installationSource: 'extension',
+      path: 'path',
+      version: '1.0.0',
+    });
+  });
+});
+
+/**
+ * Utility method to get the {@link extensionApi.CliToolInstaller} object registered by kind
+ */
+async function getCliToolInstaller(): Promise<extensionApi.CliToolInstaller> {
+  await activate();
+
+  return await vi.waitFor<extensionApi.CliToolInstaller>(() => {
+    expect(CLI_TOOL_MOCK.registerInstaller).toHaveBeenCalled();
+    const listener = vi.mocked(CLI_TOOL_MOCK.registerInstaller).mock.calls[0][0];
+    expect(listener).toBeDefined();
+    return listener;
+  });
 }
 
-test('try to update before selecting cli tool version should throw an error', async () => {
-  const update: extensionApi.CliToolSelectUpdate = await getCliToolUpdate();
-  await expect(() => update?.doUpdate({} as unknown as extensionApi.Logger)).rejects.toThrowError(
-    'Cannot update test-storage-path/kind version 0.0.1. No release selected.',
-  );
-});
-
-test('update updatable version should update version', async () => {
-  const installBinaryToSystemMock = vi.spyOn(util, 'installBinaryToSystem').mockResolvedValue('path');
-  vi.mocked(kindInstallerMock.getKindCliStoragePath).mockReturnValue('storage-path');
-  vi.mocked(kindInstallerMock.promptUserForVersion).mockResolvedValue({
-    tag: 'v1.0.0',
-  } as unknown as KindGithubReleaseArtifactMetadata);
-  const update: extensionApi.CliToolUpdate | extensionApi.CliToolSelectUpdate = await getCliToolUpdate();
-  await update?.selectVersion();
-  await update.doUpdate({} as unknown as extensionApi.Logger);
-
-  expect(kindInstallerMock.download).toHaveBeenCalledWith({
-    tag: 'v1.0.0',
-  });
-  expect(kindInstallerMock.getKindCliStoragePath).toHaveBeenCalled();
-
-  expect(installBinaryToSystemMock).toHaveBeenCalledWith('storage-path', 'kind');
-  expect(cliToolMock.updateVersion).toHaveBeenCalledWith({
-    installationSource: 'extension',
-    path: 'path',
-    version: '1.0.0',
-  });
-});
-
-test('try to install when there is already an existing version should throw an error', async () => {
-  vi.spyOn(util, 'getKindBinaryInfo').mockResolvedValue({
-    version: '0.0.1',
-    path: 'test-storage-path/kind',
+describe('cli#install', () => {
+  beforeEach(() => {
+    // mock no kind detected
+    vi.mocked(util.getKindBinaryInfo).mockRejectedValue('no kind');
   });
 
-  vi.spyOn(util, 'getSystemBinaryPath').mockReturnValue('test-storage-path/kind');
+  test('try to install when there is already an existing version should throw an error', async () => {
+    // mock existing cli tool
+    vi.mocked(util.getKindBinaryInfo).mockResolvedValue({
+      version: '0.0.1',
+      path: 'test-storage-path/kind',
+    });
 
-  let cliToolInstaller: extensionApi.CliToolInstaller | undefined;
-  vi.mocked(cliToolMock.registerInstaller).mockImplementation(mInstall => {
-    cliToolInstaller = mInstall;
-    return { dispose: vi.fn() };
-  });
-  vi.spyOn(podmanDesktopApi.cli, 'createCliTool').mockReturnValue(cliToolMock);
+    const cliToolInstaller: extensionApi.CliToolInstaller = await getCliToolInstaller();
 
-  await extension.activate(
-    vi.mocked<extensionApi.ExtensionContext>({
-      subscriptions: {
-        push: vi.fn(),
-      },
-    } as unknown as extensionApi.ExtensionContext),
-  );
-
-  await vi.waitFor(() => {
-    expect(cliToolInstaller).toBeDefined();
+    await expect(() => cliToolInstaller?.doInstall({} as unknown as extensionApi.Logger)).rejects.toThrowError(
+      `Cannot install kind. Version 0.0.1 in test-storage-path/kind is already installed.`,
+    );
   });
 
-  if (!cliToolInstaller) throw new Error('undefined update');
+  test('try to install before selecting cli tool version should throw an error', async () => {
+    const cliToolInstaller: extensionApi.CliToolInstaller = await getCliToolInstaller();
 
-  await expect(() => cliToolInstaller?.doInstall({} as unknown as extensionApi.Logger)).rejects.toThrowError(
-    `Cannot install kind. Version 0.0.1 in test-storage-path/kind is already installed.`,
-  );
-});
-
-test('try to install before selecting cli tool version should throw an error', async () => {
-  vi.spyOn(util, 'getKindBinaryInfo').mockRejectedValue('no kind');
-
-  let cliToolInstaller: extensionApi.CliToolInstaller | undefined;
-  vi.mocked(cliToolMock.registerInstaller).mockImplementation(mInstall => {
-    cliToolInstaller = mInstall;
-    return { dispose: vi.fn() };
-  });
-  vi.spyOn(podmanDesktopApi.cli, 'createCliTool').mockReturnValue(cliToolMock);
-
-  await extension.activate(
-    vi.mocked<extensionApi.ExtensionContext>({
-      subscriptions: {
-        push: vi.fn(),
-      },
-    } as unknown as extensionApi.ExtensionContext),
-  );
-
-  await vi.waitFor(() => {
-    expect(cliToolInstaller).toBeDefined();
+    await expect(() => cliToolInstaller?.doInstall({} as unknown as extensionApi.Logger)).rejects.toThrowError(
+      `Cannot install kind. No release selected.`,
+    );
   });
 
-  if (!cliToolInstaller) throw new Error('undefined update');
+  test('after selecting the version to be installed it should download kind', async () => {
+    vi.mocked(util.installBinaryToSystem).mockResolvedValue('path');
+    // mock prompt result
+    vi.mocked(KIND_INSTALLER_MOCK.promptUserForVersion).mockResolvedValue({
+      tag: 'v1.0.0',
+    } as unknown as KindGithubReleaseArtifactMetadata);
 
-  await expect(() => cliToolInstaller?.doInstall({} as unknown as extensionApi.Logger)).rejects.toThrowError(
-    `Cannot install kind. No release selected.`,
-  );
-});
+    const cliToolInstaller: extensionApi.CliToolInstaller = await getCliToolInstaller();
 
-test('after selecting the version to be installed it should download kind', async () => {
-  const installBinaryToSystemMock = vi.spyOn(util, 'installBinaryToSystem').mockResolvedValue('path');
-  vi.spyOn(util, 'getKindBinaryInfo').mockRejectedValue('no kind');
-  vi.mocked(kindInstallerMock.promptUserForVersion).mockResolvedValue({
-    tag: 'v1.0.0',
-  } as unknown as KindGithubReleaseArtifactMetadata);
+    // mock workflow (user select version then we install it)
+    await cliToolInstaller?.selectVersion();
+    await cliToolInstaller?.doInstall({} as unknown as extensionApi.Logger);
 
-  let installer: extensionApi.CliToolInstaller | undefined;
-  vi.mocked(cliToolMock.registerInstaller).mockImplementation(mInstaller => {
-    installer = mInstaller;
-    return { dispose: vi.fn() };
-  });
-  vi.spyOn(podmanDesktopApi.cli, 'createCliTool').mockReturnValue(cliToolMock);
-
-  await extension.activate(
-    vi.mocked<extensionApi.ExtensionContext>({
-      subscriptions: {
-        push: vi.fn(),
-      },
-    } as unknown as extensionApi.ExtensionContext),
-  );
-
-  await vi.waitFor(() => {
-    expect(installer).toBeDefined();
+    expect(KIND_INSTALLER_MOCK.download).toHaveBeenCalledWith({
+      tag: 'v1.0.0',
+    });
+    expect(KIND_INSTALLER_MOCK.getKindCliStoragePath).toHaveBeenCalled();
+    expect(util.installBinaryToSystem).toHaveBeenCalledWith('storage-path', 'kind');
+    expect(CLI_TOOL_MOCK.updateVersion).toHaveBeenCalledWith({
+      installationSource: 'extension',
+      path: 'path',
+      version: '1.0.0',
+    });
   });
 
-  await installer?.selectVersion();
+  test('if installing system wide fails, it should not throw', async () => {
+    // mock error when trying to install system wide
+    vi.mocked(util.installBinaryToSystem).mockRejectedValue('error');
+    // mock user select v1.0.0
+    vi.mocked(KIND_INSTALLER_MOCK.promptUserForVersion).mockResolvedValue({
+      tag: 'v1.0.0',
+    } as unknown as KindGithubReleaseArtifactMetadata);
 
-  await installer?.doInstall({} as unknown as extensionApi.Logger);
-  expect(kindInstallerMock.download).toHaveBeenCalledWith({
-    tag: 'v1.0.0',
-  });
-  expect(kindInstallerMock.getKindCliStoragePath).toHaveBeenCalled();
-  expect(installBinaryToSystemMock).toHaveBeenCalledWith('storage-path', 'kind');
-  expect(cliToolMock.updateVersion).toHaveBeenCalledWith({
-    installationSource: 'extension',
-    path: 'path',
-    version: '1.0.0',
+    const cliToolInstaller: extensionApi.CliToolInstaller = await getCliToolInstaller();
+
+    await cliToolInstaller?.selectVersion();
+
+    await cliToolInstaller?.doInstall({} as unknown as extensionApi.Logger);
+
+    // ensure the download has been called
+    expect(KIND_INSTALLER_MOCK.download).toHaveBeenCalledWith({
+      tag: 'v1.0.0',
+    });
+    expect(KIND_INSTALLER_MOCK.getKindCliStoragePath).toHaveBeenCalled();
+    expect(util.installBinaryToSystem).toHaveBeenCalledWith('storage-path', 'kind');
+    expect(CLI_TOOL_MOCK.updateVersion).toHaveBeenCalledWith({
+      installationSource: 'extension',
+      path: 'storage-path',
+      version: '1.0.0',
+    });
   });
 });
 
-test('if installing system wide fails, it should not throw', async () => {
-  const installBinaryToSystemMock = vi.spyOn(util, 'installBinaryToSystem').mockRejectedValue('error');
-  vi.spyOn(util, 'getKindBinaryInfo').mockRejectedValue('no kind');
-  vi.mocked(kindInstallerMock.promptUserForVersion).mockResolvedValue({
-    tag: 'v1.0.0',
-  } as unknown as KindGithubReleaseArtifactMetadata);
-
-  let installer: extensionApi.CliToolInstaller | undefined;
-  vi.mocked(cliToolMock.registerInstaller).mockImplementation(mInstaller => {
-    installer = mInstaller;
-    return { dispose: vi.fn() };
-  });
-  vi.spyOn(podmanDesktopApi.cli, 'createCliTool').mockReturnValue(cliToolMock);
-
-  await extension.activate(
-    vi.mocked<extensionApi.ExtensionContext>({
-      subscriptions: {
-        push: vi.fn(),
-      },
-    } as unknown as extensionApi.ExtensionContext),
-  );
-
-  await vi.waitFor(() => {
-    expect(installer).toBeDefined();
+describe('cli#uninstall', () => {
+  beforeEach(() => {
+    // mock binary exists (otherwise we can't uninstall it)
+    vi.mocked(util.getKindBinaryInfo).mockResolvedValue({
+      version: '0.0.1',
+      path: 'test-storage-path/kind',
+    });
   });
 
-  await installer?.selectVersion();
+  test('by uninstalling it should delete all executables', async () => {
+    // mock the binary exists
+    vi.mocked(fs.existsSync).mockReturnValue(true);
 
-  await installer?.doInstall({} as unknown as extensionApi.Logger);
-  expect(kindInstallerMock.download).toHaveBeenCalledWith({
-    tag: 'v1.0.0',
-  });
-  expect(kindInstallerMock.getKindCliStoragePath).toHaveBeenCalled();
-  expect(installBinaryToSystemMock).toHaveBeenCalledWith('storage-path', 'kind');
-  expect(cliToolMock.updateVersion).toHaveBeenCalledWith({
-    installationSource: 'extension',
-    path: 'storage-path',
-    version: '1.0.0',
-  });
-});
+    const cliToolInstaller: extensionApi.CliToolInstaller = await getCliToolInstaller();
 
-test('by uninstalling it should delete all executables', async () => {
-  vi.mock('node:fs');
-  vi.spyOn(util, 'getKindBinaryInfo').mockResolvedValue({
-    version: '0.0.1',
-    path: 'test-storage-path/kind',
+    await cliToolInstaller?.doUninstall({} as unknown as extensionApi.Logger);
+    expect(fs.promises.unlink).toHaveBeenNthCalledWith(1, 'storage-path');
+    expect(fs.promises.unlink).toHaveBeenNthCalledWith(2, 'test-storage-path/kind');
   });
 
-  vi.spyOn(util, 'getSystemBinaryPath').mockReturnValue('test-storage-path/kind');
-  vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+  test('if unlink fails because of a permission issue, it should delete all binaries as admin', async () => {
+    // mock the binary exists
+    vi.mocked(fs.existsSync).mockReturnValue(true);
 
-  let installer: extensionApi.CliToolInstaller | undefined;
-  vi.mocked(cliToolMock.registerInstaller).mockImplementation(mInstaller => {
-    installer = mInstaller;
-    return { dispose: vi.fn() };
-  });
-  vi.spyOn(podmanDesktopApi.cli, 'createCliTool').mockReturnValue(cliToolMock);
+    // mock issue with unlink
+    vi.mocked(fs.promises.unlink).mockRejectedValue({
+      code: 'EACCES',
+    } as unknown as Error);
 
-  await extension.activate(
-    vi.mocked<extensionApi.ExtensionContext>({
-      subscriptions: {
-        push: vi.fn(),
-      },
-    } as unknown as extensionApi.ExtensionContext),
-  );
+    const cliToolInstaller: extensionApi.CliToolInstaller = await getCliToolInstaller();
 
-  await vi.waitFor(() => {
-    expect(installer).toBeDefined();
-  });
+    await cliToolInstaller?.doUninstall({} as unknown as extensionApi.Logger);
 
-  await installer?.doUninstall({} as unknown as extensionApi.Logger);
-  expect(fs.promises.unlink).toHaveBeenNthCalledWith(1, 'storage-path');
-  expect(fs.promises.unlink).toHaveBeenNthCalledWith(2, 'test-storage-path/kind');
-});
-
-test('if unlink fails because of a permission issue, it should delete all binaries as admin', async () => {
-  vi.mock('node:fs');
-  vi.spyOn(util, 'getKindBinaryInfo').mockResolvedValue({
-    version: '0.0.1',
-    path: 'test-storage-path/kind',
-  });
-
-  vi.spyOn(util, 'getSystemBinaryPath').mockReturnValue('test-storage-path/kind');
-  vi.spyOn(fs, 'existsSync').mockReturnValue(true);
-  vi.mocked(fs.promises.unlink).mockRejectedValue({
-    code: 'EACCES',
-  } as unknown as Error);
-  const command = process.platform === 'win32' ? 'del' : 'rm';
-
-  let installer: extensionApi.CliToolInstaller | undefined;
-  vi.mocked(cliToolMock.registerInstaller).mockImplementation(mInstaller => {
-    installer = mInstaller;
-    return { dispose: vi.fn() };
-  });
-  vi.spyOn(podmanDesktopApi.cli, 'createCliTool').mockReturnValue(cliToolMock);
-
-  await extension.activate(
-    vi.mocked<extensionApi.ExtensionContext>({
-      subscriptions: {
-        push: vi.fn(),
-      },
-    } as unknown as extensionApi.ExtensionContext),
-  );
-
-  await vi.waitFor(() => {
-    expect(installer).toBeDefined();
-  });
-
-  await installer?.doUninstall({} as unknown as extensionApi.Logger);
-  expect(podmanDesktopApi.process.exec).toHaveBeenNthCalledWith(1, command, ['storage-path'], { isAdmin: true });
-  expect(podmanDesktopApi.process.exec).toHaveBeenNthCalledWith(2, command, ['test-storage-path/kind'], {
-    isAdmin: true,
+    // check command
+    const command = process.platform === 'win32' ? 'del' : 'rm';
+    expect(podmanDesktopApi.process.exec).toHaveBeenNthCalledWith(1, command, ['storage-path'], { isAdmin: true });
+    expect(podmanDesktopApi.process.exec).toHaveBeenNthCalledWith(2, command, ['test-storage-path/kind'], {
+      isAdmin: true,
+    });
   });
 });


### PR DESCRIPTION
### What does this PR do?

While working on https://github.com/podman-desktop/podman-desktop/pull/10980 I faced some issues with the tests. This PR clean the `kind/extension.spec` to enforce tests are independent, (spy not leaking to other tests).

### Changes

- Change `vi.clearAllMocks` to `vi.resetAllMocks` in `beforeEach`.
- mocking `node:fs` instead of using spy
- mocking `./util` instead of using spy
- grouping tests with describe `cli#install`, `cli#uninstall` and `cli#update` because they share _setup code_ (placed in beforeEach instead of copy paste).
- Replacing most of `vi.spy` with `vi.mocked`
- Define mock in `beforeEach` not in `vi.mock`

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Prior to https://github.com/podman-desktop/podman-desktop/pull/10980

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
