### PR TITLE
chore: add telemetry to kubernetes dashboard cards

### DIFF
--- a/packages/renderer/src/lib/kube/KubernetesDashboardGuideCard.spec.ts
+++ b/packages/renderer/src/lib/kube/KubernetesDashboardGuideCard.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,22 +20,13 @@ import '@testing-library/jest-dom/vitest';
 
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
-import { beforeAll, expect, test, vi } from 'vitest';
+import { expect, test } from 'vitest';
 
 import KubernetesDashboardGuideCard from './KubernetesDashboardGuideCard.svelte';
 
-const openExternalMock = vi.fn();
-
-// fake the window object
-beforeAll(() => {
-  Object.defineProperty(window, 'openExternal', {
-    value: openExternalMock,
-  });
-});
-
 test('Verify basic card format', async () => {
   const title = 'a title';
-  render(KubernetesDashboardGuideCard, { title: title, link: 'test' });
+  render(KubernetesDashboardGuideCard, { title: title, link: 'test', image: '' });
 
   const titleComp = screen.getByText(title);
   expect(titleComp).toBeInTheDocument();
@@ -53,13 +44,16 @@ test('Verify basic card format', async () => {
 });
 
 test('Expect clicking works', async () => {
-  const link = 'http://test-link';
-  render(KubernetesDashboardGuideCard, { title: 'a title', link: link });
+  const params = { title: 'a title', link: 'test-link', image: '' };
+  render(KubernetesDashboardGuideCard, params);
 
   const button = screen.getByRole('button', { name: 'Read more' });
   expect(button).toBeInTheDocument();
 
-  expect(openExternalMock).not.toHaveBeenCalled();
   await userEvent.click(button);
-  expect(openExternalMock).toHaveBeenCalledWith(link);
+  expect(window.openExternal).toHaveBeenCalledWith(params.link);
+  expect(window.telemetryTrack).toHaveBeenCalledWith('kubernetes.dashboard.guide', {
+    title: params.title,
+    link: params.link,
+  });
 });

--- a/packages/renderer/src/lib/kube/KubernetesDashboardGuideCard.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesDashboardGuideCard.svelte
@@ -10,7 +10,11 @@ interface Props {
 let { title, link, image }: Props = $props();
 
 async function openLink(): Promise<void> {
-  await window.openExternal(link);
+  try {
+    await window.openExternal(link);
+  } finally {
+    await window.telemetryTrack('kubernetes.dashboard.guide', { title: title, link: link });
+  }
 }
 </script>
 

--- a/packages/renderer/src/lib/kube/KubernetesDashboardResourceCard.spec.ts
+++ b/packages/renderer/src/lib/kube/KubernetesDashboardResourceCard.spec.ts
@@ -48,5 +48,9 @@ test('Expect clicking works', async () => {
   expect(type).toBeInTheDocument();
 
   await userEvent.click(type);
-  expect(window.navigateToRoute).toBeCalledWith('kubernetes', { kind: 'Service' });
+  expect(window.navigateToRoute).toBeCalledWith('kubernetes', { kind: params.kind });
+  expect(window.telemetryTrack).toBeCalledWith('kubernetes.dashboard.resource', {
+    type: params.type,
+    kind: params.kind,
+  });
 });

--- a/packages/renderer/src/lib/kube/KubernetesDashboardResourceCard.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesDashboardResourceCard.svelte
@@ -12,7 +12,11 @@ interface Props {
 let { type, Icon, activeCount, count, kind }: Props = $props();
 
 async function openLink(): Promise<void> {
-  await window.navigateToRoute('kubernetes', { kind: kind });
+  try {
+    await window.navigateToRoute('kubernetes', { kind: kind });
+  } finally {
+    await window.telemetryTrack('kubernetes.dashboard.resource', { type: type, kind: kind });
+  }
 }
 </script>
 


### PR DESCRIPTION
### What does this PR do?

Adds a telemetry event when clicking on either the resource or guide cards on the Kubernetes dashboard.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #10207.

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature