### PR TITLE
chore: add summary page cronjobs

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -28,6 +28,7 @@ import type {
   Context as KubernetesContext,
   KubernetesObject,
   V1ConfigMap,
+  V1CronJob,
   V1Deployment,
   V1Ingress,
   V1NamespaceList,
@@ -2490,6 +2491,13 @@ export class PluginSystem {
       'kubernetes-client:readNamespacedSecret',
       async (_listener, name: string, namespace: string): Promise<V1Secret | undefined> => {
         return kubernetesClient.readNamespacedSecret(name, namespace);
+      },
+    );
+
+    this.ipcHandle(
+      'kubernetes-client:readNamespacedCronJob',
+      async (_listener, name: string, namespace: string): Promise<V1CronJob | undefined> => {
+        return kubernetesClient.readNamespacedCronJob(name, namespace);
       },
     );
 

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -18,6 +18,7 @@ import ContainerDetails from './lib/container/ContainerDetails.svelte';
 import ContainerExport from './lib/container/ContainerExport.svelte';
 import ContainerList from './lib/container/ContainerList.svelte';
 import ContextKey from './lib/context/ContextKey.svelte';
+import CronJobDetails from './lib/cronjob/CronJobDetails.svelte';
 import CronJobList from './lib/cronjob/CronJobList.svelte';
 import DashboardPage from './lib/dashboard/DashboardPage.svelte';
 import DeploymentDetails from './lib/deployments/DeploymentDetails.svelte';
@@ -305,6 +306,9 @@ window.events?.receive('navigate', (navigationRequest: unknown) => {
           </Route>
           <Route path="/kubernetes/cronjobs" breadcrumb="CronJobs" navigationHint="root">
             <CronJobList />
+          </Route>
+          <Route path="/kubernetes/cronjobs/:name/:namespace/*" breadcrumb="CronJob Details" let:meta navigationHint="details">
+            <CronJobDetails name={decodeURI(meta.params.name)} namespace={decodeURI(meta.params.namespace)} />
           </Route>
           <Route
             path="/kubernetes/ingressesRoutes/ingress/:name/:namespace/*"

--- a/packages/renderer/src/lib/cronjob/CronJobColumnName.svelte
+++ b/packages/renderer/src/lib/cronjob/CronJobColumnName.svelte
@@ -1,14 +1,20 @@
 <script lang="ts">
+import { router } from 'tinro';
+
 import type { CronJobUI } from './CronJobUI';
 
 interface Props {
   object: CronJobUI;
 }
 let { object }: Props = $props();
+
+function openDetails(): void {
+  router.goto(`/kubernetes/cronjobs/${encodeURI(object.name)}/${encodeURI(object.namespace)}/summary`);
+}
 </script>
 
 <!-- Add the summary in the future, keep hover:cursor-pointer so we do not forget! -->
-<button class="hover:cursor-pointer flex flex-col max-w-full">
+<button class="hover:cursor-pointer flex flex-col max-w-full" onclick={openDetails}>
   <div class="text-[var(--pd-table-body-text-highlight)] max-w-full overflow-hidden text-ellipsis">
     {object.name}
   </div>

--- a/packages/renderer/src/lib/cronjob/CronJobDetails.spec.ts
+++ b/packages/renderer/src/lib/cronjob/CronJobDetails.spec.ts
@@ -1,0 +1,53 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import type { KubernetesObject, V1CronJob } from '@kubernetes/client-node';
+import { render, screen } from '@testing-library/svelte';
+import { writable } from 'svelte/store';
+import { expect, test, vi } from 'vitest';
+
+import * as kubeContextStore from '/@/stores/kubernetes-contexts-state';
+
+import CronJobDetails from './CronJobDetails.svelte';
+
+const cronjob: V1CronJob = {
+  apiVersion: 'v1',
+  kind: 'CronJob',
+  metadata: {
+    name: 'my-cronjob',
+    namespace: 'default',
+  },
+} as V1CronJob;
+
+vi.mock('/@/stores/kubernetes-contexts-state', async () => {
+  return {
+    kubernetesCurrentContextCronJobs: vi.fn(),
+  };
+});
+
+test('Expect renders CronJob details', async () => {
+  // mock object store
+  const cronjobs = writable<KubernetesObject[]>([cronjob]);
+  vi.mocked(kubeContextStore).kubernetesCurrentContextCronJobs = cronjobs;
+
+  render(CronJobDetails, { name: 'my-cronjob', namespace: 'default' });
+
+  expect(screen.getByText('my-cronjob')).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/cronjob/CronJobDetails.svelte
+++ b/packages/renderer/src/lib/cronjob/CronJobDetails.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+import type { V1CronJob } from '@kubernetes/client-node';
+import { StatusIcon, Tab } from '@podman-desktop/ui-svelte';
+import { onMount } from 'svelte';
+import { router } from 'tinro';
+import { stringify } from 'yaml';
+
+import { kubernetesCurrentContextCronJobs } from '/@/stores/kubernetes-contexts-state';
+
+import Route from '../../Route.svelte';
+import MonacoEditor from '../editor/MonacoEditor.svelte';
+import CronJobIcon from '../images/CronJobIcon.svelte';
+import KubeEditYAML from '../kube/KubeEditYAML.svelte';
+import DetailsPage from '../ui/DetailsPage.svelte';
+import StateChange from '../ui/StateChange.svelte';
+import { getTabUrl, isTabSelected } from '../ui/Util';
+import { CronJobUtils } from './cronjob-utils';
+import CronJobActions from './CronJobActions.svelte';
+import CronJobDetailsSummary from './CronJobDetailsSummary.svelte';
+import type { CronJobUI } from './CronJobUI';
+
+interface Props {
+  name: string;
+  namespace: string;
+}
+let { name, namespace }: Props = $props();
+
+let cronjob = $state<CronJobUI | undefined>();
+let detailsPage = $state<DetailsPage | undefined>();
+let kubeCronJob = $state<V1CronJob | undefined>();
+let kubeError = $state<string | undefined>();
+
+onMount(() => {
+  const cronjobUtils = new CronJobUtils();
+  // loading cronjob info
+  return kubernetesCurrentContextCronJobs.subscribe(cronjobs => {
+    const matchingCronJob = cronjobs.find(
+      cronjob => cronjob.metadata?.name === name && cronjob.metadata?.namespace === namespace,
+    );
+    if (matchingCronJob) {
+      cronjob = cronjobUtils.getCronJobUI(matchingCronJob);
+      loadDetails().catch((err: unknown) => console.error(`Error getting CronJob details ${cronjob?.name}`, err));
+    } else if (detailsPage) {
+      // the cronjob has been deleted
+      detailsPage.close();
+    }
+  });
+});
+
+async function loadDetails(): Promise<void> {
+  const getKubeCronJob = await window.kubernetesReadNamespacedCronJob(name, namespace);
+  if (getKubeCronJob) {
+    kubeCronJob = getKubeCronJob;
+  } else {
+    kubeError = `Unable to retrieve Kubernetes details for ${name}`;
+  }
+}
+</script>
+
+{#if cronjob}
+  <DetailsPage title={cronjob.name} subtitle={cronjob.namespace} bind:this={detailsPage}>
+    <StatusIcon slot="icon" icon={CronJobIcon} size={24} status={cronjob.status} />
+    <svelte:fragment slot="actions">
+      <CronJobActions cronjob={cronjob} detailed={true} />
+    </svelte:fragment>
+    <div slot="detail" class="flex py-2 w-full justify-end text-sm text-[var(--pd-content-text)]">
+      <StateChange state={cronjob.status} />
+    </div>
+    <svelte:fragment slot="tabs">
+      <Tab title="Summary" selected={isTabSelected($router.path, 'summary')} url={getTabUrl($router.path, 'summary')} />
+      <Tab title="Inspect" selected={isTabSelected($router.path, 'inspect')} url={getTabUrl($router.path, 'inspect')} />
+      <Tab title="Kube" selected={isTabSelected($router.path, 'kube')} url={getTabUrl($router.path, 'kube')} />
+    </svelte:fragment>
+    <svelte:fragment slot="content">
+      <Route path="/summary" breadcrumb="Summary" navigationHint="tab">
+        <CronJobDetailsSummary cronjob={kubeCronJob} kubeError={kubeError} />
+      </Route>
+      <Route path="/inspect" breadcrumb="Inspect" navigationHint="tab">
+        <MonacoEditor content={JSON.stringify(kubeCronJob, undefined, 2)} language="json" />
+      </Route>
+      <Route path="/kube" breadcrumb="Kube" navigationHint="tab">
+        <KubeEditYAML content={stringify(kubeCronJob)} />
+      </Route>
+    </svelte:fragment>
+  </DetailsPage>
+{/if}

--- a/packages/renderer/src/lib/cronjob/CronJobDetailsSummary.spec.ts
+++ b/packages/renderer/src/lib/cronjob/CronJobDetailsSummary.spec.ts
@@ -1,0 +1,60 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import type { V1CronJob } from '@kubernetes/client-node';
+import { render, screen } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import CronJobDetailsSummary from './CronJobDetailsSummary.svelte';
+
+const cronjob: V1CronJob = {
+  apiVersion: 'v1',
+  kind: 'CronJob',
+  metadata: {
+    name: 'my-cronjob',
+    namespace: 'default',
+  },
+} as V1CronJob;
+
+const kubeError = 'Error retrieving CronJob';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('Expect to render CronJob details when CronJob data is available', async () => {
+  render(CronJobDetailsSummary, { cronjob: cronjob, kubeError: undefined });
+
+  expect(screen.getByText('my-cronjob')).toBeInTheDocument();
+});
+
+test('Expect to show error message when there is a kube error', async () => {
+  render(CronJobDetailsSummary, { cronjob: cronjob, kubeError: kubeError });
+
+  const errorMessage = screen.getByText(kubeError);
+  expect(errorMessage).toBeInTheDocument();
+});
+
+test('Expect to show loading indicator when CronJob data is not available', async () => {
+  render(CronJobDetailsSummary, {});
+
+  const loadingMessage = screen.getByText('Loading ...');
+  expect(loadingMessage).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/cronjob/CronJobDetailsSummary.svelte
+++ b/packages/renderer/src/lib/cronjob/CronJobDetailsSummary.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+import type { V1CronJob } from '@kubernetes/client-node';
+import { ErrorMessage } from '@podman-desktop/ui-svelte';
+
+import Table from '/@/lib/details/DetailsTable.svelte';
+import KubeCronJobArtifact from '/@/lib/kube/details/KubeCronJobArtifact.svelte';
+import KubeCronJobStatusArtifact from '/@/lib/kube/details/KubeCronJobStatusArtifact.svelte';
+import KubeObjectMetaArtifact from '/@/lib/kube/details/KubeObjectMetaArtifact.svelte';
+
+interface Props {
+  cronjob?: V1CronJob;
+  kubeError?: string;
+}
+
+let { cronjob, kubeError }: Props = $props();
+</script>
+
+<!-- Show the kube error if we're unable to retrieve the data correctly, but we still want to show the
+basic information -->
+{#if kubeError}
+  <ErrorMessage error={kubeError} />
+{/if}
+
+<Table>
+  {#if cronjob}
+    <KubeObjectMetaArtifact artifact={cronjob.metadata} />
+    <KubeCronJobStatusArtifact artifact={cronjob.status} />
+    <KubeCronJobArtifact artifact={cronjob.spec} />
+  {:else}
+    <p class="text-[var(--pd-state-info)] font-medium">Loading ...</p>
+  {/if}
+</Table>

--- a/packages/renderer/src/lib/kube/details/KubeCronJobArtifact.spec.ts
+++ b/packages/renderer/src/lib/kube/details/KubeCronJobArtifact.spec.ts
@@ -1,0 +1,68 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import type { V1CronJobSpec } from '@kubernetes/client-node';
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import KubeCronJobArtifact from './KubeCronJobArtifact.svelte';
+
+const fakeCronJobSpec: V1CronJobSpec = {
+  schedule: '*/5 * * * *',
+  concurrencyPolicy: 'Forbid',
+  failedJobsHistoryLimit: 1,
+  successfulJobsHistoryLimit: 3,
+  startingDeadlineSeconds: 30,
+  suspend: false,
+  timeZone: 'UTC',
+  jobTemplate: {
+    metadata: { name: 'example-job' },
+  },
+} as V1CronJobSpec;
+
+test('Renders CronJob correctly with complete data', () => {
+  render(KubeCronJobArtifact, { artifact: fakeCronJobSpec });
+  expect(screen.getByText('Schedule')).toBeInTheDocument();
+  expect(screen.getByText('*/5 * * * *')).toBeInTheDocument();
+  expect(screen.getByText('Concurrency Policy')).toBeInTheDocument();
+  expect(screen.getByText('Forbid')).toBeInTheDocument();
+  expect(screen.getByText('Failed Jobs History Limit')).toBeInTheDocument();
+  expect(screen.getByText('1')).toBeInTheDocument();
+  expect(screen.getByText('Successful Jobs History Limit')).toBeInTheDocument();
+  expect(screen.getByText('3')).toBeInTheDocument();
+  expect(screen.getByText('Starting Deadline Seconds')).toBeInTheDocument();
+  expect(screen.getByText('30')).toBeInTheDocument();
+  expect(screen.getByText('Suspend')).toBeInTheDocument();
+  expect(screen.getByText('False')).toBeInTheDocument();
+  expect(screen.getByText('Time Zone')).toBeInTheDocument();
+  expect(screen.getByText('UTC')).toBeInTheDocument();
+});
+
+test('Handles undefined artifact gracefully', () => {
+  render(KubeCronJobArtifact, { artifact: undefined });
+
+  expect(screen.queryByText('Schedule')).not.toBeInTheDocument();
+  expect(screen.queryByText('Concurrency Policy')).not.toBeInTheDocument();
+  expect(screen.queryByText('Failed Jobs History Limit')).not.toBeInTheDocument();
+  expect(screen.queryByText('Successful Jobs History Limit')).not.toBeInTheDocument();
+  expect(screen.queryByText('Starting Deadline Seconds')).not.toBeInTheDocument();
+  expect(screen.queryByText('Suspend')).not.toBeInTheDocument();
+  expect(screen.queryByText('Time Zone')).not.toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/kube/details/KubeCronJobArtifact.svelte
+++ b/packages/renderer/src/lib/kube/details/KubeCronJobArtifact.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+import type { V1CronJobSpec } from '@kubernetes/client-node';
+
+import Cell from '/@/lib/details/DetailsCell.svelte';
+import Title from '/@/lib/details/DetailsTitle.svelte';
+
+import { capitalize } from '../../ui/Util';
+
+interface Props {
+  artifact?: V1CronJobSpec;
+}
+
+let { artifact }: Props = $props();
+</script>
+  
+  {#if artifact}
+    <tr>
+      <Title>Details</Title>
+    </tr>
+    {#if artifact.schedule}
+      <tr>
+        <Cell>Schedule</Cell>
+        <Cell>{artifact.schedule}</Cell>
+      </tr>
+    {/if}
+    {#if artifact.concurrencyPolicy}
+      <tr>
+        <Cell>Concurrency Policy</Cell>
+        <Cell>{artifact.concurrencyPolicy}</Cell>
+      </tr>
+    {/if}
+    {#if artifact.failedJobsHistoryLimit !== undefined}
+      <tr>
+        <Cell>Failed Jobs History Limit</Cell>
+        <Cell>{artifact.failedJobsHistoryLimit}</Cell>
+      </tr>
+    {/if}
+    {#if artifact.successfulJobsHistoryLimit !== undefined}
+      <tr>
+        <Cell>Successful Jobs History Limit</Cell>
+        <Cell>{artifact.successfulJobsHistoryLimit}</Cell>
+      </tr>
+    {/if}
+    {#if artifact.startingDeadlineSeconds !== undefined}
+      <tr>
+        <Cell>Starting Deadline Seconds</Cell>
+        <Cell>{artifact.startingDeadlineSeconds}</Cell>
+      </tr>
+    {/if}
+    {#if artifact.suspend !== undefined}
+      <tr>
+        <Cell>Suspend</Cell>
+        <Cell>{capitalize(artifact.suspend.toString())}</Cell>
+      </tr>
+    {/if}
+    {#if artifact.timeZone}
+      <tr>
+        <Cell>Time Zone</Cell>
+        <Cell>{artifact.timeZone}</Cell>
+      </tr>
+    {/if}
+  {/if}

--- a/packages/renderer/src/lib/kube/details/KubeCronJobStatusArtifact.spec.ts
+++ b/packages/renderer/src/lib/kube/details/KubeCronJobStatusArtifact.spec.ts
@@ -1,0 +1,51 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import type { V1CronJobStatus } from '@kubernetes/client-node';
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import KubeCronJobStatusArtifact from './KubeCronJobStatusArtifact.svelte';
+
+const fakeCronJobStatus: V1CronJobStatus = {
+  lastScheduleTime: new Date(),
+  lastSuccessfulTime: new Date(),
+  active: [{ name: 'cronjob-123' }, { name: 'cronjob-456' }],
+};
+
+test('Renders CronJob status correctly with complete data', () => {
+  render(KubeCronJobStatusArtifact, { artifact: fakeCronJobStatus });
+  expect(screen.getByText('Last Schedule Time')).toBeInTheDocument();
+  expect(screen.getByText('Last Successful Time')).toBeInTheDocument();
+  expect(screen.getByText('Active Jobs')).toBeInTheDocument();
+
+  // Check that cronjob-123 is shown anywhere in the page, as it's part of the list, just use regex
+  expect(screen.getByText(/cronjob-123/)).toBeInTheDocument();
+  expect(screen.getByText(/cronjob-456/)).toBeInTheDocument();
+});
+
+test('Handles undefined artifact gracefully', () => {
+  render(KubeCronJobStatusArtifact, { artifact: undefined });
+
+  // Expect not to find any status info if artifact is undefined
+  expect(screen.queryByText('Last Schedule Time')).not.toBeInTheDocument();
+  expect(screen.queryByText('Last Successful Time')).not.toBeInTheDocument();
+  expect(screen.queryByText('Active Jobs')).not.toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/kube/details/KubeCronJobStatusArtifact.svelte
+++ b/packages/renderer/src/lib/kube/details/KubeCronJobStatusArtifact.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+import type { V1CronJobStatus } from '@kubernetes/client-node';
+
+import Cell from '/@/lib/details/DetailsCell.svelte';
+import Title from '/@/lib/details/DetailsTitle.svelte';
+
+interface Props {
+  artifact?: V1CronJobStatus;
+}
+
+let { artifact }: Props = $props();
+</script>
+  
+  {#if artifact && (artifact.lastScheduleTime ?? artifact.lastSuccessfulTime ?? artifact.active)}
+    <tr>
+      <Title>Status</Title>
+    </tr>
+    {#if artifact.lastScheduleTime}
+      <tr>
+        <Cell>Last Schedule Time</Cell>
+        <Cell>{artifact.lastScheduleTime}</Cell>
+      </tr>
+    {/if}
+    {#if artifact.lastSuccessfulTime}
+      <tr>
+        <Cell>Last Successful Time</Cell>
+        <Cell>{artifact.lastSuccessfulTime}</Cell>
+      </tr>
+    {/if}
+    {#if artifact.active}
+      <tr>
+        <Cell>Active Jobs</Cell>
+        <Cell>
+              {#each artifact.active as job}
+                  {job.name}
+                  <br />
+              {/each}
+        </Cell>
+      </tr>
+    {/if}
+  {/if}


### PR DESCRIPTION
chore: add summary page cronjobs

### What does this PR do?

* Adds the summary page for cronjobs
* Adds missing function (readNamespacedCronJob) to index.ts plugin

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

![Screenshot 2025-02-05 at 1 42 21 PM](https://github.com/user-attachments/assets/ca1daac9-d532-47fd-bd59-a2f307223fc8)



https://github.com/user-attachments/assets/708efccb-2e17-4754-8380-cd35822dcc4a


### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

This PR is the last part that:

Closes https://github.com/podman-desktop/podman-desktop/issues/10560

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

1. Create an example CronJob
2. Click on the name to get to the summary page

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
