### PR TITLE
fix(podman): running deactivate to ensure test isolation

### DIFF
--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -348,8 +348,9 @@ beforeEach(() => {
   });
 });
 
-afterEach(() => {
+afterEach(async () => {
   console.error = originalConsoleError;
+  await extension.deactivate();
 });
 
 describe.each([

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -1879,19 +1879,19 @@ export async function getJSONMachineListByProvider(containerMachineProvider?: st
 }
 
 export async function deactivate(): Promise<void> {
-  console.log('stopping podman extension');
-  // cleanup
   stopLoop = true;
-  listeners.clear();
-  podmanMachinesInfo.clear();
-  currentConnections.clear();
-  containerProviderConnections.clear();
-
+  console.log('stopping podman extension');
   await stopAutoStartedMachine().then(() => {
     if (autoMachineStarted) {
       console.log('stopped autostarted machine', autoMachineName);
     }
   });
+
+  // cleanup
+  listeners.clear();
+  podmanMachinesInfo.clear();
+  currentConnections.clear();
+  containerProviderConnections.clear();
 }
 
 const PODMAN_MINIMUM_VERSION_FOR_NOW_FLAG_INIT = '4.0.0';

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -1879,8 +1879,14 @@ export async function getJSONMachineListByProvider(containerMachineProvider?: st
 }
 
 export async function deactivate(): Promise<void> {
-  stopLoop = true;
   console.log('stopping podman extension');
+  // cleanup
+  stopLoop = true;
+  listeners.clear();
+  podmanMachinesInfo.clear();
+  currentConnections.clear();
+  containerProviderConnections.clear();
+
   await stopAutoStartedMachine().then(() => {
     if (autoMachineStarted) {
       console.log('stopped autostarted machine', autoMachineName);


### PR DESCRIPTION
### What does this PR do?

While working on https://github.com/podman-desktop/podman-desktop/pull/10768 I noticed that tests were not really isolated, and some tests were leaking with each other.

To ensure some sort of isolation, clearing podman extension content in `deactivate` function, and running deactivate function in afterEach.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Required for https://github.com/podman-desktop/podman-desktop/pull/10768

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are ensuring no regression
