### PR TITLE
chore: remove kubernetes pods from pods page

### DIFF
--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -250,7 +250,7 @@ const row = new TableRow<PodInfoUI>({ selectable: (_pod): boolean => true });
       defaultSortColumn="Name"
       on:update={(): PodInfoUI[] => (pods = pods)}>
     </Table>
-    
+
     {#if $filtered.length === 0 && providerConnections.length === 0}
       <NoContainerEngineEmptyScreen />
     {:else if $filtered.length === 0}

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -3,6 +3,7 @@ import { faTrash } from '@fortawesome/free-solid-svg-icons';
 import {
   Button,
   FilteredEmptyScreen,
+  Link,
   NavPage,
   Table,
   TableColumn,
@@ -116,6 +117,10 @@ async function deleteSelectedPods(): Promise<void> {
   bulkDeleteInProgress = false;
 }
 
+async function openKubePods(): Promise<void> {
+  await window.navigateToRoute('kubernetes', { kind: 'Pod' });
+}
+
 let selectedItemsNumber: number = $state(0);
 let table: Table;
 
@@ -193,39 +198,45 @@ const row = new TableRow<PodInfoUI>({ selectable: (_pod): boolean => true });
   </svelte:fragment>
 
   <svelte:fragment slot="tabs">
-    <Button
-      type="tab"
-      on:click={(): void => {
-        searchTerm = searchTerm
-          .split(' ')
-          .filter(pattern => pattern !== 'is:running' && pattern !== 'is:stopped')
-          .join(' ');
-      }}
-      selected={!searchTerm.includes('is:stopped') && !searchTerm.includes('is:running')}>All</Button>
-    <Button
-      type="tab"
-      on:click={(): void => {
-        let temp = searchTerm
-          .trim()
-          .split(' ')
-          .filter(term => term !== 'is:stopped' && term !== 'is:running')
-          .join(' ')
-          .trim();
-        searchTerm = temp ? `${temp} is:running` : 'is:running';
-      }}
-      selected={searchTerm.includes('is:running')}>Running</Button>
-    <Button
-      type="tab"
-      on:click={(): void => {
-        let temp = searchTerm
-          .trim()
-          .split(' ')
-          .filter(term => term !== 'is:stopped' && term !== 'is:running')
-          .join(' ')
-          .trim();
-        searchTerm = temp ? `${temp} is:stopped` : 'is:stopped';
-      }}
-      selected={searchTerm.includes('is:stopped')}>Stopped</Button>
+    <div class="flex flex-col gap-3">
+      <div class="self-center text-[var(--pd-table-body-text)]">Looking for pods running on a Kubernetes cluster? We have moved them to the <Link on:click={openKubePods}>Kubernetes &gt; Pods</Link> page.</div>
+
+      <div class="flex flex-row">
+        <Button
+          type="tab"
+          on:click={(): void => {
+            searchTerm = searchTerm
+              .split(' ')
+              .filter(pattern => pattern !== 'is:running' && pattern !== 'is:stopped')
+              .join(' ');
+          }}
+          selected={!searchTerm.includes('is:stopped') && !searchTerm.includes('is:running')}>All</Button>
+        <Button
+          type="tab"
+          on:click={(): void => {
+            let temp = searchTerm
+              .trim()
+              .split(' ')
+              .filter(term => term !== 'is:stopped' && term !== 'is:running')
+              .join(' ')
+              .trim();
+            searchTerm = temp ? `${temp} is:running` : 'is:running';
+          }}
+          selected={searchTerm.includes('is:running')}>Running</Button>
+        <Button
+          type="tab"
+          on:click={(): void => {
+            let temp = searchTerm
+              .trim()
+              .split(' ')
+              .filter(term => term !== 'is:stopped' && term !== 'is:running')
+              .join(' ')
+              .trim();
+            searchTerm = temp ? `${temp} is:stopped` : 'is:stopped';
+          }}
+          selected={searchTerm.includes('is:stopped')}>Stopped</Button>
+      </div>
+    </div>
   </svelte:fragment>
 
   <div class="flex min-w-full h-full" slot="content">
@@ -239,7 +250,7 @@ const row = new TableRow<PodInfoUI>({ selectable: (_pod): boolean => true });
       defaultSortColumn="Name"
       on:update={(): PodInfoUI[] => (pods = pods)}>
     </Table>
-
+    
     {#if $filtered.length === 0 && providerConnections.length === 0}
       <NoContainerEngineEmptyScreen />
     {:else if $filtered.length === 0}

--- a/packages/renderer/src/stores/pods.spec.ts
+++ b/packages/renderer/src/stores/pods.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,6 @@ const listPodsMock: Mock<() => Promise<PodInfo[]>> = vi.fn();
 Object.defineProperty(global, 'window', {
   value: {
     listPods: listPodsMock,
-    kubernetesListPods: vi.fn().mockImplementation(() => Promise.resolve([])),
     events: {
       receive: eventEmitter.receive,
     },

--- a/packages/renderer/src/stores/pods.ts
+++ b/packages/renderer/src/stores/pods.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022-2023 Red Hat, Inc.
+ * Copyright (C) 2022-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,25 +77,17 @@ export const filtered = derived([searchPattern, podsInfos], ([$searchPattern, $i
     });
 });
 
+const listPods = (): Promise<PodInfo[]> => {
+  return window.listPods();
+};
+
 export const podsEventStore = new EventStore<PodInfo[]>(
   'pods',
   podsInfos,
   checkForUpdate,
   windowEvents,
   windowListeners,
-  grabAllPods,
+  listPods,
   PodIcon,
 );
 podsEventStore.setupWithDebounce();
-
-export async function grabAllPods(): Promise<PodInfo[]> {
-  let result = await window.listPods();
-  try {
-    const pods = await window.kubernetesListPods();
-    result = result.concat(pods);
-  } finally {
-    podsInfos.set(result);
-  }
-
-  return result;
-}


### PR DESCRIPTION
### What does this PR do?

First part of #8819. Removes the data for Kubernetes pods from the Pods page, and
adds a simple message to the top for anyone trying to figure out where their Kube
pods are.

This is the core initial/minimal breaking change for the user, without any of the
internal or UI cleanup.

### Screenshot / video of UI

<img width="688" alt="Screenshot 2025-02-24 at 10 49 56 AM" src="https://github.com/user-attachments/assets/34b7a419-6d64-4d9a-ab36-d61d69c0a49e" />

### What issues does this PR fix or reference?

First part of #8819.

### How to test this PR?

Create pods on Podman and a cluster. Confirm that the Pods page only shows the former and includes the new message.

- [x] Tests are covering the bug fix or the new feature