### PR TITLE
chore(test): extract kubernetes operations to a dedicated utility file

### DIFF
--- a/tests/playwright/src/index.ts
+++ b/tests/playwright/src/index.ts
@@ -83,3 +83,4 @@ export * from './model/pages/welcome-page';
 export * from './model/workbench/navigation';
 export * from './model/workbench/status-bar';
 export * from './utility/cluster-operations';
+export * from './utility/kubernetes';

--- a/tests/playwright/src/specs/deploy-to-kubernetes.spec.ts
+++ b/tests/playwright/src/specs/deploy-to-kubernetes.spec.ts
@@ -20,7 +20,7 @@ import { ContainerState } from '../model/core/states';
 import type { ContainerInteractiveParams } from '../model/core/types';
 import { createKindCluster, deleteCluster } from '../utility/cluster-operations';
 import { expect as playExpect, test } from '../utility/fixtures';
-import { deployPodToCluster } from '../utility/kubernetes';
+import { deployContainerToCluster } from '../utility/kubernetes';
 import { deleteContainer, deleteImage, ensureCliInstalled } from '../utility/operations';
 import { waitForPodmanMachineStartup } from '../utility/wait';
 
@@ -98,6 +98,6 @@ test.describe.serial('Deploy a container to the Kind cluster', { tag: '@k8s_e2e'
   });
 
   test('Deploy the container ', async ({ page }) => {
-    await deployPodToCluster(page, CONTAINER_NAME, KUBERNETES_CONTEXT, DEPLOYED_POD_NAME);
+    await deployContainerToCluster(page, CONTAINER_NAME, KUBERNETES_CONTEXT, DEPLOYED_POD_NAME);
   });
 });

--- a/tests/playwright/src/specs/deploy-to-kubernetes.spec.ts
+++ b/tests/playwright/src/specs/deploy-to-kubernetes.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,9 @@
 
 import { ContainerState } from '../model/core/states';
 import type { ContainerInteractiveParams } from '../model/core/types';
-import { ContainerDetailsPage } from '../model/pages/container-details-page';
 import { createKindCluster, deleteCluster } from '../utility/cluster-operations';
 import { expect as playExpect, test } from '../utility/fixtures';
+import { deployPodToCluster } from '../utility/kubernetes';
 import { deleteContainer, deleteImage, ensureCliInstalled } from '../utility/operations';
 import { waitForPodmanMachineStartup } from '../utility/wait';
 
@@ -97,15 +97,7 @@ test.describe.serial('Deploy a container to the Kind cluster', { tag: '@k8s_e2e'
     await playExpect.poll(async () => containerDetails.getState()).toBe(ContainerState.Running);
   });
 
-  test('Deploy the container ', async ({ page, navigationBar }) => {
-    const containerDetailsPage = new ContainerDetailsPage(page, CONTAINER_NAME);
-    await playExpect(containerDetailsPage.heading).toBeVisible();
-    const deployToKubernetesPage = await containerDetailsPage.openDeployToKubernetesPage();
-    await deployToKubernetesPage.deployPod(CONTAINER_NAME, { useKubernetesServices: true }, KUBERNETES_CONTEXT);
-
-    const podsPage = await navigationBar.openPods();
-    await playExpect
-      .poll(async () => podsPage.deployedPodExists(DEPLOYED_POD_NAME, 'kubernetes'), { timeout: 15_000 })
-      .toBeTruthy();
+  test('Deploy the container ', async ({ page }) => {
+    await deployPodToCluster(page, CONTAINER_NAME, KUBERNETES_CONTEXT, DEPLOYED_POD_NAME);
   });
 });

