### PR TITLE
feat: add apiVersion and kind to kubernetes objects

### DIFF
--- a/packages/main/src/plugin/kubernetes/configmaps-resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/configmaps-resource-factory.ts
@@ -54,6 +54,6 @@ export class ConfigmapsResourceFactory extends ResourceFactoryBase implements Re
     const apiClient = kubeconfig.getKubeConfig().makeApiClient(CoreV1Api);
     const listFn = (): Promise<V1ConfigMapList> => apiClient.listNamespacedConfigMap({ namespace });
     const path = `/api/v1/namespaces/${namespace}/configmaps`;
-    return new ResourceInformer<V1ConfigMap>(kubeconfig, path, listFn, 'configmaps');
+    return new ResourceInformer<V1ConfigMap>(kubeconfig, path, listFn, { kind: 'ConfigMap', plural: 'configmaps' });
   }
 }

--- a/packages/main/src/plugin/kubernetes/configmaps-resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/configmaps-resource-factory.ts
@@ -54,6 +54,6 @@ export class ConfigmapsResourceFactory extends ResourceFactoryBase implements Re
     const apiClient = kubeconfig.getKubeConfig().makeApiClient(CoreV1Api);
     const listFn = (): Promise<V1ConfigMapList> => apiClient.listNamespacedConfigMap({ namespace });
     const path = `/api/v1/namespaces/${namespace}/configmaps`;
-    return new ResourceInformer<V1ConfigMap>(kubeconfig, path, listFn, { kind: 'ConfigMap', plural: 'configmaps' });
+    return new ResourceInformer<V1ConfigMap>({ kubeconfig, path, listFn, kind: 'ConfigMap', plural: 'configmaps' });
   }
 }

--- a/packages/main/src/plugin/kubernetes/cronjobs-resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/cronjobs-resource-factory.ts
@@ -54,6 +54,6 @@ export class CronjobsResourceFactory extends ResourceFactoryBase implements Reso
     const apiClient = kubeconfig.getKubeConfig().makeApiClient(BatchV1Api);
     const listFn = (): Promise<V1CronJobList> => apiClient.listNamespacedCronJob({ namespace });
     const path = `/apis/batch/v1/namespaces/${namespace}/cronjobs`;
-    return new ResourceInformer<V1CronJob>(kubeconfig, path, listFn, 'cronjobs');
+    return new ResourceInformer<V1CronJob>(kubeconfig, path, listFn, { kind: 'CronJob', plural: 'cronjobs' });
   }
 }

--- a/packages/main/src/plugin/kubernetes/cronjobs-resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/cronjobs-resource-factory.ts
@@ -54,6 +54,6 @@ export class CronjobsResourceFactory extends ResourceFactoryBase implements Reso
     const apiClient = kubeconfig.getKubeConfig().makeApiClient(BatchV1Api);
     const listFn = (): Promise<V1CronJobList> => apiClient.listNamespacedCronJob({ namespace });
     const path = `/apis/batch/v1/namespaces/${namespace}/cronjobs`;
-    return new ResourceInformer<V1CronJob>(kubeconfig, path, listFn, { kind: 'CronJob', plural: 'cronjobs' });
+    return new ResourceInformer<V1CronJob>({ kubeconfig, path, listFn, kind: 'CronJob', plural: 'cronjobs' });
   }
 }

--- a/packages/main/src/plugin/kubernetes/deployments-resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/deployments-resource-factory.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024, 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,6 +55,6 @@ export class DeploymentsResourceFactory extends ResourceFactoryBase implements R
     const apiClient = kubeconfig.getKubeConfig().makeApiClient(AppsV1Api);
     const listFn = (): Promise<V1DeploymentList> => apiClient.listNamespacedDeployment({ namespace });
     const path = `/apis/apps/v1/namespaces/${namespace}/deployments`;
