### PR TITLE
fix: handle ApiException error during waitForPod/JobDeletion

### DIFF
--- a/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
@@ -283,12 +283,11 @@ vi.mock('/@/plugin/kubernetes/kubernetes-port-forward-service', async () => {
 
 const execMock = vi.fn();
 beforeAll(() => {
-  vi.mock('@kubernetes/client-node', async () => {
-    // eslint-disable-next-line @typescript-eslint/consistent-type-imports
-    const actual = await vi.importActual<typeof import('@kubernetes/client-node')>('@kubernetes/client-node');
+  vi.mock('@kubernetes/client-node', async importOriginal => {
+    const original = await importOriginal<typeof clientNode>();
     return {
       // we need to use original ApiException
-      ...actual,
+      ...original,
       KubeConfig: vi.fn(),
       CoreV1Api: {},
       AppsV1Api: {},

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
@@ -284,7 +284,11 @@ vi.mock('/@/plugin/kubernetes/kubernetes-port-forward-service', async () => {
 const execMock = vi.fn();
 beforeAll(() => {
   vi.mock('@kubernetes/client-node', async () => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+    const actual = await vi.importActual<typeof import('@kubernetes/client-node')>('@kubernetes/client-node');
     return {
+      // we need to use original ApiException
+      ...actual,
       KubeConfig: vi.fn(),
       CoreV1Api: {},
       AppsV1Api: {},
@@ -1646,7 +1650,9 @@ test('Should return true if the job is deleted within the timeout', async () => 
   const namespace = 'test-namespace';
   const jobName = 'test-job';
 
-  batchApiMock.readNamespacedJobStatus = vi.fn().mockRejectedValueOnce({ response: { statusCode: 404 } });
+  batchApiMock.readNamespacedJobStatus = vi
+    .fn()
+    .mockRejectedValueOnce(new clientNode.ApiException(404, 'a message', {}, {}));
 
   const result = await client.testWaitForJobDeletion(batchApiMock, namespace, jobName);
   expect(result).toBe(true);
@@ -1697,7 +1703,7 @@ test('Should throw an exception if a read namespaced job status API call returns
   const namespace = 'test-namespace';
   const jobName = 'test-job';
 
-  const errorResponse = { response: { statusCode: 500 } };
+  const errorResponse = new clientNode.ApiException(500, 'a message', {}, {});
   batchApiMock.readNamespacedJobStatus = vi.fn().mockRejectedValue(errorResponse);
 
   await expect(client.testWaitForJobDeletion(batchApiMock, namespace, jobName)).rejects.toThrow(
@@ -2027,7 +2033,9 @@ test('Should return true if the pod is successfully deleted', async () => {
   const namespace = 'default';
   const podName = 'test-pod';
 
-  (coreApiMock.readNamespacedPodStatus as Mock).mockRejectedValueOnce({ response: { statusCode: 404 } });
+  (coreApiMock.readNamespacedPodStatus as Mock).mockRejectedValueOnce(
+    new clientNode.ApiException(404, 'a message', {}, {}),
+  );
 
   const result = await client.testWaitForPodDeletion(coreApiMock as CoreV1Api, podName, namespace);
 
@@ -2081,7 +2089,7 @@ test('Should throw an error if an unexpected error occurs and it differs than 40
   const namespace = 'default';
   const podName = 'test-pod';
 
-  const errorResponse = { response: { statusCode: 500 } };
+  const errorResponse = new clientNode.ApiException(500, 'a message', {}, {});
   (coreApiMock.readNamespacedPodStatus as Mock).mockRejectedValueOnce(errorResponse);
 
   await expect(client.testWaitForPodDeletion(coreApiMock as CoreV1Api, podName, namespace)).rejects.toThrow(

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.ts
@@ -48,6 +48,7 @@ import type {
   V1Status,
 } from '@kubernetes/client-node';
 import {
+  ApiException,
   ApisApi,
   AppsV1Api,
   BatchV1Api,
@@ -1481,16 +1482,12 @@ export class KubernetesClient {
         await new Promise(resolve => setTimeout(resolve, 1000));
       } catch (e) {
         const error = e ?? {};
-        if (typeof error === 'object' && 'response' in error) {
-          const axiosError = error as { response: { statusCode: number } };
-          if (axiosError.response.statusCode === 404) {
-            return true;
-          }
+        if (error instanceof ApiException && error.code === 404) {
+          return true;
         }
         throw e;
       }
     }
-
     return false;
   }
 
@@ -1623,11 +1620,8 @@ export class KubernetesClient {
         await new Promise(resolve => setTimeout(resolve, 1000));
       } catch (e) {
         const error = e ?? {};
-        if (typeof error === 'object' && 'response' in error) {
-          const axiosError = error as { response: { statusCode: number } };
-          if (axiosError.response.statusCode === 404) {
-            return true;
-          }
+        if (error instanceof ApiException && error.code === 404) {
+          return true;
         }
         throw e;
       }


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Fix `waitForPodDeletion` and `waitForJobDeletion` to handle error as `ApiException`

The format of the error returned by the kubernetes-client library changed when updated to v1.x.


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes #10841 

### How to test this PR?

- Start a standalone pod, then restart it. It should be restarted correctly
- Create a job, then restart a pod created by this job. The job should be re-created correctly

- [x] Tests are covering the bug fix or the new feature
