### PR TITLE
fix: refresh machine settings after podman installation

### DIFF
--- a/extensions/podman/packages/extension/src/podman-install.ts
+++ b/extensions/podman/packages/extension/src/podman-install.ts
@@ -27,6 +27,7 @@ import { BaseCheck, OrCheck, SequenceCheck } from './base-check';
 import { getDetectionChecks } from './detection-checks';
 import type { MachineJSON } from './extension';
 import {
+  calcPodmanMachineSetting,
   getJSONMachineList,
   isLibkrunSupported,
   isRootfulMachineInitSupported,
@@ -181,6 +182,7 @@ export class PodmanInstall {
           PODMAN_PROVIDER_LIBKRUN_SUPPORTED_KEY,
           isLibkrunSupported(newInstalledPodman.version),
         );
+        await calcPodmanMachineSetting();
       }
       // update detections checks
       provider.updateDetectionChecks(getDetectionChecks(newInstalledPodman));


### PR DESCRIPTION
Fixes #10246

### What does this PR do?

Refresh machine settings after Podman is installed

### Screenshot / video of UI


![onboarding](https://github.com/user-attachments/assets/6043ebb9-5ab1-4003-8ec0-ccf003032d9b)

### What issues does this PR fix or reference?

#10246 

### How to test this PR?

Run onboarding on Windows with Podman uninstalled before and check that all fields are available when creating an HyperV Podman 

- [X] Tests are covering the bug fix or the new feature
