### PR TITLE
chore: increase size of checkboxes

### DIFF
--- a/packages/ui/src/lib/checkbox/Checkbox.spec.ts
+++ b/packages/ui/src/lib/checkbox/Checkbox.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023, 2024 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,8 @@ test('Basic check', async () => {
   expect(checkbox).toBeInTheDocument();
   expect(checkbox).toBeEnabled();
   expect(checkbox).toHaveClass('top-0 left-0 w-px h-px');
+  expect(checkbox).toHaveClass('opacity-0');
+  expect(checkbox).toHaveClass('text-xl');
 
   const parent = checkbox.parentElement;
   expect(parent).toBeInTheDocument();
@@ -54,6 +56,7 @@ test('Basic check', async () => {
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveClass('text-[var(--pd-input-checkbox-unchecked)]');
   expect(icon).toHaveClass('hover:text-[var(--pd-input-checkbox-focused-unchecked)]');
+  expect(icon).toHaveStyle('font-size: 1.3em');
 });
 
 test('Check checked state', async () => {
@@ -72,6 +75,7 @@ test('Check checked state', async () => {
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveClass('text-[var(--pd-input-checkbox-checked)]');
   expect(icon).toHaveClass('hover:text-[var(--pd-input-checkbox-focused-checked)]');
+  expect(icon).toHaveStyle('font-size: 1.3em');
 });
 
 test('Check indeterminate state', async () => {
@@ -90,6 +94,7 @@ test('Check indeterminate state', async () => {
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveClass('text-[var(--pd-input-checkbox-indeterminate)]');
   expect(icon).toHaveClass('hover:text-[var(--pd-input-checkbox-focused-indeterminate)]');
+  expect(icon).toHaveStyle('font-size: 1.3em');
 });
 
 test('Check disabled state', async () => {
@@ -108,6 +113,7 @@ test('Check disabled state', async () => {
   const icon = peer?.children[0];
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveClass('text-[var(--pd-input-checkbox-disabled)]');
+  expect(icon).toHaveStyle('font-size: 1.3em');
 });
 
 test('Check tooltips', async () => {

--- a/packages/ui/src/lib/checkbox/Checkbox.spec.ts
+++ b/packages/ui/src/lib/checkbox/Checkbox.spec.ts
@@ -56,7 +56,7 @@ test('Basic check', async () => {
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveClass('text-[var(--pd-input-checkbox-unchecked)]');
   expect(icon).toHaveClass('hover:text-[var(--pd-input-checkbox-focused-unchecked)]');
-  expect(icon).toHaveStyle('font-size: 1.3em');
+  expect(icon).toHaveStyle('font-size: 1.33em');
 });
 
 test('Check checked state', async () => {
@@ -75,7 +75,7 @@ test('Check checked state', async () => {
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveClass('text-[var(--pd-input-checkbox-checked)]');
   expect(icon).toHaveClass('hover:text-[var(--pd-input-checkbox-focused-checked)]');
-  expect(icon).toHaveStyle('font-size: 1.3em');
+  expect(icon).toHaveStyle('font-size: 1.33em');
 });
 
 test('Check indeterminate state', async () => {
@@ -94,7 +94,7 @@ test('Check indeterminate state', async () => {
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveClass('text-[var(--pd-input-checkbox-indeterminate)]');
   expect(icon).toHaveClass('hover:text-[var(--pd-input-checkbox-focused-indeterminate)]');
-  expect(icon).toHaveStyle('font-size: 1.3em');
+  expect(icon).toHaveStyle('font-size: 1.33em');
 });
 
 test('Check disabled state', async () => {
@@ -113,7 +113,7 @@ test('Check disabled state', async () => {
   const icon = peer?.children[0];
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveClass('text-[var(--pd-input-checkbox-disabled)]');
-  expect(icon).toHaveStyle('font-size: 1.3em');
+  expect(icon).toHaveStyle('font-size: 1.33em');
 });
 
 test('Check tooltips', async () => {

--- a/packages/ui/src/lib/checkbox/Checkbox.svelte
+++ b/packages/ui/src/lib/checkbox/Checkbox.svelte
@@ -14,6 +14,7 @@ export let name: string | undefined = undefined;
 export let required = false;
 
 const dispatch = createEventDispatcher<{ click: boolean }>();
+const faSize = '1.33x';
 
 function onClick(
   event: MouseEvent & {
@@ -33,20 +34,20 @@ function onClick(
       class:cursor-pointer={!disabled}
       class:cursor-not-allowed={disabled}>
       {#if disabled}
-        <Fa size="1.3x" icon={faSquare} class="text-[var(--pd-input-checkbox-disabled)]" />
+        <Fa size={faSize} icon={faSquare} class="text-[var(--pd-input-checkbox-disabled)]" />
       {:else if indeterminate}
         <Fa
-          size="1.3x"
+          size={faSize}
           icon={faMinusSquare}
           class="text-[var(--pd-input-checkbox-indeterminate)] hover:text-[var(--pd-input-checkbox-focused-indeterminate)]" />
       {:else if checked}
         <Fa
-          size="1.3x"
+          size={faSize}
           icon={faCheckSquare}
           class="text-[var(--pd-input-checkbox-checked)] hover:text-[var(--pd-input-checkbox-focused-checked)]" />
       {:else}
         <Fa
-          size="1.3x"
+          size={faSize}
           icon={faOutlineSquare}
           class="text-[var(--pd-input-checkbox-unchecked)] hover:text-[var(--pd-input-checkbox-focused-unchecked)]" />
       {/if}

--- a/packages/ui/src/lib/checkbox/Checkbox.svelte
+++ b/packages/ui/src/lib/checkbox/Checkbox.svelte
@@ -33,20 +33,20 @@ function onClick(
       class:cursor-pointer={!disabled}
       class:cursor-not-allowed={disabled}>
       {#if disabled}
-        <Fa size="1.1x" icon={faSquare} class="text-[var(--pd-input-checkbox-disabled)]" />
+        <Fa size="1.3x" icon={faSquare} class="text-[var(--pd-input-checkbox-disabled)]" />
       {:else if indeterminate}
         <Fa
-          size="1.1x"
+          size="1.3x"
           icon={faMinusSquare}
           class="text-[var(--pd-input-checkbox-indeterminate)] hover:text-[var(--pd-input-checkbox-focused-indeterminate)]" />
       {:else if checked}
         <Fa
-          size="1.1x"
+          size="1.3x"
           icon={faCheckSquare}
           class="text-[var(--pd-input-checkbox-checked)] hover:text-[var(--pd-input-checkbox-focused-checked)]" />
       {:else}
         <Fa
-          size="1.1x"
+          size="1.3x"
           icon={faOutlineSquare}
           class="text-[var(--pd-input-checkbox-unchecked)] hover:text-[var(--pd-input-checkbox-focused-unchecked)]" />
       {/if}
@@ -61,7 +61,7 @@ function onClick(
       required={required}
       class:cursor-pointer={!disabled}
       class:cursor-not-allowed={disabled}
-      class="opacity-0 absolute top-0 left-0 w-px h-px text-lg"
+      class="opacity-0 absolute top-0 left-0 w-px h-px text-xl"
       on:click={onClick} />
   </div>
   <slot />


### PR DESCRIPTION
### What does this PR do?

Our checkboxes are a bit small, I've noticed it too. This just bumps them up a little bit so they're easier to see and click.

### Screenshot / video of UI

Before:

<img width="130" alt="Screenshot 2025-02-13 at 9 11 43 AM" src="https://github.com/user-attachments/assets/391a02ac-1224-4a55-8545-c369939a555f" />
<img width="130" alt="Screenshot 2025-02-13 at 9 11 52 AM" src="https://github.com/user-attachments/assets/a79e15b8-e0b9-426c-926f-a8a37c89fb7d" />

After:

<img width="130" alt="Screenshot 2025-02-13 at 8 52 52 AM" src="https://github.com/user-attachments/assets/8b29f33e-caea-40a3-bacd-c62bf071cdd6" />
<img width="130" alt="Screenshot 2025-02-13 at 8 53 37 AM" src="https://github.com/user-attachments/assets/dc6fcd3c-1596-45ee-95ba-d9f0159b8726" />

### What issues does this PR fix or reference?

Fixes #11133.

### How to test this PR?

Looks at lists and pages with checkboxes, e.g. Images and Run Image form.

- [x] Tests are covering the bug fix or the new feature