### PR TITLE
fix(run-image-page): checkbox interactive name used

### DIFF
--- a/tests/playwright/src/model/pages/run-image-page.ts
+++ b/tests/playwright/src/model/pages/run-image-page.ts
@@ -121,7 +121,7 @@ export class RunImagePage extends BasePage {
         // disable the checkbox in advanced tab
         await this.activateTab('Advanced');
         const checkbox = this.page.getByRole('checkbox', {
-          name: 'Interactive: Keep STDIN',
+          name: 'Use interactive',
         });
         if (optionalParams.interactive) {
           await checkbox.check();


### PR DESCRIPTION
### What does this PR do?

When using the following code in a playwright test

```ts
const containers = await runImage.startContainer('potatoes', {
  interactive: false,
});
```

The test timeout, and the root cause were the name used for the checkbox locator of the interactive option. The name is the `title`of the checkbox component here

https://github.com/podman-desktop/podman-desktop/blob/bb1c3c0fbddcbabd2d5950d2939f6e920bc0d40f/packages/renderer/src/lib/image/RunImage.svelte#L828

Which is `Use interactive` not `Interactive: Keep STDIN`.

This was not an issue before, as we don't seems to have any tests starting a container and disabling the interactive option.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

Not sure if I should be writing a test 

cc @podman-desktop/qe-reviewers 
