### PR TITLE
chore: common kubernetes ui objects

### DIFF
--- a/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretUI.ts
+++ b/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretUI.ts
@@ -16,12 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { KubernetesObjectUI } from '../objects/KubernetesObjectUI';
+import type { KubernetesNamespacedObjectUI } from '../objects/KubernetesObjectUI';
 
-export interface ConfigMapSecretUI extends KubernetesObjectUI {
-  namespace: string;
+export interface ConfigMapSecretUI extends KubernetesNamespacedObjectUI {
   keys: string[];
-  selected: boolean;
   type: string;
   created?: Date;
 }

--- a/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretUI.ts
+++ b/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretUI.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-export interface ConfigMapSecretUI {
-  name: string;
+import type { KubernetesObjectUI } from '../objects/KubernetesObjectUI';
+
+export interface ConfigMapSecretUI extends KubernetesObjectUI {
   namespace: string;
-  status: string;
   keys: string[];
   selected: boolean;
   type: string;

--- a/packages/renderer/src/lib/configmaps-secrets/configmap-secret-utils.spec.ts
+++ b/packages/renderer/src/lib/configmaps-secrets/configmap-secret-utils.spec.ts
@@ -30,6 +30,7 @@ beforeEach(() => {
 
 test('expect configmap UI conversion', async () => {
   const configMap = {
+    kind: 'ConfigMap',
     metadata: {
       name: 'my-configmap',
       namespace: 'test-namespace',
@@ -40,6 +41,7 @@ test('expect configmap UI conversion', async () => {
     },
   } as V1ConfigMap;
   const configMapUI = configMapSecretUtils.getConfigMapSecretUI(configMap);
+  expect(configMapUI.kind).toEqual('ConfigMap');
   expect(configMapUI.name).toEqual('my-configmap');
   expect(configMapUI.namespace).toEqual('test-namespace');
   expect(configMapUI.keys).toEqual(['key1', 'key2']);
@@ -47,6 +49,7 @@ test('expect configmap UI conversion', async () => {
 
 test('expect secret UI conversion', async () => {
   const secret = {
+    kind: 'Secret',
     metadata: {
       name: 'my-secret',
       namespace: 'test-namespace',
@@ -58,6 +61,7 @@ test('expect secret UI conversion', async () => {
     type: 'Opaque',
   } as V1Secret;
   const secretUI = configMapSecretUtils.getConfigMapSecretUI(secret);
+  expect(secretUI.kind).toEqual('Secret');
   expect(secretUI.name).toEqual('my-secret');
   expect(secretUI.namespace).toEqual('test-namespace');
   expect(secretUI.keys).toEqual(['key1', 'key2']);

--- a/packages/renderer/src/lib/configmaps-secrets/configmap-secret-utils.ts
+++ b/packages/renderer/src/lib/configmaps-secrets/configmap-secret-utils.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ export class ConfigMapSecretUtils {
     }
 
     return {
+      kind: type === 'ConfigMap' ? 'ConfigMap' : 'Secret',
       name: storage.metadata?.name ?? '',
       namespace: storage.metadata?.namespace ?? '',
       status: 'RUNNING',

--- a/packages/renderer/src/lib/cronjob/CronJobUI.ts
+++ b/packages/renderer/src/lib/cronjob/CronJobUI.ts
@@ -16,10 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-export interface CronJobUI {
+import type { KubernetesObjectUI } from '../objects/KubernetesObjectUI';
+
+export interface CronJobUI extends KubernetesObjectUI {
   uid: string;
-  name: string;
-  status: string;
   namespace: string;
   created?: Date;
   selected: boolean;

--- a/packages/renderer/src/lib/cronjob/CronJobUI.ts
+++ b/packages/renderer/src/lib/cronjob/CronJobUI.ts
@@ -16,13 +16,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { KubernetesObjectUI } from '../objects/KubernetesObjectUI';
+import type { KubernetesNamespacedObjectUI } from '../objects/KubernetesObjectUI';
 
-export interface CronJobUI extends KubernetesObjectUI {
+export interface CronJobUI extends KubernetesNamespacedObjectUI {
   uid: string;
-  namespace: string;
   created?: Date;
-  selected: boolean;
 
   // The "schedule" in cron format. See: https://en.wikipedia.org/wiki/Cron
   schedule: string;

--- a/packages/renderer/src/lib/cronjob/cronjob-utils.spec.ts
+++ b/packages/renderer/src/lib/cronjob/cronjob-utils.spec.ts
@@ -30,6 +30,7 @@ beforeEach(() => {
 
 test('expect basic UI conversion', async () => {
   const cronjob = {
+    kind: 'CronJob',
     metadata: {
       name: 'my-cronjob',
       namespace: 'test-namespace',
@@ -37,6 +38,7 @@ test('expect basic UI conversion', async () => {
     status: {},
   } as V1CronJob;
   const cronjobUI = cronjobUtils.getCronJobUI(cronjob);
+  expect(cronjobUI.kind).toEqual('CronJob');
   expect(cronjobUI.name).toEqual('my-cronjob');
   expect(cronjobUI.namespace).toEqual('test-namespace');
 });

--- a/packages/renderer/src/lib/deployments/DeploymentUI.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentUI.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-export interface DeploymentUI {
+import type { KubernetesObjectUI } from '../objects/KubernetesObjectUI.ts';
+
+export interface DeploymentUI extends KubernetesObjectUI {
   uid: string;
-  name: string;
-  status: string;
   namespace: string;
   replicas: number;
   ready: number;

--- a/packages/renderer/src/lib/deployments/DeploymentUI.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentUI.ts
@@ -16,15 +16,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { KubernetesObjectUI } from '../objects/KubernetesObjectUI.ts';
+import type { KubernetesNamespacedObjectUI } from '../objects/KubernetesObjectUI.ts';
 
-export interface DeploymentUI extends KubernetesObjectUI {
+export interface DeploymentUI extends KubernetesNamespacedObjectUI {
   uid: string;
-  namespace: string;
   replicas: number;
   ready: number;
   created?: Date;
-  selected: boolean;
   conditions: DeploymentCondition[];
 }
 

--- a/packages/renderer/src/lib/deployments/deployment-utils.spec.ts
+++ b/packages/renderer/src/lib/deployments/deployment-utils.spec.ts
@@ -40,6 +40,7 @@ test('expect basic UI conversion', async () => {
     },
   } as V1Deployment;
   const deploymentUI = deploymentUtils.getDeploymentUI(deployment);
+  expect(deploymentUI.kind).toEqual('Deployment');
   expect(deploymentUI.name).toEqual('my-deployment');
   expect(deploymentUI.namespace).toEqual('test-namespace');
   expect(deploymentUI.replicas).toEqual(4);

--- a/packages/renderer/src/lib/deployments/deployment-utils.ts
+++ b/packages/renderer/src/lib/deployments/deployment-utils.ts
@@ -41,6 +41,7 @@ export class DeploymentUtils {
     }
 
     return {
+      kind: 'Deployment',
       uid: deployment.metadata?.uid ?? '',
       name: deployment.metadata?.name ?? '',
       status: status,

--- a/packages/renderer/src/lib/ingresses-routes/IngressUI.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressUI.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,10 +18,10 @@
 
 import type { V1IngressRule } from '@kubernetes/client-node';
 
-export interface IngressUI {
-  name: string;
+import type { KubernetesObjectUI } from '../objects/KubernetesObjectUI';
+
+export interface IngressUI extends KubernetesObjectUI {
   namespace: string;
-  status: string;
   rules?: Array<V1IngressRule>;
   selected: boolean;
   created?: Date;

--- a/packages/renderer/src/lib/ingresses-routes/IngressUI.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressUI.ts
@@ -18,11 +18,9 @@
 
 import type { V1IngressRule } from '@kubernetes/client-node';
 
-import type { KubernetesObjectUI } from '../objects/KubernetesObjectUI';
+import type { KubernetesNamespacedObjectUI } from '../objects/KubernetesObjectUI';
 
-export interface IngressUI extends KubernetesObjectUI {
-  namespace: string;
+export interface IngressUI extends KubernetesNamespacedObjectUI {
   rules?: Array<V1IngressRule>;
-  selected: boolean;
   created?: Date;
 }

--- a/packages/renderer/src/lib/ingresses-routes/RouteUI.ts
+++ b/packages/renderer/src/lib/ingresses-routes/RouteUI.ts
@@ -16,20 +16,18 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { KubernetesObjectUI } from '../objects/KubernetesObjectUI';
+import type { KubernetesNamespacedObjectUI } from '../objects/KubernetesObjectUI';
 
 export interface RouteToReference {
   kind: string;
   name: string;
 }
 
-export interface RouteUI extends KubernetesObjectUI {
-  namespace: string;
+export interface RouteUI extends KubernetesNamespacedObjectUI {
   host: string;
   port?: string;
   path?: string;
   to: RouteToReference;
-  selected: boolean;
   tlsEnabled: boolean;
   created?: Date;
 }

--- a/packages/renderer/src/lib/ingresses-routes/RouteUI.ts
+++ b/packages/renderer/src/lib/ingresses-routes/RouteUI.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { KubernetesObjectUI } from '../objects/KubernetesObjectUI';
+
 export interface RouteToReference {
   kind: string;
   name: string;
 }
 
-export interface RouteUI {
-  name: string;
+export interface RouteUI extends KubernetesObjectUI {
   namespace: string;
-  status: string;
   host: string;
   port?: string;
   path?: string;

--- a/packages/renderer/src/lib/ingresses-routes/ingress-route-utils.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/ingress-route-utils.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2024 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ beforeEach(() => {
 });
 
 const ingressUI: IngressUI = {
+  kind: 'Ingress',
   name: 'my-ingress',
   namespace: 'test-namespace',
   status: 'RUNNING',
@@ -58,6 +59,7 @@ const ingressUI: IngressUI = {
 };
 
 const ingressUIWith2Paths: IngressUI = {
+  kind: 'Ingress',
   name: 'my-ingress',
   namespace: 'test-namespace',
   status: 'RUNNING',
@@ -96,6 +98,7 @@ const ingressUIWith2Paths: IngressUI = {
 };
 
 const routeUI: RouteUI = {
+  kind: 'Route',
   name: 'my-route',
   namespace: 'test-namespace',
   status: 'RUNNING',
@@ -138,6 +141,7 @@ test('expect basic UI conversion for ingress', async () => {
     },
   } as V1Ingress;
   const ingressUI = ingressRouteUtils.getIngressUI(ingress);
+  expect(ingressUI.kind).toEqual('Ingress');
   expect(ingressUI.name).toEqual('my-ingress');
   expect(ingressUI.namespace).toEqual('test-namespace');
   expect(ingressUI.rules).toBeDefined();
@@ -162,6 +166,7 @@ test('expect basic UI conversion for route with port', async () => {
     },
   } as V1Route;
   const routeUI = ingressRouteUtils.getRouteUI(route);
+  expect(routeUI.kind).toEqual('Route');
   expect(routeUI.name).toEqual('my-route');
   expect(routeUI.namespace).toEqual('test-namespace');
   expect(routeUI.host).toEqual(route.spec.host);
@@ -187,6 +192,7 @@ test('expect basic UI conversion for route with path', async () => {
     },
   } as V1Route;
   const routeUI = ingressRouteUtils.getRouteUI(route);
+  expect(routeUI.kind).toEqual('Route');
   expect(routeUI.name).toEqual('my-route');
   expect(routeUI.namespace).toEqual('test-namespace');
   expect(routeUI.host).toEqual(route.spec.host);

--- a/packages/renderer/src/lib/ingresses-routes/ingress-route-utils.ts
+++ b/packages/renderer/src/lib/ingresses-routes/ingress-route-utils.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ export interface HostPathObject {
 export class IngressRouteUtils {
   getIngressUI(ingress: V1Ingress): IngressUI {
     return {
+      kind: 'Ingress',
       name: ingress.metadata?.name ?? '',
       namespace: ingress.metadata?.namespace ?? '',
       status: 'RUNNING',
@@ -41,6 +42,7 @@ export class IngressRouteUtils {
   }
   getRouteUI(route: V1Route): RouteUI {
     return {
+      kind: 'Route',
       name: route.metadata?.name ?? '',
       namespace: route.metadata?.namespace ?? '',
       status: 'RUNNING',

--- a/packages/renderer/src/lib/kube/pods/PodUI.ts
+++ b/packages/renderer/src/lib/kube/pods/PodUI.ts
@@ -16,11 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { KubernetesObjectUI } from '../../objects/KubernetesObjectUI';
 import type { PodInfoContainerUI } from '../../pod/PodInfoUI';
 
-export interface PodUI {
-  name: string;
-  status: string;
+export interface PodUI extends KubernetesObjectUI {
   namespace: string;
   created?: Date;
   selected: boolean;

--- a/packages/renderer/src/lib/kube/pods/PodUI.ts
+++ b/packages/renderer/src/lib/kube/pods/PodUI.ts
@@ -16,13 +16,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { KubernetesObjectUI } from '../../objects/KubernetesObjectUI';
+import type { KubernetesNamespacedObjectUI } from '../../objects/KubernetesObjectUI';
 import type { PodInfoContainerUI } from '../../pod/PodInfoUI';
 
-export interface PodUI extends KubernetesObjectUI {
-  namespace: string;
+export interface PodUI extends KubernetesNamespacedObjectUI {
   created?: Date;
-  selected: boolean;
   node?: string;
   containers: PodInfoContainerUI[];
 }

--- a/packages/renderer/src/lib/kube/pods/pod-utils.spec.ts
+++ b/packages/renderer/src/lib/kube/pods/pod-utils.spec.ts
@@ -59,6 +59,7 @@ const podInfo = {
 test('Expect to get node and namespace from pod info', () => {
   const pod = podUtils.getPodUI(podInfo);
 
+  expect(pod.kind).toBe('Pod');
   expect(pod.name).toBe('my-pod');
   expect(pod.node).toBe('test-node');
   expect(pod.namespace).toBe('test-namespace');

--- a/packages/renderer/src/lib/kube/pods/pod-utils.ts
+++ b/packages/renderer/src/lib/kube/pods/pod-utils.ts
@@ -49,6 +49,7 @@ export class PodUtils {
       }) ?? [];
 
     return {
+      kind: 'Pod',
       name: pod.metadata?.name ?? '',
       status: this.getStatus(pod.metadata?.deletionTimestamp ? 'DELETING' : (pod.status?.phase ?? '')),
       created: pod.metadata?.creationTimestamp,

--- a/packages/renderer/src/lib/node/NodeUI.ts
+++ b/packages/renderer/src/lib/node/NodeUI.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2024 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-export interface NodeUI {
+import type { KubernetesObjectUI } from '../objects/KubernetesObjectUI';
+
+export interface NodeUI extends KubernetesObjectUI {
   uid: string;
-  name: string;
-  status: string;
   role: 'control-plane' | 'node';
   version: string;
   osImage: string;

--- a/packages/renderer/src/lib/node/node-utils.spec.ts
+++ b/packages/renderer/src/lib/node/node-utils.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ beforeEach(() => {
 describe('Node UI conversion', () => {
   test('expect basic node UI conversion', async () => {
     const node = {
+      kind: 'Node',
       metadata: {
         name: 'kube-node',
         labels: {
@@ -50,6 +51,7 @@ describe('Node UI conversion', () => {
 
     const nodeUI = nodeUtils.getNodeUI(node);
 
+    expect(nodeUI.kind).toEqual('Node');
     expect(nodeUI.name).toEqual('kube-node');
     expect(nodeUI.status).toEqual('RUNNING');
     expect(nodeUI.role).toEqual('control-plane');

--- a/packages/renderer/src/lib/node/node-utils.ts
+++ b/packages/renderer/src/lib/node/node-utils.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2024 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,6 +60,7 @@ export class NodeUtils {
     const containerRuntime = node.status?.nodeInfo?.containerRuntimeVersion ?? '';
 
     return {
+      kind: 'Node',
       uid: node.metadata?.uid ?? '',
       name: node.metadata?.name ?? '',
       status,

--- a/packages/renderer/src/lib/objects/KubernetesObjectUI.ts
+++ b/packages/renderer/src/lib/objects/KubernetesObjectUI.ts
@@ -19,7 +19,10 @@
 export interface KubernetesObjectUI {
   kind?: string;
   name: string;
-  namespace?: string;
   status: string;
-  selected?: boolean;
+}
+
+export interface KubernetesNamespacedObjectUI extends KubernetesObjectUI {
+  namespace: string;
+  selected: boolean;
 }

--- a/packages/renderer/src/lib/objects/KubernetesObjectUI.ts
+++ b/packages/renderer/src/lib/objects/KubernetesObjectUI.ts
@@ -16,25 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { V1CronJob } from '@kubernetes/client-node';
-
-import type { CronJobUI } from './CronJobUI';
-
-export class CronJobUtils {
-  getCronJobUI(cronjob: V1CronJob): CronJobUI {
-    return {
-      kind: 'CronJob',
-      uid: cronjob.metadata?.uid ?? '',
-      name: cronjob.metadata?.name ?? '',
-      status: 'RUNNING',
-      namespace: cronjob.metadata?.namespace ?? '',
-      created: cronjob.metadata?.creationTimestamp,
-      selected: false,
-      schedule: cronjob.spec?.schedule ?? '',
-      suspended: cronjob.spec?.suspend ?? false,
-      lastScheduleTime: cronjob.status?.lastScheduleTime,
-      // Get the number of "active" jobs, we just get the length of the array
-      active: cronjob.status?.active?.length ?? 0,
-    };
-  }
+export interface KubernetesObjectUI {
+  kind?: string;
+  name: string;
+  namespace?: string;
+  status: string;
+  selected?: boolean;
 }

--- a/packages/renderer/src/lib/objects/KubernetesObjectsList.svelte
+++ b/packages/renderer/src/lib/objects/KubernetesObjectsList.svelte
@@ -11,11 +11,12 @@ import { withBulkConfirmation } from '../actions/BulkActions';
 import KubeActions from '../kube/KubeActions.svelte';
 import { listenResources } from '../kube/resources-listen';
 import KubernetesCurrentContextConnectionBadge from '../ui/KubernetesCurrentContextConnectionBadge.svelte';
+import type { KubernetesObjectUI } from './KubernetesObjectUI';
 
 export interface Kind {
   resource: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  transformer: (o: KubernetesObject) => any;
+  transformer: (o: KubernetesObject) => KubernetesObjectUI;
   delete: (name: string) => Promise<void>;
   isResource: (o: KubernetesObject) => boolean;
   legacySearchPatternStore: Writable<string>;

--- a/packages/renderer/src/lib/pvc/PVCUI.ts
+++ b/packages/renderer/src/lib/pvc/PVCUI.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-export interface PVCUI {
-  name: string;
+import type { KubernetesObjectUI } from '../objects/KubernetesObjectUI';
+
+export interface PVCUI extends KubernetesObjectUI {
   namespace: string;
-  status: string;
   storageClass: string;
   accessModes: string[];
   size: string;

--- a/packages/renderer/src/lib/pvc/PVCUI.ts
+++ b/packages/renderer/src/lib/pvc/PVCUI.ts
@@ -16,13 +16,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { KubernetesObjectUI } from '../objects/KubernetesObjectUI';
+import type { KubernetesNamespacedObjectUI } from '../objects/KubernetesObjectUI';
 
-export interface PVCUI extends KubernetesObjectUI {
-  namespace: string;
+export interface PVCUI extends KubernetesNamespacedObjectUI {
   storageClass: string;
   accessModes: string[];
   size: string;
-  selected: boolean;
   created?: Date;
 }

--- a/packages/renderer/src/lib/pvc/pvc-utils.spec.ts
+++ b/packages/renderer/src/lib/pvc/pvc-utils.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ beforeEach(() => {
 describe('PVC UI conversion', () => {
   test('expect basic PVC UI conversion', async () => {
     const fakePVC = {
+      kind: 'PersistentVolumeClaim',
       metadata: {
         name: 'pvc-1',
         namespace: 'default',
@@ -52,6 +53,7 @@ describe('PVC UI conversion', () => {
 
     const pvcUI = pvcUtils.getPVCUI(fakePVC);
 
+    expect(pvcUI.kind).toEqual('PersistentVolumeClaim');
     expect(pvcUI.name).toEqual('pvc-1');
     expect(pvcUI.namespace).toEqual('default');
     expect(pvcUI.status).toEqual('RUNNING');

--- a/packages/renderer/src/lib/pvc/pvc-utils.ts
+++ b/packages/renderer/src/lib/pvc/pvc-utils.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ export class PVCUtils {
     }
 
     return {
+      kind: 'PersistentVolumeClaim',
       name: pvc.metadata?.name ?? '',
       namespace: pvc.metadata?.namespace ?? '',
       status,

--- a/packages/renderer/src/lib/service/ServiceUI.ts
+++ b/packages/renderer/src/lib/service/ServiceUI.ts
@@ -16,13 +16,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { KubernetesObjectUI } from '../objects/KubernetesObjectUI';
+import type { KubernetesNamespacedObjectUI } from '../objects/KubernetesObjectUI';
 
-export interface ServiceUI extends KubernetesObjectUI {
+export interface ServiceUI extends KubernetesNamespacedObjectUI {
   uid: string;
-  namespace: string;
   created?: Date;
-  selected: boolean;
   type: string;
   clusterIP: string;
   loadBalancerIPs?: string;

--- a/packages/renderer/src/lib/service/ServiceUI.ts
+++ b/packages/renderer/src/lib/service/ServiceUI.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-export interface ServiceUI {
+import type { KubernetesObjectUI } from '../objects/KubernetesObjectUI';
+
+export interface ServiceUI extends KubernetesObjectUI {
   uid: string;
-  name: string;
-  status: string;
   namespace: string;
   created?: Date;
   selected: boolean;

--- a/packages/renderer/src/lib/service/service-utils.spec.ts
+++ b/packages/renderer/src/lib/service/service-utils.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ beforeEach(() => {
 
 test('expect basic UI conversion', async () => {
   const service = {
+    kind: 'Service',
     metadata: {
       name: 'my-service',
       namespace: 'test-namespace',
@@ -37,6 +38,7 @@ test('expect basic UI conversion', async () => {
     status: {},
   } as V1Service;
   const serviceUI = serviceUtils.getServiceUI(service);
+  expect(serviceUI.kind).toEqual('Service');
   expect(serviceUI.name).toEqual('my-service');
   expect(serviceUI.namespace).toEqual('test-namespace');
 });

--- a/packages/renderer/src/lib/service/service-utils.ts
+++ b/packages/renderer/src/lib/service/service-utils.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import type { ServiceUI } from './ServiceUI';
 export class ServiceUtils {
   getServiceUI(service: V1Service): ServiceUI {
     return {
+      kind: 'Service',
       uid: service.metadata?.uid ?? '',
       name: service.metadata?.name ?? '',
       status: 'RUNNING',


### PR DESCRIPTION
### What does this PR do?

Creates a new KubernetesObjectUI and uses this as the parent for all Kubernetes UI objects like DeploymentUI, etc., with an optional kind property (*). This improves typing and in future PRs will allow us to have a shared Kubernetes Name column, map from kind to plural (url), and remove Kind.isResource() from KubernetesObjectsList.

(*) Although we could make more properties required over time only name + status are required for now to keep the change manageable. E.g. enforcing kind would require changes in 35 additional test files. Look at this as the first step; we can enforce columns or evolve from here.

UI objects are using hard-coded kinds like `kind: 'Pod'` for now, because the kind is not set on our resources. As we move to the experimental mode this shouldn't be required and we could use `kind: pod.kind ?? ''`. Likewise, the kind doesn't strictly need to be set on the test objects yet but I did this so they'll be correct later.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of #11035. Replaces 90% of #11094 and a follow up PR will share the Kubernetes Name columns.

### How to test this PR?

Just a refactoring, so code review + existing tests.

- [x] Tests are covering the bug fix or the new feature