### PR TITLE
feat: add and register Cronjob resource for Kubernetes experimental mode

### DIFF
--- a/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
@@ -33,6 +33,7 @@ import { ContextPermissionsChecker } from './context-permissions-checker.js';
 import { ContextResourceRegistry } from './context-resource-registry.js';
 import type { DispatcherEvent } from './contexts-dispatcher.js';
 import { ContextsDispatcher } from './contexts-dispatcher.js';
+import { CronjobsResourceFactory } from './cronjobs-resource-factory.js';
 import { DeploymentsResourceFactory } from './deployments-resource-factory.js';
 import { IngressesResourceFactory } from './ingresses-resource-factory.js';
 import { NodesResourceFactory } from './nodes-resource-factory.js';
@@ -106,6 +107,7 @@ export class ContextsManagerExperimental {
       new NodesResourceFactory(),
       new IngressesResourceFactory(),
       new RoutesResourceFactory(),
+      new CronjobsResourceFactory(),
     ];
   }
 

--- a/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
@@ -98,16 +98,16 @@ export class ContextsManagerExperimental {
 
   protected getResourceFactories(): ResourceFactory[] {
     return [
-      new PodsResourceFactory(),
-      new DeploymentsResourceFactory(),
       new ConfigmapsResourceFactory(),
+      new CronjobsResourceFactory(),
+      new DeploymentsResourceFactory(),
+      new IngressesResourceFactory(),
+      new NodesResourceFactory(),
+      new PodsResourceFactory(),
+      new PVCsResourceFactory(),
+      new RoutesResourceFactory(),
       new SecretsResourceFactory(),
       new ServicesResourceFactory(),
-      new PVCsResourceFactory(),
-      new NodesResourceFactory(),
-      new IngressesResourceFactory(),
-      new RoutesResourceFactory(),
-      new CronjobsResourceFactory(),
     ];
   }
 

--- a/packages/main/src/plugin/kubernetes/cronjobs-resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/cronjobs-resource-factory.ts
@@ -1,0 +1,59 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1CronJob, V1CronJobList } from '@kubernetes/client-node';
+import { BatchV1Api } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from './kubeconfig-single-context.js';
+import type { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryBase } from './resource-factory.js';
+import { ResourceInformer } from './resource-informer.js';
+
+export class CronjobsResourceFactory extends ResourceFactoryBase implements ResourceFactory {
+  constructor() {
+    super({
+      resource: 'cronjobs',
+    });
+
+    this.setPermissions({
+      isNamespaced: true,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          verb: 'watch',
+          resource: 'cronjobs',
+        },
+      ],
+    });
+    this.setInformer({
+      createInformer: this.createInformer,
+    });
+  }
+
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1CronJob> {
+    const namespace = kubeconfig.getNamespace();
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(BatchV1Api);
+    const listFn = (): Promise<V1CronJobList> => apiClient.listNamespacedCronJob({ namespace });
+    const path = `/apis/batch/v1/namespaces/${namespace}/cronjobs`;
+    return new ResourceInformer<V1CronJob>(kubeconfig, path, listFn, 'cronjobs');
+  }
+}


### PR DESCRIPTION
### What does this PR do?

Add and register Cronjob resource for Kubernetes experimental mode

### Screenshot / video of UI

### What issues does this PR fix or reference?

Part of #10657 

### How to test this PR?

Create a CronJob, and check that it appears in the CronJob list page, in experimental mode.

Set the Kubernetes experimental mode in `$HOME/.local/share/containers/podman-desktop/configuration/settings.json`:

```
"kubernetes.statesExperimental": true
```

Create a CronJob:

```
apiVersion: batch/v1
kind: CronJob
metadata:
  name: hello
spec:
  schedule: "* * * * *"
  jobTemplate:
    spec:
      template:
        spec:
          containers:
          - name: hello
            image: busybox:1.28
            imagePullPolicy: IfNotPresent
            command:
            - /bin/sh
            - -c
            - date; echo Hello from the Kubernetes cluster
          restartPolicy: OnFailure
```

- [x] Tests are covering the bug fix or the new feature
