### PR TITLE
feat: display service details on Kubernetes experimental mode

### DIFF
--- a/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
@@ -35,6 +35,7 @@ import type { DispatcherEvent } from './contexts-dispatcher.js';
 import { ContextsDispatcher } from './contexts-dispatcher.js';
 import { CronjobsResourceFactory } from './cronjobs-resource-factory.js';
 import { DeploymentsResourceFactory } from './deployments-resource-factory.js';
+import { EventsResourceFactory } from './events-resource-factory.js';
 import { IngressesResourceFactory } from './ingresses-resource-factory.js';
 import { NodesResourceFactory } from './nodes-resource-factory.js';
 import { PodsResourceFactory } from './pods-resource-factory.js';
@@ -101,6 +102,7 @@ export class ContextsManagerExperimental {
       new ConfigmapsResourceFactory(),
       new CronjobsResourceFactory(),
       new DeploymentsResourceFactory(),
+      new EventsResourceFactory(),
       new IngressesResourceFactory(),
       new NodesResourceFactory(),
       new PodsResourceFactory(),

--- a/packages/main/src/plugin/kubernetes/events-resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/events-resource-factory.ts
@@ -1,0 +1,59 @@
+/**********************************************************************
+ * Copyright (C) 2024, 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { CoreV1Event, CoreV1EventList } from '@kubernetes/client-node';
+import { CoreV1Api } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from './kubeconfig-single-context.js';
+import type { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryBase } from './resource-factory.js';
+import { ResourceInformer } from './resource-informer.js';
+
+export class EventsResourceFactory extends ResourceFactoryBase implements ResourceFactory {
+  constructor() {
+    super({
+      resource: 'events',
+    });
+
+    this.setPermissions({
+      isNamespaced: true,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          verb: 'watch',
+          resource: 'events',
+        },
+      ],
+    });
+    this.setInformer({
+      createInformer: this.createInformer,
+    });
+  }
+
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<CoreV1Event> {
+    const namespace = kubeconfig.getNamespace();
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(CoreV1Api);
+    const listFn = (): Promise<CoreV1EventList> => apiClient.listNamespacedEvent({ namespace });
+    const path = `/api/v1/namespaces/${namespace}/events`;
+    return new ResourceInformer<CoreV1Event>({ kubeconfig, path, listFn, kind: 'Event', plural: 'events' });
+  }
+}

--- a/packages/renderer/src/lib/kube/resource-listen.spec.ts
+++ b/packages/renderer/src/lib/kube/resource-listen.spec.ts
@@ -1,0 +1,341 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { CoreV1Event, KubernetesObject } from '@kubernetes/client-node';
+import { type Writable, writable } from 'svelte/store';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { IDisposable } from '../../../../main/src/plugin/types/disposable';
+import { listenResource } from './resource-listen';
+import * as resourcesListen from './resources-listen';
+
+vi.mock(import('./resources-listen'), async importOriginal => {
+  const original = await importOriginal();
+  return {
+    // we want to access the original isKubernetesExperimentalMode
+    ...original,
+    listenResources: vi.fn(),
+  };
+});
+
+type initListsReturnType = {
+  updateResources: (objects: KubernetesObject[]) => void;
+  updateEvents: (objects: CoreV1Event[]) => void;
+  legacyResourceStore?: Writable<KubernetesObject[]>;
+  legacyEventsStore?: Writable<CoreV1Event[]>;
+};
+
+describe.each<{
+  experimental: boolean;
+  initLists: (resources: KubernetesObject[], events: CoreV1Event[]) => initListsReturnType;
+}>([
+  {
+    experimental: true,
+    initLists: (resources: KubernetesObject[], events: CoreV1Event[]): initListsReturnType => {
+      let resourcesCallback: (resources: KubernetesObject[]) => void;
+      let eventsCallback: (events: CoreV1Event[]) => void;
+      vi.mocked(resourcesListen.listenResources).mockImplementation(
+        async (resourceName, _options, cb): Promise<IDisposable> => {
+          if (resourceName === 'events') {
+            eventsCallback = cb;
+            setTimeout(() => eventsCallback(events));
+            return {
+              dispose: (): void => {},
+            };
+          } else {
+            resourcesCallback = cb;
+            setTimeout(() => resourcesCallback(resources));
+            return {
+              dispose: (): void => {},
+            };
+          }
+        },
+      );
+      return {
+        updateResources: (updatedObjects: KubernetesObject[]): void => {
+          resourcesCallback(updatedObjects);
+        },
+        updateEvents: (updatedObjects: CoreV1Event[]): void => {
+          eventsCallback(updatedObjects);
+        },
+      };
+    },
+  },
+  {
+    experimental: false,
+    initLists: (services: KubernetesObject[], events: CoreV1Event[]): initListsReturnType => {
+      const legacyResourceStore = writable<KubernetesObject[]>(services);
+      const legacyEventsStore = writable<CoreV1Event[]>(events);
+      return {
+        legacyResourceStore,
+        legacyEventsStore,
+        updateResources: (resources: KubernetesObject[]): void => {
+          legacyResourceStore.set(resources);
+        },
+        updateEvents: (events: CoreV1Event[]): void => {
+          legacyEventsStore.set(events);
+        },
+      };
+    },
+  },
+])('experimental is $experimental', ({ experimental, initLists }) => {
+  describe.each<{ listenEvents: boolean }>([
+    {
+      listenEvents: true,
+    },
+    {
+      listenEvents: false,
+    },
+  ])('listenEvents is $listenEvents', ({ listenEvents }) => {
+    let listener: IDisposable | undefined;
+
+    beforeEach(() => {
+      vi.mocked(window.getConfigurationValue<boolean>).mockResolvedValue(experimental);
+    });
+
+    afterEach(() => {
+      listener?.dispose();
+    });
+
+    test('onResourceNotFound is called if the resource is not found', async () => {
+      const lists = initLists([], []);
+
+      const onResourceNotFoundSpy = vi.fn();
+      const onResourceUpdatedSpy = vi.fn();
+      const onEventsUpdatedSpy = vi.fn();
+      listener = await listenResource({
+        resourceName: 'myresources',
+        name: 'res1',
+        namespace: 'ns1',
+        listenEvents,
+        legacyResourceStore: lists.legacyResourceStore,
+        legacyEventsStore: lists.legacyEventsStore,
+        onResourceNotFound: onResourceNotFoundSpy,
+        onResourceUpdated: onResourceUpdatedSpy,
+        onEventsUpdated: onEventsUpdatedSpy,
+      });
+
+      await vi.waitFor(() => {
+        expect(onResourceNotFoundSpy).toHaveBeenCalled();
+        if (listenEvents) {
+          expect(onEventsUpdatedSpy).toBeCalledWith([]);
+        } else {
+          expect(onEventsUpdatedSpy).not.toHaveBeenCalled();
+        }
+      });
+      expect(onResourceUpdatedSpy).not.toBeCalled();
+    });
+
+    test('onResourceUpdated is called if the namespaced resource is found', async () => {
+      const res1 = {
+        kind: 'MyResource',
+        metadata: {
+          name: 'res1',
+          namespace: 'ns1',
+        },
+      };
+      const res2 = {
+        kind: 'MyResource',
+        metadata: {
+          name: 'other-resource',
+          namespace: 'ns1',
+        },
+      };
+      const lists = initLists([res1, res2], []);
+
+      const onResourceNotFoundSpy = vi.fn();
+      const onResourceUpdatedSpy = vi.fn();
+      const onEventsUpdatedSpy = vi.fn();
+      listener = await listenResource({
+        resourceName: 'myresources',
+        name: 'res1',
+        namespace: 'ns1',
+        listenEvents,
+        legacyResourceStore: lists.legacyResourceStore,
+        legacyEventsStore: lists.legacyEventsStore,
+        onResourceNotFound: onResourceNotFoundSpy,
+        onResourceUpdated: onResourceUpdatedSpy,
+        onEventsUpdated: onEventsUpdatedSpy,
+      });
+
+      await vi.waitFor(() => {
+        expect(onResourceUpdatedSpy).toBeCalledWith(res1, experimental);
+        if (listenEvents) {
+          expect(onEventsUpdatedSpy).toBeCalledWith([]);
+        } else {
+          expect(onEventsUpdatedSpy).not.toHaveBeenCalled();
+        }
+      });
+      expect(onResourceNotFoundSpy).not.toHaveBeenCalled();
+    });
+
+    test('onResourceUpdated is called if the non-namespaced resource is found', async () => {
+      const res1 = {
+        kind: 'MyResource',
+        metadata: {
+          name: 'res1',
+        },
+      };
+      const res2 = {
+        kind: 'MyResource',
+        metadata: {
+          name: 'other-resource',
+        },
+      };
+      const lists = initLists([res1, res2], []);
+
+      const onResourceNotFoundSpy = vi.fn();
+      const onResourceUpdatedSpy = vi.fn();
+      const onEventsUpdatedSpy = vi.fn();
+      listener = await listenResource({
+        resourceName: 'myresources',
+        name: 'res1',
+        listenEvents,
+        legacyResourceStore: lists.legacyResourceStore,
+        legacyEventsStore: lists.legacyEventsStore,
+        onResourceNotFound: onResourceNotFoundSpy,
+        onResourceUpdated: onResourceUpdatedSpy,
+        onEventsUpdated: onEventsUpdatedSpy,
+      });
+
+      await vi.waitFor(() => {
+        expect(onResourceUpdatedSpy).toBeCalledWith(res1, experimental);
+        if (listenEvents) {
+          expect(onEventsUpdatedSpy).toBeCalledWith([]);
+        } else {
+          expect(onEventsUpdatedSpy).not.toHaveBeenCalled();
+        }
+      });
+      expect(onResourceNotFoundSpy).not.toHaveBeenCalled();
+    });
+
+    test('onResourceUpdated is called with non verbose resource', async () => {
+      const res1: KubernetesObject = {
+        kind: 'MyResource',
+        metadata: {
+          name: 'res1',
+          namespace: 'ns1',
+        },
+      };
+      const verboseRes1 = structuredClone(res1);
+      verboseRes1.metadata = {
+        ...verboseRes1.metadata,
+        managedFields: [{}],
+      };
+      const res2 = {
+        kind: 'MyResource',
+        metadata: {
+          name: 'other-resource',
+          namespace: 'ns1',
+        },
+      };
+      const lists = initLists([verboseRes1, res2], []);
+
+      const onResourceNotFoundSpy = vi.fn();
+      const onResourceUpdatedSpy = vi.fn();
+      const onEventsUpdatedSpy = vi.fn();
+      listener = await listenResource({
+        resourceName: 'myresources',
+        name: 'res1',
+        namespace: 'ns1',
+        listenEvents,
+        legacyResourceStore: lists.legacyResourceStore,
+        legacyEventsStore: lists.legacyEventsStore,
+        onResourceNotFound: onResourceNotFoundSpy,
+        onResourceUpdated: onResourceUpdatedSpy,
+        onEventsUpdated: onEventsUpdatedSpy,
+      });
+
+      await vi.waitFor(() => {
+        expect(onResourceUpdatedSpy).toBeCalledWith(res1, experimental);
+      });
+    });
+
+    test('onEventsUpdated is called with matching events only', async () => {
+      const res1 = {
+        kind: 'MyResource',
+        metadata: {
+          name: 'res1',
+          namespace: 'ns1',
+          uid: 'uid-res1',
+        },
+      };
+      const res2 = {
+        kind: 'MyResource',
+        metadata: {
+          name: 'res2',
+          namespace: 'ns1',
+          uid: 'uid-res2',
+        },
+      };
+      const event1Res1: CoreV1Event = {
+        kind: 'Event',
+        metadata: {
+          name: 'event1Res1',
+        },
+        involvedObject: {
+          uid: 'uid-res1',
+        },
+      };
+      const event2Res1: CoreV1Event = {
+        kind: 'Event',
+        metadata: {
+          name: 'event2Res1',
+        },
+        involvedObject: {
+          uid: 'uid-res1',
+        },
+      };
+      const event1Res2: CoreV1Event = {
+        kind: 'Event',
+        metadata: {
+          name: 'event1Res2',
+        },
+        involvedObject: {
+          uid: 'uid-res2',
+        },
+      };
+      const lists = initLists([res1, res2], [event1Res1, event1Res2, event2Res1]);
+
+      const onResourceNotFoundSpy = vi.fn();
+      const onResourceUpdatedSpy = vi.fn();
+      const onEventsUpdatedSpy = vi.fn();
+      listener = await listenResource({
+        resourceName: 'myresources',
+        name: 'res1',
+        namespace: 'ns1',
+        listenEvents,
+        legacyResourceStore: lists.legacyResourceStore,
+        legacyEventsStore: lists.legacyEventsStore,
+        onResourceNotFound: onResourceNotFoundSpy,
+        onResourceUpdated: onResourceUpdatedSpy,
+        onEventsUpdated: onEventsUpdatedSpy,
+      });
+
+      await vi.waitFor(() => {
+        expect(onResourceUpdatedSpy).toBeCalledWith(res1, experimental);
+        if (listenEvents) {
+          expect(onEventsUpdatedSpy).toBeCalledWith([event1Res1, event2Res1]);
+        } else {
+          expect(onEventsUpdatedSpy).not.toHaveBeenCalled();
+        }
+      });
+      expect(onResourceNotFoundSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/renderer/src/lib/kube/resource-listen.spec.ts
+++ b/packages/renderer/src/lib/kube/resource-listen.spec.ts
@@ -24,14 +24,7 @@ import type { IDisposable } from '../../../../main/src/plugin/types/disposable';
 import { listenResource } from './resource-listen';
 import * as resourcesListen from './resources-listen';
 
-vi.mock(import('./resources-listen'), async importOriginal => {
-  const original = await importOriginal();
-  return {
-    // we want to access the original isKubernetesExperimentalMode
-    ...original,
-    listenResources: vi.fn(),
-  };
-});
+vi.mock(import('./resources-listen'));
 
 type initListsReturnType = {
   updateResources: (objects: KubernetesObject[]) => void;
@@ -105,7 +98,7 @@ describe.each<{
     let listener: IDisposable | undefined;
 
     beforeEach(() => {
-      vi.mocked(window.getConfigurationValue<boolean>).mockResolvedValue(experimental);
+      vi.mocked(resourcesListen.isKubernetesExperimentalMode).mockResolvedValue(experimental);
     });
 
     afterEach(() => {

--- a/packages/renderer/src/lib/kube/resource-listen.ts
+++ b/packages/renderer/src/lib/kube/resource-listen.ts
@@ -1,0 +1,122 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { CoreV1Event, KubernetesObject } from '@kubernetes/client-node';
+import type { Readable, Unsubscriber } from 'svelte/store';
+
+import type { IDisposable } from '../../../../main/src/plugin/types/disposable';
+import { isKubernetesExperimentalMode, listenResources } from './resources-listen';
+
+export interface ListenResourceOptions {
+  resourceName: string;
+  name: string;
+  namespace?: string;
+  listenEvents?: boolean;
+
+  legacyResourceStore: Readable<KubernetesObject[]>;
+  legacyEventsStore?: Readable<KubernetesObject[]>;
+
+  onResourceNotFound: () => void;
+  onResourceUpdated: (resource: KubernetesObject, experimental: boolean) => void;
+  onEventsUpdated?: (events: CoreV1Event[]) => void;
+}
+
+/** listenResource listens for a specific resource (resourceName, name, namespace)
+ *  and fires events when:
+ *  - the resource is not found
+ *  - the resource is updated (will send the resource without managedFields)
+ *  - the events attached to the resource are updated, optionally
+ */
+export async function listenResource(options: ListenResourceOptions): Promise<IDisposable | undefined> {
+  let resourcesListener: IDisposable | undefined;
+  let eventsListener: IDisposable | undefined;
+
+  let resourcesUnsubscriber: Unsubscriber;
+  let eventsUnsubscriber: Unsubscriber;
+
+  let allEvents: KubernetesObject[] = [];
+  let resource: KubernetesObject | undefined;
+
+  const refreshEvents = (): void => {
+    if (options.listenEvents) {
+      const events = allEvents
+        .map(ev => (isCoreV1Event(ev) ? ev : undefined))
+        .filter(ev => !!ev)
+        .filter(ev => ev.involvedObject.uid === resource?.metadata?.uid);
+      options.onEventsUpdated?.(events);
+    }
+  };
+
+  const onUpdatedResources = (updatedResources: KubernetesObject[]): void => {
+    const matchingResource = updatedResources.find(
+      srv =>
+        srv.metadata?.name === options.name && (!options.namespace || srv.metadata?.namespace === options.namespace),
+    );
+    if (matchingResource) {
+      resource = matchingResource;
+      const kubeResource = nonVerbose(matchingResource);
+      options.onResourceUpdated(kubeResource, isExperimental);
+      refreshEvents();
+    } else {
+      options.onResourceNotFound();
+    }
+  };
+
+  const isExperimental = await isKubernetesExperimentalMode();
+  if (isExperimental) {
+    resourcesListener = await listenResources(options.resourceName, {}, onUpdatedResources);
+    if (options.listenEvents) {
+      eventsListener = await listenResources('events', {}, (updatedEvents: KubernetesObject[]) => {
+        allEvents = updatedEvents;
+        refreshEvents();
+      });
+    }
+  } else {
+    resourcesUnsubscriber = options.legacyResourceStore.subscribe(onUpdatedResources);
+    if (options.listenEvents && options.legacyEventsStore) {
+      eventsUnsubscriber = options.legacyEventsStore.subscribe(updatedEvents => {
+        allEvents = updatedEvents.map(e => ({ kind: 'Event', ...e }));
+        refreshEvents();
+      });
+    }
+  }
+
+  return {
+    dispose: (): void => {
+      resourcesListener?.dispose();
+      eventsListener?.dispose();
+      resourcesUnsubscriber?.();
+      eventsUnsubscriber?.();
+    },
+  };
+}
+
+// removes "verbose" fields from a Kubernetes resource description:
+// - metadata.managedFields
+function nonVerbose(resource: KubernetesObject): KubernetesObject {
+  if (resource.metadata?.managedFields) {
+    const result = structuredClone(resource);
+    delete result.metadata?.managedFields;
+    return result;
+  }
+  return resource;
+}
+
+function isCoreV1Event(resource: KubernetesObject): resource is CoreV1Event {
+  return resource.kind === 'Event';
+}

--- a/packages/renderer/src/lib/kube/resources-listen.ts
+++ b/packages/renderer/src/lib/kube/resources-listen.ts
@@ -114,7 +114,7 @@ function filter(resources: KubernetesObject[], searchTerm: string): KubernetesOb
   return resources.filter(resource => findMatchInLeaves(resource, searchTerm.toLowerCase()));
 }
 
