### PR TITLE
chore(extension-api): adding annotations properties on inspect objects

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -2492,6 +2492,7 @@ declare module '@podman-desktop/api' {
       Layers?: string[];
       BaseLayer?: string;
     };
+    Annotations: { [key: string]: string };
   }
 
   export interface NetworkContainer {
@@ -2750,6 +2751,7 @@ declare module '@podman-desktop/api' {
     CpuPercent?: number;
     CpuRealtimePeriod?: number;
     CpuRealtimeRuntime?: number;
+    Annotations: { [key: string]: string };
   }
 
   /**
@@ -2862,7 +2864,6 @@ declare module '@podman-desktop/api' {
       Entrypoint?: string | string[];
       OnBuild?: unknown;
       Labels: { [label: string]: string };
-      Annotations: { [label: string]: string };
     };
     NetworkSettings: {
       Bridge: string;
@@ -2912,7 +2913,6 @@ declare module '@podman-desktop/api' {
         Memory: number;
         Labels: unknown;
       };
-      Annotations: { [label: string]: string };
     };
   }
 

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -2862,6 +2862,7 @@ declare module '@podman-desktop/api' {
       Entrypoint?: string | string[];
       OnBuild?: unknown;
       Labels: { [label: string]: string };
+      Annotations: { [label: string]: string };
     };
     NetworkSettings: {
       Bridge: string;
@@ -2911,6 +2912,7 @@ declare module '@podman-desktop/api' {
         Memory: number;
         Labels: unknown;
       };
+      Annotations: { [label: string]: string };
     };
   }
 


### PR DESCRIPTION
### What does this PR do?

I noticed while playing with ramalama that the `Annotations` fields where missing on `ContainerInspectInfo` and `ImageInspectInfo`.

Ref
- https://docs.podman.io/en/latest/_static/api.html#tag/containers/operation/ContainerInspectLibpod
- https://docs.podman.io/en/latest/_static/api.html#tag/images/operation/ImageInspectLibpod

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

N/A