-    return new ResourceInformer<V1Deployment>(kubeconfig, path, listFn, { kind: 'Deployment', plural: 'deployments' });
+    return new ResourceInformer<V1Deployment>({ kubeconfig, path, listFn, kind: 'Deployment', plural: 'deployments' });
   }
 }

--- a/packages/main/src/plugin/kubernetes/deployments-resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/deployments-resource-factory.ts
@@ -55,6 +55,6 @@ export class DeploymentsResourceFactory extends ResourceFactoryBase implements R
     const apiClient = kubeconfig.getKubeConfig().makeApiClient(AppsV1Api);
     const listFn = (): Promise<V1DeploymentList> => apiClient.listNamespacedDeployment({ namespace });
     const path = `/apis/apps/v1/namespaces/${namespace}/deployments`;
-    return new ResourceInformer<V1Deployment>(kubeconfig, path, listFn, 'deployments');
+    return new ResourceInformer<V1Deployment>(kubeconfig, path, listFn, { kind: 'Deployment', plural: 'deployments' });
   }
 }

--- a/packages/main/src/plugin/kubernetes/ingresses-resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/ingresses-resource-factory.ts
@@ -55,6 +55,6 @@ export class IngressesResourceFactory extends ResourceFactoryBase implements Res
     const apiClient = kubeconfig.getKubeConfig().makeApiClient(NetworkingV1Api);
     const listFn = (): Promise<V1IngressList> => apiClient.listNamespacedIngress({ namespace });
     const path = `/apis/networking.k8s.io/v1/namespaces/${namespace}/ingresses`;
-    return new ResourceInformer<V1Ingress>(kubeconfig, path, listFn, { kind: 'Ingress', plural: 'ingresses' });
+    return new ResourceInformer<V1Ingress>({ kubeconfig, path, listFn, kind: 'Ingress', plural: 'ingresses' });
   }
 }

--- a/packages/main/src/plugin/kubernetes/ingresses-resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/ingresses-resource-factory.ts
@@ -55,6 +55,6 @@ export class IngressesResourceFactory extends ResourceFactoryBase implements Res
     const apiClient = kubeconfig.getKubeConfig().makeApiClient(NetworkingV1Api);
     const listFn = (): Promise<V1IngressList> => apiClient.listNamespacedIngress({ namespace });
     const path = `/apis/networking.k8s.io/v1/namespaces/${namespace}/ingresses`;
-    return new ResourceInformer<V1Ingress>(kubeconfig, path, listFn, 'ingresses');
+    return new ResourceInformer<V1Ingress>(kubeconfig, path, listFn, { kind: 'Ingress', plural: 'ingresses' });
   }
 }

--- a/packages/main/src/plugin/kubernetes/nodes-resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/nodes-resource-factory.ts
@@ -53,6 +53,6 @@ export class NodesResourceFactory extends ResourceFactoryBase implements Resourc
     const apiClient = kubeconfig.getKubeConfig().makeApiClient(CoreV1Api);
     const listFn = (): Promise<V1NodeList> => apiClient.listNode();
     const path = `/api/v1/nodes`;
-    return new ResourceInformer<V1Node>(kubeconfig, path, listFn, 'nodes');
+    return new ResourceInformer<V1Node>(kubeconfig, path, listFn, { kind: 'Node', plural: 'nodes' });
   }
 }

--- a/packages/main/src/plugin/kubernetes/nodes-resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/nodes-resource-factory.ts
@@ -53,6 +53,6 @@ export class NodesResourceFactory extends ResourceFactoryBase implements Resourc
     const apiClient = kubeconfig.getKubeConfig().makeApiClient(CoreV1Api);
     const listFn = (): Promise<V1NodeList> => apiClient.listNode();
     const path = `/api/v1/nodes`;
-    return new ResourceInformer<V1Node>(kubeconfig, path, listFn, { kind: 'Node', plural: 'nodes' });
+    return new ResourceInformer<V1Node>({ kubeconfig, path, listFn, kind: 'Node', plural: 'nodes' });
   }
 }

