### PR TITLE
chore: update ProviderWidget tooltips

### DIFF
--- a/packages/renderer/src/lib/statusbar/ProviderWidget.spec.ts
+++ b/packages/renderer/src/lib/statusbar/ProviderWidget.spec.ts
@@ -77,22 +77,26 @@ test('Expect the prop command to be used when it is passed with the entry', asyn
   expect(router.goto).toBeCalledWith('/some/page');
 });
 
-test('Expect title to include container provider connections', () => {
+test('Expect tooltip to include container provider connections', () => {
   providerMock.containerConnections = [
     { name: 'connection 1', status: 'ready' } as unknown as ProviderContainerConnectionInfo,
     { name: 'connection 2', status: 'ready' } as unknown as ProviderContainerConnectionInfo,
+    { name: 'connection 3', status: 'stopped' } as unknown as ProviderContainerConnectionInfo,
   ];
   render(ProviderWidget, { entry: providerMock });
 
   expect(screen.getByText('Running: connection 1, connection 2')).toBeInTheDocument();
+  expect(screen.getByText('Off: connection 3')).toBeInTheDocument();
 });
 
-test('Expect title to include Kubernetes provider connections', () => {
+test('Expect tooltip to include Kubernetes provider connections', () => {
   providerMock.kubernetesConnections = [
     { name: 'connection 1', status: 'ready' } as unknown as ProviderKubernetesConnectionInfo,
     { name: 'connection 2', status: 'ready' } as unknown as ProviderKubernetesConnectionInfo,
+    { name: 'connection 3', status: 'stopped' } as unknown as ProviderKubernetesConnectionInfo,
   ];
   render(ProviderWidget, { entry: providerMock });
 
   expect(screen.getByText('Running: connection 1, connection 2')).toBeInTheDocument();
+  expect(screen.getByText('Off: connection 3')).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/statusbar/ProviderWidget.spec.ts
+++ b/packages/renderer/src/lib/statusbar/ProviderWidget.spec.ts
@@ -85,7 +85,8 @@ test('Expect tooltip to include container provider connections', () => {
   ];
   render(ProviderWidget, { entry: providerMock });
 
-  expect(screen.getByText('Running: connection 1, connection 2')).toBeInTheDocument();
+  expect(screen.getByText('Running: connection 1')).toBeInTheDocument();
+  expect(screen.getByText('Running: connection 2')).toBeInTheDocument();
   expect(screen.getByText('Off: connection 3')).toBeInTheDocument();
 });
 
@@ -97,6 +98,7 @@ test('Expect tooltip to include Kubernetes provider connections', () => {
   ];
   render(ProviderWidget, { entry: providerMock });
 
-  expect(screen.getByText('Running: connection 1, connection 2')).toBeInTheDocument();
+  expect(screen.getByText('Running: connection 1')).toBeInTheDocument();
+  expect(screen.getByText('Running: connection 2')).toBeInTheDocument();
   expect(screen.getByText('Off: connection 3')).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/statusbar/ProviderWidget.spec.ts
+++ b/packages/renderer/src/lib/statusbar/ProviderWidget.spec.ts
@@ -79,20 +79,20 @@ test('Expect the prop command to be used when it is passed with the entry', asyn
 
 test('Expect title to include container provider connections', () => {
   providerMock.containerConnections = [
-    { name: 'connection 1' } as unknown as ProviderContainerConnectionInfo,
-    { name: 'connection 2' } as unknown as ProviderContainerConnectionInfo,
+    { name: 'connection 1', status: 'ready' } as unknown as ProviderContainerConnectionInfo,
+    { name: 'connection 2', status: 'ready' } as unknown as ProviderContainerConnectionInfo,
   ];
   render(ProviderWidget, { entry: providerMock });
 
-  expect(screen.getByTitle('connection 1, connection 2')).toBeInTheDocument();
+  expect(screen.getByText('ready: connection 1, connection 2')).toBeInTheDocument();
 });
 
 test('Expect title to include Kubernetes provider connections', () => {
   providerMock.kubernetesConnections = [
-    { name: 'connection 1' } as unknown as ProviderKubernetesConnectionInfo,
-    { name: 'connection 2' } as unknown as ProviderKubernetesConnectionInfo,
+    { name: 'connection 1', status: 'ready' } as unknown as ProviderKubernetesConnectionInfo,
+    { name: 'connection 2', status: 'ready' } as unknown as ProviderKubernetesConnectionInfo,
   ];
   render(ProviderWidget, { entry: providerMock });
 
-  expect(screen.getByTitle('connection 1, connection 2')).toBeInTheDocument();
+  expect(screen.getByText('ready: connection 1, connection 2')).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/statusbar/ProviderWidget.spec.ts
+++ b/packages/renderer/src/lib/statusbar/ProviderWidget.spec.ts
@@ -84,7 +84,7 @@ test('Expect title to include container provider connections', () => {
   ];
   render(ProviderWidget, { entry: providerMock });
 
-  expect(screen.getByText('ready: connection 1, connection 2')).toBeInTheDocument();
+  expect(screen.getByText('Running: connection 1, connection 2')).toBeInTheDocument();
 });
 
 test('Expect title to include Kubernetes provider connections', () => {
@@ -94,5 +94,5 @@ test('Expect title to include Kubernetes provider connections', () => {
   ];
   render(ProviderWidget, { entry: providerMock });
 
-  expect(screen.getByText('ready: connection 1, connection 2')).toBeInTheDocument();
+  expect(screen.getByText('Running: connection 1, connection 2')).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/statusbar/ProviderWidget.svelte
+++ b/packages/renderer/src/lib/statusbar/ProviderWidget.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { Button } from '@podman-desktop/ui-svelte';
+import { Button, Tooltip } from '@podman-desktop/ui-svelte';
 import { router } from 'tinro';
 
 import type { ProviderInfo } from '/@api/provider-info';
@@ -23,22 +23,41 @@ let tooltipText = $derived.by(() => {
   }
   return tooltip;
 });
+
+let providerStatus = $derived.by(() => {
+  if (entry.containerConnections.length > 0) {
+    return entry.containerConnections[0].status;
+  } else if (entry.kubernetesConnections.length > 0) {
+    return entry.kubernetesConnections[0].status;
+  } else {
+    return entry.status;
+  }
+});
 </script>
-  
-<Button
-  on:click={command}
-  class="rounded-none gap-1 flex h-full min-w-fit items-center hover:bg-[var(--pd-statusbar-hover-bg)] hover:cursor-pointer relative text-base text-[var(--pd-button-text)] bg-transparent"
-  title={tooltipText}
-  aria-label={entry.name}
-  padding="px-2 py-1">
-  
-  {#if entry.containerConnections.length > 0 || entry.kubernetesConnections.length > 0 || entry.status }
-    <ProviderWidgetStatus entry={entry} />
-  {/if}
-  {#if entry.images.icon}
-    <IconImage image={entry.images.icon} class="max-h-3 grayscale" alt={entry.name}></IconImage>
-  {/if}
-  {#if entry.name}
-    <span class="whitespace-nowrap h-fit">{entry.name}</span>
-  {/if}
-</Button>
+
+<div >
+<Tooltip top  class="mb-[20px]">
+  <div slot="tip" class=" py-2 px-4">
+    {#if entry.containerConnections.length > 0 || entry.kubernetesConnections.length > 0 || entry.status }
+      <ProviderWidgetStatus entry={entry} />
+    {/if}
+    {providerStatus}: {tooltipText}
+  </div>
+  <Button
+    on:click={command}
+    class="rounded-none gap-1 flex h-full min-w-fit items-center hover:bg-[var(--pd-statusbar-hover-bg)] hover:cursor-pointer relative text-base text-[var(--pd-button-text)] bg-transparent"
+    aria-label={entry.name}
+    padding="px-2 py-1">
+    
+    {#if entry.containerConnections.length > 0 || entry.kubernetesConnections.length > 0 || entry.status }
+      <ProviderWidgetStatus entry={entry} />
+    {/if}
+    {#if entry.images.icon}
+      <IconImage image={entry.images.icon} class="max-h-3 grayscale" alt={entry.name}></IconImage>
+    {/if}
+    {#if entry.name}
+      <span class="whitespace-nowrap h-fit">{entry.name}</span>
+    {/if}
+  </Button>
+</Tooltip>
+</div>

--- a/packages/renderer/src/lib/statusbar/ProviderWidget.svelte
+++ b/packages/renderer/src/lib/statusbar/ProviderWidget.svelte
@@ -7,6 +7,7 @@ import type { ProviderInfo } from '/@api/provider-info';
 
 import IconImage from '../appearance/IconImage.svelte';
 import ProviderWidgetStatus from './ProviderWidgetStatus.svelte';
+import { getStatusName } from './ProviderWidgetStatus.ts';
 
 interface Props {
   entry: ProviderInfo;
@@ -43,8 +44,6 @@ let connectionsStatuses = $derived.by(() => {
   }
   return connectionsStatuses;
 });
-
-let providerStatus = $state('');
 </script>
 
 <div >
@@ -54,7 +53,7 @@ let providerStatus = $state('');
       {#each connectionsStatuses as status}
         <div class="flex flex-row items-center h-fit">
           <ProviderWidgetStatus status={status.status} class="mr-1 mt-1"/>
-          {status.status}: {status.connecions}
+          {getStatusName(status.status)}: {status.connecions}
         </div>
       {/each}
     </div>
@@ -66,7 +65,7 @@ let providerStatus = $state('');
     padding="px-2 py-1">
     
     {#if entry.containerConnections.length > 0 || entry.kubernetesConnections.length > 0 || entry.status }
-      <ProviderWidgetStatus entry={entry}  bind:displayProviderStatus={providerStatus}/>
+      <ProviderWidgetStatus entry={entry} />
     {/if}
     {#if entry.images.icon}
       <IconImage image={entry.images.icon} class="max-h-3 grayscale" alt={entry.name}></IconImage>

--- a/packages/renderer/src/lib/statusbar/ProviderWidget.svelte
+++ b/packages/renderer/src/lib/statusbar/ProviderWidget.svelte
@@ -28,7 +28,7 @@ let providerStatus = $state('');
 </script>
 
 <div >
-<Tooltip top  class="mb-[20px]">
+<Tooltip top class="mb-[20px]">
   <div slot="tip" class=" py-2 px-4">
     {#if entry.containerConnections.length > 0 || entry.kubernetesConnections.length > 0 || entry.status }
       <ProviderWidgetStatus entry={entry}/>

--- a/packages/renderer/src/lib/statusbar/ProviderWidget.svelte
+++ b/packages/renderer/src/lib/statusbar/ProviderWidget.svelte
@@ -6,8 +6,8 @@ import { router } from 'tinro';
 import type { ProviderInfo } from '/@api/provider-info';
 
 import IconImage from '../appearance/IconImage.svelte';
+import { getStatusName } from './ProviderWidgetStatus';
 import ProviderWidgetStatus from './ProviderWidgetStatus.svelte';
-import { getStatusName } from './ProviderWidgetStatus.ts';
 
 interface Props {
   entry: ProviderInfo;

--- a/packages/renderer/src/lib/statusbar/ProviderWidget.svelte
+++ b/packages/renderer/src/lib/statusbar/ProviderWidget.svelte
@@ -11,7 +11,7 @@ import ProviderWidgetStatus from './ProviderWidgetStatus.svelte';
 interface Props {
   entry: ProviderInfo;
   command?: () => void;
-  disableTooltip: boolean;
+  disableTooltip?: boolean;
 }
 
 let { entry, command = (): void => router.goto('/preferences/resources'), disableTooltip = false }: Props = $props();

--- a/packages/renderer/src/lib/statusbar/ProviderWidget.svelte
+++ b/packages/renderer/src/lib/statusbar/ProviderWidget.svelte
@@ -24,22 +24,14 @@ let tooltipText = $derived.by(() => {
   return tooltip;
 });
 
-let providerStatus = $derived.by(() => {
-  if (entry.containerConnections.length > 0) {
-    return entry.containerConnections[0].status;
-  } else if (entry.kubernetesConnections.length > 0) {
-    return entry.kubernetesConnections[0].status;
-  } else {
-    return entry.status;
-  }
-});
+let providerStatus = $state('');
 </script>
 
 <div >
 <Tooltip top  class="mb-[20px]">
   <div slot="tip" class=" py-2 px-4">
     {#if entry.containerConnections.length > 0 || entry.kubernetesConnections.length > 0 || entry.status }
-      <ProviderWidgetStatus entry={entry} />
+      <ProviderWidgetStatus entry={entry}/>
     {/if}
     {providerStatus}: {tooltipText}
   </div>
@@ -50,7 +42,7 @@ let providerStatus = $derived.by(() => {
     padding="px-2 py-1">
     
     {#if entry.containerConnections.length > 0 || entry.kubernetesConnections.length > 0 || entry.status }
-      <ProviderWidgetStatus entry={entry} />
+      <ProviderWidgetStatus entry={entry}  bind:displayProviderStatus={providerStatus}/>
     {/if}
     {#if entry.images.icon}
       <IconImage image={entry.images.icon} class="max-h-3 grayscale" alt={entry.name}></IconImage>

--- a/packages/renderer/src/lib/statusbar/ProviderWidgetStatus.svelte
+++ b/packages/renderer/src/lib/statusbar/ProviderWidgetStatus.svelte
@@ -1,23 +1,31 @@
 
 <script lang="ts">
-import type { ProviderStatus } from '@podman-desktop/api';
+import type { ProviderConnectionStatus, ProviderStatus } from '@podman-desktop/api';
 
 import type { ProviderInfo } from '/@api/provider-info';
 
 interface Props {
-  entry: ProviderInfo;
+  entry?: ProviderInfo;
   displayProviderStatus?: string;
+  status?: ProviderStatus | ProviderConnectionStatus;
+  class?: string;
 }
 
-let { entry, displayProviderStatus = $bindable() }: Props = $props();
+let { entry, displayProviderStatus = $bindable(), status, class: className = '' }: Props = $props();
 
 let providerStatus = $derived.by(() => {
-  if (entry.containerConnections.length > 0) {
-    return entry.containerConnections[0].status;
-  } else if (entry.kubernetesConnections.length > 0) {
-    return entry.kubernetesConnections[0].status;
+  if (entry) {
+    if (entry.containerConnections.length > 0) {
+      return entry.containerConnections[0].status;
+    } else if (entry.kubernetesConnections.length > 0) {
+      return entry.kubernetesConnections[0].status;
+    } else {
+      return entry.status;
+    }
+  } else if (status) {
+    return status;
   } else {
-    return entry.status;
+    return 'unknown';
   }
 });
 
@@ -63,9 +71,9 @@ const faRegularIconStatus: ProviderStatus[] = ['ready', 'started', 'stopped', 'e
 </script>
 
 {#if providerStatus === 'starting' || providerStatus === 'stopping'}
-  <div aria-label="Connection Status Icon" class="w-3 h-3 rounded-full animate-spin border border-solid border-[var(--pd-action-button-spinner)] border-t-transparent"></div>
+  <div aria-label="Connection Status Icon" class="w-3 h-3 rounded-full animate-spin border border-solid border-[var(--pd-action-button-spinner)] border-t-transparent {className}"></div>
 {:else}
-  <div aria-label="Connection Status Icon" class="w-3 h-3"
+  <div aria-label="Connection Status Icon" class="w-3 h-3 {className}"
     class:fa-regular={faRegularIconStatus.includes(providerStatus)}
     class:fa={providerStatus === 'not-installed'}
     class:fa-circle-check={providerStatus === 'ready' || providerStatus === 'started'}

--- a/packages/renderer/src/lib/statusbar/ProviderWidgetStatus.svelte
+++ b/packages/renderer/src/lib/statusbar/ProviderWidgetStatus.svelte
@@ -6,9 +6,10 @@ import type { ProviderInfo } from '/@api/provider-info';
 
 interface Props {
   entry: ProviderInfo;
+  displayProviderStatus?: string;
 }
 
-let { entry }: Props = $props();
+let { entry, displayProviderStatus = $bindable() }: Props = $props();
 
 let providerStatus = $derived.by(() => {
   if (entry.containerConnections.length > 0) {
@@ -17,6 +18,44 @@ let providerStatus = $derived.by(() => {
     return entry.kubernetesConnections[0].status;
   } else {
     return entry.status;
+  }
+});
+
+$effect(() => {
+  switch (providerStatus) {
+    case 'ready':
+      displayProviderStatus = 'Running';
+      break;
+    case 'started':
+      displayProviderStatus = 'Running';
+      break;
+    case 'error':
+      displayProviderStatus = 'Error';
+      break;
+    case 'starting':
+      displayProviderStatus = 'Starting';
+      break;
+    case 'stopping':
+      displayProviderStatus = 'Stopping';
+      break;
+    case 'stopped':
+      displayProviderStatus = 'Off';
+      break;
+    case 'unknown':
+      displayProviderStatus = 'Unknown';
+      break;
+    case 'not-installed':
+      displayProviderStatus = 'Not installed';
+      break;
+    case 'installed':
+      displayProviderStatus = 'Installed but not ready';
+      break;
+    case 'configuring':
+      displayProviderStatus = 'Configuring';
+      break;
+    case 'configured':
+      displayProviderStatus = 'Off';
+      break;
   }
 });
 

--- a/packages/renderer/src/lib/statusbar/ProviderWidgetStatus.svelte
+++ b/packages/renderer/src/lib/statusbar/ProviderWidgetStatus.svelte
@@ -6,12 +6,11 @@ import type { ProviderInfo } from '/@api/provider-info';
 
 interface Props {
   entry?: ProviderInfo;
-  displayProviderStatus?: string;
   status?: ProviderStatus | ProviderConnectionStatus;
   class?: string;
 }
 
-let { entry, displayProviderStatus = $bindable(), status, class: className = '' }: Props = $props();
+let { entry, status, class: className = '' }: Props = $props();
 
 let providerStatus = $derived.by(() => {
   if (entry) {
@@ -26,44 +25,6 @@ let providerStatus = $derived.by(() => {
     return status;
   } else {
     return 'unknown';
-  }
-});
-
-$effect(() => {
-  switch (providerStatus) {
-    case 'ready':
-      displayProviderStatus = 'Running';
-      break;
-    case 'started':
-      displayProviderStatus = 'Running';
-      break;
-    case 'error':
-      displayProviderStatus = 'Error';
-      break;
-    case 'starting':
-      displayProviderStatus = 'Starting';
-      break;
-    case 'stopping':
-      displayProviderStatus = 'Stopping';
-      break;
-    case 'stopped':
-      displayProviderStatus = 'Off';
-      break;
-    case 'unknown':
-      displayProviderStatus = 'Unknown';
-      break;
-    case 'not-installed':
-      displayProviderStatus = 'Not installed';
-      break;
-    case 'installed':
-      displayProviderStatus = 'Installed but not ready';
-      break;
-    case 'configuring':
-      displayProviderStatus = 'Configuring';
-      break;
-    case 'configured':
-      displayProviderStatus = 'Off';
-      break;
   }
 });
 

--- a/packages/renderer/src/lib/statusbar/ProviderWidgetStatus.svelte
+++ b/packages/renderer/src/lib/statusbar/ProviderWidgetStatus.svelte
@@ -24,9 +24,9 @@ const faRegularIconStatus: ProviderStatus[] = ['ready', 'started', 'stopped', 'e
 </script>
 
 {#if providerStatus === 'starting' || providerStatus === 'stopping'}
-  <div aria-label="Connection Status Icon" title={providerStatus} class="w-3 h-3 rounded-full animate-spin border border-solid border-[var(--pd-action-button-spinner)] border-t-transparent"></div>
+  <div aria-label="Connection Status Icon" class="w-3 h-3 rounded-full animate-spin border border-solid border-[var(--pd-action-button-spinner)] border-t-transparent"></div>
 {:else}
-  <div aria-label="Connection Status Icon" title={providerStatus} class="w-3 h-3"
+  <div aria-label="Connection Status Icon" class="w-3 h-3"
     class:fa-regular={faRegularIconStatus.includes(providerStatus)}
     class:fa={providerStatus === 'not-installed'}
     class:fa-circle-check={providerStatus === 'ready' || providerStatus === 'started'}

--- a/packages/renderer/src/lib/statusbar/ProviderWidgetStatus.ts
+++ b/packages/renderer/src/lib/statusbar/ProviderWidgetStatus.ts
@@ -21,27 +21,23 @@ import type { ProviderConnectionStatus, ProviderStatus } from '@podman-desktop/a
 export function getStatusName(status: ProviderStatus | ProviderConnectionStatus): string {
   switch (status) {
     case 'ready':
-      return 'Running';
     case 'started':
       return 'Running';
+    case 'stopped':
+    case 'configured':
+      return 'Off';
     case 'error':
       return 'Error';
     case 'starting':
       return 'Starting';
     case 'stopping':
       return 'Stopping';
-    case 'stopped':
-      return 'Off';
-    case 'unknown':
-      return 'Unknown';
     case 'not-installed':
       return 'Not installed';
     case 'installed':
       return 'Installed but not ready';
     case 'configuring':
       return 'Configuring';
-    case 'configured':
-      return 'Off';
     default:
       return 'Unknown';
   }

--- a/packages/renderer/src/lib/statusbar/ProviderWidgetStatus.ts
+++ b/packages/renderer/src/lib/statusbar/ProviderWidgetStatus.ts
@@ -1,0 +1,48 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { ProviderConnectionStatus, ProviderStatus } from '@podman-desktop/api';
+
+export function getStatusName(status: ProviderStatus | ProviderConnectionStatus): string {
+  switch (status) {
+    case 'ready':
+      return 'Running';
+    case 'started':
+      return 'Running';
+    case 'error':
+      return 'Error';
+    case 'starting':
+      return 'Starting';
+    case 'stopping':
+      return 'Stopping';
+    case 'stopped':
+      return 'Off';
+    case 'unknown':
+      return 'Unknown';
+    case 'not-installed':
+      return 'Not installed';
+    case 'installed':
+      return 'Installed but not ready';
+    case 'configuring':
+      return 'Configuring';
+    case 'configured':
+      return 'Off';
+    default:
+      return 'Unknown';
+  }
+}

--- a/packages/renderer/src/lib/statusbar/StatusBar.svelte
+++ b/packages/renderer/src/lib/statusbar/StatusBar.svelte
@@ -90,7 +90,7 @@ onDestroy(() => {
   class="flex justify-between px-1 bg-[var(--pd-statusbar-bg)] text-[var(--pd-statusbar-text)] text-sm space-x-2 z-40"
   role="contentinfo"
   aria-label="Status Bar">
-  <div class="flex flex-nowrap gap-x-1.5 h-full truncate">
+  <div class="flex flex-nowrap gap-x-1.5 h-full text-ellipsis whitespace-nowrap">
     {#each leftEntries as entry}
       <StatusBarItem entry={entry} />
     {/each}


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR updated the tooltips of the ProviderWidget to be one tooltip with the icon, status, and provider names

### Screenshot / video of UI
[Screencast from 2025-02-18 13-33-54.webm](https://github.com/user-attachments/assets/62b32e9c-98d4-4882-a4cd-dc1ddb6cb4c6)


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Fixes https://github.com/podman-desktop/podman-desktop/issues/10921

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
