### PR TITLE
feat(status-bar): pin-unpin providers

### DIFF
--- a/packages/api/src/status-bar/pin-constants.ts
+++ b/packages/api/src/status-bar/pin-constants.ts
@@ -1,0 +1,25 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export enum STATUS_BAR_PIN_CONSTANTS {
+  TOGGLE_MENU = 'statusbar:toggle-pin-menu',
+  TOGGLE_MENU_COMMAND = 'statusbar:pin',
+  PIN_OPTIONS_UPDATE = 'statusbar:pin:update',
+  PINNED_CONFIGURATION_PROPERTY = 'pinned',
+  STATUS_BAR_CONFIGURATION = 'preferences.status-bar',
+}

--- a/packages/api/src/status-bar/pin-option.ts
+++ b/packages/api/src/status-bar/pin-option.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export interface PinOption {
+  label: string;
+  value: string;
+  pinned: boolean;
+}

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -564,13 +564,7 @@ export class PluginSystem {
       }
     });
 
-    const pinRegistry = new PinRegistry(
-      statusBarRegistry,
-      commandRegistry,
-      apiSender,
-      configurationRegistry,
-      providerRegistry,
-    );
+    const pinRegistry = new PinRegistry(commandRegistry, apiSender, configurationRegistry, providerRegistry);
     pinRegistry.init();
 
     statusBarRegistry.setEntry('help', false, -1, undefined, 'Help', 'fa fa-question-circle', true, 'help');

