### PR TITLE
feat: display troubleshooting info for experimental Kubernetes monitoring 

### DIFF
--- a/packages/api/src/kubernetes-troubleshooting.ts
+++ b/packages/api/src/kubernetes-troubleshooting.ts
@@ -1,0 +1,43 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export interface KubernetesTroubleshootingInformation {
+  healthCheckers: KubernetesTroubleshootingHealthChecker[];
+  permissionCheckers: KubernetesTroubleshootingPermissionChecker[];
+  informers: KubernetesTroubleshootingInformer[];
+}
+
+export interface KubernetesTroubleshootingHealthChecker {
+  contextName: string;
+  checking: boolean;
+  reachable: boolean;
+}
+
+export interface KubernetesTroubleshootingPermissionChecker {
+  contextName: string;
+  resourceName: string;
+  permitted: boolean;
+  reason?: string;
+}
+
+export interface KubernetesTroubleshootingInformer {
+  contextName: string;
+  resourceName: string;
+  isOffline: boolean;
+  objectsCount?: number;
+}

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -98,6 +98,7 @@ import type { KubernetesNavigationRequest } from '/@api/kubernetes-navigation.js
 import type { ForwardConfig, ForwardOptions } from '/@api/kubernetes-port-forward-model.js';
 import type { ResourceCount } from '/@api/kubernetes-resource-count.js';
 import type { KubernetesContextResources } from '/@api/kubernetes-resources.js';
+import type { KubernetesTroubleshootingInformation } from '/@api/kubernetes-troubleshooting.js';
 import type { ManifestCreateOptions, ManifestInspectInfo, ManifestPushOptions } from '/@api/manifest-info.js';
 import type { NetworkInspectInfo } from '/@api/network-info.js';
 import type { NotificationCard, NotificationCardOptions } from '/@api/notification.js';
@@ -2989,6 +2990,13 @@ export class PluginSystem {
       'extension-development-folders:removeDevelopmentFolder',
       async (_listener: unknown, path: string): Promise<void> => {
         return extensionDevelopmentFolders.removeDevelopmentFolder(path);
+      },
+    );
+
+    this.ipcHandle(
+      'kubernetes:getTroubleshootingInformation',
+      async (_listener: unknown): Promise<KubernetesTroubleshootingInformation> => {
+        return kubernetesClient.getTroubleshootingInformation();
       },
     );
 

--- a/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.ts
@@ -20,6 +20,7 @@ import type { ContextHealth } from '/@api/kubernetes-contexts-healths.js';
 import type { ContextPermission } from '/@api/kubernetes-contexts-permissions.js';
 import type { ResourceCount } from '/@api/kubernetes-resource-count.js';
 import type { KubernetesContextResources } from '/@api/kubernetes-resources.js';
+import type { KubernetesTroubleshootingInformation } from '/@api/kubernetes-troubleshooting.js';
 
 import type { ApiSenderType } from '../api.js';
 import type { ContextHealthState } from './context-health-checker.js';
@@ -82,5 +83,9 @@ export class ContextsStatesDispatcher {
 
   getResources(contextNames: string[], resourceName: string): KubernetesContextResources[] {
     return this.manager.getResources(contextNames, resourceName);
+  }
+
+  getTroubleshootingInformation(): KubernetesTroubleshootingInformation {
+    return this.manager.getTroubleshootingInformation();
   }
 }

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.ts
@@ -80,6 +80,7 @@ import type { ContextGeneralState, ResourceName } from '/@api/kubernetes-context
 import type { ForwardConfig, ForwardOptions } from '/@api/kubernetes-port-forward-model.js';
 import type { ResourceCount } from '/@api/kubernetes-resource-count.js';
 import type { KubernetesContextResources } from '/@api/kubernetes-resources.js';
+import type { KubernetesTroubleshootingInformation } from '/@api/kubernetes-troubleshooting.js';
 import type { V1Route } from '/@api/openshift-types.js';
 
 import type { ApiSenderType } from '../api.js';
@@ -1741,5 +1742,14 @@ export class KubernetesClient {
       );
     }
     return this.contextsStatesDispatcher.getResources(contextNames, resourceName);
