### PR TITLE
feat: use KubernetesObjectsList for Kube pods

### DIFF
--- a/packages/renderer/src/lib/kube/pods/PodsList.spec.ts
+++ b/packages/renderer/src/lib/kube/pods/PodsList.spec.ts
@@ -21,13 +21,16 @@ import '@testing-library/jest-dom/vitest';
 import type { KubernetesObject, V1Pod } from '@kubernetes/client-node';
 import { fireEvent, render, screen, within } from '@testing-library/svelte';
 import { writable } from 'svelte/store';
-import { beforeEach, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import * as states from '/@/stores/kubernetes-contexts-state';
 
+import type { IDisposable } from '../../../../../main/src/plugin/types/disposable';
+import * as resourcesListen from '../resources-listen';
 import PodsList from './PodsList.svelte';
 
 vi.mock('/@/stores/kubernetes-contexts-state');
+vi.mock('../resources-listen');
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -37,200 +40,259 @@ beforeEach(() => {
   vi.mocked(states).kubernetesCurrentContextState = writable();
 });
 
-test('Expect pod empty screen', async () => {
-  vi.mocked(states).kubernetesCurrentContextPodsFiltered = writable<KubernetesObject[]>([]);
-  render(PodsList);
-  const noPods = screen.getByRole('heading', { name: 'No pods' });
-  expect(noPods).toBeInTheDocument();
-});
-
-test('Expect pods list', async () => {
-  const pod: V1Pod = {
-    apiVersion: 'v1',
-    kind: 'Pod',
-    metadata: { name: 'my-pod', namespace: 'default' },
-    spec: {
-      containers: [
-        {
-          name: 'test-container',
-          ports: [{ name: 'http', containerPort: 8080 }],
-        },
-      ],
+describe.each<{
+  experimental: boolean;
+  initMocks: () => void;
+  initObjectsList: (objects: KubernetesObject[]) => { update: (objects: KubernetesObject[]) => void };
+}>([
+  {
+    experimental: true,
+    initMocks: (): void => {
+      vi.mocked(states).kubernetesCurrentContextPodsFiltered = writable();
     },
-  };
-  vi.mocked(states).kubernetesCurrentContextPodsFiltered = writable<KubernetesObject[]>([pod]);
-
-  render(PodsList);
-  const podName = screen.getByRole('cell', { name: 'my-pod default' });
-  expect(podName).toBeInTheDocument();
-});
-
-test('Expect correct column overflow', async () => {
-  const pod: V1Pod = {
-    apiVersion: 'v1',
-    kind: 'Pod',
-    metadata: { name: 'my-pod', namespace: 'default' },
-    spec: {
-      containers: [
-        {
-          name: 'test-container',
-          ports: [{ name: 'http', containerPort: 8080 }],
+    initObjectsList: (objects: KubernetesObject[]): { update: (objects: KubernetesObject[]) => void } => {
+      let callback: (resoures: KubernetesObject[]) => void;
+      vi.mocked(resourcesListen.listenResources).mockImplementation(
+        async (_resources, _options, cb): Promise<IDisposable> => {
+          callback = cb;
+          setTimeout(() => callback(objects));
+          return {
+            dispose: (): void => {},
+          };
         },
-      ],
-    },
-  };
-  vi.mocked(states).kubernetesCurrentContextPodsFiltered = writable<KubernetesObject[]>([pod]);
-
-  render(PodsList);
-  const rows = await screen.findAllByRole('row');
-  expect(rows).toBeDefined();
-  expect(rows.length).toBe(2);
-
-  const cells = await within(rows[1]).findAllByRole('cell');
-  expect(cells).toBeDefined();
-  expect(cells.length).toBe(7);
-
-  expect(cells[2]).toHaveClass('overflow-hidden');
-  expect(cells[3]).toHaveClass('overflow-hidden');
-  expect(cells[4]).not.toHaveClass('overflow-hidden');
-  expect(cells[5]).toHaveClass('overflow-hidden');
-});
-
-test('Expect filter empty screen', async () => {
-  vi.mocked(states).kubernetesCurrentContextPodsFiltered = writable<KubernetesObject[]>([]);
-
-  render(PodsList, { searchTerm: 'No match' });
-  const filterButton = screen.getByRole('button', { name: 'Clear filter' });
-  expect(filterButton).toBeInTheDocument();
-});
-
-test('Expect user confirmation to pop up when preferences require', async () => {
-  const pod: V1Pod = {
-    apiVersion: 'v1',
-    kind: 'Pod',
-    metadata: { name: 'my-pod', namespace: 'default' },
-    spec: {
-      containers: [
-        {
-          name: 'test-container',
-          ports: [{ name: 'http', containerPort: 8080 }],
+      );
+      return {
+        update: (updatedObjects: KubernetesObject[]): void => {
+          callback(updatedObjects);
         },
-      ],
+      };
     },
-  };
-  vi.mocked(states).kubernetesCurrentContextPodsFiltered = writable<KubernetesObject[]>([pod]);
-
-  render(PodsList);
-
-  const checkboxes = screen.getAllByRole('checkbox', { name: 'Toggle pod' });
-  await fireEvent.click(checkboxes[0]);
-
-  vi.mocked(window.getConfigurationValue).mockResolvedValue(true);
-
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 1 });
-
-  const deleteButton = screen.getByRole('button', { name: 'Delete 1 selected items' });
-  await fireEvent.click(deleteButton);
-
-  expect(window.showMessageBox).toHaveBeenCalledOnce();
-
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
-  await fireEvent.click(deleteButton);
-  expect(window.showMessageBox).toHaveBeenCalledTimes(2);
-  await vi.waitFor(() => expect(window.kubernetesDeletePod).toHaveBeenCalled());
-});
-
-test('pods list is updated when kubernetesCurrentContextPodsFiltered changes', async () => {
-  const pod1: V1Pod = {
-    apiVersion: 'v1',
-    kind: 'Pod',
-    metadata: { name: 'my-pod-1', namespace: 'test-namespace' },
-    spec: {
-      containers: [
-        {
-          name: 'test-container',
-          ports: [{ name: 'http', containerPort: 8080 }],
+  },
+  {
+    experimental: false,
+    initMocks: (): void => {
+      vi.mocked(resourcesListen.listenResources).mockResolvedValue(undefined);
+    },
+    initObjectsList: (objects: KubernetesObject[]): { update: (objects: KubernetesObject[]) => void } => {
+      const store = writable<KubernetesObject[]>(objects);
+      vi.mocked(states).kubernetesCurrentContextPodsFiltered = store;
+      return {
+        update: (objects: KubernetesObject[]): void => {
+          store.set(objects);
         },
-      ],
+      };
     },
-  };
-  const pod2: V1Pod = {
-    apiVersion: 'v1',
-    kind: 'Pod',
-    metadata: { name: 'my-pod-2', namespace: 'test-namespace' },
-    spec: {
-      containers: [
-        {
-          name: 'test-container',
-          ports: [{ name: 'http', containerPort: 8080 }],
-        },
-      ],
-    },
-  };
-  const filtered = writable<KubernetesObject[]>([pod1, pod2]);
-  vi.mocked(states).kubernetesCurrentContextPodsFiltered = filtered;
+  },
+])('kubernetes experimental is %s', ({ experimental: _experimental, initObjectsList, initMocks }) => {
+  beforeEach(() => {
+    initMocks();
+  });
 
-  const component = render(PodsList);
-  const podName1 = screen.getByRole('cell', { name: 'my-pod-1 test-namespace' });
-  expect(podName1).toBeInTheDocument();
-  const podName2 = screen.getByRole('cell', { name: 'my-pod-2 test-namespace' });
-  expect(podName2).toBeInTheDocument();
+  test('Expect pod empty screen', async () => {
+    initObjectsList([]);
+    render(PodsList);
+    const noPods = screen.getByRole('heading', { name: 'No pods' });
+    expect(noPods).toBeInTheDocument();
+  });
 
-  filtered.set([pod2]);
-  await component.rerender({});
-
-  const podName1after = screen.queryByRole('cell', { name: 'my-pod-1 test-namespace' });
-  expect(podName1after).not.toBeInTheDocument();
-  const podName2after = screen.getByRole('cell', { name: 'my-pod-2 test-namespace' });
-  expect(podName2after).toBeInTheDocument();
-});
-
-test('Expect the pod1 row to have 3 status dots with the correct colors and the pod2 row to have 1 status dot', async () => {
-  const pod: V1Pod = {
-    apiVersion: 'v1',
-    kind: 'Pod',
-    metadata: { name: 'my-pod-1', namespace: 'test-namespace' },
-    status: {
-      containerStatuses: [
-        {
-          containerID: 'container-1',
-          name: 'container-1-name',
-          state: {
-            waiting: {},
+  test('Expect pods list', async () => {
+    const pod: V1Pod = {
+      apiVersion: 'v1',
+      kind: 'Pod',
+      metadata: { name: 'my-pod', namespace: 'default' },
+      spec: {
+        containers: [
+          {
+            name: 'test-container',
+            ports: [{ name: 'http', containerPort: 8080 }],
           },
-        },
-        {
-          containerID: 'container-2',
-          name: 'container-2-name',
-          state: {
-            terminated: {},
+        ],
+      },
+    };
+    initObjectsList([pod]);
+
+    render(PodsList);
+    await vi.waitFor(() => {
+      const podName = screen.getByRole('cell', { name: 'my-pod default' });
+      expect(podName).toBeInTheDocument();
+    });
+  });
+
+  test('Expect correct column overflow', async () => {
+    const pod: V1Pod = {
+      apiVersion: 'v1',
+      kind: 'Pod',
+      metadata: { name: 'my-pod', namespace: 'default' },
+      spec: {
+        containers: [
+          {
+            name: 'test-container',
+            ports: [{ name: 'http', containerPort: 8080 }],
           },
-        },
-        {
-          containerID: 'container-3',
-          name: 'container-3-name',
-          state: {
-            running: {},
+        ],
+      },
+    };
+    initObjectsList([pod]);
+
+    render(PodsList);
+
+    await vi.waitFor(async () => {
+      const rows = await screen.findAllByRole('row');
+      expect(rows).toBeDefined();
+      expect(rows.length).toBe(2);
+
+      const cells = await within(rows[1]).findAllByRole('cell');
+      expect(cells).toBeDefined();
+      expect(cells.length).toBe(7);
+
+      expect(cells[2]).toHaveClass('overflow-hidden');
+      expect(cells[3]).toHaveClass('overflow-hidden');
+      expect(cells[4]).not.toHaveClass('overflow-hidden');
+      expect(cells[5]).toHaveClass('overflow-hidden');
+    });
+  });
+
+  test('Expect filter empty screen', async () => {
+    initObjectsList([]);
+
+    render(PodsList, { searchTerm: 'No match' });
+    const filterButton = screen.getByRole('button', { name: 'Clear filter' });
+    expect(filterButton).toBeInTheDocument();
+  });
+
+  test('Expect user confirmation to pop up when preferences require', async () => {
+    const pod: V1Pod = {
+      apiVersion: 'v1',
+      kind: 'Pod',
+      metadata: { name: 'my-pod', namespace: 'default' },
+      spec: {
+        containers: [
+          {
+            name: 'test-container',
+            ports: [{ name: 'http', containerPort: 8080 }],
           },
-        },
-      ],
-    },
-  } as unknown as V1Pod;
-  const filtered = writable<KubernetesObject[]>([pod]);
-  vi.mocked(states).kubernetesCurrentContextPodsFiltered = filtered;
+        ],
+      },
+    };
+    initObjectsList([pod]);
 
-  render(PodsList);
+    render(PodsList);
 
-  // Should render 3 status dots, reordered
-  const statusDots = screen.getAllByTestId('status-dot');
-  expect(statusDots.length).toBe(3);
+    await vi.waitFor(async () => {
+      const checkboxes = screen.getAllByRole('checkbox', { name: 'Toggle pod' });
+      await fireEvent.click(checkboxes[0]);
+    });
 
-  expect(statusDots[0].title).toBe('container-3-name: Running');
-  expect(statusDots[0]).toHaveClass('bg-[var(--pd-status-running)]');
+    vi.mocked(window.getConfigurationValue).mockResolvedValue(true);
 
-  expect(statusDots[1].title).toBe('container-1-name: Waiting');
-  expect(statusDots[1]).toHaveClass('bg-[var(--pd-status-waiting)]');
+    vi.mocked(window.showMessageBox).mockResolvedValue({ response: 1 });
 
-  expect(statusDots[2].title).toBe('container-2-name: Terminated');
-  expect(statusDots[2]).toHaveClass('bg-[var(--pd-status-terminated)]');
+    const deleteButton = screen.getByRole('button', { name: 'Delete 1 selected items' });
+    await fireEvent.click(deleteButton);
+
+    expect(window.showMessageBox).toHaveBeenCalledOnce();
+
+    vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+    await fireEvent.click(deleteButton);
+    expect(window.showMessageBox).toHaveBeenCalledTimes(2);
+    await vi.waitFor(() => expect(window.kubernetesDeletePod).toHaveBeenCalled());
+  });
+
+  test('pods list is updated when kubernetesCurrentContextPodsFiltered changes', async () => {
+    const pod1: V1Pod = {
+      apiVersion: 'v1',
+      kind: 'Pod',
+      metadata: { name: 'my-pod-1', namespace: 'test-namespace' },
+      spec: {
+        containers: [
+          {
+            name: 'test-container',
+            ports: [{ name: 'http', containerPort: 8080 }],
+          },
+        ],
+      },
+    };
+    const pod2: V1Pod = {
+      apiVersion: 'v1',
+      kind: 'Pod',
+      metadata: { name: 'my-pod-2', namespace: 'test-namespace' },
+      spec: {
+        containers: [
+          {
+            name: 'test-container',
+            ports: [{ name: 'http', containerPort: 8080 }],
+          },
+        ],
+      },
+    };
+    const list = initObjectsList([pod1, pod2]);
+
+    const component = render(PodsList);
+
+    await vi.waitFor(() => {
+      const podName1 = screen.getByRole('cell', { name: 'my-pod-1 test-namespace' });
+      expect(podName1).toBeInTheDocument();
+      const podName2 = screen.getByRole('cell', { name: 'my-pod-2 test-namespace' });
+      expect(podName2).toBeInTheDocument();
+    });
+
+    list.update([pod2]);
+    await component.rerender({});
+
+    const podName1after = screen.queryByRole('cell', { name: 'my-pod-1 test-namespace' });
+    expect(podName1after).not.toBeInTheDocument();
+    const podName2after = screen.getByRole('cell', { name: 'my-pod-2 test-namespace' });
+    expect(podName2after).toBeInTheDocument();
+  });
+
+  test('Expect the pod1 row to have 3 status dots with the correct colors and the pod2 row to have 1 status dot', async () => {
+    const pod: V1Pod = {
+      apiVersion: 'v1',
+      kind: 'Pod',
+      metadata: { name: 'my-pod-1', namespace: 'test-namespace' },
+      status: {
+        containerStatuses: [
+          {
+            containerID: 'container-1',
+            name: 'container-1-name',
+            state: {
+              waiting: {},
+            },
+          },
+          {
+            containerID: 'container-2',
+            name: 'container-2-name',
+            state: {
+              terminated: {},
+            },
+          },
+          {
+            containerID: 'container-3',
+            name: 'container-3-name',
+            state: {
+              running: {},
+            },
+          },
+        ],
+      },
+    } as unknown as V1Pod;
+    initObjectsList([pod]);
+
+    render(PodsList);
+
+    await vi.waitFor(() => {
+      // Should render 3 status dots, reordered
+      const statusDots = screen.getAllByTestId('status-dot');
+      expect(statusDots.length).toBe(3);
+
+      expect(statusDots[0].title).toBe('container-3-name: Running');
+      expect(statusDots[0]).toHaveClass('bg-[var(--pd-status-running)]');
+
+      expect(statusDots[1].title).toBe('container-1-name: Waiting');
+      expect(statusDots[1]).toHaveClass('bg-[var(--pd-status-waiting)]');
+
+      expect(statusDots[2].title).toBe('container-2-name: Terminated');
+      expect(statusDots[2]).toHaveClass('bg-[var(--pd-status-terminated)]');
+    });
+  });
 });

--- a/packages/renderer/src/lib/kube/pods/PodsList.svelte
+++ b/packages/renderer/src/lib/kube/pods/PodsList.svelte
@@ -1,23 +1,12 @@
 <script lang="ts">
-import { faTrash } from '@fortawesome/free-solid-svg-icons';
-import {
-  Button,
-  FilteredEmptyScreen,
-  NavPage,
-  Table,
-  TableColumn,
-  TableDurationColumn,
-  TableRow,
-} from '@podman-desktop/ui-svelte';
+import { TableColumn, TableDurationColumn, TableRow } from '@podman-desktop/ui-svelte';
 import moment from 'moment';
 
-import KubernetesCurrentContextConnectionBadge from '/@/lib/ui/KubernetesCurrentContextConnectionBadge.svelte';
 import { kubernetesCurrentContextPodsFiltered, podSearchPattern } from '/@/stores/kubernetes-contexts-state';
 
-import { withBulkConfirmation } from '../../actions/BulkActions';
 import PodIcon from '../../images/PodIcon.svelte';
+import KubernetesObjectsList from '../../objects/KubernetesObjectsList.svelte';
 import PodEmptyScreen from '../../pod/PodEmptyScreen.svelte';
-import KubeApplyYamlButton from '../KubeApplyYAMLButton.svelte';
 import { PodUtils } from './pod-utils';
 import PodColumnActions from './PodColumnActions.svelte';
 import PodColumnContainers from './PodColumnContainers.svelte';
@@ -36,34 +25,6 @@ $effect(() => {
 });
 
 const podUtils = new PodUtils();
-const pods = $derived($kubernetesCurrentContextPodsFiltered.map(pod => podUtils.getPodUI(pod)));
-
-// delete the items selected in the list
-let bulkDeleteInProgress = $state<boolean>(false);
-async function deleteSelectedPods(): Promise<void> {
-  const selectedPods = pods.filter(pod => pod.selected);
-  if (selectedPods.length === 0) {
-    return;
-  }
-
-  // mark pods for deletion
-  bulkDeleteInProgress = true;
-  selectedPods.forEach(pod => (pod.status = 'DELETING'));
-
-  await Promise.all(
-    selectedPods.map(async pod => {
-      try {
-        await window.kubernetesDeletePod(pod.name);
-      } catch (e) {
-        console.error('error while deleting pod', e);
-      }
-    }),
-  );
-  bulkDeleteInProgress = false;
-}
-
-let selectedItemsNumber = $state<number>(0);
-let table: Table;
 
 let statusColumn = new TableColumn<PodUI>('Status', {
   align: 'center',
@@ -102,50 +63,24 @@ const columns = [
 const row = new TableRow<PodUI>({ selectable: (_pod): boolean => true });
 </script>
 
-<NavPage bind:searchTerm={searchTerm} title="pods">
-  <svelte:fragment slot="additional-actions">
-    <KubeApplyYamlButton />
-  </svelte:fragment>
-
-  <svelte:fragment slot="bottom-additional-actions">
-    {#if selectedItemsNumber > 0}
-      <Button
-        on:click={(): void =>
-          withBulkConfirmation(
-            deleteSelectedPods,
-            `delete ${selectedItemsNumber} pod${selectedItemsNumber > 1 ? 's' : ''}`,
-          )}
-        title="Delete {selectedItemsNumber} selected items"
-        inProgress={bulkDeleteInProgress}
-        icon={faTrash} />
-      <span>On {selectedItemsNumber} selected items.</span>
-    {/if}
-    <div class="flex grow justify-end">
-      <KubernetesCurrentContextConnectionBadge />
-    </div>
-  </svelte:fragment>
-
-  <div class="flex min-w-full h-full" slot="content">
-    <Table
-      kind="pod"
-      bind:this={table}
-      bind:selectedItemsNumber={selectedItemsNumber}
-      data={pods}
-      columns={columns}
-      row={row}
-      defaultSortColumn="Name">
-    </Table>
-
-    {#if $kubernetesCurrentContextPodsFiltered.length === 0}
-      {#if searchTerm}
-        <FilteredEmptyScreen
-          icon={PodIcon}
-          kind="pods"
-          searchTerm={searchTerm}
-          on:resetFilter={(): string => (searchTerm = '')} />
-      {:else}
-        <PodEmptyScreen />
-      {/if}
-    {/if}
-  </div>
-</NavPage>
+<KubernetesObjectsList
+  kinds={[{
+    resource: 'pods',
+    transformer: podUtils.getPodUI.bind(podUtils),
+    delete: window.kubernetesDeletePod,
+    isResource: (): boolean => true,
+    legacySearchPatternStore: podSearchPattern,
+    legacyObjectStore: kubernetesCurrentContextPodsFiltered,
+  }]}
+  singular="pod"
+  plural="pods"
+  icon={PodIcon}
+  searchTerm={searchTerm}
+  columns={columns}
+  row={row}
+>
+  <!-- eslint-disable-next-line sonarjs/no-unused-vars -->
+  {#snippet emptySnippet()}
+    <PodEmptyScreen />
+  {/snippet}
+</KubernetesObjectsList>


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Use KubernetesObjectsList for Kube pods

### Screenshot / video of UI


### What issues does this PR fix or reference?

Part of #10657

### How to test this PR?

Have pods running, and check they appear in experimental and non-experimental mode in the Kubernetes > Pods list page

Set the Kubernetes experimental mode in `$HOME/.local/share/containers/podman-desktop/configuration/settings.json`:

```
"kubernetes.statesExperimental": true
```


- [x] Tests are covering the bug fix or the new feature
