### PR TITLE
fix: add priority based sorting for onboarding

### DIFF
--- a/extensions/compose/package.json
+++ b/extensions/compose/package.json
@@ -31,6 +31,7 @@
     ],
     "onboarding": {
       "title": "Compose Setup",
+      "priority": 60,
       "enablement": "!compose.isComposeInstalledSystemWide",
       "steps": [
         {

--- a/extensions/kubectl-cli/package.json
+++ b/extensions/kubectl-cli/package.json
@@ -31,6 +31,7 @@
     ],
     "onboarding": {
       "title": "kubectl Setup",
+      "priority": 30,
       "enablement": "!kubectl.isKubectlInstalledSystemWide",
       "steps": [
         {

--- a/extensions/podman/packages/extension/package.json
+++ b/extensions/podman/packages/extension/package.json
@@ -233,6 +233,7 @@
     },
     "onboarding": {
       "title": "Podman Setup",
+      "priority": 1,
       "steps": [
         {
           "id": "checkInstalledCommand",

--- a/packages/api/src/onboarding.ts
+++ b/packages/api/src/onboarding.ts
@@ -49,6 +49,7 @@ export interface OnboardingStep {
 
 export interface Onboarding {
   title: string;
+  priority?: number;
   description?: string;
   media?: { path: string; altText: string };
   steps: OnboardingStep[];
@@ -57,6 +58,7 @@ export interface Onboarding {
 
 export interface OnboardingInfo extends Onboarding {
   extension: string;
+  removable: boolean;
   name: string;
   displayName: string;
   icon: string;

--- a/packages/main/src/plugin/onboarding-registry.ts
+++ b/packages/main/src/plugin/onboarding-registry.ts
@@ -55,6 +55,7 @@ export class OnboardingRegistry {
     return {
       ...onboarding,
       extension: extension.id,
+      removable: extension.removable,
       name: extension.name,
       displayName: extension.manifest?.displayName ?? extension.name,
       description: extension.manifest?.description ?? '',
@@ -90,7 +91,22 @@ export class OnboardingRegistry {
   }
 
   listOnboarding(): OnboardingInfo[] {
-    return Array.from(this.onboardingInfos.values());
+    const comparePriorities = (p1: number, p2: number): number => {
+      if (p1 === p2) {
+        return 0;
+      }
+      return p1 < p2 ? -1 : 1;
+    };
+    return Array.from(this.onboardingInfos.values()).toSorted((a, b) => {
+      if (a.removable && b.removable) {
+        return comparePriorities(a.priority ?? 100, b.priority ?? 100);
+      } else if (a.removable && !b.removable) {
+        return 1;
+      } else if (!a.removable && b.removable) {
+        return -1;
+      }
+      return comparePriorities(a.priority ?? 100, b.priority ?? 100);
+    });
   }
 
   updateStepState(status: OnboardingStatus, extension: string, stepId?: string): void {

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftOnboardingAndProperties.spec.ts
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftOnboardingAndProperties.spec.ts
@@ -46,6 +46,7 @@ beforeEach(() => {
 test('Expect to have onboarding button for extension', async () => {
   const onboardingInfo: OnboardingInfo = {
     extension: 'myExtensionId',
+    removable: true,
     name: '',
     displayName: '',
     icon: '',

--- a/packages/renderer/src/lib/onboarding/Onboarding.spec.ts
+++ b/packages/renderer/src/lib/onboarding/Onboarding.spec.ts
@@ -49,6 +49,7 @@ test('Expect to have the "Try again" and Cancel buttons if the step represent a 
   onboardingList.set([
     {
       extension: 'id',
+      removable: true,
       title: 'onboarding',
       name: 'foobar',
       displayName: 'FooBar',
@@ -80,6 +81,7 @@ test('Expect not to have the "Try again" and "Cancel" buttons if the step repres
   onboardingList.set([
     {
       extension: 'id',
+      removable: true,
       title: 'onboarding',
       name: 'foobar',
       displayName: 'FooBar',
@@ -111,6 +113,7 @@ test('Expect to have the "Step Body" div if the step does not include a componen
   onboardingList.set([
     {
       extension: 'id',
+      removable: true,
       title: 'onboarding',
       name: 'foobar',
       displayName: 'FooBar',
@@ -140,6 +143,7 @@ test('Expect to have the embedded component if the step includes a component', a
   onboardingList.set([
     {
       extension: 'id',
+      removable: true,
       title: 'onboarding',
       name: 'foobar',
       displayName: 'FooBar',
@@ -171,6 +175,7 @@ test('Expect content to show / render when when clause is true', async () => {
   onboardingList.set([
     {
       extension: 'id',
+      removable: true,
       title: 'onboarding',
       name: 'foobar',
       displayName: 'FooBar',
@@ -207,6 +212,7 @@ test('Expect content to NOT show / render when when clause is false', async () =
   onboardingList.set([
     {
       extension: 'id',
+      removable: true,
       title: 'onboarding',
       name: 'foobar',
       displayName: 'FooBar',
@@ -246,6 +252,7 @@ test('Expect content with "when" to change dynamically when setting has been upd
   onboardingList.set([
     {
       extension: 'id',
+      removable: true,
       title: 'onboarding',
       name: 'foobar',
       displayName: 'FooBar',
@@ -296,6 +303,7 @@ test('Expect Step Body to clean up if new step has no content to display.', asyn
   onboardingList.set([
     {
       extension: 'id',
+      removable: true,
       title: 'onboarding',
       name: 'foobar',
       displayName: 'FooBar',
@@ -355,6 +363,7 @@ test('Expect that Esc closes', async () => {
   onboardingList.set([
     {
       extension: 'id',
+      removable: true,
       title: 'onboarding',
       name: 'foobar',
       displayName: 'FooBar',
@@ -405,6 +414,7 @@ test('Expect onboarding to handle two extension ids and global onboarding set to
   onboardingList.set([
     {
       extension: 'id',
+      removable: true,
       title: 'Foobar Onboarding',
       name: 'foobar',
       displayName: 'FooBar',
@@ -438,6 +448,7 @@ test('Expect onboarding to handle two extension ids and global onboarding set to
     },
     {
       extension: 'id2',
+      removable: true,
       title: 'Foobar2 Onboarding',
       name: 'foobar2',
       displayName: 'FooBar2',
@@ -542,6 +553,7 @@ test('Expect onboarding to handle two extension ids and global onboarding set to
   onboardingList.set([
     {
       extension: 'id',
+      removable: true,
       title: 'Foobar Onboarding',
       name: 'foobar',
       displayName: 'FooBar',
@@ -575,6 +587,7 @@ test('Expect onboarding to handle two extension ids and global onboarding set to
     },
     {
       extension: 'id2',
+      removable: true,
       title: 'Foobar2 Onboarding',
       name: 'foobar2',
       displayName: 'FooBar2',
@@ -675,6 +688,7 @@ test('Expect onboarding to be reset when starting completed onboarding', async (
   onboardingList.set([
     {
       extension: 'id',
+      removable: true,
       title: 'onboarding',
       name: 'foobar',
       displayName: 'FooBar',

--- a/packages/renderer/src/lib/onboarding/onboarding-utils.spec.ts
+++ b/packages/renderer/src/lib/onboarding/onboarding-utils.spec.ts
@@ -69,6 +69,7 @@ test('Expect to have the when clause returned in its original form if it does no
 test('Expect cleanContext to remove onboarding values from context and reset the state of all steps', async () => {
   const onboarding: OnboardingInfo = {
     extension: 'id',
+    removable: true,
     name: 'name',
     displayName: 'displayName',
     icon: 'icon',
@@ -104,6 +105,7 @@ test('Expect cleanContext to remove onboarding values from context and reset the
 test('Expect that the onboarding is not completed if atleast one step has not been completed', async () => {
   const onboarding: OnboardingInfo = {
     extension: 'id',
+    removable: true,
     name: 'name',
     displayName: 'displayName',
     icon: 'icon',
@@ -130,6 +132,7 @@ test('Expect that the onboarding is not completed if atleast one step has not be
 test('Expect that the onboarding is not completed if its status is not set', async () => {
   const onboarding: OnboardingInfo = {
     extension: 'id',
+    removable: true,
     name: 'name',
     displayName: 'displayName',
     icon: 'icon',
@@ -156,6 +159,7 @@ test('Expect that the onboarding is not completed if its status is not set', asy
 test('Expect that the onboarding is completed if all its steps are completed and its status is set', async () => {
   const onboarding: OnboardingInfo = {
     extension: 'id',
+    removable: true,
     name: 'name',
     displayName: 'displayName',
     icon: 'icon',
@@ -182,6 +186,7 @@ test('Expect that the onboarding is completed if all its steps are completed and
 test('Expect the setup of multiple onboardings to be completed if all have been completed', async () => {
   const onboarding1: OnboardingInfo = {
     extension: 'id',
+    removable: true,
     name: 'name',
     displayName: 'displayName',
     icon: 'icon',
@@ -203,6 +208,7 @@ test('Expect the setup of multiple onboardings to be completed if all have been 
   };
   const onboarding2: OnboardingInfo = {
     extension: 'id',
+    removable: true,
     name: 'name',
     displayName: 'displayName',
     icon: 'icon',
@@ -229,6 +235,7 @@ test('Expect the setup of multiple onboardings to be completed if all have been 
 test('Expect the setup of multiple onboardings to be uncompleted if atleast one have not been completed', async () => {
   const onboarding1: OnboardingInfo = {
     extension: 'id',
+    removable: true,
     name: 'name',
     displayName: 'displayName',
     icon: 'icon',
@@ -250,6 +257,7 @@ test('Expect the setup of multiple onboardings to be uncompleted if atleast one 
   };
   const onboarding2: OnboardingInfo = {
     extension: 'id',
+    removable: true,
     name: 'name',
     displayName: 'displayName',
     icon: 'icon',
@@ -282,6 +290,7 @@ test('Expect the step to be considered NOT completed if the active step have not
 
   const onboarding: OnboardingInfo = {
     extension: 'id',
+    removable: true,
     name: 'name',
     displayName: 'displayName',
     icon: 'icon',
@@ -315,6 +324,7 @@ test('Expect the step to be completed if the step is considered completed if onl
 
   const onboarding: OnboardingInfo = {
     extension: 'id',
+    removable: true,
     name: 'name',
     displayName: 'displayName',
     icon: 'icon',
@@ -348,6 +358,7 @@ test('Expect the step to NOT be completed if the step is considered completed if
 
   const onboarding: OnboardingInfo = {
     extension: 'id',
+    removable: true,
     name: 'name',
     displayName: 'displayName',
     icon: 'icon',
@@ -381,6 +392,7 @@ test('Expect the step to be completed if the step is considered completed if a c
 
   const onboarding: OnboardingInfo = {
     extension: 'id',
+    removable: true,
     name: 'name',
     displayName: 'displayName',
     icon: 'icon',
@@ -419,6 +431,7 @@ test('Expect the step to NOT be completed if the step is considered completed if
 
   const onboarding: OnboardingInfo = {
     extension: 'id',
+    removable: true,
     name: 'name',
     displayName: 'displayName',
     icon: 'icon',
@@ -457,6 +470,7 @@ test('Expect the step to NOT be completed if the step is considered completed if
 
   const onboarding: OnboardingInfo = {
     extension: 'id',
+    removable: true,
     name: 'name',
     displayName: 'displayName',
     icon: 'icon',
@@ -494,6 +508,7 @@ test('Expect the step to NOT be completed if the step is considered completed if
 
   const onboarding: OnboardingInfo = {
     extension: 'id',
+    removable: true,
     name: 'name',
     displayName: 'displayName',
     icon: 'icon',
@@ -527,6 +542,7 @@ test('Expect the step to be completed if the negated context value is true', asy
 
   const onboarding: OnboardingInfo = {
     extension: 'id',
+    removable: true,
     name: 'name',
     displayName: 'displayName',
     icon: 'icon',
@@ -564,6 +580,7 @@ test('Expect the step status to be updated but not the onboarding as it is not t
 
   const onboarding: OnboardingInfo = {
     extension: 'id',
+    removable: true,
     name: 'name',
     displayName: 'displayName',
     icon: 'icon',
@@ -596,6 +613,7 @@ test('Expect the step and the onboarding status to be updated as it is the last 
 
   const onboarding: OnboardingInfo = {
     extension: 'id',
+    removable: true,
     name: 'name',
     displayName: 'displayName',
     icon: 'icon',

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
@@ -330,6 +330,7 @@ test('Expect to redirect to onboarding page if setup button is clicked', async (
 
   const onboarding: OnboardingInfo = {
     extension: 'id',
+    removable: true,
     steps: [],
     title: 'onboarding',
     enablement: 'true',
@@ -356,6 +357,7 @@ test('Expect setup button to appear even if provider status is set to unknown an
   // Onboarding is enabled
   const onboarding: OnboardingInfo = {
     extension: 'id',
+    removable: true,
     steps: [],
     title: 'onboarding',
     enablement: 'true',
@@ -400,6 +402,7 @@ test('Expect to redirect to extension preferences page if onboarding is disabled
 
   const onboarding: OnboardingInfo = {
     extension: 'id',
+    removable: true,
     steps: [],
     title: 'onboarding',
     enablement: 'false',
@@ -429,6 +432,7 @@ test('Expect to not have cog icon button if provider has no active onboarding no
 
   const onboarding: OnboardingInfo = {
     extension: 'id',
+    removable: true,
     steps: [],
     title: 'onboarding',
     enablement: 'false',
@@ -471,6 +475,7 @@ test('Expect to redirect to extension onboarding page if onboarding is enabled a
 
   const onboarding: OnboardingInfo = {
     extension: 'id',
+    removable: true,
     steps: [],
     title: 'onboarding',
     enablement: 'true',

--- a/packages/renderer/src/lib/welcome/WelcomePage.spec.ts
+++ b/packages/renderer/src/lib/welcome/WelcomePage.spec.ts
@@ -84,6 +84,7 @@ test('Expect welcome screen to show three checked onboarding providers', async (
   onboardingList.set([
     {
       extension: 'id',
+      removable: true,
       title: 'onboarding',
       name: 'foobar1',
       displayName: 'FooBar1',
@@ -100,6 +101,7 @@ test('Expect welcome screen to show three checked onboarding providers', async (
     },
     {
       extension: 'id',
+      removable: true,
       title: 'onboarding',
       name: 'foobar2',
       displayName: 'FooBar2',
@@ -116,6 +118,7 @@ test('Expect welcome screen to show three checked onboarding providers', async (
     },
     {
       extension: 'id',
+      removable: true,
       title: 'onboarding',
       name: 'foobar3',
       displayName: 'FooBar3',
@@ -199,6 +202,7 @@ test('Make sure the provider with name podman appears first even if its 2nd in t
   onboardingList.set([
     {
       extension: 'test.extension.id',
+      removable: true,
       title: 'onboarding',
       name: 'foobar1',
       displayName: 'FooBar1',
@@ -215,6 +219,7 @@ test('Make sure the provider with name podman appears first even if its 2nd in t
     },
     {
       extension: 'podman.extension.id',
+      removable: true,
       title: 'onboarding',
       name: 'podman',
       displayName: 'Podman',
@@ -231,6 +236,7 @@ test('Make sure the provider with name podman appears first even if its 2nd in t
     },
     {
       extension: 'test.extension.id2',
+      removable: true,
       title: 'onboarding',
       name: 'foobar3',
       displayName: 'FooBar3',


### PR DESCRIPTION
### What does this PR do?

This PR adds onboarding priority sorting. Smaller priority number and built-in extension comes first.

### Screenshot / video of UI

Welcome and onboarding steps now in the same order

### What issues does this PR fix or reference?

Fix #10851.

### How to test this PR?

Remove podman desktop configuration from home folder and restart podman desktop

- [x] Tests are covering the bug fix or the new feature
