### PR TITLE
chore: use navigation for kube resource card links

### DIFF
--- a/packages/renderer/src/lib/kube/KubernetesDashboard.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesDashboard.svelte
@@ -123,14 +123,14 @@ async function openKubernetesDocumentation(): Promise<void> {
                 <!-- Metrics - non-collapsible -->
                 <div class="text-xl pt-2">Metrics</div>
                 <div class="grid grid-cols-4 gap-4">
-                    <KubernetesDashboardResourceCard type='Nodes' Icon={NodeIcon} activeCount={activeNodeCount} count={nodeCount} link='/kubernetes/nodes'/>
-                    <KubernetesDashboardResourceCard type='Deployments' Icon={DeploymentIcon} activeCount={activeDeploymentsCount} count={deploymentCount} link='/kubernetes/deployments'/>
-                    <KubernetesDashboardResourceCard type='Pods' Icon={PodIcon} count={podCount} link='/kubernetes/pods'/>
-                    <KubernetesDashboardResourceCard type='Services' Icon={ServiceIcon} count={serviceCount} link='/kubernetes/services'/>
-                    <KubernetesDashboardResourceCard type='Ingresses & Routes' Icon={IngressRouteIcon} count={ingressRouteCount} link='/kubernetes/ingressesRoutes'/>
-                    <KubernetesDashboardResourceCard type='Persistent Volume Claims' Icon={PvcIcon} count={pvcCount} link='/kubernetes/persistentvolumeclaims'/>
-                    <KubernetesDashboardResourceCard type='ConfigMaps & Secrets' Icon={ConfigMapSecretIcon} count={configMapSecretCount} link='/kubernetes/configmapsSecrets'/>
-                    <KubernetesDashboardResourceCard type='CronJobs' Icon={CronJobIcon as Component} count={cronjobCount} link='/kubernetes/cronjobs'/>
+                    <KubernetesDashboardResourceCard type='Nodes' Icon={NodeIcon} activeCount={activeNodeCount} count={nodeCount} kind='Node'/>
+                    <KubernetesDashboardResourceCard type='Deployments' Icon={DeploymentIcon} activeCount={activeDeploymentsCount} count={deploymentCount} kind='Deployment'/>
+                    <KubernetesDashboardResourceCard type='Pods' Icon={PodIcon} count={podCount} kind='Pod'/>
+                    <KubernetesDashboardResourceCard type='Services' Icon={ServiceIcon} count={serviceCount} kind='Service'/>
+                    <KubernetesDashboardResourceCard type='Ingresses & Routes' Icon={IngressRouteIcon} count={ingressRouteCount} kind='Ingress'/>
+                    <KubernetesDashboardResourceCard type='Persistent Volume Claims' Icon={PvcIcon} count={pvcCount} kind='PersistentVolumeClaim'/>
+                    <KubernetesDashboardResourceCard type='ConfigMaps & Secrets' Icon={ConfigMapSecretIcon} count={configMapSecretCount} kind='ConfigMap'/>
+                    <KubernetesDashboardResourceCard type='CronJobs' Icon={CronJobIcon as Component} count={cronjobCount} kind='CronJob'/>
                 </div>
                 <!-- Graphs -->
                 

--- a/packages/renderer/src/lib/kube/KubernetesDashboardResourceCard.spec.ts
+++ b/packages/renderer/src/lib/kube/KubernetesDashboardResourceCard.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,14 +20,13 @@ import '@testing-library/jest-dom/vitest';
 
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
-import { router } from 'tinro';
-import { expect, test, vi } from 'vitest';
+import { expect, test } from 'vitest';
 
 import NodeIcon from '../images/NodeIcon.svelte';
 import KubernetesDashboardResourceCard from './KubernetesDashboardResourceCard.svelte';
 
 test('Verify basic card format', async () => {
-  const params = { type: 'a type', Icon: NodeIcon, count: 4, link: 'test' };
+  const params = { type: 'a type', Icon: NodeIcon, count: 4, kind: 'Pod' };
   render(KubernetesDashboardResourceCard, params);
 
   const type = screen.getByText(params.type);
@@ -42,15 +41,12 @@ test('Verify basic card format', async () => {
 });
 
 test('Expect clicking works', async () => {
-  const gotoSpy = vi.spyOn(router, 'goto');
-
-  const params = { type: 'a type', Icon: NodeIcon, count: 4, link: 'test-link' };
+  const params = { type: 'a type', Icon: NodeIcon, count: 4, kind: 'Service' };
   render(KubernetesDashboardResourceCard, params);
 
   const type = screen.getByText(params.type);
   expect(type).toBeInTheDocument();
 
-  expect(gotoSpy).not.toHaveBeenCalled();
   await userEvent.click(type);
-  expect(gotoSpy).toHaveBeenCalledWith(params.link);
+  expect(window.navigateToRoute).toBeCalledWith('kubernetes', { kind: 'Service' });
 });

--- a/packages/renderer/src/lib/kube/KubernetesDashboardResourceCard.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesDashboardResourceCard.svelte
@@ -1,19 +1,18 @@
 <script lang="ts">
 import type { Component } from 'svelte';
-import { router } from 'tinro';
 
 interface Props {
   type: string;
   Icon: Component;
   activeCount?: number;
   count: number;
-  link: string;
+  kind: string;
 }
 
-let { type, Icon, activeCount, count, link }: Props = $props();
+let { type, Icon, activeCount, count, kind }: Props = $props();
 
-function openLink(): void {
-  router.goto(link);
+async function openLink(): Promise<void> {
+  await window.navigateToRoute('kubernetes', { kind: kind });
 }
 </script>
 


### PR DESCRIPTION
### What does this PR do?

Now that we have Kubernetes resource navigation, we can replace the hardcoded links on the dashboard with navigation requests. Minor, but allows us to move/fix routes in the future with one less place to fix.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of #11219 

### How to test this PR?

Confirm clicking on any resource card on the Kubernetes dashboard still works.

- [x] Tests are covering the bug fix or the new feature