### PR TITLE
chore(extension-api): adding missing properties to Mounts property in `ContainerInspectInfo`

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -2837,8 +2837,10 @@ declare module '@podman-desktop/api' {
     };
     Mounts: Array<{
       Name?: string;
+      Type: string;
       Source: string;
       Destination: string;
+      Driver?: string;
       Mode: string;
       RW: boolean;
       Propagation: string;


### PR DESCRIPTION
### What does this PR do?

The `Mounts` properties for the `ContainerInspectInfo` is missing the `Type` and  `Driver` property. 

We can see it is already defined in the `ContainerInfo`.

https://github.com/podman-desktop/podman-desktop/blob/f06bacce25592549d76c253063d0c2c5d243b4f3/packages/extension-api/src/extension-api.d.ts#L2552-L2561

And we can get this info from `podman container inspect <id>`.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