--- a/packages/main/src/plugin/kubernetes/pods-resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/pods-resource-factory.ts
@@ -54,6 +54,6 @@ export class PodsResourceFactory extends ResourceFactoryBase implements Resource
     const apiClient = kubeconfig.getKubeConfig().makeApiClient(CoreV1Api);
     const listFn = (): Promise<V1PodList> => apiClient.listNamespacedPod({ namespace });
     const path = `/api/v1/namespaces/${namespace}/pods`;
-    return new ResourceInformer<V1Pod>(kubeconfig, path, listFn, { kind: 'Pod', plural: 'pods' });
+    return new ResourceInformer<V1Pod>({ kubeconfig, path, listFn, kind: 'Pod', plural: 'pods' });
   }
 }

--- a/packages/main/src/plugin/kubernetes/pods-resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/pods-resource-factory.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024, 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,6 +54,6 @@ export class PodsResourceFactory extends ResourceFactoryBase implements Resource
     const apiClient = kubeconfig.getKubeConfig().makeApiClient(CoreV1Api);
     const listFn = (): Promise<V1PodList> => apiClient.listNamespacedPod({ namespace });
     const path = `/api/v1/namespaces/${namespace}/pods`;
-    return new ResourceInformer<V1Pod>(kubeconfig, path, listFn, 'pods');
+    return new ResourceInformer<V1Pod>(kubeconfig, path, listFn, { kind: 'Pod', plural: 'pods' });
   }
 }

--- a/packages/main/src/plugin/kubernetes/pvcs-resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/pvcs-resource-factory.ts
@@ -55,6 +55,9 @@ export class PVCsResourceFactory extends ResourceFactoryBase implements Resource
     const listFn = (): Promise<V1PersistentVolumeClaimList> =>
       apiClient.listNamespacedPersistentVolumeClaim({ namespace });
     const path = `/api/v1/namespaces/${namespace}/persistentvolumeclaims`;
-    return new ResourceInformer<V1PersistentVolumeClaim>(kubeconfig, path, listFn, 'persistentvolumeclaims');
+    return new ResourceInformer<V1PersistentVolumeClaim>(kubeconfig, path, listFn, {
+      kind: 'PersistentVolumeClaim',
+      plural: 'persistentvolumeclaims',
+    });
   }
 }

--- a/packages/main/src/plugin/kubernetes/pvcs-resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/pvcs-resource-factory.ts
@@ -55,7 +55,10 @@ export class PVCsResourceFactory extends ResourceFactoryBase implements Resource
     const listFn = (): Promise<V1PersistentVolumeClaimList> =>
       apiClient.listNamespacedPersistentVolumeClaim({ namespace });
     const path = `/api/v1/namespaces/${namespace}/persistentvolumeclaims`;
