### PR TITLE
refactor(kind): extract cli logic from activate

### DIFF
--- a/extensions/kind/src/extension.spec.ts
+++ b/extensions/kind/src/extension.spec.ts
@@ -20,7 +20,7 @@ import * as fs from 'node:fs';
 
 import type * as extensionApi from '@podman-desktop/api';
 import * as podmanDesktopApi from '@podman-desktop/api';
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import * as extension from './extension';
 import type { KindGithubReleaseArtifactMetadata } from './kind-installer';
@@ -115,6 +115,10 @@ beforeEach(() => {
   vi.mocked(podmanDesktopApi.containerEngine.listContainers).mockResolvedValue([]);
   vi.mocked(util.removeVersionPrefix).mockReturnValue('1.0.0');
   vi.mocked(util.getSystemBinaryPath).mockReturnValue('test-storage-path/kind');
+});
+
+afterEach(() => {
+  extension.deactivate();
 });
 
 function activate(options?: Partial<extensionApi.ExtensionContext>): Promise<void> {
@@ -305,7 +309,7 @@ describe('cli#update', () => {
   test('try to update before selecting cli tool version should throw an error', async () => {
     const update: extensionApi.CliToolSelectUpdate = await getCliToolUpdate();
     await expect(() => update?.doUpdate({} as unknown as extensionApi.Logger)).rejects.toThrowError(
-      'Cannot update kind version 0.0.1. No release selected.',
+      'Cannot update test-storage-path/kind version 0.0.1. No release selected.',
     );
   });
 
@@ -374,7 +378,7 @@ describe('cli#install', () => {
     const cliToolInstaller: extensionApi.CliToolInstaller = await getCliToolInstaller();
 
     await expect(() => cliToolInstaller?.doInstall({} as unknown as extensionApi.Logger)).rejects.toThrowError(
-      `Cannot install kind. Version 0.0.1 is already installed.`,
+      `Cannot install kind. Version 0.0.1 in test-storage-path/kind is already installed.`,
     );
   });
 

--- a/extensions/kind/src/extension.spec.ts
+++ b/extensions/kind/src/extension.spec.ts
@@ -86,6 +86,7 @@ const CLI_TOOL_MOCK: extensionApi.CliTool = {
   registerUpdate: vi.fn(),
   registerInstaller: vi.fn(),
   updateVersion: vi.fn(),
+  version: '0.0.1',
 } as unknown as extensionApi.CliTool;
 
 beforeEach(() => {
@@ -304,7 +305,7 @@ describe('cli#update', () => {
   test('try to update before selecting cli tool version should throw an error', async () => {
     const update: extensionApi.CliToolSelectUpdate = await getCliToolUpdate();
     await expect(() => update?.doUpdate({} as unknown as extensionApi.Logger)).rejects.toThrowError(
-      'Cannot update test-storage-path/kind version 0.0.1. No release selected.',
+      'Cannot update kind version 0.0.1. No release selected.',
     );
   });
 
@@ -349,11 +350,21 @@ async function getCliToolInstaller(): Promise<extensionApi.CliToolInstaller> {
 
 describe('cli#install', () => {
   beforeEach(() => {
+    // mock create cli tool
+    vi.mocked(podmanDesktopApi.cli.createCliTool).mockReturnValue({
+      ...CLI_TOOL_MOCK,
+      version: undefined,
+      dispose: vi.fn(),
+    });
+
     // mock no kind detected
     vi.mocked(util.getKindBinaryInfo).mockRejectedValue('no kind');
   });
 
   test('try to install when there is already an existing version should throw an error', async () => {
+    // mock create cli tool (existing version)
+    vi.mocked(podmanDesktopApi.cli.createCliTool).mockReturnValue(CLI_TOOL_MOCK);
+
     // mock existing cli tool
     vi.mocked(util.getKindBinaryInfo).mockResolvedValue({
       version: '0.0.1',
@@ -363,7 +374,7 @@ describe('cli#install', () => {
     const cliToolInstaller: extensionApi.CliToolInstaller = await getCliToolInstaller();
 
     await expect(() => cliToolInstaller?.doInstall({} as unknown as extensionApi.Logger)).rejects.toThrowError(
-      `Cannot install kind. Version 0.0.1 in test-storage-path/kind is already installed.`,
+      `Cannot install kind. Version 0.0.1 is already installed.`,
     );
   });
 

--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -422,7 +422,7 @@ async function registerCliTool(
       return releaseVersionToUpdateTo;
     },
     doUpdate: async (): Promise<void> => {
-      if (!kindCli?.version) {
+      if (!kindCli?.version || !kindPath) {
         throw new Error(`Cannot update ${KIND_CLI_NAME}. No cli tool installed.`);
       }
 
@@ -432,7 +432,7 @@ async function registerCliTool(
       }
 
       if (!releaseToUpdateTo || !releaseVersionToUpdateTo) {
-        throw new Error(`Cannot update kind version ${kindCli.version}. No release selected.`);
+        throw new Error(`Cannot update ${kindPath} version ${binary?.version}. No release selected.`);
       }
 
       // download, install system wide and update cli version
@@ -466,8 +466,10 @@ async function registerCliTool(
       return releaseVersionToInstall;
     },
     doInstall: async _logger => {
-      if (kindCli?.version) {
-        throw new Error(`Cannot install ${KIND_CLI_NAME}. Version ${kindCli.version} is already installed.`);
+      if (kindCli?.version || kindPath) {
+        throw new Error(
+          `Cannot install ${KIND_CLI_NAME}. Version ${kindCli?.version} in ${kindPath} is already installed.`,
+        );
       }
       if (!releaseToInstall || !releaseVersionToInstall) {
         throw new Error(`Cannot install ${KIND_CLI_NAME}. No release selected.`);
@@ -562,4 +564,6 @@ async function deleteFileAsAdmin(filePath: string): Promise<void> {
 
 export function deactivate(): void {
   console.log('stopping kind extension');
+  kindPath = undefined;
+  kindCli = undefined;
 }

--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -61,6 +61,8 @@ const registeredKubernetesConnections: {
 let kindCli: CliTool | undefined;
 let kindPath: string | undefined;
 
+let installer: KindInstaller;
+
 const imageHandler = new ImageHandler();
 
 async function registerProvider(
@@ -336,10 +338,17 @@ export async function moveImage(
   }
 }
 
-export async function activate(extensionContext: extensionApi.ExtensionContext): Promise<void> {
-  const telemetryLogger = extensionApi.env.createTelemetryLogger();
+/**
+ * Function to register the kind cli tool
+ * @param extensionContext
+ * @param telemetryLogger
+ */
+async function registerCliTool(
+  extensionContext: extensionApi.ExtensionContext,
+  telemetryLogger: extensionApi.TelemetryLogger,
+): Promise<void> {
   const octokit = new Octokit();
-  const installer = new KindInstaller(extensionContext.storagePath, telemetryLogger, octokit);
+  installer = new KindInstaller(extensionContext.storagePath, telemetryLogger, octokit);
 
   let binary: { path: string; version: string } | undefined = undefined;
   let installationSource: extensionApi.CliToolInstallationSource | undefined;
@@ -363,32 +372,22 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   }
 
   // if the binary exists (either system-wide or in extension storage), we get its version/path
-  let binaryVersion: string | undefined;
-  let binaryPath: string | undefined;
   if (binary) {
-    binaryVersion = binary.version;
-    binaryPath = binary.path;
-    kindPath = binaryPath;
+    kindPath = binary.path;
   }
+
   // we register it
   kindCli = extensionApi.cli.createCliTool({
     name: KIND_CLI_NAME,
     images: {
       icon: './icon.png',
     },
-    version: binaryVersion,
-    path: binaryPath,
+    version: binary?.version,
+    path: binary?.path,
     displayName: KIND_DISPLAY_NAME,
     markdownDescription: KIND_MARKDOWN,
     installationSource,
   });
-
-  // let's create a provider
-  await createProvider(extensionContext, telemetryLogger);
-
-  // if we do not have anything installed, let's add it to the status bar
-  let releaseToInstall: KindGithubReleaseArtifactMetadata | undefined;
-  let releaseVersionToInstall: string | undefined;
 
   extensionContext.subscriptions.push(kindCli);
 
@@ -396,6 +395,11 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   if (installationSource === 'external') {
     return;
   }
+
+  // if we do not have anything installed, let's add it to the status bar
+  let releaseToInstall: KindGithubReleaseArtifactMetadata | undefined;
+  let releaseVersionToInstall: string | undefined;
+
   // register the updater to allow users to upgrade/downgrade their cli
   let releaseToUpdateTo: KindGithubReleaseArtifactMetadata | undefined;
   let releaseVersionToUpdateTo: string | undefined;
@@ -412,13 +416,13 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   const update = {
     version: latestVersion !== kindCli.version ? latestVersion : undefined,
     selectVersion: async (): Promise<string> => {
-      const selected = await installer.promptUserForVersion(binaryVersion);
+      const selected = await installer.promptUserForVersion(binary?.version);
       releaseToUpdateTo = selected;
       releaseVersionToUpdateTo = removeVersionPrefix(selected.tag);
       return releaseVersionToUpdateTo;
     },
     doUpdate: async (): Promise<void> => {
-      if (!binaryVersion || !binaryPath) {
+      if (!kindCli?.version) {
         throw new Error(`Cannot update ${KIND_CLI_NAME}. No cli tool installed.`);
       }
 
@@ -428,7 +432,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
       }
 
       if (!releaseToUpdateTo || !releaseVersionToUpdateTo) {
-        throw new Error(`Cannot update ${binaryPath} version ${binaryVersion}. No release selected.`);
+        throw new Error(`Cannot update kind version ${kindCli.version}. No release selected.`);
       }
 
       // download, install system wide and update cli version
@@ -444,7 +448,6 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
         installationSource: 'extension',
         path: cliPath,
       });
-      binaryVersion = releaseVersionToUpdateTo;
       if (releaseVersionToUpdateTo === latestVersion) {
         delete update.version;
       } else {
@@ -463,10 +466,8 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
       return releaseVersionToInstall;
     },
     doInstall: async _logger => {
-      if (binaryVersion ?? binaryPath) {
-        throw new Error(
-          `Cannot install ${KIND_CLI_NAME}. Version ${binaryVersion} in ${binaryPath} is already installed.`,
-        );
+      if (kindCli?.version) {
+        throw new Error(`Cannot install ${KIND_CLI_NAME}. Version ${kindCli.version} is already installed.`);
       }
       if (!releaseToInstall || !releaseVersionToInstall) {
         throw new Error(`Cannot install ${KIND_CLI_NAME}. No release selected.`);
@@ -487,8 +488,6 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
         path: cliPath,
         installationSource: 'extension',
       });
-      binaryVersion = releaseVersionToInstall;
-      binaryPath = cliPath;
       kindPath = cliPath;
       if (releaseVersionToInstall === latestVersion) {
         delete update.version;
@@ -499,7 +498,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
       releaseToInstall = undefined;
     },
     doUninstall: async _logger => {
-      if (!binaryVersion) {
+      if (!kindCli?.version) {
         throw new Error(`Cannot uninstall ${KIND_CLI_NAME}. No version detected.`);
       }
 
@@ -512,11 +511,19 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
       await deleteFile(systemPath);
 
       // update the version and path to undefined
-      binaryVersion = undefined;
-      binaryPath = undefined;
       kindPath = undefined;
     },
   });
+}
+
+export async function activate(extensionContext: extensionApi.ExtensionContext): Promise<void> {
+  const telemetryLogger = extensionApi.env.createTelemetryLogger();
+
+  // let's register the CLI Tool
+  await registerCliTool(extensionContext, telemetryLogger);
+
+  // let's create a provider
+  await createProvider(extensionContext, telemetryLogger);
 }
 
 async function deleteFile(filePath: string): Promise<void> {


### PR DESCRIPTION
### What does this PR do?

### Changes

1. Remove scoped variables (`binaryVersion` and `binaryPath`) were scoped to `activate` and were used like global variables

https://github.com/podman-desktop/podman-desktop/blob/bbcc04a9ce18f9b3a5b273122f7239ed174bdefa/extensions/kind/src/extension.ts#L365-L372

Instead of using the `binaryVersion` we use the `CliTool#version` property, so this is a real global variable
Instead of using `binaryPath` we use the global variable `kindPath`

2. Cleaning `kindPath` & `kindCli` in `deactivate`: tests were a bit leaking between each other, (the scoped variable prevented the leak, but since removing them, tests were failing due to interacting with each other)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Required for https://github.com/podman-desktop/podman-desktop/pull/10980

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
