### PR TITLE
fix: copying docker-compose to fails on windows

### DIFF
--- a/extensions/compose/src/cli-run.ts
+++ b/extensions/compose/src/cli-run.ts
@@ -58,7 +58,7 @@ export async function installBinaryToSystem(binaryPath: string, binaryName: stri
   let command: string | undefined;
   if (system === 'win32') {
     // admin privileges are are not needed on Windows
-    await fs.promises.copyFile(binaryPath, destinationPath)
+    await fs.promises.copyFile(binaryPath, destinationPath);
     return destinationPath;
   } else if (system === 'darwin') {
     command = 'exec';

--- a/extensions/compose/src/cli-run.ts
+++ b/extensions/compose/src/cli-run.ts
@@ -57,8 +57,9 @@ export async function installBinaryToSystem(binaryPath: string, binaryName: stri
   let args: string[] = [];
   let command: string | undefined;
   if (system === 'win32') {
-    command = 'copy';
-    args = [`"${binaryPath}"`, `"${destinationPath}"`];
+    // admin privileges are are not needed on Windows
+    await fs.promises.copyFile(binaryPath, destinationPath)
+    return destinationPath;
   } else if (system === 'darwin') {
     command = 'exec';
     args = ['cp', '-f', binaryPath, destinationPath];
@@ -85,7 +86,7 @@ export async function installBinaryToSystem(binaryPath: string, binaryName: stri
     if (!command) {
       throw new Error('No command defined');
     }
-    // Use admin prileges / ask for password for copying to /usr/local/bin
+    // Use admin privileges / ask for password for copying to /usr/local/bin
     await extensionApi.process.exec(command, args, { isAdmin: true });
     console.log(`Successfully installed '${binaryName}' binary.`);
     if (!process.env.PATH?.includes(destinationFolder)) {


### PR DESCRIPTION
### What does this PR do?

PR changes how docker-compose.exe copied to destination folder on windows. No user privilege lifting is required for destination folder.

### Screenshot / video of UI

### What issues does this PR fix or reference?

Fix #6543.

### How to test this PR?

Install docker-compose on windows using CLI Tools page and no privilege lifting requests should be shown

- [x] Tests are covering the bug fix or the new feature