-    return new ResourceInformer<V1PersistentVolumeClaim>(kubeconfig, path, listFn, {
+    return new ResourceInformer<V1PersistentVolumeClaim>({
+      kubeconfig,
+      path,
+      listFn,
       kind: 'PersistentVolumeClaim',
       plural: 'persistentvolumeclaims',
     });

--- a/packages/main/src/plugin/kubernetes/resource-informer.spec.ts
+++ b/packages/main/src/plugin/kubernetes/resource-informer.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024, 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,12 +87,15 @@ test('ResourceInformer should eventually return the list of resources', async ()
   const listFn = vi.fn();
   const kubeconfig = new KubeConfigSingleContext(kc, contexts[0]!);
   const items = [{ metadata: { name: 'res1', namespace: 'ns1' } }, { metadata: { name: 'res2', namespace: 'ns1' } }];
-  listFn.mockResolvedValue({ items: items });
-  const informer = new ResourceInformer<MyResource>(kubeconfig, '/a/path', listFn, 'myresource');
+  listFn.mockResolvedValue({ apiVersion: 'v8', items: items });
+  const informer = new ResourceInformer<MyResource>(kubeconfig, '/a/path', listFn, {
+    kind: 'MyResource',
+    plural: 'myresources',
+  });
   const result = informer.start();
   await vi.waitFor(() => {
     const list = result.list();
-    expect(list).toEqual(items);
+    expect(list).toEqual(items.map(i => ({ apiVersion: 'v8', kind: 'MyResource', ...i })));
   });
 });
 
@@ -103,12 +106,15 @@ test('ResourceInformer should fire onCacheUpdated event with countChanged to tru
   const kubeconfig = new KubeConfigSingleContext(kc, contexts[0]!);
   const items = [{ metadata: { name: 'res1', namespace: 'ns1' } }, { metadata: { name: 'res2', namespace: 'ns1' } }];
   listFn.mockResolvedValue({ items: items });
-  const informer = new ResourceInformer<MyResource>(kubeconfig, '/a/path', listFn, 'myresource');
+  const informer = new ResourceInformer<MyResource>(kubeconfig, '/a/path', listFn, {
+    kind: 'MyResource',
+    plural: 'myresources',
+  });
   const onCacheUpdatedCB = vi.fn();
   informer.onCacheUpdated(onCacheUpdatedCB);
   informer.start();
   await vi.waitFor(() => {
-    expect(onCacheUpdatedCB).toHaveBeenCalledWith({ kubeconfig, resourceName: 'myresource', countChanged: true });
+    expect(onCacheUpdatedCB).toHaveBeenCalledWith({ kubeconfig, resourceName: 'myresources', countChanged: true });
   });
 });
 
@@ -122,7 +128,10 @@ test('ResourceInformer should fire onCacheUpdated event with countChanged to tru
     { metadata: { name: 'res2', namespace: 'ns1' } },
   ] as MyResource[];
   listFn.mockResolvedValue({ items: items });
