### PR TITLE
chore: fix navigateToRoute args

### DIFF
--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -244,7 +244,7 @@ export function initExposure(): void {
     },
   );
 
-  contextBridge.exposeInMainWorld('navigateToRoute', async (routeId: string, args: unknown[]): Promise<void> => {
+  contextBridge.exposeInMainWorld('navigateToRoute', async (routeId: string, ...args: unknown[]): Promise<void> => {
     return ipcRenderer.invoke('navigation:navigateToRoute', routeId, ...args);
   });
 

--- a/packages/renderer/src/lib/deployments/DeploymentColumnName.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnName.spec.ts
@@ -54,9 +54,11 @@ test('Expect clicking works', async () => {
 
   await fireEvent.click(text);
 
-  expect(navigationSpy).toBeCalledWith('kubernetes', [
-    { kind: 'Deployment', name: deployment.name, namespace: deployment.namespace },
-  ]);
+  expect(navigationSpy).toBeCalledWith('kubernetes', {
+    kind: 'Deployment',
+    name: deployment.name,
+    namespace: deployment.namespace,
+  });
 });
 
 test('Expect to show namespace in column', async () => {

--- a/packages/renderer/src/lib/deployments/DeploymentColumnName.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnName.svelte
@@ -7,7 +7,7 @@ interface Props {
 let { object }: Props = $props();
 
 async function openDetails(): Promise<void> {
-  await window.navigateToRoute('kubernetes', [{ kind: 'Deployment', name: object.name, namespace: object.namespace }]);
+  await window.navigateToRoute('kubernetes', { kind: 'Deployment', name: object.name, namespace: object.namespace });
 }
 </script>
 


### PR DESCRIPTION
### What does this PR do?

When I added Kubernetes navigation and exposed navigateToRoute to the renderer (#11166) I missed one spread, which forces you to pass all args in an array instead of the normal pattern. This just fixes that and the use of it in the soon to be deleted (#11230) DeploymentColumnName.

Required for #11230 / #11124.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Check clicking on the name column on the Deployments page still works.

- [x] Tests are covering the bug fix or the new feature