### PR TITLE
fix: libkrun is only supported on silicon/M* macs

### DIFF
--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -2350,19 +2350,29 @@ describe('checkRosettaMacArm', async () => {
   });
 });
 
+test('isLibkrunSupported should return false with 5.3.0 on intel', async () => {
+  vi.mocked(extensionApi.env).isMac = true;
+  vi.mocked(arch).mockReturnValue('x64');
+  const enabled = extension.isLibkrunSupported('5.3.0');
+  expect(enabled).toBeFalsy();
+});
+
 test('isLibkrunSupported should return true with prelease older than rc1', async () => {
+  vi.mocked(arch).mockReturnValue('arm64');
   vi.mocked(extensionApi.env).isMac = true;
   const enabled = extension.isLibkrunSupported('5.2.0-rc2');
   expect(enabled).toBeTruthy();
 });
 
 test('isLibkrunSupported should return true with 5.2.0 version', async () => {
+  vi.mocked(arch).mockReturnValue('arm64');
   vi.mocked(extensionApi.env).isMac = true;
   const enabled = extension.isLibkrunSupported('5.2.0');
   expect(enabled).toBeTruthy();
 });
 
 test('isLibkrunSupported should return false with previous 5.1.2 version', async () => {
+  vi.mocked(arch).mockReturnValue('arm64');
   vi.mocked(extensionApi.env).isMac = true;
   const enabled = extension.isLibkrunSupported('5.1.2');
   expect(enabled).toBeFalsy();

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -1921,9 +1921,13 @@ export function isUserModeNetworkingSupported(podmanVersion: string): boolean {
 
 const PODMAN_MINIMUM_VERSION_FOR_LIBKRUN_SUPPORT = '5.2.0-rc1';
 
-// Checks if libkrun is supported. Only Mac platform allows this parameter to be tuned
+// Checks if libkrun is supported. Only Mac/silicon platform allows this parameter to be tuned
 export function isLibkrunSupported(podmanVersion: string): boolean {
-  return extensionApi.env.isMac && compareVersions(podmanVersion, PODMAN_MINIMUM_VERSION_FOR_LIBKRUN_SUPPORT) >= 0;
+  return (
+    extensionApi.env.isMac &&
+    os.arch() === 'arm64' &&
+    compareVersions(podmanVersion, PODMAN_MINIMUM_VERSION_FOR_LIBKRUN_SUPPORT) >= 0
+  );
 }
 
 // Set wslEnabled. Used for testing purposes


### PR DESCRIPTION
### What does this PR do?
podman 5.4.0+ onwards throw an error now when trying to list podman machines on a unsupported provider
we were issuing two calls on macOS, one for libkrun and one for applehv and since 5.4 as we received an error it makes podman as being in an error state.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes #11120 

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
