### PR TITLE
fix(ListItemButtonIcon): only use inline-flex when hidden is not set

### DIFF
--- a/packages/renderer/src/lib/ui/ListItemButtonIcon.spec.ts
+++ b/packages/renderer/src/lib/ui/ListItemButtonIcon.spec.ts
@@ -155,3 +155,35 @@ test('With custom Fa icon', async () => {
   // check it is a svelte-fa class
   expect(svgElement).toHaveClass('svelte-fa');
 });
+
+test('expect button to not have inline-flex when hidden is true', async () => {
+  const title = 'title';
+
+  render(ListItemButtonIcon, {
+    title,
+    icon: faRocket,
+    hidden: true,
+    menu: false,
+  });
+
+  const listItemSpan = screen.getByTitle(title);
+  expect(listItemSpan).toBeInTheDocument();
+  expect(listItemSpan).toHaveClass('hidden');
+  expect(listItemSpan).not.toHaveClass('inline-flex');
+});
+
+test('expect button to have inline-flex when hidden is false', async () => {
+  const title = 'title';
+
+  render(ListItemButtonIcon, {
+    title,
+    icon: faRocket,
+    hidden: false,
+    menu: false,
+  });
+
+  const listItemSpan = screen.getByTitle(title);
+  expect(listItemSpan).toBeInTheDocument();
+  expect(listItemSpan).not.toHaveClass('hidden');
+  expect(listItemSpan).toHaveClass('inline-flex');
+});

--- a/packages/renderer/src/lib/ui/ListItemButtonIcon.svelte
+++ b/packages/renderer/src/lib/ui/ListItemButtonIcon.svelte
@@ -89,13 +89,13 @@ onDestroy(() => {
 });
 
 const buttonDetailedClass =
-  'text-[var(--pd-action-button-details-text)] bg-[var(--pd-action-button-details-bg)] hover:text-[var(--pd-action-button-details-hover-text)] font-medium rounded-lg text-sm inline-flex items-center px-3 py-2 text-center';
+  'text-[var(--pd-action-button-details-text)] bg-[var(--pd-action-button-details-bg)] hover:text-[var(--pd-action-button-details-hover-text)] font-medium rounded-lg text-sm items-center px-3 py-2 text-center';
 const buttonDetailedDisabledClass =
-  'text-[var(--pd-action-button-details-disabled-text)] bg-[var(--pd-action-button-details-disabled-bg)] font-medium rounded-lg text-sm inline-flex items-center px-3 py-2 text-center';
+  'text-[var(--pd-action-button-details-disabled-text)] bg-[var(--pd-action-button-details-disabled-bg)] font-medium rounded-lg text-sm  items-center px-3 py-2 text-center';
 const buttonClass =
-  'text-[var(--pd-action-button-text)] hover:bg-[var(--pd-action-button-hover-bg)] hover:text-[var(--pd-action-button-hover-text)] font-medium rounded-full inline-flex items-center px-2 py-2 text-center';
+  'text-[var(--pd-action-button-text)] hover:bg-[var(--pd-action-button-hover-bg)] hover:text-[var(--pd-action-button-hover-text)] font-medium rounded-full items-center px-2 py-2 text-center';
 const buttonDisabledClass =
-  'text-[var(--pd-action-button-disabled-text)] font-medium rounded-full inline-flex items-center px-2 py-2 text-center';
+  'text-[var(--pd-action-button-disabled-text)] font-medium rounded-full items-center px-2 py-2 text-center';
 
 function handleClick(): void {
   if (enabled && !inProgress) {
@@ -133,6 +133,7 @@ const styleClass = $derived(
     class="{styleClass} relative"
     class:disabled={inProgress}
     class:hidden={hidden}
+    class:inline-flex={!hidden}
     disabled={!enabled}>
     {#if fontAwesomeIcon}
       <Fa class="h-4 w-4 {iconOffset}" icon={fontAwesomeIcon} />


### PR DESCRIPTION
### What does this PR do?

When both class `inline-flex` and `hidden` are set, the `inline-flex` is taking over the hidden. Leading to this property not being used.

![image](https://github.com/user-attachments/assets/4d3b7c8a-0487-4e88-a868-9503eaf32e38)


I suspect the svelte5 migration ( https://github.com/podman-desktop/podman-desktop/pull/10490 ) to have some internal changes with the `class:<name>={condition}` to change the ordering and therefore behaviour.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/11109

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