-async function isKubernetesExperimentalMode(): Promise<boolean> {
+export async function isKubernetesExperimentalMode(): Promise<boolean> {
   try {
     return (await window.getConfigurationValue<boolean>('kubernetes.statesExperimental')) ?? false;
   } catch {

--- a/packages/renderer/src/lib/service/ServiceDetails.spec.ts
+++ b/packages/renderer/src/lib/service/ServiceDetails.spec.ts
@@ -22,17 +22,18 @@ import type { CoreV1Event, KubernetesObject, V1Service } from '@kubernetes/clien
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { writable } from 'svelte/store';
 import { router } from 'tinro';
-import { beforeAll, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { lastPage } from '/@/stores/breadcrumb';
-import * as kubeContextStore from '/@/stores/kubernetes-contexts-state';
+import * as states from '/@/stores/kubernetes-contexts-state';
 
+import type { IDisposable } from '../../../../main/src/plugin/types/disposable';
+import * as resourcesListen from '../kube/resources-listen';
 import ServiceDetails from './ServiceDetails.svelte';
 import * as serviceDetailsSummary from './ServiceDetailsSummary.svelte';
 
-const kubernetesDeleteServiceMock = vi.fn();
-
 const service: V1Service = {
+  kind: 'Service',
   metadata: {
     uid: '12345678',
     name: 'my-service',
@@ -41,102 +42,171 @@ const service: V1Service = {
   status: {},
 };
 
-vi.mock('/@/stores/kubernetes-contexts-state', async () => {
+vi.mock(import('../kube/resources-listen'), async importOriginal => {
+  // we want to keep the original nonVerbose
+  const original = await importOriginal();
   return {
-    kubernetesCurrentContextServices: vi.fn(),
+    ...original,
+    listenResources: vi.fn(),
+    isKubernetesExperimentalMode: vi.fn(),
   };
 });
 
-beforeAll(() => {
-  Object.defineProperty(window, 'kubernetesDeleteService', { value: kubernetesDeleteServiceMock });
-  Object.defineProperty(window, 'kubernetesReadNamespacedService', { value: vi.fn() });
+vi.mock('/@/stores/kubernetes-contexts-state');
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  router.goto('http://localhost:3000');
 });
 
-test('Expect redirect to previous page if service is deleted', async () => {
-  const showMessageBoxMock = vi.fn();
-  Object.defineProperty(window, 'showMessageBox', { value: showMessageBoxMock });
-  showMessageBoxMock.mockResolvedValue({ response: 0 });
+type initListsReturnType = {
+  updateServices: (objects: KubernetesObject[]) => void;
+  updateEvents: (objects: CoreV1Event[]) => void;
+};
 
-  const routerGotoSpy = vi.spyOn(router, 'goto');
+describe.each<{
+  experimental: boolean;
+  initLists: (services: KubernetesObject[], events: CoreV1Event[]) => initListsReturnType;
+}>([
+  {
+    experimental: false,
+    initLists: (services: KubernetesObject[], events: CoreV1Event[]): initListsReturnType => {
+      const servciesStore = writable<KubernetesObject[]>(services);
+      vi.mocked(states).kubernetesCurrentContextServices = servciesStore;
+      const eventsStore = writable<CoreV1Event[]>(events);
+      vi.mocked(states).kubernetesCurrentContextEvents = eventsStore;
+      return {
+        updateServices: (services: KubernetesObject[]): void => {
+          servciesStore.set(services);
+        },
+        updateEvents: (events: CoreV1Event[]): void => {
+          eventsStore.set(events);
+        },
+      };
+    },
+  },
+  {
+    experimental: true,
+    initLists: (services: KubernetesObject[], events: CoreV1Event[]): initListsReturnType => {
+      let servicesCallback: (resoures: KubernetesObject[]) => void;
+      let eventsCallback: (resoures: CoreV1Event[]) => void;
+      vi.mocked(resourcesListen.listenResources).mockImplementation(
+        async (resourceName, _options, cb): Promise<IDisposable> => {
+          if (resourceName === 'services') {
+            servicesCallback = cb;
+            setTimeout(() => servicesCallback(services));
+            return {
+              dispose: (): void => {},
+            };
+          } else {
+            eventsCallback = cb;
+            setTimeout(() => eventsCallback(events));
+            return {
+              dispose: (): void => {},
+            };
+          }
+        },
+      );
+      return {
+        updateServices: (updatedObjects: KubernetesObject[]): void => {
+          servicesCallback(updatedObjects);
+        },
+        updateEvents: (updatedObjects: CoreV1Event[]): void => {
+          eventsCallback(updatedObjects);
+        },
+      };
+    },
+  },
+])('is experimental: $experimental', ({ experimental, initLists }) => {
+  beforeEach(() => {
+    vi.mocked(resourcesListen.isKubernetesExperimentalMode).mockResolvedValue(experimental);
+  });
+  test('Expect redirect to previous page if service is deleted', async () => {
+    vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
 
-  // mock object store
-  const services = writable<KubernetesObject[]>([service]);
-  vi.mocked(kubeContextStore).kubernetesCurrentContextServices = services;
+    const routerGotoSpy = vi.spyOn(router, 'goto');
 
-  // remove service from the store when we call delete
-  kubernetesDeleteServiceMock.mockImplementation(() => {
-    services.set([]);
+    // mock object store
+    const list = initLists([service], []);
+
+    // remove service from the store when we call delete
+    vi.mocked(window.kubernetesDeleteService).mockImplementation(async () => {
+      list.updateServices([]);
+    });
+
+    // define a fake lastPage so we can check where we will be redirected
+    lastPage.set({ name: 'Fake Previous', path: '/last' });
+
+    // render the component
+    render(ServiceDetails, { name: 'my-service', namespace: 'default' });
+    await vi.waitFor(() => {
+      expect(screen.getByText('my-service')).toBeInTheDocument();
+    });
+
+    // grab current route
+    const currentRoute = window.location;
+    expect(currentRoute.href).toBe('http://localhost:3000/');
+
+    // click on delete button
+    const deleteButton = screen.getByRole('button', { name: 'Delete Service' });
+    await fireEvent.click(deleteButton);
+
+    expect(window.showMessageBox).toHaveBeenCalledOnce();
+
+    // Wait for confirmation modal to disappear after clicking on delete
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+
+    // check that delete method has been called
+    expect(window.kubernetesDeleteService).toHaveBeenCalled();
+
+    // expect that we have called the router when page has been removed
+    // to jump to the previous page
+    expect(routerGotoSpy).toBeCalledWith('/last');
+
+    // confirm updated route
+    const afterRoute = window.location;
+    expect(afterRoute.href).toBe('http://localhost:3000/last');
   });
 
-  // define a fake lastPage so we can check where we will be redirected
-  lastPage.set({ name: 'Fake Previous', path: '/last' });
-
-  // render the component
-  render(ServiceDetails, { name: 'my-service', namespace: 'default' });
-  expect(screen.getByText('my-service')).toBeInTheDocument();
-
-  // grab current route
-  const currentRoute = window.location;
-  expect(currentRoute.href).toBe('http://localhost:3000/');
-
-  // click on delete button
-  const deleteButton = screen.getByRole('button', { name: 'Delete Service' });
-  await fireEvent.click(deleteButton);
-
-  expect(showMessageBoxMock).toHaveBeenCalledOnce();
-
-  // Wait for confirmation modal to disappear after clicking on delete
-  await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
-
-  // check that delete method has been called
-  expect(kubernetesDeleteServiceMock).toHaveBeenCalled();
-
-  // expect that we have called the router when page has been removed
-  // to jump to the previous page
-  expect(routerGotoSpy).toBeCalledWith('/last');
-
-  // confirm updated route
-  const afterRoute = window.location;
-  expect(afterRoute.href).toBe('http://localhost:3000/last');
-});
-
-test('Expect ServiceDetailsSummary to be called with related events only', async () => {
-  const serviceDetailsSummarySpy = vi.spyOn(serviceDetailsSummary, 'default');
-  // mock object stores
-  const servicesStore = writable<KubernetesObject[]>([service]);
-  vi.mocked(kubeContextStore).kubernetesCurrentContextServices = servicesStore;
-
-  const events: CoreV1Event[] = [
-    {
-      metadata: {
-        name: 'event1',
+  test('Expect ServiceDetailsSummary to be called with related events only', async () => {
+    const serviceDetailsSummarySpy = vi.spyOn(serviceDetailsSummary, 'default');
+    const events: CoreV1Event[] = [
+      {
+        kind: 'Event',
+        metadata: {
+          name: 'event1',
+        },
+        involvedObject: { uid: '12345678' },
       },
-      involvedObject: { uid: '12345678' },
-    },
-    {
-      metadata: {
-        name: 'event2',
+      {
+        kind: 'Event',
+        metadata: {
+          name: 'event2',
+        },
+        involvedObject: { uid: '12345678' },
       },
-      involvedObject: { uid: '12345678' },
-    },
-    {
-      metadata: {
-        name: 'event3',
+      {
+        kind: 'Event',
+        metadata: {
+          name: 'event3',
+        },
+        involvedObject: { uid: '1234' },
       },
-      involvedObject: { uid: '1234' },
-    },
-  ];
-  const eventsStore = writable<CoreV1Event[]>(events);
-  vi.mocked(kubeContextStore).kubernetesCurrentContextEvents = eventsStore;
+    ];
 
-  vi.mocked(window.kubernetesReadNamespacedService).mockResolvedValue(service);
+    initLists([service], events);
 
-  render(ServiceDetails, { name: 'my-service', namespace: 'default' });
-  router.goto('summary');
-  await waitFor(() => {
-    expect(serviceDetailsSummarySpy).toHaveBeenCalledWith(expect.anything(), {
-      service: service,
-      events: [events[0], events[1]],
+    if (!experimental) {
+      vi.mocked(window.kubernetesReadNamespacedService).mockResolvedValue(service);
+    }
+
+    render(ServiceDetails, { name: 'my-service', namespace: 'default' });
+    router.goto('summary');
+    await vi.waitFor(() => {
+      expect(serviceDetailsSummarySpy).toHaveBeenCalledWith(expect.anything(), {
+        service: service,
+        events: [events[0], events[1]],
+      });
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?

In Kubernetes experimental mode:

- registers the Event resource
- create a `listenResource` helper for Details pages
- use `listenResource` for Services details

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes #11183 
Part of #10657 

### How to test this PR?

Test in experimental and non experimental mode:
- create a service 
- go to Kubernetes > Services > Details
- check that the summary of service is displayed
- check that Inspect tab displays YAML
- check that the service can be updated from the Kube tab
- create and delete events for the service(1) and check they are displayed reactively in the Summary page

(1) you can create events manually with:
```
apiVersion: v1
count: 1
involvedObject:
  apiVersion: v1
  kind: Service
  name: svc1                                <-- replace with name of service
  namespace: default                        <-- replace with namespace of service
  uid: e9cef2cc-2fb8-409c-9c92-ff4f57e247fb <-- replace with uid of service
kind: Event
lastTimestamp: "2025-02-17T15:05:49Z"
message: test message
metadata:
  creationTimestamp: "2025-02-17T08:22:46Z"
  name: svc1-event1
  namespace: default                        <-- replace with namespace of service
reason: BackOff
reportingComponent: kubelet
reportingInstance: kind-cluster-control-plane
source:
  component: kubelet
  host: kind-cluster-control-plane
type: Normal
```

- [x] Tests are covering the bug fix or the new feature
