### PR TITLE
feat(PodsLists): make the age column sortable

### DIFF
--- a/packages/renderer/src/lib/pod/PodsList.spec.ts
+++ b/packages/renderer/src/lib/pod/PodsList.spec.ts
@@ -522,7 +522,7 @@ const runningPod: PodInfo = {
       Status: 'running',
     },
   ],
-  Created: '',
+  Created: new Date().toISOString(), // now
   Id: 'beab25123a40',
   InfraId: 'pod1',
   Labels: {},
@@ -544,7 +544,7 @@ const stoppedPod: PodInfo = {
       Status: 'stopped',
     },
   ],
-  Created: '',
+  Created: new Date(new Date().getTime() - 1000 * 60).toISOString(), // now - 1 hour
   Id: 'e8129c5720b3',
   InfraId: 'pod2',
   Labels: {},
@@ -671,12 +671,37 @@ test('Expect age column to be sortable', async () => {
   window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
   window.dispatchEvent(new CustomEvent('extensions-already-started'));
 
+  await vi.waitUntil(() => get(providerInfos).length === 1 && get(podsInfos).length === 2, { timeout: 5000 });
+
   const { getAllByRole } = render(PodsList);
 
   // get all the column and found the age column by text content
   const ageColumn = getAllByRole('columnheader').find(header => header.textContent?.trim() === 'Age');
-  expect(ageColumn).toBeDefined();
+  if (!ageColumn) throw new Error('Age column is required');
 
   // Ensure the fa sort icon is visible
   expect(Array.from(ageColumn?.children ?? []).some(child => child.classList.contains('fa-sort'))).toBeTruthy();
+
+  // let's sort
+  await fireEvent.click(ageColumn);
+
+  // Wait for the right ordering (stoppedPod is now - 1 hour & runningPod is now)
+  await vi.waitFor(() => {
+    const items = getAllByRole('row');
+    expect(items).toHaveLength(3);
+    const [, first, second] = items;
+    // stopped should be first (old => new)
+    expect(first.textContent).toContain(stoppedPod.Name);
+    expect(second.textContent).toContain(runningPod.Name);
+  });
+
+  // let's invert the sorting
+  await fireEvent.click(ageColumn);
+
+  await vi.waitFor(() => {
+    const [, first, second] = getAllByRole('row');
+    // not inverted, running should be first (new => old)
+    expect(first.textContent).toContain(runningPod.Name);
+    expect(second.textContent).toContain(stoppedPod.Name);
+  });
 });

--- a/packages/renderer/src/lib/pod/PodsList.spec.ts
+++ b/packages/renderer/src/lib/pod/PodsList.spec.ts
@@ -663,3 +663,20 @@ test('Expect user confirmation to pop up when preferences require', async () => 
   expect(window.showMessageBox).toHaveBeenCalledTimes(2);
   await vi.waitFor(() => expect(window.removePod).toHaveBeenCalled());
 });
+
+test('Expect age column to be sortable', async () => {
+  getProvidersInfoMock.mockResolvedValue([provider]);
+  listPodsMock.mockResolvedValue([stoppedPod, runningPod]);
+  kubernetesListPodsMock.mockResolvedValue([]);
+  window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
+  window.dispatchEvent(new CustomEvent('extensions-already-started'));
+
+  const { getAllByRole } = render(PodsList);
+
+  // get all the column and found the age column by text content
+  const ageColumn = getAllByRole('columnheader').find(header => header.textContent?.trim() === 'Age');
+  expect(ageColumn).toBeDefined();
+
+  // Ensure the fa sort icon is visible
+  expect(Array.from(ageColumn?.children ?? []).some(child => child.classList.contains('fa-sort'))).toBeTruthy();
+});

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -146,6 +146,7 @@ let containersColumn = new TableColumn<PodInfoUI>('Containers', {
 
 let ageColumn = new TableColumn<PodInfoUI, Date | undefined>('Age', {
   renderer: TableDurationColumn,
+  comparator: (a, b): number => new Date(a.created).getTime() - new Date(b.created).getTime(),
   renderMapping(object): Date | undefined {
     return podUtils.getUpDate(object);
   },


### PR DESCRIPTION
### What does this PR do?

Allow pods to be sorted using their created property.

### Screenshot / video of UI

![image](https://github.com/user-attachments/assets/f86f762b-0311-4541-9a8f-5a37aa08230e)

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/10763

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

**Testing manually**

1. Create two Podman pods
2. Go to pods page
3. assert sort icon is visible next to Age column
4. Sorting should work as expected
