### PR TITLE
fix: do not start informers for non permitted resources

### DIFF
--- a/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
@@ -136,6 +136,10 @@ export class ContextsManagerExperimental {
         newPermissionChecker.onPermissionResult(this.onPermissionResult.bind(this));
 
         newPermissionChecker.onPermissionResult((event: ContextPermissionResult) => {
+          if (!event.permitted) {
+            // if the user does not have watch permission, do not try to start informers on these resources
+            return;
+          }
           for (const resource of event.resources) {
             const contextName = event.kubeConfig.getKubeConfig().currentContext;
             const factory = this.#resourceFactoryHandler.getResourceFactoryByResourceName(resource);


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Do not start informers for non permitted resources

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of #10657 

### How to test this PR?

Connect to a cluster with no permission on some resource (see test preparation at https://github.com/podman-desktop/podman-desktop/issues/10655), and check that logs do not contain errors concerning informers errors on these resources

- [x] Tests are covering the bug fix or the new feature
