### PR TITLE
fix: fix navigation after setting up podman

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -149,7 +149,7 @@ window.events?.receive('kubernetes-navigation', (args: unknown) => {
         <SendFeedback />
         <ToastHandler />
         <ToastTaskNotifications />
-        <Route path="/" breadcrumb="Dashboard Page">
+        <Route path="/" breadcrumb="Dashboard Page" navigationHint="root">
           <DashboardPage />
         </Route>
         <Route path="/containers" breadcrumb="Containers" navigationHint="root">


### PR DESCRIPTION
### What does this PR do?

Fix navigation back to the dashboard after set up button pressed.

### Screenshot / video of UI


https://github.com/user-attachments/assets/8426f2fa-088a-44b3-9e13-b0d64ff8079c


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fix #9206.

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