+  }
+
+  public getTroubleshootingInformation(): KubernetesTroubleshootingInformation {
+    if (!this.contextsStatesDispatcher) {
+      throw new Error(
+        `contextsStatesDispatcher is undefined when getting troubleshooting information. This should not happen in Kubernetes experimental`,
+      );
+    }
+    return this.contextsStatesDispatcher.getTroubleshootingInformation();
   }
 }

--- a/packages/main/src/plugin/kubernetes/resource-informer.ts
+++ b/packages/main/src/plugin/kubernetes/resource-informer.ts
@@ -169,4 +169,8 @@ export class ResourceInformer<T extends KubernetesObject> implements Disposable 
       );
     });
   }
+
+  isOffline(): boolean {
+    return this.#offline;
+  }
 }

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -75,6 +75,7 @@ import type { ContextGeneralState, ResourceName } from '/@api/kubernetes-context
 import type { ForwardConfig, ForwardOptions } from '/@api/kubernetes-port-forward-model';
 import type { ResourceCount } from '/@api/kubernetes-resource-count';
 import type { KubernetesContextResources } from '/@api/kubernetes-resources';
+import type { KubernetesTroubleshootingInformation } from '/@api/kubernetes-troubleshooting';
 import type { ManifestCreateOptions, ManifestInspectInfo, ManifestPushOptions } from '/@api/manifest-info';
 import type { NetworkInspectInfo } from '/@api/network-info';
 import type { NotificationCard, NotificationCardOptions } from '/@api/notification';
@@ -2412,6 +2413,13 @@ export function initExposure(): void {
   contextBridge.exposeInMainWorld('trackExtensionFolder', async (path: string): Promise<void> => {
     return ipcInvoke('extension-development-folders:addDevelopmentFolder', path);
   });
+
+  contextBridge.exposeInMainWorld(
+    'kubernetesGetTroubleshootingInformation',
+    async (): Promise<KubernetesTroubleshootingInformation> => {
+      return ipcInvoke('kubernetes:getTroubleshootingInformation');
+    },
+  );
 }
 
 // expose methods

--- a/packages/renderer/src/lib/kube/resources-listen.ts
+++ b/packages/renderer/src/lib/kube/resources-listen.ts
@@ -114,7 +114,7 @@ function filter(resources: KubernetesObject[], searchTerm: string): KubernetesOb
   return resources.filter(resource => findMatchInLeaves(resource, searchTerm.toLowerCase()));
 }
 
