### PR TITLE
feat: display PVCs in Kubernetes experimental mode

### DIFF
--- a/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024 - 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import type { DispatcherEvent } from './contexts-dispatcher.js';
 import { ContextsDispatcher } from './contexts-dispatcher.js';
 import { DeploymentsResourceFactory } from './deployments-resource-factory.js';
 import { PodsResourceFactory } from './pods-resource-factory.js';
+import { PVCsResourceFactory } from './pvcs-resource-factory.js';
 import type { ResourceFactory } from './resource-factory.js';
 import { ResourceFactoryHandler } from './resource-factory-handler.js';
 import type { CacheUpdatedEvent, OfflineEvent, ResourceInformer } from './resource-informer.js';
@@ -97,6 +98,7 @@ export class ContextsManagerExperimental {
       new ConfigmapsResourceFactory(),
       new SecretsResourceFactory(),
       new ServicesResourceFactory(),
+      new PVCsResourceFactory(),
     ];
   }
 

--- a/packages/main/src/plugin/kubernetes/pvcs-resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/pvcs-resource-factory.ts
@@ -1,0 +1,60 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1PersistentVolumeClaim, V1PersistentVolumeClaimList } from '@kubernetes/client-node';
+import { CoreV1Api } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from './kubeconfig-single-context.js';
+import type { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryBase } from './resource-factory.js';
+import { ResourceInformer } from './resource-informer.js';
+
+export class PVCsResourceFactory extends ResourceFactoryBase implements ResourceFactory {
+  constructor() {
+    super({
+      resource: 'persistentvolumeclaims',
+    });
+
+    this.setPermissions({
+      isNamespaced: true,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          verb: 'watch',
+          resource: 'persistentvolumeclaims',
+        },
+      ],
+    });
+    this.setInformer({
+      createInformer: this.createInformer,
+    });
+  }
+
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1PersistentVolumeClaim> {
+    const namespace = kubeconfig.getNamespace();
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(CoreV1Api);
+    const listFn = (): Promise<V1PersistentVolumeClaimList> =>
+      apiClient.listNamespacedPersistentVolumeClaim({ namespace });
+    const path = `/api/v1/namespaces/${namespace}/persistentvolumeclaims`;
+    return new ResourceInformer<V1PersistentVolumeClaim>(kubeconfig, path, listFn, 'persistentvolumeclaims');
+  }
+}

