### PR TITLE
feat: display Nodes list in Kubernetes experimental mode

### DIFF
--- a/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
@@ -34,6 +34,7 @@ import { ContextResourceRegistry } from './context-resource-registry.js';
 import type { DispatcherEvent } from './contexts-dispatcher.js';
 import { ContextsDispatcher } from './contexts-dispatcher.js';
 import { DeploymentsResourceFactory } from './deployments-resource-factory.js';
+import { NodesResourceFactory } from './nodes-resource-factory.js';
 import { PodsResourceFactory } from './pods-resource-factory.js';
 import { PVCsResourceFactory } from './pvcs-resource-factory.js';
 import type { ResourceFactory } from './resource-factory.js';
@@ -100,6 +101,7 @@ export class ContextsManagerExperimental {
       new SecretsResourceFactory(),
       new ServicesResourceFactory(),
       new PVCsResourceFactory(),
+      new NodesResourceFactory(),
     ];
   }
 

--- a/packages/main/src/plugin/kubernetes/nodes-resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/nodes-resource-factory.ts
@@ -1,0 +1,58 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1Node, V1NodeList } from '@kubernetes/client-node';
+import { CoreV1Api } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from './kubeconfig-single-context.js';
+import type { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryBase } from './resource-factory.js';
+import { ResourceInformer } from './resource-informer.js';
+
+export class NodesResourceFactory extends ResourceFactoryBase implements ResourceFactory {
+  constructor() {
+    super({
+      resource: 'nodes',
+    });
+
+    this.setPermissions({
+      isNamespaced: false,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          verb: 'watch',
+          resource: 'nodes',
+        },
+      ],
+    });
+    this.setInformer({
+      createInformer: this.createInformer,
+    });
+  }
+
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1Node> {
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(CoreV1Api);
+    const listFn = (): Promise<V1NodeList> => apiClient.listNode();
+    const path = `/api/v1/nodes`;
+    return new ResourceInformer<V1Node>(kubeconfig, path, listFn, 'nodes');
+  }
+}

--- a/packages/renderer/src/lib/node/NodesList.spec.ts
+++ b/packages/renderer/src/lib/node/NodesList.spec.ts
@@ -67,8 +67,10 @@ test('Expect nodes list', async () => {
 
   render(NodesList);
 
-  const nodeName = screen.getByRole('cell', { name: 'node1' });
-  expect(nodeName).toBeInTheDocument();
+  await vi.waitFor(() => {
+    const nodeName = screen.getByRole('cell', { name: 'node1' });
+    expect(nodeName).toBeInTheDocument();
+  });
 
   const nodeRole = screen.getByRole('cell', { name: 'Control Plane' });
   expect(nodeRole).toBeInTheDocument();


### PR DESCRIPTION
### What does this PR do?

Display Nodes list in Kubernetes experimental mode

~~Adding the Node resource to the `resourceFactoryHandler` shows that the logic does not support multiple permissionCheckers for a single kubecontext (we now have one permission check for namespaced resources, and one for non-namespaced resources).~~

~~This PR contains a patch to support multiple permissions checkers per kubeconfig, but this data structure is hardly maintainable. I'll work o another PR to flatten this structure as a simple array.~~ (done in https://github.com/podman-desktop/podman-desktop/pull/11058)

### Screenshot / video of UI

### What issues does this PR fix or reference?

Part of #10657 

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
