### PR TITLE
chore: remove unnecessary no-explicit-any

### DIFF
--- a/extensions/podman/packages/extension/src/podman-remote-connections.spec.ts
+++ b/extensions/podman/packages/extension/src/podman-remote-connections.spec.ts
@@ -16,8 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import * as fs from 'node:fs';
 
 import * as extensionApi from '@podman-desktop/api';

--- a/extensions/podman/packages/extension/src/podman-remote-ssh-tunnel.spec.ts
+++ b/extensions/podman/packages/extension/src/podman-remote-ssh-tunnel.spec.ts
@@ -16,7 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { rm } from 'node:fs/promises';
 import { type AddressInfo, createConnection, createServer } from 'node:net';
 import { tmpdir } from 'node:os';


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Remove unnecessary no-explicit-any from podman-remote-connections.spec.ts and podman-remote-ssh-tunnel.spec.ts

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of #10598 

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