--- a/packages/renderer/src/lib/pvc/PVCList.spec.ts
+++ b/packages/renderer/src/lib/pvc/PVCList.spec.ts
@@ -56,8 +56,10 @@ test('Expect PVC list', async () => {
 
   render(PVCList);
 
-  const pvcName = screen.getByRole('cell', { name: 'pvc1 default' });
-  expect(pvcName).toBeInTheDocument();
+  await vi.waitFor(() => {
+    const pvcName = screen.getByRole('cell', { name: 'pvc1 default' });
+    expect(pvcName).toBeInTheDocument();
+  });
 });
 
 test('Expect user confirmation to pop up when preferences require', async () => {
@@ -72,8 +74,10 @@ test('Expect user confirmation to pop up when preferences require', async () => 
 
   render(PVCList);
 
-  const pvcName1 = screen.getByRole('cell', { name: 'pvc12 default' });
-  expect(pvcName1).toBeInTheDocument();
+  await vi.waitFor(() => {
+    const pvcName1 = screen.getByRole('cell', { name: 'pvc12 default' });
+    expect(pvcName1).toBeInTheDocument();
+  });
 
   const checkboxes = screen.getAllByRole('checkbox', { name: 'Toggle PVC' });
   await fireEvent.click(checkboxes[0]);
@@ -110,10 +114,13 @@ test('PVCs list is updated when kubernetesCurrentContextPersistentVolumeClaimsFi
   vi.mocked(states).kubernetesCurrentContextPersistentVolumeClaimsFiltered = filtered;
 
   const component = render(PVCList);
-  const pvcName1 = screen.getByRole('cell', { name: 'my-pvc-1 test-namespace' });
-  expect(pvcName1).toBeInTheDocument();
-  const pvcName2 = screen.getByRole('cell', { name: 'my-pvc-2 test-namespace' });
-  expect(pvcName2).toBeInTheDocument();
+
+  await vi.waitFor(() => {
+    const pvcName1 = screen.getByRole('cell', { name: 'my-pvc-1 test-namespace' });
+    expect(pvcName1).toBeInTheDocument();
+    const pvcName2 = screen.getByRole('cell', { name: 'my-pvc-2 test-namespace' });
+    expect(pvcName2).toBeInTheDocument();
+  });
 
   filtered.set([pvc2]);
   await component.rerender({});

--- a/packages/renderer/src/lib/pvc/PVCList.svelte
+++ b/packages/renderer/src/lib/pvc/PVCList.svelte
@@ -1,26 +1,14 @@
 <script lang="ts">
-import { faTrash } from '@fortawesome/free-solid-svg-icons';
-import {
-  Button,
-  FilteredEmptyScreen,
-  NavPage,
-  Table,
-  TableColumn,
-  TableDurationColumn,
-  TableRow,
-  TableSimpleColumn,
-} from '@podman-desktop/ui-svelte';
+import { TableColumn, TableDurationColumn, TableRow, TableSimpleColumn } from '@podman-desktop/ui-svelte';
 import moment from 'moment';
 
-import KubeActions from '/@/lib/kube/KubeActions.svelte';
-import KubernetesCurrentContextConnectionBadge from '/@/lib/ui/KubernetesCurrentContextConnectionBadge.svelte';
 import {
   kubernetesCurrentContextPersistentVolumeClaimsFiltered,
   persistentVolumeClaimSearchPattern,
 } from '/@/stores/kubernetes-contexts-state';
 
-import { withBulkConfirmation } from '../actions/BulkActions';
 import PVCIcon from '../images/PVCIcon.svelte';
+import KubernetesObjectsList from '../objects/KubernetesObjectsList.svelte';
 import { PVCUtils } from './pvc-utils';
 import PVCColumnActions from './PVCColumnActions.svelte';
 import PvcColumnMode from './PVCColumnMode.svelte';
@@ -40,35 +28,6 @@ $effect(() => {
 });
 
 const pvcUtils = new PVCUtils();
-
-const pvcs = $derived($kubernetesCurrentContextPersistentVolumeClaimsFiltered.map(pvc => pvcUtils.getPVCUI(pvc)));
-
-// delete the items selected in the list
-let bulkDeleteInProgress = $state<boolean>(false);
-async function deleteSelectedPVCs(): Promise<void> {
-  const selectedPVCs = pvcs.filter(pvc => pvc.selected);
-  if (selectedPVCs.length === 0) {
-    return;
-  }
-
-  // mark pvcs for deletion
-  bulkDeleteInProgress = true;
-  selectedPVCs.forEach(pvc => (pvc.status = 'DELETING'));
-
-  await Promise.all(
-    selectedPVCs.map(async pvc => {
-      try {
-        await window.kubernetesDeletePersistentVolumeClaim(pvc.name);
-      } catch (e) {
-        console.error('error while deleting pvc', e);
-      }
-    }),
-  );
-  bulkDeleteInProgress = false;
-}
-
-let selectedItemsNumber = $state<number>(0);
-let table: Table;
 
 let statusColumn = new TableColumn<PVCUI>('Status', {
   align: 'center',
@@ -119,46 +78,24 @@ const columns = [
 const row = new TableRow<PVCUI>({ selectable: (_pvc): boolean => true });
 </script>
 
-<NavPage bind:searchTerm={searchTerm} title="persistent volume claims">
-  <svelte:fragment slot="additional-actions">
-    <KubeActions />
-  </svelte:fragment>
-
-  <svelte:fragment slot="bottom-additional-actions">
-    {#if selectedItemsNumber > 0}
-      <Button
-        on:click={(): void =>
-          withBulkConfirmation(
-            deleteSelectedPVCs,
-            `delete ${selectedItemsNumber} PVC${selectedItemsNumber > 1 ? 's' : ''}`,
-          )}
-        title="Delete {selectedItemsNumber} selected items"
-        inProgress={bulkDeleteInProgress}
-        icon={faTrash} />
-      <span>On {selectedItemsNumber} selected items.</span>
-    {/if}
-    <div class="flex grow justify-end">
-      <KubernetesCurrentContextConnectionBadge />
-    </div>
-  </svelte:fragment>
-
-  <div class="flex min-w-full h-full" slot="content">
-    <Table
-      kind="PVC"
-      bind:this={table}
-      bind:selectedItemsNumber={selectedItemsNumber}
-      data={pvcs}
-      columns={columns}
-      row={row}
-      defaultSortColumn="Name">
-    </Table>
-
-    {#if $kubernetesCurrentContextPersistentVolumeClaimsFiltered.length === 0}
-      {#if searchTerm}
-        <FilteredEmptyScreen icon={PVCIcon} kind="pvcs" bind:searchTerm={searchTerm} />
-      {:else}
-        <PVCEmptyScreen />
-      {/if}
-    {/if}
-  </div>
-</NavPage>
+<KubernetesObjectsList
+  kinds={[{
+    resource: 'persistentvolumeclaims',
+    transformer: pvcUtils.getPVCUI,
+    delete: window.kubernetesDeletePersistentVolumeClaim,
+    isResource: (): boolean => true,
+    legacySearchPatternStore: persistentVolumeClaimSearchPattern,
+    legacyObjectStore: kubernetesCurrentContextPersistentVolumeClaimsFiltered,
+  }]}
+  singular="PVC"
+  plural="PVCs"
+  icon={PVCIcon}
+  searchTerm={searchTerm}
+  columns={columns}
+  row={row}
+  >
+  <!-- eslint-disable-next-line sonarjs/no-unused-vars -->
+  {#snippet emptySnippet()}
+    <PVCEmptyScreen />
+  {/snippet}
+</KubernetesObjectsList>


### PR DESCRIPTION
### What does this PR do?

- backend: registers PVCs resources
- frontend: use KubernetesObjectsList for PVCs list

### Screenshot / video of UI


### What issues does this PR fix or reference?

Part of #10657 

### How to test this PR?

Set the Kubernetes experimental mode in `$HOME/.local/share/containers/podman-desktop/configuration/settings.json`:

```
"kubernetes.statesExperimental": true
```

Also check that it is still working in non experimental mode


- [x] Tests are covering the bug fix or the new feature