--- a/packages/main/src/plugin/statusbar/pin-registry.spec.ts
+++ b/packages/main/src/plugin/statusbar/pin-registry.spec.ts
@@ -1,0 +1,320 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type {
+  Configuration,
+  UpdateContainerConnectionEvent,
+  UpdateKubernetesConnectionEvent,
+} from '@podman-desktop/api';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { ApiSenderType } from '/@/plugin/api.js';
+import type { CommandRegistry } from '/@/plugin/command-registry.js';
+import type { ConfigurationRegistry } from '/@/plugin/configuration-registry.js';
+import type { ProviderRegistry } from '/@/plugin/provider-registry.js';
+import { PinRegistry } from '/@/plugin/statusbar/pin-registry.js';
+import type { ProviderInfo } from '/@api/provider-info.js';
+import { STATUS_BAR_PIN_CONSTANTS } from '/@api/status-bar/pin-constants.js';
+
+const COMMAND_REGISTRY_MOCK: CommandRegistry = {
+  registerCommand: vi.fn(),
+} as unknown as CommandRegistry;
+
+const API_SENDER_MOCK: ApiSenderType = {
+  send: vi.fn(),
+} as unknown as ApiSenderType;
+
+const CONFIGURATION_REGISTRY_MOCK: ConfigurationRegistry = {
+  getConfiguration: vi.fn(),
+  registerConfigurations: vi.fn(),
+} as unknown as ConfigurationRegistry;
+
+const PROVIDER_REGISTRY_MOCK: ProviderRegistry = {
+  getProviderInfos: vi.fn(),
+  onDidUpdateContainerConnection: vi.fn(),
+  onDidUpdateKubernetesConnection: vi.fn(),
+} as unknown as ProviderRegistry;
+
+const KIND_ONE_CLUSTER_PROVIDER: ProviderInfo = {
+  id: 'kind',
+  name: 'Kind',
+  kubernetesConnections: [
+    {
+      name: 'kind-cluster',
+    },
+  ],
+  containerConnections: [],
+} as unknown as ProviderInfo;
+
+const KIND_EMPTY_CLUSTER_PROVIDER: ProviderInfo = {
+  ...KIND_ONE_CLUSTER_PROVIDER,
+  kubernetesConnections: [],
+};
+
+const PODMAN_PROVIDER: ProviderInfo = {
+  id: 'podman',
+  name: 'Podman',
+  kubernetesConnections: [],
+  containerConnections: [
+    {
+      name: 'podman-machine-default',
+      displayName: 'Podman Machine Default',
+      status: 'started',
+      type: 'podman',
+    },
+  ],
+} as unknown as ProviderInfo;
+
+const COMPOSE_PROVIDER: ProviderInfo = {
+  id: 'compose',
+  name: 'compose',
+  kubernetesConnections: [],
+  containerConnections: [],
+} as unknown as ProviderInfo;
+
+const CONFIGURATION_MOCK: Configuration = {
+  get: vi.fn(),
+  update: vi.fn(),
+} as unknown as Configuration;
+
+function getPinRegistry(): PinRegistry {
+  return new PinRegistry(COMMAND_REGISTRY_MOCK, API_SENDER_MOCK, CONFIGURATION_REGISTRY_MOCK, PROVIDER_REGISTRY_MOCK);
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(PROVIDER_REGISTRY_MOCK.getProviderInfos).mockReturnValue([
+    PODMAN_PROVIDER,
+    KIND_ONE_CLUSTER_PROVIDER,
+    COMPOSE_PROVIDER,
+  ]);
+  vi.mocked(CONFIGURATION_REGISTRY_MOCK.getConfiguration).mockReturnValue(CONFIGURATION_MOCK);
+});
+
+describe('getOptions', () => {
+  test('getOptions should filter ProviderRegistry#getProviderInfos result', () => {
+    const pinRegistry = getPinRegistry();
+    const options = pinRegistry.getOptions();
+
+    expect(options).toHaveLength(2);
+    // podman provider should be listed and pinned by default
+
+    expect(options).toEqual(
+      expect.arrayContaining([
+        {
+          value: PODMAN_PROVIDER.id,
+          label: PODMAN_PROVIDER.name,
+          pinned: true,
+        },
+        {
+          value: KIND_ONE_CLUSTER_PROVIDER.id,
+          label: KIND_ONE_CLUSTER_PROVIDER.name,
+          pinned: false,
+        },
+      ]),
+    );
+  });
+
+  test('empty providers should not be listed as options', () => {
+    // mock single provider without any connections
+    vi.mocked(PROVIDER_REGISTRY_MOCK.getProviderInfos).mockReturnValue([KIND_EMPTY_CLUSTER_PROVIDER]);
+
+    const pinRegistry = getPinRegistry();
+    const options = pinRegistry.getOptions();
+
+    expect(options).toHaveLength(0);
+  });
+});
+
+describe('init', () => {
+  test('init should register command', () => {
+    const pinRegistry = getPinRegistry();
+    pinRegistry.init();
+
+    expect(COMMAND_REGISTRY_MOCK.registerCommand).toHaveBeenCalledWith(
+      STATUS_BAR_PIN_CONSTANTS.TOGGLE_MENU_COMMAND,
+      expect.any(Function),
+    );
+  });
+
+  test('init should register configuration', () => {
+    const pinRegistry = getPinRegistry();
+    pinRegistry.init();
+
+    expect(CONFIGURATION_REGISTRY_MOCK.registerConfigurations).toHaveBeenCalledWith([
+      expect.objectContaining({
+        id: STATUS_BAR_PIN_CONSTANTS.STATUS_BAR_CONFIGURATION,
+      }),
+    ]);
+  });
+
+  test('empty configuration should use default (podman)', () => {
+    const pinRegistry = getPinRegistry();
+    pinRegistry.init();
+
+    expect(pinRegistry.getOptions()).toContainEqual({
+      value: PODMAN_PROVIDER.id,
+      label: PODMAN_PROVIDER.name,
+      pinned: true,
+    });
+  });
+
+  test('configuration value should be used if exists', () => {
+    // mock kind as pinned from configuration
+    vi.mocked(CONFIGURATION_MOCK.get).mockReturnValue([KIND_ONE_CLUSTER_PROVIDER.id]);
+
+    const pinRegistry = getPinRegistry();
+    pinRegistry.init();
+
+    expect(pinRegistry.getOptions()).toEqual(
+      expect.arrayContaining([
+        {
+          value: PODMAN_PROVIDER.id,
+          label: PODMAN_PROVIDER.name,
+          pinned: false, // false
+        },
+        {
+          value: KIND_ONE_CLUSTER_PROVIDER.id,
+          label: KIND_ONE_CLUSTER_PROVIDER.name,
+          pinned: true, // true as we defined in the configuration
+        },
+      ]),
+    );
+  });
+});
+
+describe('pin / unpin', () => {
+  let pinRegistry: PinRegistry;
+  beforeEach(() => {
+    // init
+    pinRegistry = getPinRegistry();
+    pinRegistry.init();
+  });
+
+  test('pin should save and notify', async () => {
+    pinRegistry.pin(KIND_ONE_CLUSTER_PROVIDER.id);
+
+    // 1. first we should update the configuration
+    expect(CONFIGURATION_MOCK.update).toHaveBeenCalledWith(
+      STATUS_BAR_PIN_CONSTANTS.PINNED_CONFIGURATION_PROPERTY,
+      expect.arrayContaining([PODMAN_PROVIDER.id, KIND_ONE_CLUSTER_PROVIDER.id]),
+    );
+
+    // 2. api sender should have been notified
+    await vi.waitFor(() => {
+      expect(API_SENDER_MOCK.send).toHaveBeenCalledWith(
+        STATUS_BAR_PIN_CONSTANTS.PIN_OPTIONS_UPDATE,
+        expect.arrayContaining([
+          {
+            value: KIND_ONE_CLUSTER_PROVIDER.id,
+            label: KIND_ONE_CLUSTER_PROVIDER.name,
+            pinned: true, // now true
+          },
+        ]),
+      );
+    });
+  });
+
+  test('unpin should save and notify', async () => {
+    pinRegistry.unpin(PODMAN_PROVIDER.id);
+
+    // 1. first we should update the configuration
+    expect(CONFIGURATION_MOCK.update).toHaveBeenCalledWith(STATUS_BAR_PIN_CONSTANTS.PINNED_CONFIGURATION_PROPERTY, []);
+
+    // 2. api sender should have been notified
+    await vi.waitFor(() => {
+      expect(API_SENDER_MOCK.send).toHaveBeenCalledWith(
+        STATUS_BAR_PIN_CONSTANTS.PIN_OPTIONS_UPDATE,
+        expect.arrayContaining([
+          {
+            value: PODMAN_PROVIDER.id,
+            label: PODMAN_PROVIDER.name,
+            pinned: false,
+          },
+        ]),
+      );
+    });
+  });
+});
+
+describe('provider update', () => {
+  function getListeners(): {
+    containerConnectionUpdateListener: (e: UpdateContainerConnectionEvent) => void;
+    kubernetesConnectionUpdateListener: (e: UpdateKubernetesConnectionEvent) => void;
+  } {
+    // init
+    const pinRegistry = getPinRegistry();
+    pinRegistry.init();
+
+    expect(PROVIDER_REGISTRY_MOCK.onDidUpdateContainerConnection).toHaveBeenCalledOnce();
+    expect(PROVIDER_REGISTRY_MOCK.onDidUpdateKubernetesConnection).toHaveBeenCalledOnce();
+
+    const containerConnectionUpdateListener = vi.mocked(PROVIDER_REGISTRY_MOCK.onDidUpdateContainerConnection).mock
+      .calls[0]?.[0];
+    if (!containerConnectionUpdateListener)
+      throw new Error('onDidUpdateContainerConnection mock has not been called properly');
+
+    const kubernetesConnectionUpdateListener = vi.mocked(PROVIDER_REGISTRY_MOCK.onDidUpdateKubernetesConnection).mock
+      .calls[0]?.[0];
+    if (!kubernetesConnectionUpdateListener)
+      throw new Error('onDidUpdateKubernetesConnection mock has not been called properly');
+
+    return {
+      containerConnectionUpdateListener,
+      kubernetesConnectionUpdateListener,
+    };
+  }
+
+  test('container connection update should call notify', async () => {
+    const { containerConnectionUpdateListener } = getListeners();
+
+    // ensure call count is zero
+    vi.mocked(API_SENDER_MOCK.send).mockReset();
+    expect(API_SENDER_MOCK.send).not.toHaveBeenCalled();
+
+    // simulate event
+    containerConnectionUpdateListener({
+      status: 'started',
+      providerId: 'podman',
+      connection: {},
+    } as unknown as UpdateContainerConnectionEvent);
+
+    await vi.waitFor(() => {
+      expect(API_SENDER_MOCK.send).toHaveBeenCalledWith(STATUS_BAR_PIN_CONSTANTS.PIN_OPTIONS_UPDATE, expect.any(Array));
+    });
+  });
+
+  test('kubernetes connection update should call notify', async () => {
+    const { kubernetesConnectionUpdateListener } = getListeners();
+
+    // ensure call count is zero
+    vi.mocked(API_SENDER_MOCK.send).mockReset();
+    expect(API_SENDER_MOCK.send).not.toHaveBeenCalled();
+
+    // simulate event
+    kubernetesConnectionUpdateListener({
+      status: 'started',
+      providerId: 'kind',
+      connection: {},
+    } as unknown as UpdateKubernetesConnectionEvent);
+
+    await vi.waitFor(() => {
+      expect(API_SENDER_MOCK.send).toHaveBeenCalledWith(STATUS_BAR_PIN_CONSTANTS.PIN_OPTIONS_UPDATE, expect.any(Array));
+    });
+  });
+});

