### PR TITLE
chore: remove @typescript-eslint/no-explicit-any usage in markdown

### DIFF
--- a/packages/renderer/src/lib/markdown/Markdown.svelte
+++ b/packages/renderer/src/lib/markdown/Markdown.svelte
@@ -72,7 +72,7 @@ export let inProgressMarkdownCommandExecutionCallback: (
 ) => void = () => {};
 
 // Create an event listener for updating the in-progress markdown command execution callback
-const eventListeners: ((e: unknown) => void)[] = [];
+const eventListeners: EventListener[] = [];
 
 // Render the markdown or the html+micromark markdown reactively
 $: markdown

--- a/packages/renderer/src/lib/markdown/micromark-listener-handler.ts
+++ b/packages/renderer/src/lib/markdown/micromark-listener-handler.ts
@@ -25,11 +25,11 @@ export function createListener(
     state: 'starting' | 'failed' | 'successful',
     value?: unknown,
   ) => void,
-) {
-  return (e: unknown): void => {
-    let eventTarget: object | undefined = undefined;
+): EventListener {
+  return (e: Event): void => {
+    let eventTarget: EventTarget;
 
-    if (e && typeof e === 'object' && 'target' in e && e.target && typeof e.target === 'object') {
+    if (e.target && typeof e.target === 'object') {
       eventTarget = e.target;
     } else {
       return;

--- a/packages/renderer/src/lib/markdown/micromark-listener-handler.ts
+++ b/packages/renderer/src/lib/markdown/micromark-listener-handler.ts
@@ -19,8 +19,6 @@
 import { executeButtonCommand } from './component/micromark-button';
 import { executeExpandableToggle } from './component/micromark-expandable-section';
 
-const eventObject: { target?: object } = {};
-
 export function createListener(
   inProgressMarkdownCommandExecutionCallback: (
     command: string,
@@ -29,6 +27,8 @@ export function createListener(
   ) => void,
 ) {
   return (e: unknown): void => {
+    const eventObject: { target?: object } = {};
+
     if (e && typeof e === 'object' && 'target' in e && e.target && typeof e.target === 'object') {
       eventObject.target = e.target;
     }


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Remove the explicit use of any in `markdown/micromark-listener-handler`.
Used the suggestion from https://github.com/podman-desktop/podman-desktop/pull/10981#discussion_r1944479907 to reduce the amount of checks

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/10604

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
