### PR TITLE
fix: remove check of updateContainerConnection being called

### DIFF
--- a/packages/main/src/plugin/provider-registry.spec.ts
+++ b/packages/main/src/plugin/provider-registry.spec.ts
@@ -492,22 +492,6 @@ describe('when auto-starting a container connection', async () => {
     providerRegistry.registerAutostartEngine(autostartEngine);
   });
 
-  describe('when provider does not call updateContainerConnection', () => {
-    beforeEach(() => {
-      provider.registerAutostart({
-        start: async (_logger: Logger, _context?: AutostartContext) => {},
-      });
-    });
-
-    test('a warn should be displayed', async () => {
-      vi.spyOn(console, 'warn');
-      await providerRegistry.runAutostart('0');
-      expect(console.warn).toHaveBeenCalledWith(
-        `autostart called for provider internal but provider never called updateContainerConnection. Provider needs to call this method or UpdateContainerConnection events won't be propagated`,
-      );
-    });
-  });
-
   describe('when provider calls updateContainerConnection with non-registered connection', () => {
     beforeEach(() => {
       provider.registerAutostart({

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -399,7 +399,6 @@ export class ProviderRegistry {
     // grab the provider
     const provider = this.getMatchingProvider(internalId);
 
-    let updateContainerConnectionCalled: boolean = false;
     const context = Object.freeze({
       updateContainerConnection: (containerProviderConnection: ContainerProviderConnection): void => {
         if (!this.isContainerProviderConnectionRegistered(provider, containerProviderConnection)) {
@@ -407,7 +406,6 @@ export class ProviderRegistry {
             `container connection ${containerProviderConnection.name} is not registered by provider ${provider.name}`,
           );
         }
-        updateContainerConnectionCalled = true;
         const providerConnectionInfo = this.getProviderConnectionInfo(containerProviderConnection);
         if (this.isProviderContainerConnection(providerConnectionInfo)) {
           this.fireUpdateContainerConnectionEvents(provider.id, providerConnectionInfo);
@@ -415,11 +413,6 @@ export class ProviderRegistry {
       },
     });
     await autoStart.start(new LoggerImpl(), context);
-    if (!updateContainerConnectionCalled) {
-      console.warn(
-        `autostart called for provider ${provider.id} but provider never called updateContainerConnection. Provider needs to call this method or UpdateContainerConnection events won't be propagated`,
-      );
-    }
     // send the event
     this._onDidUpdateProvider.fire({
       id: provider.id,


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Remove check of updateContainerConnection being called

In case a podman machine is already started when Podman Desktop is started (with autostart enabled), the provider does not start any machine, and `updateContainerConnection` is not being called.

As the core cannot know if the provider started a machine or not, it cannot determine if the provider should have called this method or not.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #11157 

### How to test this PR?

See steps to reproduce in #11157 

- [x] Tests are covering the bug fix or the new feature