--- a/packages/main/src/plugin/statusbar/pin-registry.ts
+++ b/packages/main/src/plugin/statusbar/pin-registry.ts
@@ -1,0 +1,142 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type containerDesktopAPI from '@podman-desktop/api';
+
+import type { ApiSenderType } from '/@/plugin/api.js';
+import type { CommandRegistry } from '/@/plugin/command-registry.js';
+import type { ConfigurationRegistry } from '/@/plugin/configuration-registry.js';
+import type { ProviderRegistry } from '/@/plugin/provider-registry.js';
+import type { StatusBarRegistry } from '/@/plugin/statusbar/statusbar-registry.js';
+import type { IDisposable } from '/@/plugin/types/disposable.js';
+import { Disposable } from '/@/plugin/types/disposable.js';
+import { STATUS_BAR_PIN_CONSTANTS } from '/@api/status-bar/pin-constants.js';
+import type { PinOption } from '/@api/status-bar/pin-option.js';
+
+export const STATUSBAR_PIN_ID = 'pin';
+
+export class PinRegistry implements IDisposable {
+  #disposables: IDisposable[] = [];
+  #pinned: Set<string> = new Set(['podman']);
+  #configuration: containerDesktopAPI.Configuration | undefined;
+
+  constructor(
+    private statusBarRegistry: StatusBarRegistry,
+    private commandRegistry: CommandRegistry,
+    private apiSender: ApiSenderType,
+    private configurationRegistry: ConfigurationRegistry,
+    private providers: ProviderRegistry,
+  ) {}
+
+  dispose(): void {
+    this.#disposables.forEach(disposable => disposable.dispose());
+    this.#disposables = [];
+    this.#pinned.clear();
+  }
+
+  private notify(): void {
+    this.apiSender.send(STATUS_BAR_PIN_CONSTANTS.PIN_OPTIONS_UPDATE, this.getOptions());
+  }
+
+  public pin(optionId: string): void {
+    this.#pinned.add(optionId);
+    this.notify();
+    // save async
+    this.save().catch(console.error);
+  }
+
+  public unpin(optionId: string): void {
+    this.#pinned.delete(optionId);
+    this.notify();
+    // save async
+    this.save().catch(console.error);
+  }
+
+  public getOptions(): Array<PinOption> {
+    return this.providers.getProviderInfos().map(provider => ({
+      value: provider.id,
+      label: provider.name,
+      pinned: this.#pinned.has(provider.id),
+    }));
+  }
+
+  private async save(): Promise<void> {
+    if (!this.#configuration) throw new Error('missing configuration object: cannot save');
+
+    await this.#configuration.update(
+      STATUS_BAR_PIN_CONSTANTS.PINNED_CONFIGURATION_PROPERTY,
+      Array.from(this.#pinned.values()),
+    );
+  }
+
+  init(): void {
+    // register pin entry
+    this.statusBarRegistry.setEntry(
+      STATUSBAR_PIN_ID,
+      true,
+      Number.MAX_VALUE,
+      undefined,
+      'Pin',
+      'fa fa-thumbtack',
+      true,
+      STATUS_BAR_PIN_CONSTANTS.TOGGLE_MENU_COMMAND,
+    );
+    this.#disposables.push(
+      Disposable.create(() => {
+        this.statusBarRegistry.removeEntry(STATUSBAR_PIN_ID);
+      }),
+    );
+
+    // register toggle menu command
+    this.#disposables.push(
+      this.commandRegistry.registerCommand(STATUS_BAR_PIN_CONSTANTS.TOGGLE_MENU_COMMAND, () => {
+        this.apiSender.send(STATUS_BAR_PIN_CONSTANTS.TOGGLE_MENU);
+      }),
+    );
+
+    // register configuration for persistence
+    this.#disposables.push(
+      this.configurationRegistry.registerConfigurations([
+        {
+          id: STATUS_BAR_PIN_CONSTANTS.STATUS_BAR_CONFIGURATION,
+          title: 'Status Bar Pin',
+          type: 'object',
+          properties: {
+            [STATUS_BAR_PIN_CONSTANTS.PINNED_CONFIGURATION_PROPERTY]: {
+              description: 'pinned items in the status bar',
+              type: ['string'],
+              hidden: true,
+              default: ['podman'],
+            },
+          },
+        },
+      ]),
+    );
+
+    this.#configuration = this.configurationRegistry.getConfiguration(
+      STATUS_BAR_PIN_CONSTANTS.STATUS_BAR_CONFIGURATION,
+    );
+    const options = this.#configuration.get<Array<string>>(STATUS_BAR_PIN_CONSTANTS.PINNED_CONFIGURATION_PROPERTY);
+    if (options) {
+      this.#pinned = new Set<string>(options);
+      this.notify();
+    }
+
+    // notify if container connection changed
+    this.#disposables.push(this.providers.onDidUpdateContainerConnection(this.notify.bind(this)));
+  }
+}

--- a/packages/main/src/plugin/statusbar/pin-registry.ts
+++ b/packages/main/src/plugin/statusbar/pin-registry.ts
@@ -25,8 +25,12 @@ import type { IDisposable } from '/@/plugin/types/disposable.js';
 import { STATUS_BAR_PIN_CONSTANTS } from '/@api/status-bar/pin-constants.js';
 import type { PinOption } from '/@api/status-bar/pin-option.js';
 