-  const informer = new TestResourceInformer<MyResource>(kubeconfig, '/a/path', listFn, 'myresource');
+  const informer = new TestResourceInformer<MyResource>(kubeconfig, '/a/path', listFn, {
+    kind: 'MyResource',
+    plural: 'myresources',
+  });
   const getListWatchOnMock = vi.fn();
   vi.spyOn(informer, 'getListWatch').mockReturnValue({
     on: getListWatchOnMock,
@@ -137,7 +146,7 @@ test('ResourceInformer should fire onCacheUpdated event with countChanged to tru
   informer.onCacheUpdated(onCacheUpdatedCB);
   informer.start();
   await vi.waitFor(() => {
-    expect(onCacheUpdatedCB).toHaveBeenCalledWith({ kubeconfig, resourceName: 'myresource', countChanged: true });
+    expect(onCacheUpdatedCB).toHaveBeenCalledWith({ kubeconfig, resourceName: 'myresources', countChanged: true });
   });
 });
 
@@ -151,7 +160,10 @@ test('ResourceInformer should fire onCacheUpdated event with countChanged to fal
     { metadata: { name: 'res2', namespace: 'ns1' } },
   ] as MyResource[];
   listFn.mockResolvedValue({ items: items });
-  const informer = new TestResourceInformer<MyResource>(kubeconfig, '/a/path', listFn, 'myresource');
+  const informer = new TestResourceInformer<MyResource>(kubeconfig, '/a/path', listFn, {
+    kind: 'MyResource',
+    plural: 'myresources',
+  });
   const getListWatchOnMock = vi.fn();
   vi.spyOn(informer, 'getListWatch').mockReturnValue({
     on: getListWatchOnMock,
@@ -166,7 +178,7 @@ test('ResourceInformer should fire onCacheUpdated event with countChanged to fal
   informer.onCacheUpdated(onCacheUpdatedCB);
   informer.start();
   await vi.waitFor(() => {
-    expect(onCacheUpdatedCB).toHaveBeenCalledWith({ kubeconfig, resourceName: 'myresource', countChanged: false });
+    expect(onCacheUpdatedCB).toHaveBeenCalledWith({ kubeconfig, resourceName: 'myresources', countChanged: false });
   });
 });
 
@@ -175,7 +187,10 @@ test('ResourceInformer should fire onOffline event is informer fails', async () 
   kc.loadFromOptions(kcWith2contexts);
   const listFn = vi.fn();
   const kubeconfig = new KubeConfigSingleContext(kc, contexts[0]!);
-  const informer = new TestResourceInformer<MyResource>(kubeconfig, '/a/path', listFn, 'myresource');
+  const informer = new TestResourceInformer<MyResource>(kubeconfig, '/a/path', listFn, {
+    kind: 'MyResource',
+    plural: 'myresources',
+  });
   const onCB = vi.fn();
   vi.spyOn(informer, 'getListWatch').mockReturnValue({
     on: onCB,
@@ -193,7 +208,7 @@ test('ResourceInformer should fire onOffline event is informer fails', async () 
     kubeconfig,
     offline: true,
     reason: 'an error',
-    resourceName: 'myresource',
+    resourceName: 'myresources',
   });
 });
 
@@ -202,7 +217,10 @@ test('reconnect should do nothing if there is no error', async () => {
   kc.loadFromOptions(kcWith2contexts);
   const listFn = vi.fn();
   const kubeconfig = new KubeConfigSingleContext(kc, contexts[0]!);
-  const informer = new TestResourceInformer<MyResource>(kubeconfig, '/a/path', listFn, 'myresource');
+  const informer = new TestResourceInformer<MyResource>(kubeconfig, '/a/path', listFn, {
+    kind: 'MyResource',
+    plural: 'myresources',
+  });
   const onCB = vi.fn();
   const startMock = vi.fn().mockResolvedValue({});
   vi.spyOn(informer, 'getListWatch').mockReturnValue({
@@ -228,7 +246,10 @@ test('reconnect should call start again if there is an error', async () => {
   kc.loadFromOptions(kcWith2contexts);
   const listFn = vi.fn();
   const kubeconfig = new KubeConfigSingleContext(kc, contexts[0]!);
-  const informer = new TestResourceInformer<MyResource>(kubeconfig, '/a/path', listFn, 'myresource');
+  const informer = new TestResourceInformer<MyResource>(kubeconfig, '/a/path', listFn, {
+    kind: 'MyResource',
+    plural: 'myresources',
+  });
   const onCB = vi.fn();
   const startMock = vi.fn().mockResolvedValue({});
   vi.spyOn(informer, 'getListWatch').mockReturnValue({
@@ -254,7 +275,10 @@ test('informer is stopped when disposed', async () => {
   kc.loadFromOptions(kcWith2contexts);
   const listFn = vi.fn();
   const kubeconfig = new KubeConfigSingleContext(kc, contexts[0]!);
-  const informer = new TestResourceInformer<MyResource>(kubeconfig, '/a/path', listFn, 'myresource');
+  const informer = new TestResourceInformer<MyResource>(kubeconfig, '/a/path', listFn, {
+    kind: 'MyResource',
+    plural: 'myresources',
+  });
   const onCB = vi.fn();
   const startMock = vi.fn().mockResolvedValue({});
   const stopMock = vi.fn().mockResolvedValue({});

--- a/packages/main/src/plugin/kubernetes/resource-informer.spec.ts
+++ b/packages/main/src/plugin/kubernetes/resource-informer.spec.ts
@@ -88,7 +88,10 @@ test('ResourceInformer should eventually return the list of resources', async ()
   const kubeconfig = new KubeConfigSingleContext(kc, contexts[0]!);
   const items = [{ metadata: { name: 'res1', namespace: 'ns1' } }, { metadata: { name: 'res2', namespace: 'ns1' } }];
   listFn.mockResolvedValue({ apiVersion: 'v8', items: items });
-  const informer = new ResourceInformer<MyResource>(kubeconfig, '/a/path', listFn, {
+  const informer = new ResourceInformer<MyResource>({
+    kubeconfig,
+    path: '/a/path',
+    listFn,
     kind: 'MyResource',
     plural: 'myresources',
   });
@@ -106,7 +109,10 @@ test('ResourceInformer should fire onCacheUpdated event with countChanged to tru
   const kubeconfig = new KubeConfigSingleContext(kc, contexts[0]!);
   const items = [{ metadata: { name: 'res1', namespace: 'ns1' } }, { metadata: { name: 'res2', namespace: 'ns1' } }];
   listFn.mockResolvedValue({ items: items });
-  const informer = new ResourceInformer<MyResource>(kubeconfig, '/a/path', listFn, {
+  const informer = new ResourceInformer<MyResource>({
+    kubeconfig,
+    path: '/a/path',
+    listFn,
     kind: 'MyResource',
     plural: 'myresources',
   });
@@ -128,7 +134,10 @@ test('ResourceInformer should fire onCacheUpdated event with countChanged to tru
     { metadata: { name: 'res2', namespace: 'ns1' } },
   ] as MyResource[];
   listFn.mockResolvedValue({ items: items });
-  const informer = new TestResourceInformer<MyResource>(kubeconfig, '/a/path', listFn, {
+  const informer = new TestResourceInformer<MyResource>({
+    kubeconfig,
+    path: '/a/path',
+    listFn,
     kind: 'MyResource',
     plural: 'myresources',
   });
@@ -160,7 +169,10 @@ test('ResourceInformer should fire onCacheUpdated event with countChanged to fal
     { metadata: { name: 'res2', namespace: 'ns1' } },
   ] as MyResource[];
   listFn.mockResolvedValue({ items: items });
-  const informer = new TestResourceInformer<MyResource>(kubeconfig, '/a/path', listFn, {
+  const informer = new TestResourceInformer<MyResource>({
+    kubeconfig,
+    path: '/a/path',
+    listFn,
     kind: 'MyResource',
     plural: 'myresources',
   });
@@ -187,7 +199,10 @@ test('ResourceInformer should fire onOffline event is informer fails', async () 
   kc.loadFromOptions(kcWith2contexts);
   const listFn = vi.fn();
   const kubeconfig = new KubeConfigSingleContext(kc, contexts[0]!);
-  const informer = new TestResourceInformer<MyResource>(kubeconfig, '/a/path', listFn, {
+  const informer = new TestResourceInformer<MyResource>({
+    kubeconfig,
+    path: '/a/path',
+    listFn,
     kind: 'MyResource',
     plural: 'myresources',
   });
@@ -217,7 +232,10 @@ test('reconnect should do nothing if there is no error', async () => {
   kc.loadFromOptions(kcWith2contexts);
   const listFn = vi.fn();
   const kubeconfig = new KubeConfigSingleContext(kc, contexts[0]!);
-  const informer = new TestResourceInformer<MyResource>(kubeconfig, '/a/path', listFn, {
+  const informer = new TestResourceInformer<MyResource>({
+    kubeconfig,
+    path: '/a/path',
+    listFn,
     kind: 'MyResource',
     plural: 'myresources',
   });
@@ -246,7 +264,10 @@ test('reconnect should call start again if there is an error', async () => {
   kc.loadFromOptions(kcWith2contexts);
   const listFn = vi.fn();
   const kubeconfig = new KubeConfigSingleContext(kc, contexts[0]!);
-  const informer = new TestResourceInformer<MyResource>(kubeconfig, '/a/path', listFn, {
+  const informer = new TestResourceInformer<MyResource>({
+    kubeconfig,
+    path: '/a/path',
+    listFn,
     kind: 'MyResource',
     plural: 'myresources',
   });
@@ -275,7 +296,10 @@ test('informer is stopped when disposed', async () => {
   kc.loadFromOptions(kcWith2contexts);
   const listFn = vi.fn();
   const kubeconfig = new KubeConfigSingleContext(kc, contexts[0]!);
-  const informer = new TestResourceInformer<MyResource>(kubeconfig, '/a/path', listFn, {
+  const informer = new TestResourceInformer<MyResource>({
+    kubeconfig,
+    path: '/a/path',
+    listFn,
     kind: 'MyResource',
     plural: 'myresources',
   });

--- a/packages/main/src/plugin/kubernetes/resource-informer.ts
+++ b/packages/main/src/plugin/kubernetes/resource-informer.ts
@@ -44,7 +44,10 @@ export interface OfflineEvent extends BaseEvent {
   reason?: string;
 }
 
-export interface ResourceNames {
+export interface ResourceInformerOptions<T extends KubernetesObject> {
+  kubeconfig: KubeConfigSingleContext;
+  path: string;
+  listFn: ListPromise<T>;
   kind: string;
   plural: string;
 }
@@ -64,12 +67,12 @@ export class ResourceInformer<T extends KubernetesObject> implements Disposable 
   #onOffline = new Emitter<OfflineEvent>();
   onOffline: Event<OfflineEvent> = this.#onOffline.event;
 
-  constructor(kubeconfig: KubeConfigSingleContext, path: string, listFn: ListPromise<T>, names: ResourceNames) {
-    this.#kubeConfig = kubeconfig;
-    this.#path = path;
-    this.#listFn = listFn;
-    this.#pluralName = names.plural;
-    this.#kindName = names.kind;
+  constructor(options: ResourceInformerOptions<T>) {
+    this.#kubeConfig = options.kubeconfig;
+    this.#path = options.path;
+    this.#listFn = options.listFn;
+    this.#pluralName = options.plural;
+    this.#kindName = options.kind;
   }
 
   // start the informer and returns a cache to the data

--- a/packages/main/src/plugin/kubernetes/resource-informer.ts
+++ b/packages/main/src/plugin/kubernetes/resource-informer.ts
@@ -46,9 +46,13 @@ export interface OfflineEvent extends BaseEvent {
 
 export interface ResourceInformerOptions<T extends KubernetesObject> {
   kubeconfig: KubeConfigSingleContext;
+  // the endpoint in the Kubernetes api server to list the resources
   path: string;
+  // the function to list the resources
   listFn: ListPromise<T>;
+  // the kind of the resource (Pod, ...), appearing in the `kind` field of manifests for this resource
   kind: string;
+  // the name of the resource for the 'REST API' (pods, ...), appearing in the path above
   plural: string;
 }
 

--- a/packages/main/src/plugin/kubernetes/routes-resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/routes-resource-factory.ts
@@ -63,6 +63,6 @@ export class RoutesResourceFactory extends ResourceFactoryBase implements Resour
         plural: 'routes',
       });
     const path = `/apis/route.openshift.io/v1/namespaces/${namespace}/routes`;
-    return new ResourceInformer<V1Route>(kubeconfig, path, listFn, { kind: 'Route', plural: 'routes' });
+    return new ResourceInformer<V1Route>({ kubeconfig, path, listFn, kind: 'Route', plural: 'routes' });
   }
 }

--- a/packages/main/src/plugin/kubernetes/routes-resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/routes-resource-factory.ts
@@ -63,6 +63,6 @@ export class RoutesResourceFactory extends ResourceFactoryBase implements Resour
         plural: 'routes',
       });
     const path = `/apis/route.openshift.io/v1/namespaces/${namespace}/routes`;
-    return new ResourceInformer<V1Route>(kubeconfig, path, listFn, 'routes');
+    return new ResourceInformer<V1Route>(kubeconfig, path, listFn, { kind: 'Route', plural: 'routes' });
   }
 }

--- a/packages/main/src/plugin/kubernetes/secrets-resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/secrets-resource-factory.ts
@@ -54,6 +54,6 @@ export class SecretsResourceFactory extends ResourceFactoryBase implements Resou
     const apiClient = kubeconfig.getKubeConfig().makeApiClient(CoreV1Api);
     const listFn = (): Promise<V1SecretList> => apiClient.listNamespacedSecret({ namespace });
     const path = `/api/v1/namespaces/${namespace}/secrets`;
-    return new ResourceInformer<V1Secret>(kubeconfig, path, listFn, { kind: 'Secret', plural: 'secrets' });
+    return new ResourceInformer<V1Secret>({ kubeconfig, path, listFn, kind: 'Secret', plural: 'secrets' });
   }
 }

--- a/packages/main/src/plugin/kubernetes/secrets-resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/secrets-resource-factory.ts
@@ -54,6 +54,6 @@ export class SecretsResourceFactory extends ResourceFactoryBase implements Resou
     const apiClient = kubeconfig.getKubeConfig().makeApiClient(CoreV1Api);
     const listFn = (): Promise<V1SecretList> => apiClient.listNamespacedSecret({ namespace });
     const path = `/api/v1/namespaces/${namespace}/secrets`;
-    return new ResourceInformer<V1Secret>(kubeconfig, path, listFn, 'secrets');
+    return new ResourceInformer<V1Secret>(kubeconfig, path, listFn, { kind: 'Secret', plural: 'secrets' });
   }
 }

--- a/packages/main/src/plugin/kubernetes/services-resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/services-resource-factory.ts
@@ -54,6 +54,6 @@ export class ServicesResourceFactory extends ResourceFactoryBase implements Reso
     const apiClient = kubeconfig.getKubeConfig().makeApiClient(CoreV1Api);
     const listFn = (): Promise<V1ServiceList> => apiClient.listNamespacedService({ namespace });
     const path = `/api/v1/namespaces/${namespace}/services`;
-    return new ResourceInformer<V1Service>(kubeconfig, path, listFn, 'services');
+    return new ResourceInformer<V1Service>(kubeconfig, path, listFn, { kind: 'Service', plural: 'services' });
   }
 }

--- a/packages/main/src/plugin/kubernetes/services-resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/services-resource-factory.ts
@@ -54,6 +54,6 @@ export class ServicesResourceFactory extends ResourceFactoryBase implements Reso
     const apiClient = kubeconfig.getKubeConfig().makeApiClient(CoreV1Api);
     const listFn = (): Promise<V1ServiceList> => apiClient.listNamespacedService({ namespace });
     const path = `/api/v1/namespaces/${namespace}/services`;
-    return new ResourceInformer<V1Service>(kubeconfig, path, listFn, { kind: 'Service', plural: 'services' });
+    return new ResourceInformer<V1Service>({ kubeconfig, path, listFn, kind: 'Service', plural: 'services' });
   }
 }


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Add apiVersion and kind to kubernetes objects, by passing to the informer constructor a listFn adding the kind and apiVersion, instead of the native listFn provided by Kubernetes.

In the message https://github.com/kubernetes/kubernetes/pull/127361#issuecomment-2353199198, it is explained that only the list operation does not return the kind/apiVersion, other operations do return them.

It is said in the above message that the client is removing these information, but this is not the case with the Javascript client. 

We can then expect that kind/apiVersion will be present in all resources.

Note that the listFn is only called when an informer is started, to get the original list of resources. listFn should not be called after this initial call.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes #10916 

### How to test this PR?

- Add some log into the definition of `typedList` to check that this function is called only once (per resource), after the beginning.

- Add some log to display resources received in the frontend (in KubernetesObjectsList for example)

- Start Podman Desktop with existing resources, then add, update, delete resources. All resources displayed by the frontend should contain kind/apiVersion


- [x] Tests are covering the bug fix or the new feature
