### PR TITLE
feat: kubernetes resource navigation

### DIFF
--- a/packages/api/src/kubernetes-navigation.ts
+++ b/packages/api/src/kubernetes-navigation.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export type KubernetesNavigationRequest = {
+  kind: string;
+  name?: string;
+  namespace?: string;
+};

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -674,6 +674,12 @@ export class PluginSystem {
       onboardingRegistry,
     );
 
+    commandRegistry.registerCommand('kubernetes-navigation', args => {
+      apiSender.send('kubernetes-navigation', args);
+    });
+
+    navigationManager.registerRoute({ routeId: 'kubernetes', commandId: 'kubernetes-navigation' });
+
     const extensionAnalyzer = new ExtensionAnalyzer();
 
     const extensionWatcher = new ExtensionWatcher(fileSystemMonitoring);
@@ -2837,6 +2843,13 @@ export class PluginSystem {
       }
       window.close();
     });
+
+    this.ipcHandle(
+      'navigation:navigateToRoute',
+      async (_listener, routeId: string, ...args: unknown[]): Promise<void> => {
+        return navigationManager.navigateToRoute(routeId, ...args);
+      },
+    );
 
     this.ipcHandle('onboardingRegistry:listOnboarding', async (): Promise<OnboardingInfo[]> => {
       return onboardingRegistry.listOnboarding();

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -94,6 +94,7 @@ import type { KubeContext } from '/@api/kubernetes-context.js';
 import type { ContextHealth } from '/@api/kubernetes-contexts-healths.js';
 import type { ContextPermission } from '/@api/kubernetes-contexts-permissions.js';
 import type { ContextGeneralState, ResourceName } from '/@api/kubernetes-contexts-states.js';
+import type { KubernetesNavigationRequest } from '/@api/kubernetes-navigation.js';
 import type { ForwardConfig, ForwardOptions } from '/@api/kubernetes-port-forward-model.js';
 import type { ResourceCount } from '/@api/kubernetes-resource-count.js';
 import type { KubernetesContextResources } from '/@api/kubernetes-resources.js';
@@ -674,8 +675,8 @@ export class PluginSystem {
       onboardingRegistry,
     );
 
-    commandRegistry.registerCommand('kubernetes-navigation', args => {
-      apiSender.send('kubernetes-navigation', args);
+    commandRegistry.registerCommand('kubernetes-navigation', (navRequest: KubernetesNavigationRequest) => {
+      apiSender.send('kubernetes-navigation', navRequest);
     });
 
     navigationManager.registerRoute({ routeId: 'kubernetes', commandId: 'kubernetes-navigation' });

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -244,6 +244,10 @@ export function initExposure(): void {
     },
   );
 
+  contextBridge.exposeInMainWorld('navigateToRoute', async (routeId: string, args: unknown[]): Promise<void> => {
+    return ipcRenderer.invoke('navigation:navigateToRoute', routeId, ...args);
+  });
+
   contextBridge.exposeInMainWorld('listContainers', async (): Promise<ContainerInfo[]> => {
     return ipcInvoke('container-provider-registry:listContainers');
   });

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -6,9 +6,11 @@ import { router } from 'tinro';
 
 import { handleNavigation } from '/@/navigation';
 import { NO_CURRENT_CONTEXT_ERROR } from '/@api/kubernetes-contexts-states';
+import type { KubernetesNavigationRequest } from '/@api/kubernetes-navigation';
 import type { NavigationRequest } from '/@api/navigation-request';
 
 import AppNavigation from './AppNavigation.svelte';
+import { navigateTo } from './kubernetesNavigation';
 import Appearance from './lib/appearance/Appearance.svelte';
 import ComposeDetails from './lib/compose/ComposeDetails.svelte';
 import ConfigMapDetails from './lib/configmaps-secrets/ConfigMapDetails.svelte';
@@ -106,6 +108,10 @@ window.events?.receive('show-release-notes', () => {
 window.events?.receive('navigate', (navigationRequest: unknown) => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   handleNavigation(navigationRequest as NavigationRequest<any>);
+});
+
+window.events?.receive('kubernetes-navigation', (args: unknown) => {
+  navigateTo(args as KubernetesNavigationRequest);
 });
 </script>
 

--- a/packages/renderer/src/kubernetesNavigation.spec.ts
+++ b/packages/renderer/src/kubernetesNavigation.spec.ts
@@ -1,0 +1,151 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { router } from 'tinro';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { navigateTo } from './kubernetesNavigation';
+
+// mock the router
+vi.mock('tinro', () => {
+  return {
+    router: {
+      goto: vi.fn(),
+    },
+  };
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test(`Test navigation to Nodes`, () => {
+  navigateTo({ kind: 'Node' });
+
+  expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/kubernetes/nodes');
+});
+
+test(`Test navigation to a Node`, () => {
+  navigateTo({ kind: 'Node', name: 'dummy-name' });
+
+  expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/kubernetes/nodes/dummy-name/summary');
+});
+
+test(`Test navigation to Services`, () => {
+  navigateTo({ kind: 'Service' });
+
+  expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/kubernetes/services');
+});
+
+test(`Test navigation to a Service`, () => {
+  navigateTo({ kind: 'Service', name: 'dummy-name', namespace: 'dummy-ns' });
+
+  expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/kubernetes/services/dummy-name/dummy-ns/summary');
+});
+
+test(`Test navigation to Deployments`, () => {
+  navigateTo({ kind: 'Deployment' });
+
+  expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/kubernetes/deployments');
+});
+
+test(`Test navigation to a Deployment`, () => {
+  navigateTo({ kind: 'Deployment', name: 'dummy-name', namespace: 'dummy-ns' });
+
+  expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/kubernetes/deployments/dummy-name/dummy-ns/summary');
+});
+
+test(`Test navigation to Pods`, () => {
+  navigateTo({ kind: 'Pod' });
+
+  expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/kubernetes/pods');
+});
+
+test(`Test navigation to a Pod`, () => {
+  navigateTo({ kind: 'Pod', name: 'dummy-name', namespace: 'dummy-ns' });
+
+  expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/kubernetes/pods/dummy-name/dummy-ns/summary');
+});
+
+test(`Test navigation to PersistentVolumeClaims`, () => {
+  navigateTo({ kind: 'PersistentVolumeClaim' });
+
+  expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/kubernetes/persistentvolumeclaims');
+});
+
+test(`Test navigation to a PersistentVolumeClaim`, () => {
+  navigateTo({ kind: 'PersistentVolumeClaim', name: 'dummy-name', namespace: 'dummy-ns' });
+
+  expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/kubernetes/persistentvolumeclaims/dummy-name/dummy-ns/summary');
+});
+
+test(`Test navigation to Ingresses`, () => {
+  navigateTo({ kind: 'Ingress' });
+
+  expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/kubernetes/ingressesRoutes');
+});
+
+test(`Test navigation to a Ingress`, () => {
+  navigateTo({ kind: 'Ingress', name: 'dummy-name', namespace: 'dummy-ns' });
+
+  expect(vi.mocked(router.goto)).toHaveBeenCalledWith(
+    '/kubernetes/ingressesRoutes/ingress/dummy-name/dummy-ns/summary',
+  );
+});
+
+test(`Test navigation to Routes`, () => {
+  navigateTo({ kind: 'Route' });
+
+  expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/kubernetes/ingressesRoutes');
+});
+
+test(`Test navigation to a Route`, () => {
+  navigateTo({ kind: 'Route', name: 'dummy-name', namespace: 'dummy-ns' });
+
+  expect(vi.mocked(router.goto)).toHaveBeenCalledWith(
+    '/kubernetes/ingressesRoutes/ingress/dummy-name/dummy-ns/summary',
+  );
+});
+
+test(`Test navigation to ConfigMaps`, () => {
+  navigateTo({ kind: 'ConfigMap' });
+
+  expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/kubernetes/configmapsSecrets');
+});
+
+test(`Test navigation to a ConfigMap`, () => {
+  navigateTo({ kind: 'ConfigMap', name: 'dummy-name', namespace: 'dummy-ns' });
+
+  expect(vi.mocked(router.goto)).toHaveBeenCalledWith(
+    '/kubernetes/configmapsSecrets/configmap/dummy-name/dummy-ns/summary',
+  );
+});
+
+test(`Test navigation to Secrets`, () => {
+  navigateTo({ kind: 'Secret' });
+
+  expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/kubernetes/configmapsSecrets');
+});
+
+test(`Test navigation to a Secret`, () => {
+  navigateTo({ kind: 'Secret', name: 'dummy-name', namespace: 'dummy-ns' });
+
+  expect(vi.mocked(router.goto)).toHaveBeenCalledWith(
+    '/kubernetes/configmapsSecrets/secret/dummy-name/dummy-ns/summary',
+  );
+});

--- a/packages/renderer/src/kubernetesNavigation.ts
+++ b/packages/renderer/src/kubernetesNavigation.ts
@@ -1,0 +1,62 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { router } from 'tinro';
+
+import type { KubernetesNavigationRequest } from '/@api/kubernetes-navigation';
+
+export function navigateTo(nav: KubernetesNavigationRequest): void {
+  if (!nav.name) {
+    // navigate to a kind (list)
+    gotoKubernetesResources(nav.kind);
+  } else {
+    // navigate to a specific resource
+    gotoKubernetesResource(nav.kind, nav.name, nav.namespace);
+  }
+}
+
+function gotoKubernetesResources(kind: string): void {
+  router.goto(`/kubernetes/${resourceKindToURL(kind)}`);
+}
+
+function gotoKubernetesResource(kind: string, name: string, namespace?: string): void {
+  if (namespace) {
+    if (kind === 'Ingress' || kind === 'Route') {
+      router.goto(`/kubernetes/${resourceKindToURL(kind)}/ingress/${name}/${namespace}/summary`);
+    } else if (kind === 'ConfigMap') {
+      router.goto(`/kubernetes/${resourceKindToURL(kind)}/configmap/${name}/${namespace}/summary`);
+    } else if (kind === 'Secret') {
+      router.goto(`/kubernetes/${resourceKindToURL(kind)}/secret/${name}/${namespace}/summary`);
+    } else {
+      router.goto(`/kubernetes/${resourceKindToURL(kind)}/${name}/${namespace}/summary`);
+    }
+  } else {
+    router.goto(`/kubernetes/${resourceKindToURL(kind)}/${name}/summary`);
+  }
+}
+
+function resourceKindToURL(kind: string): string {
+  // handle the special cases in our urls
+  if (kind === 'Ingress' || kind === 'Route') {
+    return 'ingressesRoutes';
+  } else if (kind === 'ConfigMap' || kind === 'Secret') {
+    return 'configmapsSecrets';
+  }
+  // otherwise do the simple conversion
+  return kind.toLowerCase() + 's';
+}

--- a/packages/renderer/src/lib/deployments/DeploymentColumnName.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnName.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2024 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@
 import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen } from '@testing-library/svelte';
-import { router } from 'tinro';
 import { expect, test, vi } from 'vitest';
 
 import DeploymentColumnName from './DeploymentColumnName.svelte';
@@ -51,11 +50,13 @@ test('Expect clicking works', async () => {
   expect(text).toBeInTheDocument();
 
   // test click
-  const routerGotoSpy = vi.spyOn(router, 'goto');
+  const navigationSpy = vi.spyOn(window, 'navigateToRoute');
 
   await fireEvent.click(text);
 
-  expect(routerGotoSpy).toBeCalledWith('/kubernetes/deployments/my-deployment/default/summary');
+  expect(navigationSpy).toBeCalledWith('kubernetes', [
+    { kind: 'Deployment', name: deployment.name, namespace: deployment.namespace },
+  ]);
 });
 
 test('Expect to show namespace in column', async () => {

--- a/packages/renderer/src/lib/deployments/DeploymentColumnName.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnName.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-import { router } from 'tinro';
-
 import type { DeploymentUI } from './DeploymentUI';
 
 interface Props {
@@ -8,8 +6,8 @@ interface Props {
 }
 let { object }: Props = $props();
 
-function openDetails(): void {
-  router.goto(`/kubernetes/deployments/${encodeURI(object.name)}/${encodeURI(object.namespace)}/summary`);
+async function openDetails(): Promise<void> {
+  await window.navigateToRoute('kubernetes', [{ kind: 'Deployment', name: object.name, namespace: object.namespace }]);
 }
 </script>
 


### PR DESCRIPTION
### What does this PR do?

Adds a navigation route to any Kubernetes resource.

- Adds a new 'kubernetes-navigation' command that accepts a KubernetesNavigationRequest with kind, name, and namespace, along with a 'kubernetes' navigation route.
- The command fires an event to the renderer, and a listener in App.svelte forwards to kubernetesNavigation to route to the correct URL.
- Exposes the navigation manager navigateToRoute() to the renderer. Used in the deployment name column to show it in use.

The only interesting bit in kubernetesNavigation are the special cases where our URLs don't match the normal pattern. We could improve this, but that's a separate issue.

Future PRs would convert other name columns, and we would discuss if we should remove Kubernetes support from navigation.ts.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #11124.

### How to test this PR?

Go to Deployments, clicking on a name should still bring you to the details.

- [x] Tests are covering the bug fix or the new feature