### PR TITLE
chore: add class prop to tip slot in tooltip

### DIFF
--- a/packages/ui/src/lib/tooltip/Tooltip.svelte
+++ b/packages/ui/src/lib/tooltip/Tooltip.svelte
@@ -86,7 +86,7 @@ export let left = false;
     {/if}
     {#if $$slots.tip && !tip && !$tooltipHidden}
       <div
-        class="inline-block rounded-md bg-[var(--pd-tooltip-bg)] text-[var(--pd-tooltip-text)] border-[1px] border-[var(--pd-tooltip-border)]"
+        class="inline-block rounded-md bg-[var(--pd-tooltip-bg)] text-[var(--pd-tooltip-text)] border-[1px] border-[var(--pd-tooltip-border)] {$$props.class}"
         aria-label="tooltip">
         <slot name="tip" />
       </div>

--- a/packages/ui/src/lib/tooltip/TooltipSpec.spec.ts
+++ b/packages/ui/src/lib/tooltip/TooltipSpec.spec.ts
@@ -49,6 +49,13 @@ test('Expect basic prop styling', async () => {
   expect(element).toHaveClass('border-[1px]');
 });
 
+test('Expect class styling to apply to tip slot div', async () => {
+  render(TooltipSpec, { classStyle: 'my-[5px] mx-[10px]' });
+
+  const slotElement = screen.getByLabelText('tooltip');
+  expect(slotElement).toHaveClass('my-[5px] mx-[10px]');
+});
+
 function createTest(props: Record<string, boolean>, locationName: string, expectedStyle = locationName): void {
   test(`Expect property ${locationName} to add ${expectedStyle} class to parent element`, () => {
     render(TooltipSpec, { tipSlot: tip, ...props });

--- a/packages/ui/src/lib/tooltip/TooltipSpec.svelte
+++ b/packages/ui/src/lib/tooltip/TooltipSpec.svelte
@@ -11,6 +11,7 @@ export let bottom = false;
 export let bottomLeft = false;
 export let bottomRight = false;
 export let left = false;
+export let classStyle = '';
 </script>
 
 <Tooltip
@@ -22,7 +23,8 @@ export let left = false;
   bottom={bottom}
   bottomLeft={bottomLeft}
   bottomRight={bottomRight}
-  left={left}>
+  left={left}
+  class={classStyle}>
   <slot />
   <svelte:fragment slot="tip">
     {#if tipSlot}


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR adds the class prop to the tip slot div in tooltip

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/pull/11194

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