--- a/tests/playwright/src/utility/kubernetes.ts
+++ b/tests/playwright/src/utility/kubernetes.ts
@@ -121,6 +121,8 @@ export async function changeDeploymentYamlFile(
   page: Page,
   resourceType: KubernetesResources,
   deploymentName: string,
+  currentReplicaCount: number = 3,
+  updatedReplicaCount: number = 5,
 ): Promise<void> {
   return test.step(`Change deployment kubernetes cluster resource`, async () => {
     const navigationBar = new NavigationBar(page);
@@ -129,7 +131,7 @@ export async function changeDeploymentYamlFile(
       .poll(async () => await podsPage.countPodReplicas(deploymentName), {
         timeout: 60_000,
       })
-      .toBe(3);
+      .toBe(currentReplicaCount);
 
     const kubernetesBar = await navigationBar.openKubernetes();
     const deploymentsPage = await kubernetesBar.openTabPage(resourceType);
@@ -137,13 +139,16 @@ export async function changeDeploymentYamlFile(
     await playExpect(deploymentsPage.getResourceRowByName(deploymentName)).toBeVisible();
     const deploymentDetails = await deploymentsPage.openResourceDetails(deploymentName, resourceType);
     await playExpect(deploymentDetails.heading).toBeVisible();
-    await deploymentDetails.editKubernetsYamlFile('replicas: 3', 'replicas: 5');
+    await deploymentDetails.editKubernetsYamlFile(
+      `replicas: ${currentReplicaCount}`,
+      `replicas: ${updatedReplicaCount}`,
+    );
 
     await navigationBar.openPods();
     await playExpect
       .poll(async () => await podsPage.countPodReplicas(deploymentName), {
         timeout: 60_000,
       })
-      .toBe(5);
+      .toBe(updatedReplicaCount);
   });
 }

--- a/tests/playwright/src/utility/kubernetes.ts
+++ b/tests/playwright/src/utility/kubernetes.ts
@@ -1,0 +1,149 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Page } from '@playwright/test';
+import test, { expect as playExpect } from '@playwright/test';
+
+import type { KubernetesResourceState } from '../model/core/states';
+import type { KubernetesResources, PlayKubernetesOptions } from '../model/core/types';
+import { ContainerDetailsPage } from '../model/pages/container-details-page';
+import type { PodsPage } from '../model/pages/pods-page';
+import { NavigationBar } from '../model/workbench/navigation';
+import { handleConfirmationDialog } from './operations';
+
+export async function deployPodToCluster(
+  page: Page,
+  containerName: string,
+  kubernetesContext: string,
+  deployedPodName: string,
+): Promise<void> {
+  return test.step(`Deploy pod '${deployedPodName}' to Kubernetes cluster`, async () => {
+    const containerDetailsPage = new ContainerDetailsPage(page, containerName);
+    const navigationBar = new NavigationBar(page);
+
+    await playExpect(containerDetailsPage.heading).toBeVisible();
+    const deployToKubernetesPage = await containerDetailsPage.openDeployToKubernetesPage();
+    await deployToKubernetesPage.deployPod(containerName, { useKubernetesServices: true }, kubernetesContext);
+
+    const podsPage = await navigationBar.openPods();
+    await playExpect
+      .poll(async () => podsPage.deployedPodExists(deployedPodName, 'kubernetes'), { timeout: 15_000 })
+      .toBeTruthy();
+  });
+}
+
+export async function createKubernetesResource(
+  page: Page,
+  resourceType: KubernetesResources,
+  resourceName: string,
+  resourceYamlPath: string,
+  kubernetesRuntime: PlayKubernetesOptions,
+): Promise<void> {
+  return test.step(`Create ${resourceType} kubernetes resource: ${resourceName}`, async () => {
+    const navigationBar = new NavigationBar(page);
+
+    await applyYamlFileToCluster(page, resourceYamlPath, kubernetesRuntime);
+    const kubernetesBar = await navigationBar.openKubernetes();
+    const kubernetesResourcePage = await kubernetesBar.openTabPage(resourceType);
+    await playExpect(kubernetesResourcePage.heading).toBeVisible();
+    await playExpect(kubernetesResourcePage.getResourceRowByName(resourceName)).toBeVisible();
+  });
+}
+
+export async function deleteKubernetesResource(
+  page: Page,
+  resourceType: KubernetesResources,
+  resourceName: string,
+): Promise<void> {
+  return test.step(`Delete ${resourceType} kubernetes resource: ${resourceName}`, async () => {
+    const navigationBar = new NavigationBar(page);
+
+    const kubernetesBar = await navigationBar.openKubernetes();
+    const pvcsPage = await kubernetesBar.openTabPage(resourceType);
+    await pvcsPage.deleteKubernetesResource(resourceName);
+    await handleConfirmationDialog(page);
+    await playExpect(pvcsPage.getResourceRowByName(resourceName)).not.toBeVisible({ timeout: 30_000 });
+  });
+}
+
+export async function checkKubernetesResourceState(
+  page: Page,
+  resourceType: KubernetesResources,
+  resourceName: string,
+  expectedResourceState: KubernetesResourceState,
+  timeout: number = 50_000,
+): Promise<void> {
+  return test.step(`Check ${resourceType} kubernetes resource state, should be ${expectedResourceState}`, async () => {
+    const navigationBar = new NavigationBar(page);
+    const kubernetesBar = await navigationBar.openKubernetes();
+
+    const kubernetesResourcePage = await kubernetesBar.openTabPage(resourceType);
+    const kubernetesResourceDetails = await kubernetesResourcePage.openResourceDetails(resourceName, resourceType);
+    await playExpect(kubernetesResourceDetails.heading).toBeVisible();
+    await playExpect
+      .poll(async () => kubernetesResourceDetails.getState(), { timeout: timeout })
+      .toEqual(expectedResourceState);
+  });
+}
+
+export async function applyYamlFileToCluster(
+  page: Page,
+  resourceYamlPath: string,
+  kubernetesRuntime: PlayKubernetesOptions,
+): Promise<PodsPage> {
+  return test.step(`Apply YAML file to Kubernetes cluster`, async () => {
+    const navigationBar = new NavigationBar(page);
+    const podsPage = await navigationBar.openPods();
+
+    await playExpect(podsPage.heading).toBeVisible();
+    const playYamlPage = await podsPage.openPlayKubeYaml();
+    await playExpect(playYamlPage.heading).toBeVisible();
+    return await playYamlPage.playYaml(resourceYamlPath, kubernetesRuntime);
+  });
+}
+
+export async function changeDeploymentYamlFile(
+  page: Page,
+  resourceType: KubernetesResources,
+  deploymentName: string,
+): Promise<void> {
+  return test.step(`Change deployment kubernetes cluster resource`, async () => {
+    const navigationBar = new NavigationBar(page);
+    const podsPage = await navigationBar.openPods();
+    await playExpect
+      .poll(async () => await podsPage.countPodReplicas(deploymentName), {
+        timeout: 60_000,
+      })
+      .toBe(3);
+
+    const kubernetesBar = await navigationBar.openKubernetes();
+    const deploymentsPage = await kubernetesBar.openTabPage(resourceType);
+    await playExpect(deploymentsPage.heading).toBeVisible();
+    await playExpect(deploymentsPage.getResourceRowByName(deploymentName)).toBeVisible();
+    const deploymentDetails = await deploymentsPage.openResourceDetails(deploymentName, resourceType);
+    await playExpect(deploymentDetails.heading).toBeVisible();
+    await deploymentDetails.editKubernetsYamlFile('replicas: 3', 'replicas: 5');
+
+    await navigationBar.openPods();
+    await playExpect
+      .poll(async () => await podsPage.countPodReplicas(deploymentName), {
+        timeout: 60_000,
+      })
+      .toBe(5);
+  });
+}

--- a/tests/playwright/src/utility/kubernetes.ts
+++ b/tests/playwright/src/utility/kubernetes.ts
@@ -26,13 +26,13 @@ import type { PodsPage } from '../model/pages/pods-page';
 import { NavigationBar } from '../model/workbench/navigation';
 import { handleConfirmationDialog } from './operations';
 
-export async function deployPodToCluster(
+export async function deployContainerToCluster(
   page: Page,
   containerName: string,
   kubernetesContext: string,
   deployedPodName: string,
 ): Promise<void> {
-  return test.step(`Deploy pod '${deployedPodName}' to Kubernetes cluster`, async () => {
+  return test.step(`Deploy '${containerName}' and verify pod '${deployedPodName}' appears in the Kubernetes environment`, async () => {
     const containerDetailsPage = new ContainerDetailsPage(page, containerName);
     const navigationBar = new NavigationBar(page);
 


### PR DESCRIPTION
Signed-off-by: Anton Misskii <amisskii@redhat.com>

### What does this PR do?

Extracts Kubernetes operations to a dedicated utility file for reusability across environments


### What issues does this PR fix or reference?

https://github.com/podman-desktop/podman-desktop/issues/11205

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
