### PR TITLE
fix: update order of statusbar items

### DIFF
--- a/packages/renderer/src/lib/statusbar/StatusBar.svelte
+++ b/packages/renderer/src/lib/statusbar/StatusBar.svelte
@@ -91,9 +91,6 @@ onDestroy(() => {
   role="contentinfo"
   aria-label="Status Bar">
   <div class="flex flex-nowrap gap-x-1.5 h-full truncate">
-    {#each leftEntries as entry}
-      <StatusBarItem entry={entry} />
-    {/each}
     {#if experimentalProvidersStatusBar}
       {#each containerProviders as entry}
         <ProviderWidget entry={entry}/>
@@ -102,6 +99,9 @@ onDestroy(() => {
         <ProviderWidget entry={entry}/>
       {/each}
     {/if}
+    {#each leftEntries as entry}
+      <StatusBarItem entry={entry} />
+    {/each}
   </div>
   <div class="flex flex-wrap flex-row-reverse gap-x-1.5 h-full place-self-end">
     {#each rightEntries as entry}


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Fixes the order in the statusbar so that the providers would be first, followed by the current context and extensions.

### Screenshot / video of UI
![Screenshot from 2025-02-10 10-28-22](https://github.com/user-attachments/assets/1934c3f2-910d-4a90-988f-718bdee0447c)

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Fixes https://github.com/podman-desktop/podman-desktop/issues/10920

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
