### PR TITLE
fix: svelte reactivity on Map

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
@@ -508,6 +508,51 @@ test(`Expect create with unchecked and checked checkboxes`, async () => {
   );
 });
 
+test(`cpu value is updated`, async () => {
+  const taskId = 4;
+  const callback = mockCallback(async () => {});
+
+  const booleanProperties: IConfigurationPropertyRecordedSchema[] = [
+    {
+      default: 4,
+      minimum: 1,
+      maximum: 1000,
+      title: 'CPUs',
+      parentId: '',
+      scope: 'ContainerProviderConnectionFactory',
+      id: 'test.cpus',
+      type: 'number',
+      format: 'cpu',
+      description: 'cpus',
+    },
+  ];
+
+  // eslint-disable-next-line @typescript-eslint/await-thenable
+  render(PreferencesConnectionCreationOrEditRendering, {
+    properties: booleanProperties,
+    providerInfo,
+    connectionInfo: undefined,
+    propertyScope,
+    callback,
+    pageIsLoading: false,
+    taskId,
+  });
+  await vi.waitFor(async () => {
+    const editButton = screen.getByRole('button', { name: 'Edit' });
+    await fireEvent.click(editButton);
+  });
+  await vi.waitFor(async () => {
+    const valueInput = screen.getByRole('textbox', { name: 'cpus' });
+    await userEvent.type(valueInput, '99');
+  });
+  const saveButton = screen.getByRole('button', { name: 'Save' });
+  await fireEvent.click(saveButton);
+
+  await vi.waitFor(async () => {
+    screen.getByDisplayValue('499');
+  });
+});
+
 test(`Expect create with unchecked and checked checkboxes having multiple scopes`, async () => {
   const taskId = 4;
   const callback = mockCallback(async () => {});

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
@@ -270,7 +270,7 @@ function internalSetConfigurationValue(id: string, modified: boolean, value: str
   } else {
     configurationValues.set(id, { modified, value });
   }
-  configurationValues = configurationValues;
+  configurationValues = $state.snapshot(configurationValues);
 }
 
 function setConfigurationValue(id: string, value: string | boolean | number): void {


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Fixes reactivity on Map, on `PreferencesConnectionCreationOrEditRendering` component.

See https://github.com/sveltejs/svelte/issues/11346

### Screenshot / video of UI


### What issues does this PR fix or reference?

Fixes #10857 

### How to test this PR?

- Go to Settings > Podman > Create new...
- Set values (CPUs, memory, etc), and check that they are correctly used for creating the machine

- [ ] Tests are covering the bug fix or the new feature