+/**
+ * The {@link PinRegistry} hold the pinned options on the providers part of the status bar.
+ */
 export class PinRegistry implements IDisposable {
   #disposables: IDisposable[] = [];
+  // default to podman
   #pinned: Set<string> = new Set(['podman']);
   #configuration: containerDesktopAPI.Configuration | undefined;
 
@@ -117,7 +121,8 @@ export class PinRegistry implements IDisposable {
       this.notify();
     }
 
-    // notify if container connection changed
+    // notify if container connection / kubernetes connection changed
     this.#disposables.push(this.providers.onDidUpdateContainerConnection(this.notify.bind(this)));
+    this.#disposables.push(this.providers.onDidUpdateKubernetesConnection(this.notify.bind(this)));
   }
 }

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -90,6 +90,7 @@ import type {
 import type { ProxyState } from '/@api/proxy';
 import type { PullEvent } from '/@api/pull-event';
 import type { ReleaseNotesInfo } from '/@api/release-notes-info';
+import type { PinOption } from '/@api/status-bar/pin-option';
 import type { ViewInfoUI } from '/@api/view-info';
 import type { VolumeInspectInfo, VolumeListInfo } from '/@api/volume-info';
 import type { WebviewInfo } from '/@api/webview-info';
@@ -208,6 +209,18 @@ export function initExposure(): void {
   // Handle protocol to install extensions by delegating to the renderer process
   ipcRenderer.on('podman-desktop-protocol:install-extension', (_, extensionId: string) => {
     apiSender.send('install-extension:from-id', extensionId);
+  });
+
+  contextBridge.exposeInMainWorld('getStatusBarPinOptions', async (): Promise<Array<PinOption>> => {
+    return ipcInvoke('statusbar:pin:get-options');
+  });
+
+  contextBridge.exposeInMainWorld('pinStatusBar', async (optionId: string): Promise<Array<PinOption>> => {
+    return ipcInvoke('statusbar:pin', optionId);
+  });
+
+  contextBridge.exposeInMainWorld('unpinStatusBar', async (optionId: string): Promise<Array<PinOption>> => {
+    return ipcInvoke('statusbar:unpin', optionId);
   });
 
   contextBridge.exposeInMainWorld('clearTasks', async (): Promise<void> => {

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -215,11 +215,11 @@ export function initExposure(): void {
     return ipcInvoke('statusbar:pin:get-options');
   });
 
-  contextBridge.exposeInMainWorld('pinStatusBar', async (optionId: string): Promise<Array<PinOption>> => {
+  contextBridge.exposeInMainWorld('pinStatusBar', async (optionId: string): Promise<void> => {
     return ipcInvoke('statusbar:pin', optionId);
   });
 
-  contextBridge.exposeInMainWorld('unpinStatusBar', async (optionId: string): Promise<Array<PinOption>> => {
+  contextBridge.exposeInMainWorld('unpinStatusBar', async (optionId: string): Promise<void> => {
     return ipcInvoke('statusbar:unpin', optionId);
   });
 

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -4,6 +4,7 @@ import '@fortawesome/fontawesome-free/css/all.min.css';
 
 import { router } from 'tinro';
 
+import PinActions from '/@/lib/statusbar/PinActions.svelte';
 import { handleNavigation } from '/@/navigation';
 import { NO_CURRENT_CONTEXT_ERROR } from '/@api/kubernetes-contexts-states';
 import type { NavigationRequest } from '/@api/navigation-request';
@@ -372,6 +373,7 @@ window.events?.receive('navigate', (navigationRequest: unknown) => {
       </div>
     </div>
     <HelpActions/>
+    <PinActions/>
     <StatusBar />
   </main>
 </Route>

--- a/packages/renderer/src/lib/help/HelpMenu.svelte
+++ b/packages/renderer/src/lib/help/HelpMenu.svelte
@@ -5,7 +5,7 @@ let dropDownHeight: number;
 let dropDownWidth: number;
 let dropDownElement: HTMLElement;
 
-const STATUS_BAR_HEIGHT = 24;
+const STATUS_BAR_HEIGHT = 26;
 
 function updateMenuLocation(): void {
   dropDownElement.style.top = `${window.innerHeight - dropDownHeight - STATUS_BAR_HEIGHT}px`;
@@ -20,7 +20,7 @@ onMount(() => {
 onDestroy(() => window.removeEventListener('resize', updateMenuLocation));
 </script>
 
-<div 
+<div
   bind:offsetHeight={dropDownHeight}
   bind:offsetWidth={dropDownWidth}
   bind:this={dropDownElement}

--- a/packages/renderer/src/lib/statusbar/PinActions.spec.ts
+++ b/packages/renderer/src/lib/statusbar/PinActions.spec.ts
@@ -1,0 +1,210 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, type RenderResult } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import type { Component, ComponentProps } from 'svelte';
+import { get } from 'svelte/store';
+import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import PinActions from '/@/lib/statusbar/PinActions.svelte';
+import ProviderWidget from '/@/lib/statusbar/ProviderWidget.svelte';
+import { providerInfos } from '/@/stores/providers';
+import { statusBarPinned } from '/@/stores/statusbar-pinned';
+import type { ProviderInfo } from '/@api/provider-info';
+import { STATUS_BAR_PIN_CONSTANTS } from '/@api/status-bar/pin-constants';
+
+vi.mock('/@/lib/statusbar/ProviderWidget.svelte');
+
+const CONTAINER_CONNECTION_PROVIDER = {
+  name: 'podman',
+  id: 'podman',
+  containerConnections: [{}],
+  kubernetesConnections: [],
+  status: 'ready',
+  images: {},
+} as unknown as ProviderInfo;
+
+const KUBERNETES_CONNECTION_PROVIDER = {
+  name: 'kind',
+  id: 'kind',
+  containerConnections: [],
+  kubernetesConnections: [{}],
+  status: 'ready',
+  images: {},
+} as unknown as ProviderInfo;
+
+const RESIZE_OBSERVER_MOCK: ResizeObserver = {
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+} as unknown as ResizeObserver;
+
+beforeAll(() => {
+  Object.defineProperty(window, 'events', { value: { receive: vi.fn() } });
+  Object.defineProperty(window, 'ResizeObserver', { value: vi.fn() });
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  // define two providers
+  providerInfos.set([CONTAINER_CONNECTION_PROVIDER, KUBERNETES_CONNECTION_PROVIDER]);
+
+  // pin podman
+  statusBarPinned.set([
+    {
+      label: CONTAINER_CONNECTION_PROVIDER.name,
+      value: CONTAINER_CONNECTION_PROVIDER.id,
+      pinned: true,
+    },
+  ]);
+
+  vi.mocked(window.ResizeObserver).mockReturnValue(RESIZE_OBSERVER_MOCK);
+
+  vi.mocked(window.unpinStatusBar).mockResolvedValue(undefined);
+  vi.mocked(window.pinStatusBar).mockResolvedValue(undefined);
+});
+
+function getListener(): () => void {
+  expect(window.events.receive).toHaveBeenCalledOnce();
+  const [channel, listener] = vi.mocked(window.events.receive).mock.calls[0];
+
+  expect(channel).toStrictEqual(STATUS_BAR_PIN_CONSTANTS.TOGGLE_MENU);
+  expect(listener).toBeInstanceOf(Function);
+
+  return listener;
+}
+
+test('should register windows#events#receive', async () => {
+  render(PinActions);
+
+  const listener = getListener();
+  expect(listener).toBeDefined();
+});
+
+/**
+ * utility function to directly get the render result with the menu opened (default is hidden/closed)
+ */
+async function getOpenedPinActions(): Promise<RenderResult<Component<ComponentProps<typeof PinActions>>>> {
+  const { getByTitle, ...result } = render(PinActions);
+
+  // call toggle listener (will open the menu)
+  const listener = getListener();
+  listener();
+
+  // wait for the menu to be open
+  await vi.waitFor(() => {
+    const element = getByTitle('Help Menu Items');
+    expect(element).toBeInTheDocument();
+  });
+
+  return {
+    getByTitle,
+    ...result,
+  };
+}
+
+test('opened menu should render provider based on pin options', async () => {
+  // ensure we only have one item in the store
+  expect(get(statusBarPinned)).toHaveLength(1);
+
+  // render
+  await getOpenedPinActions();
+
+  // ensure we only rendered one item
+  expect(ProviderWidget).toHaveBeenCalledOnce();
+  expect(ProviderWidget).toHaveBeenCalledWith(expect.anything(), {
+    class: 'w-full',
+    pinIcon: 'pin',
+    entry: CONTAINER_CONNECTION_PROVIDER,
+    command: expect.any(Function),
+  });
+});
+
+test('escape should hide the menu', async () => {
+  // render
+  const { queryByTitle } = await getOpenedPinActions();
+
+  await userEvent.keyboard('{Escape}');
+
+  await vi.waitFor(() => {
+    expect(queryByTitle('Help Menu Items')).toBeNull();
+  });
+});
+
+describe('pin / unpin', () => {
+  /**
+   * Utility method to get the function provided as props#command to the {@link ProviderWidget}
+   * @param providerId
+   */
+  function getProviderWidget(providerId: string): () => void {
+    const call: [unknown, ComponentProps<typeof ProviderWidget>] | undefined = vi
+      .mocked(ProviderWidget)
+      .mock.calls.find(([_, { entry }]) => entry.id === providerId);
+    // throw if we cannot found the specific call we are looking for
+    if (!call) throw new Error(`cannot find ProviderWidget call for providerId ${providerId}`);
+    // deconstruct the props
+    const [, { command }] = call;
+
+    // throw if command is undefined
+    if (!command) throw new Error(`missing command props on ProviderWidget render for providerId ${providerId}`);
+    return command;
+  }
+
+  beforeEach(() => {
+    // pin podman
+    statusBarPinned.set([
+      {
+        label: CONTAINER_CONNECTION_PROVIDER.name,
+        value: CONTAINER_CONNECTION_PROVIDER.id,
+        pinned: true, // podman pinned
+      },
+      {
+        label: KUBERNETES_CONNECTION_PROVIDER.name,
+        value: KUBERNETES_CONNECTION_PROVIDER.id,
+        pinned: false, // kubernetes not pinned
+      },
+    ]);
+  });
+
+  test('expect pinned provider to have unpin command', async () => {
+    // render
+    await getOpenedPinActions();
+
+    // get the command
+    const command = getProviderWidget(CONTAINER_CONNECTION_PROVIDER.id);
+    // call the command
+    command();
+
+    expect(window.unpinStatusBar).toHaveBeenCalledWith(CONTAINER_CONNECTION_PROVIDER.id);
+  });
+
+  test('expect unpinned provider to have pin command', async () => {
+    // render
+    await getOpenedPinActions();
+
+    // get the command
+    const command = getProviderWidget(KUBERNETES_CONNECTION_PROVIDER.id);
+    // call the command
+    command();
+
+    expect(window.pinStatusBar).toHaveBeenCalledWith(KUBERNETES_CONNECTION_PROVIDER.id);
+  });
+});

--- a/packages/renderer/src/lib/statusbar/PinActions.spec.ts
+++ b/packages/renderer/src/lib/statusbar/PinActions.spec.ts
@@ -131,7 +131,7 @@ test('opened menu should render provider based on pin options', async () => {
   // ensure we only rendered one item
   expect(ProviderWidget).toHaveBeenCalledOnce();
   expect(ProviderWidget).toHaveBeenCalledWith(expect.anything(), {
-    class: 'w-full',
+    class: expect.any(String),
     pinIcon: 'pin',
     entry: CONTAINER_CONNECTION_PROVIDER,
     command: expect.any(Function),

--- a/packages/renderer/src/lib/statusbar/PinActions.svelte
+++ b/packages/renderer/src/lib/statusbar/PinActions.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+import { faThumbtack, faThumbtackSlash } from '@fortawesome/free-solid-svg-icons';
+import { DropdownMenu } from '@podman-desktop/ui-svelte';
+
+import { statusBarPinned } from '/@/stores/statusbar-pinned';
+import { STATUS_BAR_PIN_CONSTANTS } from '/@api/status-bar/pin-constants';
+import type { PinOption } from '/@api/status-bar/pin-option';
+
+import PinMenu from './PinMenu.svelte';
+
+let showMenu: boolean = $state(false);
+let outsideWindow: HTMLDivElement;
+window.events?.receive(STATUS_BAR_PIN_CONSTANTS.TOGGLE_MENU, toggleMenu);
+
+function toggleMenu(): void {
+  showMenu = !showMenu;
+}
+
+function handleEscape({ key }: KeyboardEvent): void {
+  if (key === 'Escape') {
+    showMenu = false;
+  }
+}
+
+function onWindowClick(e: Event): void {
+  const target = e.target as HTMLElement;
+  // Listen to anything **but** the button that has "data-task-button" attribute with a value of "Help"
+  if (target && target.getAttribute('data-task-button') !== 'Pin') {
+    showMenu = outsideWindow.contains(target);
+  }
+}
+
+function onItemClick(option: PinOption): void {
+  console.log('onClick', option);
+  if (option.pinned) {
+    window.unpinStatusBar($state.snapshot(option.value)).catch(console.error);
+  } else {
+    window.pinStatusBar($state.snapshot(option.value)).catch(console.error);
+  }
+}
+</script>
+
+<svelte:window on:keyup={handleEscape} on:click={onWindowClick}/>
+
+<div bind:this={outsideWindow}>
+  {#if showMenu}
+    <PinMenu>
+      {#each $statusBarPinned as option }
+        <DropdownMenu.Item
+          title={option.label}
+          tooltip={option.label}
+          enabled={true}
+          icon={option.pinned?faThumbtack:faThumbtackSlash}
+          onClick={onItemClick.bind(undefined, option)}
+        />
+      {/each}
+    </PinMenu>
+  {/if}
+</div>

--- a/packages/renderer/src/lib/statusbar/PinActions.svelte
+++ b/packages/renderer/src/lib/statusbar/PinActions.svelte
@@ -35,7 +35,6 @@ function onWindowClick(e: Event): void {
   const target = e.target as HTMLElement;
   // Listen to anything **but** the button that has "data-task-button" attribute with a value of "Help"
   if (target && target.getAttribute('data-task-button') !== 'Pin') {
-    console.log('clicked on', target);
     showMenu = outsideWindow.contains(target);
   }
 }

--- a/packages/renderer/src/lib/statusbar/PinActions.svelte
+++ b/packages/renderer/src/lib/statusbar/PinActions.svelte
@@ -56,7 +56,7 @@ function pin(providerId: string): void {
     <PinMenu>
       {#each providers.entries() as [provider, pinned] }
         <ProviderWidget
-          class="w-full"
+          class="w-full text-[var(--pd-dropdown-item-text)] hover:rounded-md hover:!bg-[var(--pd-dropdown-item-hover-bg)] hover:text-[var(--pd-dropdown-item-hover-text)]"
           entry={provider}
           command={pinned?unpin.bind(undefined, provider.id):pin.bind(undefined, provider.id)}
           pinIcon={pinned?'pin':'unpin'}

--- a/packages/renderer/src/lib/statusbar/PinActions.svelte
+++ b/packages/renderer/src/lib/statusbar/PinActions.svelte
@@ -14,7 +14,11 @@ window.events?.receive(STATUS_BAR_PIN_CONSTANTS.TOGGLE_MENU, toggleMenu);
 let pinned: Set<string> = $derived(new Set($statusBarPinned.filter(pin => pin.pinned).map(pin => pin.value)));
 
 let providers: Map<ProviderInfo, boolean> = $derived(
-  new Map($providerInfos.map(provider => [provider, pinned.has(provider.id)])),
+  new Map(
+    $providerInfos
+      .filter(provider => provider.containerConnections.length > 0 || provider.kubernetesConnections.length > 0)
+      .map(provider => [provider, pinned.has(provider.id)]),
+  ),
 );
 
 function toggleMenu(): void {

--- a/packages/renderer/src/lib/statusbar/PinActions.svelte
+++ b/packages/renderer/src/lib/statusbar/PinActions.svelte
@@ -11,13 +11,13 @@ let showMenu: boolean = $state(false);
 let outsideWindow: HTMLDivElement;
 window.events?.receive(STATUS_BAR_PIN_CONSTANTS.TOGGLE_MENU, toggleMenu);
 
-let pinned: Set<string> = $derived(new Set($statusBarPinned.filter(pin => pin.pinned).map(pin => pin.value)));
+let pinned: Map<string, boolean> = $derived(new Map($statusBarPinned.map(pin => [pin.value, pin.pinned])));
 
 let providers: Map<ProviderInfo, boolean> = $derived(
   new Map(
     $providerInfos
-      .filter(provider => provider.containerConnections.length > 0 || provider.kubernetesConnections.length > 0)
-      .map(provider => [provider, pinned.has(provider.id)]),
+      .filter(provider => pinned.has(provider.id))
+      .map(provider => [provider, pinned.get(provider.id) ?? false]),
   ),
 );
 
@@ -57,7 +57,8 @@ function pin(providerId: string): void {
       {#each providers.entries() as [provider, pinned] }
         <ProviderWidget
           class="w-full"
-          entry={provider} command={pinned?unpin.bind(undefined, provider.id):pin.bind(undefined, provider.id)}
+          entry={provider}
+          command={pinned?unpin.bind(undefined, provider.id):pin.bind(undefined, provider.id)}
           pinIcon={pinned?'pin':'unpin'}
         />
       {/each}

--- a/packages/renderer/src/lib/statusbar/PinMenu.svelte
+++ b/packages/renderer/src/lib/statusbar/PinMenu.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+import { onDestroy, onMount } from 'svelte';
+
+let dropDownHeight: number;
+let dropDownElement: HTMLElement;
+
+const STATUS_BAR_HEIGHT = 26;
+
+function updateMenuLocation(): void {
+  dropDownElement.style.top = `${window.innerHeight - dropDownHeight - STATUS_BAR_HEIGHT}px`;
+  dropDownElement.style.left = '1px';
+}
+
+onMount(() => {
+  updateMenuLocation();
+  window.addEventListener('resize', updateMenuLocation);
+});
+
+onDestroy(() => window.removeEventListener('resize', updateMenuLocation));
+</script>
+
+<div
+  bind:offsetHeight={dropDownHeight}
+  bind:this={dropDownElement}
+  class="absolute z-10"
+  data-testid="help-menu">
+  <div
+    title="Help Menu Items"
+    class="z-10 m-1 rounded-md shadow-lg bg-[var(--pd-dropdown-bg)] ring-2 ring-[var(--pd-dropdown-ring)] hover:ring-[var(--pd-dropdown-hover-ring)] divide-y divide-[var(--pd-dropdown-divider)] focus:outline-hidden">
+    <slot />
+  </div>
+</div>

--- a/packages/renderer/src/lib/statusbar/ProviderWidget.spec.ts
+++ b/packages/renderer/src/lib/statusbar/ProviderWidget.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/renderer/src/lib/statusbar/ProviderWidget.spec.ts
+++ b/packages/renderer/src/lib/statusbar/ProviderWidget.spec.ts
@@ -21,7 +21,7 @@ import type { ProviderStatus } from '@podman-desktop/api';
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { router } from 'tinro';
-import { beforeEach, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type {
   ProviderContainerConnectionInfo,
@@ -95,4 +95,21 @@ test('Expect title to include Kubernetes provider connections', () => {
   render(ProviderWidget, { entry: providerMock });
 
   expect(screen.getByTitle('connection 1, connection 2')).toBeInTheDocument();
+});
+
+describe('pinIcon props', () => {
+  test('expect no icon by default', () => {
+    const { queryByTitle } = render(ProviderWidget, { entry: providerMock });
+    expect(queryByTitle('Pinned')).toBeNull();
+  });
+
+  test('expect no icon with unpin props', () => {
+    const { queryByTitle } = render(ProviderWidget, { entry: providerMock, pinIcon: 'unpin' });
+    expect(queryByTitle('Pinned')).toBeNull();
+  });
+
+  test('Expect pin icon to be displayed', () => {
+    const { getByTitle } = render(ProviderWidget, { entry: providerMock, pinIcon: 'pin' });
+    expect(getByTitle('Pinned')).toBeInTheDocument();
+  });
 });

--- a/packages/renderer/src/lib/statusbar/ProviderWidget.svelte
+++ b/packages/renderer/src/lib/statusbar/ProviderWidget.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+import { faCheck } from '@fortawesome/free-solid-svg-icons';
 import { Button } from '@podman-desktop/ui-svelte';
+import Fa from 'svelte-fa';
 import { router } from 'tinro';
 
 import type { ProviderInfo } from '/@api/provider-info';
@@ -10,9 +12,11 @@ import ProviderWidgetStatus from './ProviderWidgetStatus.svelte';
 interface Props {
   entry: ProviderInfo;
   command?: () => void;
+  class?: string;
+  pinIcon?: 'pin' | 'unpin';
 }
 
-let { entry, command = (): void => router.goto('/preferences/resources') }: Props = $props();
+let { entry, command = (): void => router.goto('/preferences/resources'), class: className, pinIcon }: Props = $props();
 
 let tooltipText = $derived.by(() => {
   let tooltip = '';
@@ -24,14 +28,21 @@ let tooltipText = $derived.by(() => {
   return tooltip;
 });
 </script>
-  
+
 <Button
   on:click={command}
-  class="rounded-none gap-1 flex h-full min-w-fit items-center hover:bg-[var(--pd-statusbar-hover-bg)] hover:cursor-pointer relative text-base text-[var(--pd-button-text)] bg-transparent"
+  class="rounded-none gap-1 flex h-full min-w-fit items-center hover:bg-[var(--pd-statusbar-hover-bg)] hover:cursor-pointer relative text-base text-[var(--pd-button-text)] bg-transparent {className}"
   title={tooltipText}
   aria-label={entry.name}
   padding="px-2 py-1">
-  
+  {#if pinIcon}
+    <div class="w-4">
+      {#if pinIcon === 'pin'}
+        <Fa icon={faCheck} />
+      {/if}
+    </div>
+  {/if}
+
   {#if entry.containerConnections.length > 0 || entry.kubernetesConnections.length > 0 || entry.status }
     <ProviderWidgetStatus entry={entry} />
   {/if}

--- a/packages/renderer/src/lib/statusbar/ProviderWidget.svelte
+++ b/packages/renderer/src/lib/statusbar/ProviderWidget.svelte
@@ -38,7 +38,7 @@ let tooltipText = $derived.by(() => {
   {#if pinIcon}
     <div class="w-4">
       {#if pinIcon === 'pin'}
-        <Fa icon={faCheck} />
+        <Fa icon={faCheck} title="Pinned" />
       {/if}
     </div>
   {/if}

--- a/packages/renderer/src/lib/statusbar/Providers.spec.ts
+++ b/packages/renderer/src/lib/statusbar/Providers.spec.ts
@@ -1,0 +1,88 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import '@testing-library/jest-dom/vitest';
+
+import { render } from '@testing-library/svelte';
+import { tick } from 'svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import Providers from '/@/lib/statusbar/Providers.svelte';
+import ProviderWidget from '/@/lib/statusbar/ProviderWidget.svelte';
+import { providerInfos } from '/@/stores/providers';
+import { statusBarPinned } from '/@/stores/statusbar-pinned';
+import type { ProviderInfo } from '/@api/provider-info';
+
+vi.mock('/@/lib/statusbar/ProviderWidget.svelte');
+
+const CONTAINER_CONNECTION_PROVIDER = {
+  name: 'provider1',
+  containerConnections: [{}],
+  kubernetesConnections: [],
+  status: 'ready',
+  images: {},
+} as unknown as ProviderInfo;
+
+const KUBERNETES_CONNECTION_PROVIDER = {
+  name: 'provider2',
+  containerConnections: [],
+  kubernetesConnections: [{}],
+  status: 'ready',
+  images: {},
+} as unknown as ProviderInfo;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  providerInfos.set([CONTAINER_CONNECTION_PROVIDER, KUBERNETES_CONNECTION_PROVIDER]);
+});
+
+test('no pinned options should hide the pin icon', async () => {
+  statusBarPinned.set([]);
+
+  const { queryByRole } = render(Providers);
+
+  const button = queryByRole('button', { name: 'Pin' });
+  expect(button).toBeNull();
+});
+
+test('no pinned options should not render any provider widget', async () => {
+  statusBarPinned.set([]);
+
+  render(Providers);
+
+  await tick();
+
+  expect(ProviderWidget).not.toHaveBeenCalled();
+});
+
+test('pinned option should render corresponding provider widget', async () => {
+  statusBarPinned.set([
+    {
+      label: CONTAINER_CONNECTION_PROVIDER.name,
+      value: CONTAINER_CONNECTION_PROVIDER.id,
+      pinned: true,
+    },
+  ]);
+
+  render(Providers);
+
+  await vi.waitFor(() => {
+    expect(ProviderWidget).toHaveBeenCalledWith(expect.anything(), {
+      entry: CONTAINER_CONNECTION_PROVIDER,
+    });
+  });
+});

--- a/packages/renderer/src/lib/statusbar/Providers.svelte
+++ b/packages/renderer/src/lib/statusbar/Providers.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+import ProviderWidget from '/@/lib/statusbar/ProviderWidget.svelte';
+import { providerInfos } from '/@/stores/providers';
+import { statusBarPinned } from '/@/stores/statusbar-pinned';
+import type { ProviderInfo } from '/@api/provider-info';
+import { STATUS_BAR_PIN_CONSTANTS } from '/@api/status-bar/pin-constants';
+
+let pinned: Set<string> = $derived(
+  new Set($statusBarPinned.filter(option => option.pinned).map(option => option.value)),
+);
+
+let containerProviders: ProviderInfo[] = $derived(
+  $providerInfos.filter(provider => provider.containerConnections.length > 0 && pinned.has(provider.id)),
+);
+
+let kubernetesProviders = $derived(
+  $providerInfos.filter(provider => provider.kubernetesConnections.length > 0 && pinned.has(provider.id)),
+);
+
+function onclick(): void {
+  console.log('onclick provider pin (executing TOGGLE_MENU_COMMAND)');
+  window.executeCommand(STATUS_BAR_PIN_CONSTANTS.TOGGLE_MENU_COMMAND).catch(console.error);
+}
+</script>
+
+{#if pinned.size > 0}
+  <!-- We cannot use <Fa> object here, as we detect click on this button and outside to toggle the menu -->
+  <button
+    data-task-button="Pin"
+    onclick={onclick}
+    class="px-1 py-px flex h-full items-center relative hover:bg-[var(--pd-statusbar-hover-bg)] hover:cursor-pointer z-1 fa-solid fa-thumbtack"
+    title="Pin"
+    aria-label="Pin">
+  </button>
+{/if}
+
+{#each containerProviders as entry}
+  <ProviderWidget entry={entry}/>
+{/each}
+{#each kubernetesProviders as entry}
+  <ProviderWidget entry={entry}/>
+{/each}

--- a/packages/renderer/src/lib/statusbar/Providers.svelte
+++ b/packages/renderer/src/lib/statusbar/Providers.svelte
@@ -9,16 +9,9 @@ let pinned: Set<string> = $derived(
   new Set($statusBarPinned.filter(option => option.pinned).map(option => option.value)),
 );
 
-let containerProviders: ProviderInfo[] = $derived(
-  $providerInfos.filter(provider => provider.containerConnections.length > 0 && pinned.has(provider.id)),
-);
-
-let kubernetesProviders = $derived(
-  $providerInfos.filter(provider => provider.kubernetesConnections.length > 0 && pinned.has(provider.id)),
-);
+let providers: ProviderInfo[] = $derived($providerInfos.filter(provider => pinned.has(provider.id)));
 
 function onclick(): void {
-  console.log('onclick provider pin (executing TOGGLE_MENU_COMMAND)');
   window.executeCommand(STATUS_BAR_PIN_CONSTANTS.TOGGLE_MENU_COMMAND).catch(console.error);
 }
 </script>
@@ -34,9 +27,6 @@ function onclick(): void {
   </button>
 {/if}
 
-{#each containerProviders as entry}
-  <ProviderWidget entry={entry}/>
-{/each}
-{#each kubernetesProviders as entry}
+{#each providers as entry}
   <ProviderWidget entry={entry}/>
 {/each}

--- a/packages/renderer/src/lib/statusbar/Providers.svelte
+++ b/packages/renderer/src/lib/statusbar/Providers.svelte
@@ -23,7 +23,7 @@ function onclick(): void {
 }
 </script>
 
-{#if pinned.size > 0}
+{#if $statusBarPinned.length > 0}
   <!-- We cannot use <Fa> object here, as we detect click on this button and outside to toggle the menu -->
   <button
     data-task-button="Pin"

--- a/packages/renderer/src/lib/statusbar/StatusBar.svelte
+++ b/packages/renderer/src/lib/statusbar/StatusBar.svelte
@@ -1,32 +1,17 @@
 <script lang="ts">
 import { onDestroy, onMount } from 'svelte';
 
+import Providers from '/@/lib/statusbar/Providers.svelte';
 import TaskIndicator from '/@/lib/statusbar/TaskIndicator.svelte';
 import { onDidChangeConfiguration } from '/@/stores/configurationProperties';
-import { providerInfos } from '/@/stores/providers';
 import { statusBarEntries } from '/@/stores/statusbar';
-import { statusBarPinned } from '/@/stores/statusbar-pinned';
-import type { ProviderInfo } from '/@api/provider-info';
 import { ExperimentalTasksSettings } from '/@api/tasks-preferences';
 
 import type { StatusBarEntry } from '../../../../main/src/plugin/statusbar/statusbar-registry';
-import ProviderWidget from './ProviderWidget.svelte';
 import StatusBarItem from './StatusBarItem.svelte';
 
 let leftEntries: StatusBarEntry[] = $state([]);
 let rightEntries: StatusBarEntry[] = $state([]);
-
-let pinned: Set<string> = $derived(
-  new Set($statusBarPinned.filter(option => option.pinned).map(option => option.value)),
-);
-
-let containerProviders: ProviderInfo[] = $derived(
-  $providerInfos.filter(provider => provider.containerConnections.length > 0 && pinned.has(provider.id)),
-);
-
-let kubernetesProviders = $derived(
-  $providerInfos.filter(provider => provider.kubernetesConnections.length > 0 && pinned.has(provider.id)),
-);
 
 let experimentalTaskStatusBar: boolean = $state(false);
 let experimentalProvidersStatusBar: boolean = $state(false);
@@ -97,21 +82,16 @@ onDestroy(() => {
 </script>
 
 <div
-  class="flex justify-between px-1 bg-[var(--pd-statusbar-bg)] text-[var(--pd-statusbar-text)] text-sm space-x-2 z-40"
+  class="flex justify-between px-1 bg-[var(--pd-statusbar-bg)] min-h-[26px] text-[var(--pd-statusbar-text)] text-sm space-x-2 z-40"
   role="contentinfo"
   aria-label="Status Bar">
   <div class="flex flex-nowrap gap-x-1.5 h-full truncate">
+    {#if experimentalProvidersStatusBar}
+      <Providers/>
+    {/if}
     {#each leftEntries as entry}
       <StatusBarItem entry={entry} />
     {/each}
-    {#if experimentalProvidersStatusBar}
-      {#each containerProviders as entry}
-        <ProviderWidget entry={entry}/>
-      {/each}
-      {#each kubernetesProviders as entry}
-        <ProviderWidget entry={entry}/>
-      {/each}
-    {/if}
   </div>
   <div class="flex flex-wrap flex-row-reverse gap-x-1.5 h-full place-self-end">
     {#each rightEntries as entry}

--- a/packages/renderer/src/lib/statusbar/StatusBar.svelte
+++ b/packages/renderer/src/lib/statusbar/StatusBar.svelte
@@ -5,6 +5,8 @@ import TaskIndicator from '/@/lib/statusbar/TaskIndicator.svelte';
 import { onDidChangeConfiguration } from '/@/stores/configurationProperties';
 import { providerInfos } from '/@/stores/providers';
 import { statusBarEntries } from '/@/stores/statusbar';
+import { statusBarPinned } from '/@/stores/statusbar-pinned';
+import type { ProviderInfo } from '/@api/provider-info';
 import { ExperimentalTasksSettings } from '/@api/tasks-preferences';
 
 import type { StatusBarEntry } from '../../../../main/src/plugin/statusbar/statusbar-registry';
@@ -14,9 +16,17 @@ import StatusBarItem from './StatusBarItem.svelte';
 let leftEntries: StatusBarEntry[] = $state([]);
 let rightEntries: StatusBarEntry[] = $state([]);
 
-let containerProviders = $derived($providerInfos.filter(provider => provider.containerConnections.length > 0));
+let pinned: Set<string> = $derived(
+  new Set($statusBarPinned.filter(option => option.pinned).map(option => option.value)),
+);
 
-let kubernetesProviders = $derived($providerInfos.filter(provider => provider.kubernetesConnections.length > 0));
+let containerProviders: ProviderInfo[] = $derived(
+  $providerInfos.filter(provider => provider.containerConnections.length > 0 && pinned.has(provider.id)),
+);
+
+let kubernetesProviders = $derived(
+  $providerInfos.filter(provider => provider.kubernetesConnections.length > 0 && pinned.has(provider.id)),
+);
 
 let experimentalTaskStatusBar: boolean = $state(false);
 let experimentalProvidersStatusBar: boolean = $state(false);

--- a/packages/renderer/src/stores/statusbar-pinned.ts
+++ b/packages/renderer/src/stores/statusbar-pinned.ts
@@ -1,0 +1,48 @@
+/**********************************************************************
+ * Copyright (C) 2022-2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { type Writable, writable } from 'svelte/store';
+
+import { STATUS_BAR_PIN_CONSTANTS } from '/@api/status-bar/pin-constants';
+import type { PinOption } from '/@api/status-bar/pin-option';
+
+import { EventStore } from './event-store';
+
+const windowEvents = [STATUS_BAR_PIN_CONSTANTS.PIN_OPTIONS_UPDATE];
+const windowListeners = ['system-ready'];
+
+export async function checkForUpdate(): Promise<boolean> {
+  return true;
+}
+
+export const statusBarPinned: Writable<Array<PinOption>> = writable([]);
+
+// use helper here as window methods are initialized after the store in tests
+const getStatusBarPinOptions = (): Promise<Array<PinOption>> => {
+  return window.getStatusBarPinOptions();
+};
+
+const eventStore = new EventStore<Array<PinOption>>(
+  'status bar pinned',
+  statusBarPinned,
+  checkForUpdate,
+  windowEvents,
+  windowListeners,
+  getStatusBarPinOptions,
+);
+eventStore.setup();

--- a/packages/renderer/src/stores/statusbar-pinned.ts
+++ b/packages/renderer/src/stores/statusbar-pinned.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022-2023 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
### What does this PR do?

So after following discussion with many many people over a pretty long period of time. This is an iteration of pinning unpinning.

I am not writing any tests because I am waiting for feedback before going further.

cc @deboer-tim @slemeur @Firewall 

#### Some notes

- Users can pin/unpin **PROVIDERS**
- Only the Podman provider is pinned by default.
- At the start of the statusbar there is a pin icon
- User pin are persistent over restart of Podman Desktop

#### Technical limitation

Status Bar Providers (added in https://github.com/podman-desktop/podman-desktop/pull/9724) are not status bar entries. So this is two distinct elements.

With the current code, as noted by Tim we cannot unpin status bar entries (extension registered entries, version, help etc.) this is because we are treating the providers widget as status bar entries

#### Existing issues

The height of the status bar is changing, this is because the Provider Widget component is using too much space: need to be address in another PR. 

### Screenshot / video of UI

https://github.com/user-attachments/assets/737936b7-0f13-453a-975f-237579a4b540

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/9950 
Also fixes https://github.com/podman-desktop/podman-desktop/issues/10920

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature (TODO)