-async function isKubernetesExperimentalMode(): Promise<boolean> {
+export async function isKubernetesExperimentalMode(): Promise<boolean> {
   try {
     return (await window.getConfigurationValue<boolean>('kubernetes.statesExperimental')) ?? false;
   } catch {

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPage.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPage.svelte
@@ -1,19 +1,28 @@
 <script lang="ts">
 import { Page, Tab } from '@podman-desktop/ui-svelte';
+import { onMount } from 'svelte';
 import { router } from 'tinro';
 
 import Route from '/@/Route.svelte';
 
 import { lastPage } from '../../stores/breadcrumb';
+import { isKubernetesExperimentalMode } from '../kube/resources-listen';
 import { getTabUrl, isTabSelected } from '../ui/Util';
 import TroubleshootingDevToolsConsoleLogs from './TroubleshootingDevToolsConsoleLogs.svelte';
 import TroubleshootingGatherLogs from './TroubleshootingGatherLogs.svelte';
+import TroubleshootingPageKubernetes from './TroubleshootingPageKubernetes.svelte';
 import TroubleshootingPageProviders from './TroubleshootingPageProviders.svelte';
 import TroubleshootingPageStores from './TroubleshootingPageStores.svelte';
+
+let displayKubernetes = $state<boolean>(false);
 
 export function goToPreviousPage(): void {
   router.goto($lastPage.path);
 }
+
+onMount(async () => {
+  displayKubernetes = await isKubernetesExperimentalMode();
+});
 </script>
 
 <Page title="Troubleshooting" on:close={goToPreviousPage}>
@@ -30,6 +39,9 @@ export function goToPreviousPage(): void {
       selected={isTabSelected($router.path, 'gatherlogs')}
       url={getTabUrl($router.path, 'gatherlogs')} />
     <Tab title="Stores" selected={isTabSelected($router.path, 'stores')} url={getTabUrl($router.path, 'stores')} />
+    {#if displayKubernetes}
+      <Tab title="Kubernetes" selected={isTabSelected($router.path, 'kubernetes')} url={getTabUrl($router.path, 'kubernetes')} />
+    {/if}
   </div>
   <div class="flex w-full h-full overflow-auto" slot="content">
     <Route path="/repair-connections" breadcrumb="Repair & Connections" navigationHint="tab">
@@ -47,5 +59,11 @@ export function goToPreviousPage(): void {
     <Route path="/stores" breadcrumb="Stores" navigationHint="tab">
       <TroubleshootingPageStores />
     </Route>
+
+    {#if displayKubernetes}
+      <Route path="/kubernetes" breadcrumb="Kubernetes" navigationHint="tab">
+        <TroubleshootingPageKubernetes />
+      </Route>
+    {/if}
   </div>
 </Page>

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPageKubernetes.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPageKubernetes.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+import { faDatabase, faRefresh } from '@fortawesome/free-solid-svg-icons';
+import { Button } from '@podman-desktop/ui-svelte';
+import { onMount } from 'svelte';
+import Fa from 'svelte-fa';
+
+import type { KubernetesTroubleshootingInformation } from '/@api/kubernetes-troubleshooting';
+
+let info = $state<KubernetesTroubleshootingInformation>();
+
+onMount(async () => {
+  await refresh();
+});
+
+async function refresh(): Promise<void> {
+  info = await window.kubernetesGetTroubleshootingInformation();
+}
+</script>
+
+<div class="flex flex-col w-full m-4 p-4 rounded-lg bg-[var(--pd-content-card-bg)]">
+  <div class="flex flex-row align-middle items-center w-full mb-4">
+    <Fa size="1.875x" class="pr-3" icon={faDatabase} />
+    <div role="status" aria-label="stores" class="text-xl">Kubernetes monitoring</div>
+    <div class="flex flex-1 justify-end">
+      <Button title="Refresh" class="ml-5" on:click={refresh} type="link"
+        ><Fa class="h-5 w-5 cursor-pointer text-xl text-[var(--pd-button-primary-bg)]" icon={faRefresh} /></Button>
+    </div>
+  </div>
+
+  <div class="h-full overflow-auto p-2 bg-[var(--pd-invert-content-card-bg)]">
+    <h2 class="mt-2">Health Checks</h2>
+    <div class="flex flex-col space-y-4">
+    {#each info?.healthCheckers ?? [] as healthchecker}
+      <ul>
+        <li><b>{healthchecker.contextName}</b></li>
+        <li>checking: {healthchecker.checking}</li>
+        <li>reachable: {healthchecker.reachable}</li>
+      </ul>
+    {/each}
+    </div>
+
+    <h2 class="mt-2">Permission Checks</h2>
+    <div class="flex flex-col space-y-4">
+      {#each info?.permissionCheckers ?? [] as permissionChecker}
+        <ul>
+          <li><b>{permissionChecker.contextName} / {permissionChecker.resourceName}</b></li>
+          <li>permitted: {permissionChecker.permitted}</li>
+          <li>reason: {permissionChecker.reason}</li>
+        </ul>
+      {/each}
+    </div>
+
+    <h2 class="mt-2">Informers</h2>
+    <div class="flex flex-col space-y-4">
+    {#each info?.informers ?? [] as informer}
+      <ul>
+        <li><b>{informer.contextName} / {informer.resourceName}</b></li>
+        <li>is offline: {informer.isOffline}</li>
+        <li># objects: {informer.objectsCount ?? 'unknown'}</li>
+      </ul>
+    {/each}
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
### What does this PR do?

Display troubleshooting info for experimental Kubernetes monitoring 

The info is not updated reactively. The user needs to use the refresh button.

### Screenshot / video of UI

![kube-troubleshooting](https://github.com/user-attachments/assets/1cd8555c-2b5d-447f-b6fe-5d403f550203)

### What issues does this PR fix or reference?

Fixes #11212 

### How to test this PR?

set experimental mode in config file `$HOME/.local/share/containers/podman-desktop/configuration/settings.json`:
```
  "kubernetes.statesExperimental": true,
```

- [ ] Tests are covering the bug fix or the new feature
