### PR TITLE
chore: add a compare function prop for resultItems sorting in Typeahead

### DIFF
--- a/packages/renderer/src/lib/ui/Typeahead.svelte
+++ b/packages/renderer/src/lib/ui/Typeahead.svelte
@@ -11,11 +11,11 @@ interface Props {
   name?: string;
   error?: boolean;
   resultItems?: string[];
-  sort?: boolean;
   onInputChange?: (s: string) => Promise<void>;
   onChange?: (value: string) => void;
   onEnter?: () => void;
   class?: string;
+  compare?: (a: string, b: string) => number;
 }
 
 let {
@@ -28,11 +28,11 @@ let {
   name,
   error = false,
   resultItems = [],
-  sort = false,
   onInputChange,
   onChange,
   onEnter,
   class: className,
+  compare,
 }: Props = $props();
 
 let inputDelayTimeout: NodeJS.Timeout | undefined = undefined;
@@ -41,8 +41,9 @@ let list: HTMLDivElement | undefined = $state();
 let scrollElements: HTMLElement[] = $state([]);
 let value: string = $state('');
 let items: string[] = $derived(
-  sort
-    ? resultItems.toSorted((a: string, b: string) => {
+  resultItems.toSorted(
+    compare ??
+      ((a: string, b: string): number => {
         if (a.startsWith(userValue) === b.startsWith(userValue)) {
           return a.localeCompare(b);
         } else if (a.startsWith(userValue) && !b.startsWith(userValue)) {
@@ -50,8 +51,8 @@ let items: string[] = $derived(
         } else {
           return 1;
         }
-      })
-    : resultItems,
+      }),
+  ),
 );
 let opened: boolean = $state(false);
 let highlightIndex: number = $state(-1);


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR adds a new optional prop, compare, to the `Typeahead` component which will be used to sort the resultItems. If none is provided, there is default sorting
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/pull/10573

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
