### PR TITLE
feat: upgrade flatpak runtime to 24.08

### DIFF
--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -171,7 +171,7 @@ const config = {
     ],
     useWaylandFlags: 'false',
     artifactName: 'podman-desktop-${version}.${ext}',
-    runtimeVersion: '23.08',
+    runtimeVersion: '24.08',
     branch: 'main',
     files: [
       ['.flatpak-appdata.xml', '/share/metainfo/io.podman_desktop.PodmanDesktop.metainfo.xml'],

--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -127,7 +127,7 @@ jobs:
           sudo apt-get install flatpak-builder -y
           sudo apt-get install elfutils -y
           flatpak remote-add --if-not-exists flathub --user https://flathub.org/repo/flathub.flatpakrepo
-          flatpak install flathub --user -y org.freedesktop.Platform//23.08 org.freedesktop.Sdk//23.08
+          flatpak install flathub --user -y org.freedesktop.Platform//24.08 org.freedesktop.Sdk//24.08
 
       - name: Set macOS environment variables
         if: startsWith(matrix.os, 'macos')

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -106,7 +106,7 @@ jobs:
           sudo apt-get install flatpak-builder -y
           sudo apt-get install elfutils -y
           flatpak remote-add --if-not-exists flathub --user https://flathub.org/repo/flathub.flatpakrepo
-          flatpak install flathub --no-static-deltas --user -y org.freedesktop.Platform//23.08 org.freedesktop.Sdk//23.08
+          flatpak install flathub --no-static-deltas --user -y org.freedesktop.Platform//24.08 org.freedesktop.Sdk//24.08
 
       - name: Run Build
         timeout-minutes: 20

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -171,7 +171,7 @@ jobs:
           sudo apt-get install flatpak-builder -y
           sudo apt-get install elfutils -y
           flatpak remote-add --if-not-exists flathub --user https://flathub.org/repo/flathub.flatpakrepo
-          flatpak install flathub --no-static-deltas --user -y org.freedesktop.Platform//23.08 org.freedesktop.Sdk//23.08
+          flatpak install flathub --no-static-deltas --user -y org.freedesktop.Platform//24.08 org.freedesktop.Sdk//24.08
       - name: Set macOS environment variables
         if: startsWith(matrix.os, 'macos')
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,10 +76,10 @@ Requirements:
 
 Optional Linux requirements:
 
-- [Flatpak builder, runtime, and SDK, version 23.08](https://docs.flatpak.org/en/latest/first-build.html)
+- [Flatpak builder, runtime, and SDK, version 24.08](https://docs.flatpak.org/en/latest/first-build.html)
   ```sh
   flatpak remote-add --if-not-exists flathub --user https://flathub.org/repo/flathub.flatpakrepo
-  flatpak install --user flathub org.flatpak.Builder org.freedesktop.Platform//23.08 org.freedesktop.Sdk//23.08
+  flatpak install --user flathub org.flatpak.Builder org.freedesktop.Platform//24.08 org.freedesktop.Sdk//24.08
   ```
 - GNU C and C++ compiler
   Fedora/RHEL


### PR DESCRIPTION
### What does this PR do?
bump the flatpak runtime to 24.08
I also made a PR on the flathub repo

https://github.com/flathub/io.podman_desktop.PodmanDesktop/pull/67
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
```
git clone https://github.com/renner0e/io.podman_desktop.PodmanDesktop
cd io.podman_desktop.PodmanDesktop
git switch bump-runtime2048

# setup user remote and install flatpak builder
flatpak --user remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
flatpak install --user org.flatpak.Builder

flatpak run org.flatpak.Builder --install --install-deps-from=flathub --force-clean build --user io.podman_desktop.PodmanDesktop.yml
flatpak run --branch=master io.podman_desktop.PodmanDesktop
```
<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
