### PR TITLE
fix: support multiple permissions requests

### DIFF
--- a/packages/main/src/plugin/kubernetes/context-permissions-checker.spec.ts
+++ b/packages/main/src/plugin/kubernetes/context-permissions-checker.spec.ts
@@ -58,7 +58,7 @@ describe('ContextPermissionsChecker is built with a non recursive request', asyn
           reason: 'a reason',
         },
       });
-      permissionsChecker = new ContextPermissionsChecker(kubeConfig, {
+      permissionsChecker = new ContextPermissionsChecker(kubeConfig, 'ctx1', {
         attrs,
         resources,
       });
@@ -78,13 +78,17 @@ describe('ContextPermissionsChecker is built with a non recursive request', asyn
 
     test('getPermissions returns permitted true', async () => {
       const permissions = permissionsChecker.getPermissions();
-      const expected = new Map<string, ContextResourcePermission>();
-      expected.set('resource1', {
+      const expected: ContextResourcePermission[] = [];
+      expected.push({
+        contextName: 'ctx1',
+        resourceName: 'resource1',
         attrs,
         permitted: true,
         reason: 'a reason',
       });
-      expected.set('resource2', {
+      expected.push({
+        contextName: 'ctx1',
+        resourceName: 'resource2',
         attrs,
         permitted: true,
         reason: 'a reason',
@@ -102,7 +106,7 @@ describe('ContextPermissionsChecker is built with a non recursive request', asyn
           reason: 'a reason',
         },
       });
-      permissionsChecker = new ContextPermissionsChecker(kubeConfig, {
+      permissionsChecker = new ContextPermissionsChecker(kubeConfig, 'ctx1', {
         attrs,
         resources,
       });
@@ -122,13 +126,17 @@ describe('ContextPermissionsChecker is built with a non recursive request', asyn
 
     test('getPermissions returns permitted false', async () => {
       const permissions = permissionsChecker.getPermissions();
-      const expected = new Map<string, ContextResourcePermission>();
-      expected.set('resource1', {
+      const expected: ContextResourcePermission[] = [];
+      expected.push({
+        contextName: 'ctx1',
+        resourceName: 'resource1',
         attrs,
         permitted: false,
         reason: 'a reason',
       });
-      expected.set('resource2', {
+      expected.push({
+        contextName: 'ctx1',
+        resourceName: 'resource2',
         attrs,
         permitted: false,
         reason: 'a reason',
@@ -145,7 +153,7 @@ describe('ContextPermissionsChecker is built with a non recursive request', asyn
           reason: 'a reason',
         },
       });
-      permissionsChecker = new ContextPermissionsChecker(kubeConfig, {
+      permissionsChecker = new ContextPermissionsChecker(kubeConfig, 'ctx1', {
         attrs,
         resources,
       });
@@ -165,13 +173,17 @@ describe('ContextPermissionsChecker is built with a non recursive request', asyn
 
     test('getPermissions returns permitted false', async () => {
       const permissions = permissionsChecker.getPermissions();
-      const expected = new Map<string, ContextResourcePermission>();
-      expected.set('resource1', {
+      const expected: ContextResourcePermission[] = [];
+      expected.push({
+        contextName: 'ctx1',
+        resourceName: 'resource1',
         attrs,
         permitted: false,
         reason: 'a reason',
       });
-      expected.set('resource2', {
+      expected.push({
+        contextName: 'ctx1',
+        resourceName: 'resource2',
         attrs,
         permitted: false,
         reason: 'a reason',
@@ -248,7 +260,7 @@ describe('ContextPermissionsChecker is built with a recursive request', async ()
           },
         };
       });
-      permissionsChecker = new ContextPermissionsChecker(kubeConfig, {
+      permissionsChecker = new ContextPermissionsChecker(kubeConfig, 'ctx1', {
         attrs,
         resources,
         onDenyRequests: [
@@ -285,13 +297,17 @@ describe('ContextPermissionsChecker is built with a recursive request', async ()
 
     test('getPermissions returns permitted true for resource1 and false for resource2', async () => {
       const permissions = permissionsChecker.getPermissions();
-      const expected = new Map<string, ContextResourcePermission>();
-      expected.set('resource1', {
+      const expected: ContextResourcePermission[] = [];
+      expected.push({
+        contextName: 'ctx1',
+        resourceName: 'resource1',
         attrs: attrsResource1,
         permitted: true,
         reason: 'a reason 1',
       });
-      expected.set('resource2', {
+      expected.push({
+        contextName: 'ctx1',
+        resourceName: 'resource2',
         attrs: attrsResource2,
         permitted: false,
         reason: 'a reason 2',

--- a/packages/main/src/plugin/kubernetes/context-permissions-checker.ts
+++ b/packages/main/src/plugin/kubernetes/context-permissions-checker.ts
@@ -58,7 +58,7 @@ export interface ContextPermissionResult extends Permission {
 }
 
 export class ContextPermissionsChecker implements Disposable {
-  #contextName: string;
+  contextName: string;
   #kubeconfig: KubeConfigSingleContext;
   #client: AuthorizationV1Api;
   #request: ContextPermissionsRequest;
@@ -73,14 +73,10 @@ export class ContextPermissionsChecker implements Disposable {
   // If the result is denied, `onDenyRequests` will be started
   constructor(kubeconfig: KubeConfigSingleContext, contextName: string, request: ContextPermissionsRequest) {
     this.#kubeconfig = kubeconfig;
-    this.#contextName = contextName;
+    this.contextName = contextName;
     this.#request = request;
     this.#results = [];
     this.#client = this.#kubeconfig.getKubeConfig().makeApiClient(AuthorizationV1Api);
-  }
-
-  public isForContext(contextName: string): boolean {
-    return this.#contextName === contextName;
   }
 
   public async start(): Promise<void> {
@@ -88,7 +84,7 @@ export class ContextPermissionsChecker implements Disposable {
     if ((!result.allowed || result.denied) && this.#request.onDenyRequests?.length) {
       // if not permitted and sub-requests are defined, let start them and don't send any result
       for (const subreq of this.#request.onDenyRequests) {
-        const subchecker = new ContextPermissionsChecker(this.#kubeconfig, this.#contextName, subreq);
+        const subchecker = new ContextPermissionsChecker(this.#kubeconfig, this.contextName, subreq);
         this.#subCheckers.push(subchecker);
         subchecker.onPermissionResult((permissionResult: ContextPermissionResult) => {
           this.saveAndFireResult(permissionResult);
@@ -111,7 +107,7 @@ export class ContextPermissionsChecker implements Disposable {
     this.#onPermissionResult.fire(result);
     for (const resourceName of result.resources) {
       this.#results.push({
-        contextName: this.#contextName,
+        contextName: this.contextName,
         resourceName,
         attrs: result.attrs,
         permitted: result.permitted,

--- a/packages/main/src/plugin/kubernetes/context-permissions-checker.ts
+++ b/packages/main/src/plugin/kubernetes/context-permissions-checker.ts
@@ -38,25 +38,31 @@ export interface ContextPermissionsRequest {
 }
 
 // ContextResourcePermission is the permission for a specific resource
-export interface ContextResourcePermission {
+export interface Permission {
   attrs: V1ResourceAttributes;
   // permitted if allowed and not denied
   permitted: boolean;
   reason?: string;
 }
 
+export interface ContextResourcePermission extends Permission {
+  contextName: string;
+  resourceName: string;
+}
+
 // ContextPermissionResult is the result of a request, which can cover several resources
-export interface ContextPermissionResult extends ContextResourcePermission {
+export interface ContextPermissionResult extends Permission {
   kubeConfig: KubeConfigSingleContext;
   resources: string[];
 }
 
 export class ContextPermissionsChecker implements Disposable {
+  #contextName: string;
   #kubeconfig: KubeConfigSingleContext;
   #client: AuthorizationV1Api;
   #request: ContextPermissionsRequest;
   #subCheckers: ContextPermissionsChecker[] = [];
-  #results: Map<string, ContextResourcePermission>;
+  #results: ContextResourcePermission[];
 
   #onPermissionResult = new Emitter<ContextPermissionResult>();
   onPermissionResult: Event<ContextPermissionResult> = this.#onPermissionResult.event;
@@ -64,11 +70,16 @@ export class ContextPermissionsChecker implements Disposable {
   // builds a ContextPermissionsChecker which will check permissions on the current context of the given kubeConfig
   // The request will be made with `attrs` and if allowed, permissions will be given for `resources`
   // If the result is denied, `onDenyRequests` will be started
-  constructor(kubeconfig: KubeConfigSingleContext, request: ContextPermissionsRequest) {
+  constructor(kubeconfig: KubeConfigSingleContext, contextName: string, request: ContextPermissionsRequest) {
     this.#kubeconfig = kubeconfig;
+    this.#contextName = contextName;
     this.#request = request;
-    this.#results = new Map<string, ContextResourcePermission>();
+    this.#results = [];
     this.#client = this.#kubeconfig.getKubeConfig().makeApiClient(AuthorizationV1Api);
+  }
+
+  public isForContext(contextName: string): boolean {
+    return this.#contextName === contextName;
   }
 
   public async start(): Promise<void> {
@@ -76,7 +87,7 @@ export class ContextPermissionsChecker implements Disposable {
     if ((!result.allowed || result.denied) && this.#request.onDenyRequests?.length) {
       // if not permitted and sub-requests are defined, let start them and don't send any result
       for (const subreq of this.#request.onDenyRequests) {
-        const subchecker = new ContextPermissionsChecker(this.#kubeconfig, subreq);
+        const subchecker = new ContextPermissionsChecker(this.#kubeconfig, this.#contextName, subreq);
         this.#subCheckers.push(subchecker);
         subchecker.onPermissionResult((permissionResult: ContextPermissionResult) => {
           this.saveAndFireResult(permissionResult);
@@ -97,8 +108,10 @@ export class ContextPermissionsChecker implements Disposable {
 
   private saveAndFireResult(result: ContextPermissionResult): void {
     this.#onPermissionResult.fire(result);
-    for (const resource of result.resources) {
-      this.#results.set(resource, {
+    for (const resourceName of result.resources) {
+      this.#results.push({
+        contextName: this.#contextName,
+        resourceName,
         attrs: result.attrs,
         permitted: result.permitted,
         reason: result.reason,
@@ -106,7 +119,7 @@ export class ContextPermissionsChecker implements Disposable {
     }
   }
 
-  public getPermissions(): Map<string, ContextResourcePermission> {
+  public getPermissions(): ContextResourcePermission[] {
     return this.#results;
   }
 

--- a/packages/main/src/plugin/kubernetes/context-permissions-checker.ts
+++ b/packages/main/src/plugin/kubernetes/context-permissions-checker.ts
@@ -37,7 +37,7 @@ export interface ContextPermissionsRequest {
   onDenyRequests?: ContextPermissionsRequest[];
 }
 
-// ContextResourcePermission is the permission for a specific resource
+// Permission is the permission for a specific resource
 export interface Permission {
   attrs: V1ResourceAttributes;
   // permitted if allowed and not denied
@@ -45,6 +45,7 @@ export interface Permission {
   reason?: string;
 }
 
+// ContextResourcePermission is the permission for a specific resource in a specific context
 export interface ContextResourcePermission extends Permission {
   contextName: string;
   resourceName: string;

--- a/packages/main/src/plugin/kubernetes/contexts-manager-experimental.spec.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager-experimental.spec.ts
@@ -22,7 +22,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { ContextHealthState } from './context-health-checker.js';
 import { ContextHealthChecker } from './context-health-checker.js';
-import { ContextPermissionsChecker } from './context-permissions-checker.js';
+import { ContextPermissionsChecker, type ContextResourcePermission } from './context-permissions-checker.js';
 import { ContextsManagerExperimental } from './contexts-manager-experimental.js';
 import { KubeConfigSingleContext } from './kubeconfig-single-context.js';
 import type { ResourceFactory } from './resource-factory.js';
@@ -62,6 +62,18 @@ class TestContextsManagerExperimental extends ContextsManagerExperimental {
         resource: 'resource2',
       }).setPermissions({
         isNamespaced: true,
+        permissionsRequests: [
+          {
+            group: '*',
+            resource: '*',
+            verb: 'watch',
+          },
+        ],
+      }),
+      new ResourceFactoryBase({
+        resource: 'resource3',
+      }).setPermissions({
+        isNamespaced: false,
         permissionsRequests: [
           {
             group: '*',
@@ -189,6 +201,7 @@ describe('HealthChecker is built and start is called for each context the first 
         ({
           start: permissionsStartMock,
           onPermissionResult: vi.fn(),
+          isForContext: vi.fn(),
         }) as unknown as ContextPermissionsChecker,
     );
     manager = new TestContextsManagerExperimental();
@@ -225,11 +238,12 @@ describe('HealthChecker is built and start is called for each context the first 
     });
     await manager.update(kc);
 
-    expect(ContextPermissionsChecker).toHaveBeenCalledTimes(2);
-    expect(ContextPermissionsChecker).toHaveBeenCalledWith(kcSingle1, expect.anything());
-    expect(ContextPermissionsChecker).toHaveBeenCalledWith(kcSingle2, expect.anything());
+    // Twice for namespaced resources, twice for non-namespaced resources
+    expect(ContextPermissionsChecker).toHaveBeenCalledTimes(4);
+    expect(ContextPermissionsChecker).toHaveBeenCalledWith(kcSingle1, 'context1', expect.anything());
+    expect(ContextPermissionsChecker).toHaveBeenCalledWith(kcSingle2, 'context2', expect.anything());
 
-    expect(permissionsStartMock).toHaveBeenCalledTimes(2);
+    expect(permissionsStartMock).toHaveBeenCalledTimes(4);
   });
 });
 
@@ -267,10 +281,11 @@ describe('HealthChecker pass and PermissionsChecker resturns a value', async () 
     manager = new TestContextsManagerExperimental();
   });
 
-  test('informer is started for each resource', async () => {
+  test('permissions are correctly dispatched', async () => {
     const kcSingle1 = new KubeConfigSingleContext(kc, context1);
     const kcSingle2 = new KubeConfigSingleContext(kc, context2);
     let call = 0;
+    let permissionCall = 0;
     onreachableMock.mockImplementation(f => {
       call++;
       f({
@@ -280,15 +295,176 @@ describe('HealthChecker pass and PermissionsChecker resturns a value', async () 
         reachable: true,
       } as ContextHealthState);
     });
-    onPermissionResultMock.mockImplementation(f =>
-      f({
-        kubeConfig: kcSingle1,
-        resources: ['resource1', 'resource2'],
+    onPermissionResultMock.mockImplementation(f => {
+      permissionCall++;
+      switch (permissionCall) {
+        case 1:
+        case 2:
+          f({
+            kubeConfig: kcSingle1,
+            resources: ['resource1', 'resource2'],
+            permitted: true,
+          });
+          break;
+        case 3:
+        case 4:
+          f({
+            kubeConfig: kcSingle2,
+            resources: ['resource1', 'resource2'],
+            permitted: true,
+          });
+          break;
+        case 5:
+        case 6:
+          f({
+            kubeConfig: kcSingle1,
+            resources: ['resource3'],
+            permitted: true,
+          });
+          break;
+        case 7:
+        case 8:
+          f({
+            kubeConfig: kcSingle2,
+            resources: ['resource3'],
+            permitted: true,
+          });
+          break;
+      }
+    });
+    const permissions1: ContextResourcePermission[] = [
+      {
+        contextName: 'context1',
+        resourceName: 'resource1',
+        attrs: {},
         permitted: true,
-      }),
+      },
+      {
+        contextName: 'context1',
+        resourceName: 'resource2',
+        attrs: {},
+        permitted: true,
+      },
+    ];
+    const permissions2: ContextResourcePermission[] = [
+      {
+        contextName: 'context2',
+        resourceName: 'resource1',
+        attrs: {},
+        permitted: true,
+      },
+      {
+        contextName: 'context2',
+        resourceName: 'resource2',
+        attrs: {},
+        permitted: true,
+      },
+    ];
+    const permissions3: ContextResourcePermission[] = [
+      {
+        contextName: 'context1',
+        resourceName: 'resource3',
+        attrs: {},
+        permitted: true,
+      },
+    ];
+    const permissions4: ContextResourcePermission[] = [
+      {
+        contextName: 'context2',
+        resourceName: 'resource3',
+        attrs: {},
+        permitted: true,
+      },
+    ];
+    let getPermissionsCall = 0;
+    vi.mocked(ContextPermissionsChecker).mockImplementation(
+      () =>
+        ({
+          start: permissionsStartMock,
+          onPermissionResult: onPermissionResultMock,
+          isForContext: vi.fn(),
+          getPermissions: vi.fn().mockImplementation(() => {
+            getPermissionsCall++;
+            switch (getPermissionsCall) {
+              case 1:
+                return permissions1;
+              case 2:
+                return permissions2;
+              case 3:
+                return permissions3;
+              case 4:
+                return permissions4;
+            }
+            return [];
+          }),
+        }) as unknown as ContextPermissionsChecker,
     );
     await manager.update(kc);
-    expect(startMock).toHaveBeenCalledTimes(2); // on resource1 for each context (resource2 does not have informer declared)
+    const permissions = manager.getPermissions();
+    expect(permissions).toEqual([...permissions1, ...permissions2, ...permissions3, ...permissions4]);
+  });
+
+  test('informer is started for each resource', async () => {
+    const kcSingle1 = new KubeConfigSingleContext(kc, context1);
+    const kcSingle2 = new KubeConfigSingleContext(kc, context2);
+    let call = 0;
+    let permissionCall = 0;
+    onreachableMock.mockImplementation(f => {
+      call++;
+      f({
+        kubeConfig: call === 1 ? kcSingle1 : kcSingle2,
+        contextName: call === 1 ? 'context1' : 'context2',
+        checking: false,
+        reachable: true,
+      } as ContextHealthState);
+    });
+    onPermissionResultMock.mockImplementation(f => {
+      permissionCall++;
+      switch (permissionCall) {
+        case 1:
+        case 2:
+          f({
+            kubeConfig: kcSingle1,
+            resources: ['resource1', 'resource2'],
+            permitted: true,
+          });
+          break;
+        case 3:
+        case 4:
+          f({
+            kubeConfig: kcSingle2,
+            resources: ['resource1', 'resource2'],
+            permitted: true,
+          });
+          break;
+        case 5:
+        case 6:
+          f({
+            kubeConfig: kcSingle1,
+            resources: ['resource3'],
+            permitted: true,
+          });
+          break;
+        case 7:
+        case 8:
+          f({
+            kubeConfig: kcSingle2,
+            resources: ['resource3'],
+            permitted: true,
+          });
+          break;
+      }
+    });
+    vi.mocked(ContextPermissionsChecker).mockImplementation(
+      () =>
+        ({
+          start: permissionsStartMock,
+          onPermissionResult: onPermissionResultMock,
+          isForContext: vi.fn(),
+        }) as unknown as ContextPermissionsChecker,
+    );
+    await manager.update(kc);
+    expect(startMock).toHaveBeenCalledTimes(2); // on resource1 for each context (resource2 and resource3 do not have informer declared)
   });
 
   describe('informer is started', async () => {
@@ -298,6 +474,7 @@ describe('HealthChecker pass and PermissionsChecker resturns a value', async () 
       kcSingle1 = new KubeConfigSingleContext(kc, context1);
       kcSingle2 = new KubeConfigSingleContext(kc, context2);
       let call = 0;
+      let permissionCall = 0;
       onreachableMock.mockImplementation(f => {
         call++;
         f({
@@ -307,16 +484,54 @@ describe('HealthChecker pass and PermissionsChecker resturns a value', async () 
           reachable: call === 1,
         } as ContextHealthState);
       });
-      onPermissionResultMock.mockImplementation(f =>
-        f({
-          kubeConfig: call === 1 ? kcSingle1 : kcSingle2,
-          resources: ['resource1', 'resource2'],
-          permitted: true,
-        }),
-      );
+      onPermissionResultMock.mockImplementation(f => {
+        permissionCall++;
+        switch (permissionCall) {
+          case 1:
+          case 2:
+            f({
+              kubeConfig: kcSingle1,
+              resources: ['resource1', 'resource2'],
+              permitted: true,
+            });
+            break;
+          case 3:
+          case 4:
+            f({
+              kubeConfig: kcSingle2,
+              resources: ['resource1', 'resource2'],
+              permitted: true,
+            });
+            break;
+          case 5:
+          case 6:
+            f({
+              kubeConfig: kcSingle1,
+              resources: ['resource3'],
+              permitted: true,
+            });
+            break;
+          case 7:
+          case 8:
+            f({
+              kubeConfig: kcSingle2,
+              resources: ['resource3'],
+              permitted: true,
+            });
+            break;
+        }
+      });
     });
 
     test('cache updated with a change on resource count', async () => {
+      vi.mocked(ContextPermissionsChecker).mockImplementation(
+        () =>
+          ({
+            start: permissionsStartMock,
+            onPermissionResult: onPermissionResultMock,
+            isForContext: vi.fn(),
+          }) as unknown as ContextPermissionsChecker,
+      );
       onCacheUpdatedMock.mockImplementation(f => {
         f({
           kubeconfig: kcSingle1,
@@ -336,6 +551,14 @@ describe('HealthChecker pass and PermissionsChecker resturns a value', async () 
     });
 
     test('cache updated without a change on resource count', async () => {
+      vi.mocked(ContextPermissionsChecker).mockImplementation(
+        () =>
+          ({
+            start: permissionsStartMock,
+            onPermissionResult: onPermissionResultMock,
+            isForContext: vi.fn(),
+          }) as unknown as ContextPermissionsChecker,
+      );
       onCacheUpdatedMock.mockImplementation(f => {
         f({
           kubeconfig: kcSingle1,
@@ -355,6 +578,14 @@ describe('HealthChecker pass and PermissionsChecker resturns a value', async () 
     });
 
     test('getResourcesCount', async () => {
+      vi.mocked(ContextPermissionsChecker).mockImplementation(
+        () =>
+          ({
+            start: permissionsStartMock,
+            onPermissionResult: onPermissionResultMock,
+            isForContext: vi.fn(),
+          }) as unknown as ContextPermissionsChecker,
+      );
       const listMock = vi.fn();
       startMock.mockReturnValue({
         list: listMock,
@@ -378,6 +609,14 @@ describe('HealthChecker pass and PermissionsChecker resturns a value', async () 
     });
 
     test('getResources', async () => {
+      vi.mocked(ContextPermissionsChecker).mockImplementation(
+        () =>
+          ({
+            start: permissionsStartMock,
+            onPermissionResult: onPermissionResultMock,
+            isForContext: vi.fn(),
+          }) as unknown as ContextPermissionsChecker,
+      );
       const listMock = vi.fn();
       startMock.mockReturnValue({
         list: listMock,
@@ -500,6 +739,7 @@ test('HealthChecker and PermissionsChecker are disposed for each context being r
       ({
         start: permissionsStartMock,
         dispose: permissionsDisposeMock,
+        isForContext: vi.fn().mockReturnValueOnce(true).mockReturnValueOnce(false),
       }) as unknown as ContextPermissionsChecker,
   );
 
@@ -616,13 +856,14 @@ test('getPermissions calls getPermissions for each permissions checker', async (
         start: vi.fn(),
         getPermissions: getPermissionsMock,
         onPermissionResult: vi.fn(),
+        isForContext: vi.fn(),
       }) as unknown as ContextPermissionsChecker,
   );
 
   await manager.update(kc);
 
   manager.getPermissions();
-  expect(getPermissionsMock).toHaveBeenCalledTimes(2);
+  expect(getPermissionsMock).toHaveBeenCalledTimes(4);
 });
 
 test('dispose calls dispose for each health checker', async () => {
@@ -693,11 +934,12 @@ test('dispose calls dispose for each permissions checker', async () => {
         getPermissions: getPermissionsMock,
         onPermissionResult: vi.fn(),
         dispose: permissionsDisposeMock,
+        isForContext: vi.fn(),
       }) as unknown as ContextPermissionsChecker,
   );
 
   await manager.update(kc);
 
   manager.dispose();
-  expect(permissionsDisposeMock).toHaveBeenCalledTimes(2);
+  expect(permissionsDisposeMock).toHaveBeenCalledTimes(4);
 });

--- a/packages/main/src/plugin/kubernetes/contexts-manager-experimental.spec.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager-experimental.spec.ts
@@ -529,7 +529,7 @@ describe('HealthChecker pass and PermissionsChecker resturns a value', async () 
           ({
             start: permissionsStartMock,
             onPermissionResult: onPermissionResultMock,
-            isForContext: vi.fn(),
+            contextName: 'ctx',
           }) as unknown as ContextPermissionsChecker,
       );
       onCacheUpdatedMock.mockImplementation(f => {
@@ -556,7 +556,7 @@ describe('HealthChecker pass and PermissionsChecker resturns a value', async () 
           ({
             start: permissionsStartMock,
             onPermissionResult: onPermissionResultMock,
-            isForContext: vi.fn(),
+            contextName: 'ctx1',
           }) as unknown as ContextPermissionsChecker,
       );
       onCacheUpdatedMock.mockImplementation(f => {
@@ -583,7 +583,7 @@ describe('HealthChecker pass and PermissionsChecker resturns a value', async () 
           ({
             start: permissionsStartMock,
             onPermissionResult: onPermissionResultMock,
-            isForContext: vi.fn(),
+            contextName: 'ctx1',
           }) as unknown as ContextPermissionsChecker,
       );
       const listMock = vi.fn();
@@ -614,7 +614,7 @@ describe('HealthChecker pass and PermissionsChecker resturns a value', async () 
           ({
             start: permissionsStartMock,
             onPermissionResult: onPermissionResultMock,
-            isForContext: vi.fn(),
+            contextName: 'ctx1',
           }) as unknown as ContextPermissionsChecker,
       );
       const listMock = vi.fn();
@@ -734,12 +734,20 @@ test('HealthChecker and PermissionsChecker are disposed for each context being r
       }) as unknown as ContextHealthChecker,
   );
 
-  vi.mocked(ContextPermissionsChecker).mockImplementation(
+  vi.mocked(ContextPermissionsChecker).mockImplementationOnce(
     () =>
       ({
         start: permissionsStartMock,
         dispose: permissionsDisposeMock,
-        isForContext: vi.fn().mockReturnValueOnce(true).mockReturnValueOnce(false),
+        contextName: 'context1',
+      }) as unknown as ContextPermissionsChecker,
+  );
+  vi.mocked(ContextPermissionsChecker).mockImplementationOnce(
+    () =>
+      ({
+        start: permissionsStartMock,
+        dispose: permissionsDisposeMock,
+        contextName: 'context2',
       }) as unknown as ContextPermissionsChecker,
   );
 

--- a/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
@@ -18,6 +18,7 @@
 
 import type { KubeConfig, KubernetesObject, ObjectCache } from '@kubernetes/client-node';
 
+import type { ContextPermission } from '/@api/kubernetes-contexts-permissions.js';
 import type { ContextGeneralState, ResourceName } from '/@api/kubernetes-contexts-states.js';
 import type { ResourceCount } from '/@api/kubernetes-resource-count.js';
 import type { KubernetesContextResources } from '/@api/kubernetes-resources.js';
@@ -27,7 +28,7 @@ import { Emitter } from '../events/emitter.js';
 import { ConfigmapsResourceFactory } from './configmaps-resource-factory.js';
 import type { ContextHealthState } from './context-health-checker.js';
 import { ContextHealthChecker } from './context-health-checker.js';
-import type { ContextPermissionResult, ContextResourcePermission } from './context-permissions-checker.js';
+import type { ContextPermissionResult } from './context-permissions-checker.js';
 import { ContextPermissionsChecker } from './context-permissions-checker.js';
 import { ContextResourceRegistry } from './context-resource-registry.js';
 import type { DispatcherEvent } from './contexts-dispatcher.js';
@@ -55,7 +56,7 @@ export class ContextsManagerExperimental {
   #resourceFactoryHandler: ResourceFactoryHandler;
   #dispatcher: ContextsDispatcher;
   #healthCheckers: Map<string, ContextHealthChecker>;
-  #permissionsCheckers: Map<string, ContextPermissionsChecker>;
+  #permissionsCheckers: ContextPermissionsChecker[];
   #informers: ContextResourceRegistry<ResourceInformer<KubernetesObject>>;
   #objectCaches: ContextResourceRegistry<ObjectCache<KubernetesObject>>;
 
@@ -81,7 +82,7 @@ export class ContextsManagerExperimental {
     }
     // Add more resources here
     this.#healthCheckers = new Map<string, ContextHealthChecker>();
-    this.#permissionsCheckers = new Map<string, ContextPermissionsChecker>();
+    this.#permissionsCheckers = [];
     this.#informers = new ContextResourceRegistry<ResourceInformer<KubernetesObject>>();
     this.#objectCaches = new ContextResourceRegistry<ObjectCache<KubernetesObject>>();
     this.#dispatcher = new ContextsDispatcher();
@@ -116,14 +117,22 @@ export class ContextsManagerExperimental {
 
     newHealthChecker.onReachable(async (state: ContextHealthState) => {
       // register and start permissions checker
-      const previousPermissionsChecker = this.#permissionsCheckers.get(state.contextName);
-      previousPermissionsChecker?.dispose();
+      const previousPermissionsCheckers = this.#permissionsCheckers.filter(permissionChecker =>
+        permissionChecker.isForContext(state.contextName),
+      );
+      for (const checker of previousPermissionsCheckers) {
+        checker.dispose();
+      }
 
       const namespace = state.kubeConfig.getNamespace();
       const permissionRequests = this.#resourceFactoryHandler.getPermissionsRequests(namespace);
       for (const permissionRequest of permissionRequests) {
-        const newPermissionChecker = new ContextPermissionsChecker(state.kubeConfig, permissionRequest);
-        this.#permissionsCheckers.set(state.contextName, newPermissionChecker);
+        const newPermissionChecker = new ContextPermissionsChecker(
+          state.kubeConfig,
+          state.contextName,
+          permissionRequest,
+        );
+        this.#permissionsCheckers.push(newPermissionChecker);
         newPermissionChecker.onPermissionResult(this.onPermissionResult.bind(this));
 
         newPermissionChecker.onPermissionResult((event: ContextPermissionResult) => {
@@ -177,9 +186,15 @@ export class ContextsManagerExperimental {
     const healthChecker = this.#healthCheckers.get(state.contextName);
     healthChecker?.dispose();
     this.#healthCheckers.delete(state.contextName);
-    const permissionsChecker = this.#permissionsCheckers.get(state.contextName);
-    permissionsChecker?.dispose();
-    this.#permissionsCheckers.delete(state.contextName);
+    const permissionsCheckers = this.#permissionsCheckers.filter(permissionChecker =>
+      permissionChecker.isForContext(state.contextName),
+    );
+    for (const checker of permissionsCheckers) {
+      checker.dispose();
+    }
+    this.#permissionsCheckers = this.#permissionsCheckers.filter(
+      permissionChecker => !permissionChecker.isForContext(state.contextName),
+    );
   }
 
   private onStateChange(state: ContextHealthState): void {
@@ -200,12 +215,8 @@ export class ContextsManagerExperimental {
   }
 
   /* getPermissions returns the current permissions */
-  getPermissions(): Map</* contextName */ string, Map</* resource */ string, ContextResourcePermission>> {
-    const result = new Map<string, Map<string, ContextResourcePermission>>();
-    for (const [contextName, pc] of this.#permissionsCheckers.entries()) {
-      result.set(contextName, pc.getPermissions());
-    }
-    return result;
+  getPermissions(): ContextPermission[] {
+    return this.#permissionsCheckers.flatMap(permissionsChecker => permissionsChecker.getPermissions());
   }
 
   getResourcesCount(): ResourceCount[] {
@@ -268,10 +279,10 @@ export class ContextsManagerExperimental {
 
   // disposeAllPermissionsCheckers disposes all permissions checkers and removes them from registry
   private disposeAllPermissionsCheckers(): void {
-    for (const [contextName, permissionChecker] of this.#permissionsCheckers.entries()) {
+    for (const permissionChecker of this.#permissionsCheckers) {
       permissionChecker.dispose();
-      this.#permissionsCheckers.delete(contextName);
     }
+    this.#permissionsCheckers = [];
   }
 
   // disposeAllInformers disposes all informers and removes them from registry

--- a/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
@@ -117,8 +117,8 @@ export class ContextsManagerExperimental {
 
     newHealthChecker.onReachable(async (state: ContextHealthState) => {
       // register and start permissions checker
-      const previousPermissionsCheckers = this.#permissionsCheckers.filter(permissionChecker =>
-        permissionChecker.isForContext(state.contextName),
+      const previousPermissionsCheckers = this.#permissionsCheckers.filter(
+        permissionChecker => permissionChecker.contextName === state.contextName,
       );
       for (const checker of previousPermissionsCheckers) {
         checker.dispose();
@@ -186,14 +186,14 @@ export class ContextsManagerExperimental {
     const healthChecker = this.#healthCheckers.get(state.contextName);
     healthChecker?.dispose();
     this.#healthCheckers.delete(state.contextName);
-    const permissionsCheckers = this.#permissionsCheckers.filter(permissionChecker =>
-      permissionChecker.isForContext(state.contextName),
+    const permissionsCheckers = this.#permissionsCheckers.filter(
+      permissionChecker => permissionChecker.contextName === state.contextName,
     );
     for (const checker of permissionsCheckers) {
       checker.dispose();
     }
     this.#permissionsCheckers = this.#permissionsCheckers.filter(
-      permissionChecker => !permissionChecker.isForContext(state.contextName),
+      permissionChecker => permissionChecker.contextName !== state.contextName,
     );
   }
 

--- a/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.ts
@@ -65,14 +65,7 @@ export class ContextsStatesDispatcher {
   }
 
   getContextsPermissions(): ContextPermission[] {
-    return Array.from(this.manager.getPermissions().entries()).flatMap(([contextName, permissions]) => {
-      return Array.from(permissions.entries()).map(([resourceName, contextResourcePermission]) => ({
-        contextName,
-        resourceName,
-        permitted: contextResourcePermission.permitted,
-        reason: contextResourcePermission.reason,
-      }));
-    });
+    return this.manager.getPermissions();
   }
 
   updateResourcesCount(): void {


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

In Kubernetes experimental mode, support multiple permissions requests (see https://github.com/podman-desktop/podman-desktop/pull/11054 for more context)

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of #10657 

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
