### PR TITLE
fix: ports accepted type during creation

### DIFF
--- a/extensions/kind/src/create-cluster.ts
+++ b/extensions/kind/src/create-cluster.ts
@@ -141,13 +141,19 @@ export async function createCluster(
 
   // grab http host port
   let httpHostPort = 9090;
-  if (params['kind.cluster.creation.http.port'] && typeof params['kind.cluster.creation.http.port'] === 'number') {
+  if (
+    params['kind.cluster.creation.http.port'] &&
+    ['string', 'number'].includes(typeof params['kind.cluster.creation.http.port'])
+  ) {
     httpHostPort = Number(params['kind.cluster.creation.http.port']);
   }
 
   // grab https host port
   let httpsHostPort = 9443;
-  if (params['kind.cluster.creation.https.port'] && typeof params['kind.cluster.creation.https.port'] === 'number') {
+  if (
+    params['kind.cluster.creation.https.port'] &&
+    ['string', 'number'].includes(typeof params['kind.cluster.creation.https.port'])
+  ) {
     httpsHostPort = Number(params['kind.cluster.creation.https.port']);
   }
 


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

https://github.com/podman-desktop/podman-desktop/pull/10766 limited the type of ports during creation to number, but these values are provided as string

This PR changes to support number and string as type of provided ports

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes #11225 

### How to test this PR?

See steps to reproduce in #11225 

- [ ] Tests are covering the bug fix or the new feature
