### PR TITLE
feat: display services in Kubernetes experimental mode 

### DIFF
--- a/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
@@ -38,6 +38,7 @@ import type { ResourceFactory } from './resource-factory.js';
 import { ResourceFactoryHandler } from './resource-factory-handler.js';
 import type { CacheUpdatedEvent, OfflineEvent, ResourceInformer } from './resource-informer.js';
 import { SecretsResourceFactory } from './secrets-resource-factory.js';
+import { ServicesResourceFactory } from './services-resource-factory.js';
 
 const HEALTH_CHECK_TIMEOUT_MS = 5_000;
 
@@ -95,6 +96,7 @@ export class ContextsManagerExperimental {
       new DeploymentsResourceFactory(),
       new ConfigmapsResourceFactory(),
       new SecretsResourceFactory(),
+      new ServicesResourceFactory(),
     ];
   }
 

--- a/packages/main/src/plugin/kubernetes/services-resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/services-resource-factory.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/main/src/plugin/kubernetes/services-resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/services-resource-factory.ts
@@ -1,0 +1,59 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1Service, V1ServiceList } from '@kubernetes/client-node';
+import { CoreV1Api } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from './kubeconfig-single-context.js';
+import type { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryBase } from './resource-factory.js';
+import { ResourceInformer } from './resource-informer.js';
+
+export class ServicesResourceFactory extends ResourceFactoryBase implements ResourceFactory {
+  constructor() {
+    super({
+      resource: 'services',
+    });
+
+    this.setPermissions({
+      isNamespaced: true,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          verb: 'watch',
+          resource: 'services',
+        },
+      ],
+    });
+    this.setInformer({
+      createInformer: this.createInformer,
+    });
+  }
+
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1Service> {
+    const namespace = kubeconfig.getNamespace();
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(CoreV1Api);
+    const listFn = (): Promise<V1ServiceList> => apiClient.listNamespacedService({ namespace });
+    const path = `/api/v1/namespaces/${namespace}/services`;
+    return new ResourceInformer<V1Service>(kubeconfig, path, listFn, 'services');
+  }
+}

--- a/packages/renderer/src/lib/service/ServicesList.spec.ts
+++ b/packages/renderer/src/lib/service/ServicesList.spec.ts
@@ -62,8 +62,10 @@ test('Expect services list', async () => {
 
   render(ServicesList);
 
-  const serviceName = screen.getByRole('cell', { name: 'my-service test-namespace' });
-  expect(serviceName).toBeInTheDocument();
+  await vi.waitFor(() => {
+    const serviceName = screen.getByRole('cell', { name: 'my-service test-namespace' });
+    expect(serviceName).toBeInTheDocument();
+  });
 });
 
 test('Expect filter empty screen', async () => {
@@ -92,8 +94,10 @@ test('Expect user confirmation to pop up when preferences require', async () => 
 
   render(ServicesList);
 
-  const checkboxes = screen.getAllByRole('checkbox', { name: 'Toggle service' });
-  await fireEvent.click(checkboxes[0]);
+  await vi.waitFor(async () => {
+    const checkboxes = screen.getAllByRole('checkbox', { name: 'Toggle service' });
+    await fireEvent.click(checkboxes[0]);
+  });
 
   vi.mocked(window.getConfigurationValue).mockResolvedValue(true);
   vi.mocked(window.showMessageBox).mockResolvedValue({ response: 1 });
@@ -140,10 +144,13 @@ test('services list is updated when kubernetesCurrentContextServicesFiltered cha
   vi.mocked(states).kubernetesCurrentContextServicesFiltered = filtered;
 
   const component = render(ServicesList);
-  const serviceName1 = screen.getByRole('cell', { name: 'my-service-1 test-namespace' });
-  expect(serviceName1).toBeInTheDocument();
-  const serviceName2 = screen.getByRole('cell', { name: 'my-service-2 test-namespace' });
-  expect(serviceName2).toBeInTheDocument();
+
+  await vi.waitFor(async () => {
+    const serviceName1 = screen.getByRole('cell', { name: 'my-service-1 test-namespace' });
+    expect(serviceName1).toBeInTheDocument();
+    const serviceName2 = screen.getByRole('cell', { name: 'my-service-2 test-namespace' });
+    expect(serviceName2).toBeInTheDocument();
+  });
 
   filtered.set([service2]);
   await component.rerender({});


### PR DESCRIPTION
### What does this PR do?

- backend: registers services resources
- frontend: use KubernetesObjectsList for services list

### Screenshot / video of UI


### What issues does this PR fix or reference?

Part of #10657 

### How to test this PR?

Set the Kubernetes experimental mode in `$HOME/.local/share/containers/podman-desktop/configuration/settings.json`:

```
"kubernetes.statesExperimental": true
```

Also check that it is still working in non experimental mode


- [x] Tests are covering the bug fix or the new feature
