### PR TITLE
test(e2e): Parameterize expected objects on the UI stress test

### DIFF
--- a/tests/playwright/src/model/pages/main-page.ts
+++ b/tests/playwright/src/model/pages/main-page.ts
@@ -144,4 +144,29 @@ export abstract class MainPage extends BasePage {
       return rows.length > 1 ? rows.length - 1 : 0;
     });
   }
+
+  async getRowByName(name: string): Promise<Locator | undefined> {
+    return test.step(`Get row from ${this.title} page table by name: ${name}`, async () => {
+      const locator = this.page
+        .getByRole('row')
+        .and(this.page.getByLabel(name, { exact: true }))
+        .first();
+
+      return (await locator.count()) > 0 ? locator : undefined;
+    });
+  }
+
+  async waitForRowToExists(name: string, timeout = 5_000): Promise<boolean> {
+    return test.step(`Wait for row with name: ${name} to exist`, async () => {
+      await waitUntil(async () => (await this.getRowByName(name)) !== undefined, { timeout: timeout });
+      return true;
+    });
+  }
+
+  async waitForRowToBeDelete(name: string, timeout = 5_000): Promise<boolean> {
+    return test.step(`Wait for row with name: ${name} to be deleted`, async () => {
+      await waitUntil(async () => (await this.getRowByName(name)) === undefined, { timeout: timeout });
+      return true;
+    });
+  }
 }

--- a/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
+++ b/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
@@ -18,7 +18,7 @@
 import type { ImagesPage } from '../../model/pages/images-page';
 import { NavigationBar } from '../../model/workbench/navigation';
 import { expect as playExpect, test } from '../../utility/fixtures';
-import { waitForPodmanMachineStartup, waitUntil, waitWhile } from '../../utility/wait';
+import { waitForPodmanMachineStartup, waitWhile } from '../../utility/wait';
 
 const numberOfObjects = Number(process.env.OBJECT_NUM) || 100;
 console.log(`numberOfObjects => ${numberOfObjects}`);
@@ -52,9 +52,7 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
     //count images => 1 original image + (1 tagged * numberOfObjects) + 1 localhost/podman-pause from pods = numberOfObjects + 2
     await playExpect.poll(async () => await images.countRowsFromTable(), { timeout: 10_000 }).toBe(numberOfObjects + 2);
     for (let imgNum = 1; imgNum <= numberOfObjects; imgNum++) {
-      await playExpect
-        .poll(async () => await images.waitForImageExists(`localhost/my-image-${imgNum}`), { timeout: 5_000 })
-        .toBeTruthy();
+      await playExpect.poll(async () => await images.waitForImageExists(`localhost/my-image-${imgNum}`)).toBeTruthy();
     }
   });
 
@@ -66,14 +64,7 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
       .poll(async () => await containers.countRowsFromTable(), { timeout: 10_000 })
       .toBe(3 * numberOfObjects);
     for (let containerNum = 1; containerNum <= numberOfObjects; containerNum++) {
-      await playExpect
-        .poll(
-          async () =>
-            await waitUntil(async () => await containers.containerExists(`my-container-${containerNum}`), {
-              timeout: 5000,
-            }),
-        )
-        .toBeTruthy();
+      await playExpect.poll(async () => await containers.containerExists(`my-container-${containerNum}`)).toBeTruthy();
     }
   });
 
@@ -83,9 +74,7 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
     //count pods => 1 manually created * numberOfObjects = numberOfObjects
     await playExpect.poll(async () => await pods.countRowsFromTable(), { timeout: 10_000 }).toBe(numberOfObjects);
     for (let podNum = 1; podNum <= numberOfObjects; podNum++) {
-      await playExpect
-        .poll(async () => await waitUntil(async () => await pods.podExists(`my-pod-${podNum}`), { timeout: 5000 }))
-        .toBeTruthy();
+      await playExpect.poll(async () => await pods.podExists(`my-pod-${podNum}`)).toBeTruthy();
     }
   });
 });

--- a/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
+++ b/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
@@ -15,10 +15,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import type { ImagesPage } from '../../model/pages/images-page';
-import { NavigationBar } from '../../model/workbench/navigation';
 import { expect as playExpect, test } from '../../utility/fixtures';
-import { waitForPodmanMachineStartup, waitWhile } from '../../utility/wait';
+import { waitForPodmanMachineStartup } from '../../utility/wait';
 
 const numberOfObjects = Number(process.env.OBJECT_NUM) || 100;
 console.log(`numberOfObjects => ${numberOfObjects}`);
@@ -27,27 +25,15 @@ test.beforeAll(async ({ runner, welcomePage, page }) => {
   runner.setVideoAndTraceName('ui-stress-e2e');
   await welcomePage.handleWelcomePage(true);
   await waitForPodmanMachineStartup(page);
-  // wait giving a time to podman desktop to load up
-  let images: ImagesPage;
-  try {
-    images = await new NavigationBar(page).openImages();
-  } catch (error) {
-    await runner.screenshot('error-on-open-images.png');
-    throw error;
-  }
-  await waitWhile(async () => await images.pageIsEmpty(), {
-    sendError: false,
-    message: 'Images page is empty, there are no images present',
-  });
 });
 
-test.afterAll(async () => {
-  test.setTimeout(90_000);
+test.afterAll(async ({ runner }) => {
+  test.setTimeout(120_000);
+  await runner.close();
 });
 
 test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui-stress'] }, () => {
   test(`Verification of images`, async ({ navigationBar }) => {
-    test.setTimeout(30_000);
     const images = await navigationBar.openImages();
     await playExpect(images.heading).toBeVisible({ timeout: 10_000 });
     //count images => 1 original image + (1 tagged * numberOfObjects) + 1 localhost/podman-pause from pods = numberOfObjects + 2
@@ -58,7 +44,6 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
   });
 
   test(`Verification of containers`, async ({ navigationBar }) => {
-    test.setTimeout(30_000);
     const containers = await navigationBar.openContainers();
     await playExpect(containers.heading).toBeVisible({ timeout: 10_000 });
     //count containers => (1 manually created + 2 from creating pods) * numberOfObjects = 3 * numberOfObjects
@@ -71,7 +56,6 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
   });
 
   test(`Verification of pods`, async ({ navigationBar }) => {
-    test.setTimeout(30_000);
     const pods = await navigationBar.openPods();
     await playExpect(pods.heading).toBeVisible({ timeout: 10_000 });
     //count pods => 1 manually created * numberOfObjects = numberOfObjects

--- a/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
+++ b/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
@@ -34,6 +34,8 @@ test.afterAll(async ({ runner }) => {
 
 test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui-stress'] }, () => {
   test(`Verification of images`, async ({ navigationBar }) => {
+    test.setTimeout(300_000);
+
     const images = await navigationBar.openImages();
     await playExpect(images.heading).toBeVisible({ timeout: 10_000 });
     //count images => 1 original image + (1 tagged * numberOfObjects) + 1 localhost/podman-pause from pods = numberOfObjects + 2
@@ -44,6 +46,8 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
   });
 
   test(`Verification of containers`, async ({ navigationBar }) => {
+    test.setTimeout(300_000);
+
     const containers = await navigationBar.openContainers();
     await playExpect(containers.heading).toBeVisible({ timeout: 10_000 });
     //count containers => (1 manually created + 2 from creating pods) * numberOfObjects = 3 * numberOfObjects
@@ -56,6 +60,8 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
   });
 
   test(`Verification of pods`, async ({ navigationBar }) => {
+    test.setTimeout(300_000);
+
     const pods = await navigationBar.openPods();
     await playExpect(pods.heading).toBeVisible({ timeout: 10_000 });
     //count pods => 1 manually created * numberOfObjects = numberOfObjects

--- a/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
+++ b/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
@@ -47,7 +47,7 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
     test.setTimeout(30_000);
     const images = await navigationBar.openImages();
     //count images => 1 original image + (1 tagged * 10) + 1 localhost/podman-pause from pods = 12
-    await playExpect.poll(async () => images.countRowsFromTable()).toBe(12);
+    await playExpect.poll(async () => await images.countRowsFromTable(), { timeout: 10_000 }).toBe(12);
     for (let imgNum = 1; imgNum <= 10; imgNum++) {
       await playExpect
         .poll(async () => await images.waitForImageExists(`quay.io/my-image-${imgNum}`), { timeout: 5_000 })
@@ -59,7 +59,7 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
     test.setTimeout(30_000);
     const containers = await navigationBar.openContainers();
     //count containers => (1 manually created + 2 from creating pods) * 10 = 30
-    await playExpect.poll(async () => containers.countRowsFromTable()).toBe(30);
+    await playExpect.poll(async () => await containers.countRowsFromTable(), { timeout: 10_000 }).toBe(30);
     for (let containerNum = 1; containerNum <= 10; containerNum++) {
       await playExpect
         .poll(async () => await containers.containerExists(`my-container-${containerNum}`), { timeout: 5_000 })
@@ -71,7 +71,7 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
     test.setTimeout(30_000);
     const pods = await navigationBar.openPods();
     //count pods => 1 manually created * 10 = 10
-    await playExpect.poll(async () => pods.countRowsFromTable()).toBe(10);
+    await playExpect.poll(async () => await pods.countRowsFromTable(), { timeout: 10_000 }).toBe(10);
     for (let podNum = 1; podNum <= 10; podNum++) {
       await playExpect.poll(async () => await pods.podExists(`my-pod-${podNum}`), { timeout: 5_000 }).toBeTruthy();
     }

--- a/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
+++ b/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
@@ -49,6 +49,7 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
   test(`Verification of images`, async ({ navigationBar }) => {
     test.setTimeout(30_000);
     const images = await navigationBar.openImages();
+    await playExpect(images.heading).toBeVisible({ timeout: 10_000 });
     //count images => 1 original image + (1 tagged * numberOfObjects) + 1 localhost/podman-pause from pods = numberOfObjects + 2
     await playExpect.poll(async () => await images.countRowsFromTable(), { timeout: 10_000 }).toBe(numberOfObjects + 2);
     for (let imgNum = 1; imgNum <= numberOfObjects; imgNum++) {
@@ -59,6 +60,7 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
   test(`Verification of containers`, async ({ navigationBar }) => {
     test.setTimeout(30_000);
     const containers = await navigationBar.openContainers();
+    await playExpect(containers.heading).toBeVisible({ timeout: 10_000 });
     //count containers => (1 manually created + 2 from creating pods) * numberOfObjects = 3 * numberOfObjects
     await playExpect
       .poll(async () => await containers.countRowsFromTable(), { timeout: 10_000 })
@@ -71,6 +73,7 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
   test(`Verification of pods`, async ({ navigationBar }) => {
     test.setTimeout(30_000);
     const pods = await navigationBar.openPods();
+    await playExpect(pods.heading).toBeVisible({ timeout: 10_000 });
     //count pods => 1 manually created * numberOfObjects = numberOfObjects
     await playExpect.poll(async () => await pods.countRowsFromTable(), { timeout: 10_000 }).toBe(numberOfObjects);
     for (let podNum = 1; podNum <= numberOfObjects; podNum++) {

--- a/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
+++ b/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
@@ -46,9 +46,9 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
   test(`Verification of images`, async ({ navigationBar }) => {
     test.setTimeout(30_000);
     const images = await navigationBar.openImages();
-    //count images => 1 original image + (1 tagged * 10) + 1 localhost/podman-pause from pods = 12
-    await playExpect.poll(async () => await images.countRowsFromTable(), { timeout: 10_000 }).toBe(12);
-    for (let imgNum = 1; imgNum <= 10; imgNum++) {
+    //count images => 1 original image + (1 tagged * 100) + 1 localhost/podman-pause from pods = 102
+    await playExpect.poll(async () => await images.countRowsFromTable(), { timeout: 10_000 }).toBe(102);
+    for (let imgNum = 1; imgNum <= 100; imgNum++) {
       await playExpect
         .poll(async () => await images.waitForImageExists(`localhost/my-image-${imgNum}`), { timeout: 5_000 })
         .toBeTruthy();
@@ -58,9 +58,9 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
   test(`Verification of containers`, async ({ navigationBar }) => {
     test.setTimeout(30_000);
     const containers = await navigationBar.openContainers();
-    //count containers => (1 manually created + 2 from creating pods) * 10 = 30
-    await playExpect.poll(async () => await containers.countRowsFromTable(), { timeout: 10_000 }).toBe(30);
-    for (let containerNum = 1; containerNum <= 10; containerNum++) {
+    //count containers => (1 manually created + 2 from creating pods) * 100 = 300
+    await playExpect.poll(async () => await containers.countRowsFromTable(), { timeout: 10_000 }).toBe(300);
+    for (let containerNum = 1; containerNum <= 100; containerNum++) {
       await playExpect
         .poll(async () => await containers.containerExists(`my-container-${containerNum}`), { timeout: 5_000 })
         .toBeTruthy();
@@ -70,9 +70,9 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
   test(`Verification of pods`, async ({ navigationBar }) => {
     test.setTimeout(30_000);
     const pods = await navigationBar.openPods();
-    //count pods => 1 manually created * 10 = 10
-    await playExpect.poll(async () => await pods.countRowsFromTable(), { timeout: 10_000 }).toBe(10);
-    for (let podNum = 1; podNum <= 10; podNum++) {
+    //count pods => 1 manually created * 100 = 100
+    await playExpect.poll(async () => await pods.countRowsFromTable(), { timeout: 10_000 }).toBe(100);
+    for (let podNum = 1; podNum <= 100; podNum++) {
       await playExpect.poll(async () => await pods.podExists(`my-pod-${podNum}`), { timeout: 5_000 }).toBeTruthy();
     }
   });

--- a/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
+++ b/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
@@ -50,7 +50,7 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
     await playExpect.poll(async () => await images.countRowsFromTable(), { timeout: 10_000 }).toBe(12);
     for (let imgNum = 1; imgNum <= 10; imgNum++) {
       await playExpect
-        .poll(async () => await images.waitForImageExists(`quay.io/my-image-${imgNum}`), { timeout: 5_000 })
+        .poll(async () => await images.waitForImageExists(`localhost/my-image-${imgNum}`), { timeout: 5_000 })
         .toBeTruthy();
     }
   });

--- a/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
+++ b/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
@@ -41,7 +41,9 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
     //count images => 1 original image + (1 tagged * numberOfObjects) + 1 localhost/podman-pause from pods = numberOfObjects + 2
     await playExpect.poll(async () => await images.countRowsFromTable(), { timeout: 10_000 }).toBe(numberOfObjects + 2);
     for (let imgNum = 1; imgNum <= numberOfObjects; imgNum++) {
-      await playExpect.poll(async () => await images.waitForImageExists(`localhost/my-image-${imgNum}`)).toBeTruthy();
+      await playExpect
+        .poll(async () => await images.waitForImageExists(`localhost/my-image-${imgNum}`, 60_000), { timeout: 0 })
+        .toBeTruthy();
     }
   });
 
@@ -55,7 +57,9 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
       .poll(async () => await containers.countRowsFromTable(), { timeout: 10_000 })
       .toBe(3 * numberOfObjects);
     for (let containerNum = 1; containerNum <= numberOfObjects; containerNum++) {
-      await playExpect.poll(async () => await containers.containerExists(`my-container-${containerNum}`)).toBeTruthy();
+      await playExpect
+        .poll(async () => await containers.containerExists(`my-container-${containerNum}`), { timeout: 60_000 })
+        .toBeTruthy();
     }
   });
 
@@ -67,7 +71,7 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
     //count pods => 1 manually created * numberOfObjects = numberOfObjects
     await playExpect.poll(async () => await pods.countRowsFromTable(), { timeout: 10_000 }).toBe(numberOfObjects);
     for (let podNum = 1; podNum <= numberOfObjects; podNum++) {
-      await playExpect.poll(async () => await pods.podExists(`my-pod-${podNum}`)).toBeTruthy();
+      await playExpect.poll(async () => await pods.podExists(`my-pod-${podNum}`), { timeout: 60_000 }).toBeTruthy();
     }
   });
 });

--- a/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
+++ b/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
@@ -18,7 +18,7 @@
 import type { ImagesPage } from '../../model/pages/images-page';
 import { NavigationBar } from '../../model/workbench/navigation';
 import { expect as playExpect, test } from '../../utility/fixtures';
-import { waitForPodmanMachineStartup, waitWhile } from '../../utility/wait';
+import { waitForPodmanMachineStartup, waitUntil, waitWhile } from '../../utility/wait';
 
 const numberOfObjects = Number(process.env.OBJECT_NUM) || 100;
 console.log(`numberOfObjects => ${numberOfObjects}`);
@@ -67,7 +67,12 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
       .toBe(3 * numberOfObjects);
     for (let containerNum = 1; containerNum <= numberOfObjects; containerNum++) {
       await playExpect
-        .poll(async () => await containers.containerExists(`my-container-${containerNum}`), { timeout: 5_000 })
+        .poll(
+          async () =>
+            await waitUntil(async () => await containers.containerExists(`my-container-${containerNum}`), {
+              timeout: 5000,
+            }),
+        )
         .toBeTruthy();
     }
   });
@@ -78,7 +83,9 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
     //count pods => 1 manually created * numberOfObjects = numberOfObjects
     await playExpect.poll(async () => await pods.countRowsFromTable(), { timeout: 10_000 }).toBe(numberOfObjects);
     for (let podNum = 1; podNum <= numberOfObjects; podNum++) {
-      await playExpect.poll(async () => await pods.podExists(`my-pod-${podNum}`), { timeout: 5_000 }).toBeTruthy();
+      await playExpect
+        .poll(async () => await waitUntil(async () => await pods.podExists(`my-pod-${podNum}`), { timeout: 5000 }))
+        .toBeTruthy();
     }
   });
 });

--- a/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
+++ b/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
@@ -20,6 +20,9 @@ import { NavigationBar } from '../../model/workbench/navigation';
 import { expect as playExpect, test } from '../../utility/fixtures';
 import { waitForPodmanMachineStartup, waitWhile } from '../../utility/wait';
 
+const numberOfObjects = Number(process.env.OBJECT_NUM) || 100;
+console.log(`numberOfObjects => ${numberOfObjects}`);
+
 test.beforeAll(async ({ runner, welcomePage, page }) => {
   runner.setVideoAndTraceName('ui-stress-e2e');
   await welcomePage.handleWelcomePage(true);
@@ -46,9 +49,9 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
   test(`Verification of images`, async ({ navigationBar }) => {
     test.setTimeout(30_000);
     const images = await navigationBar.openImages();
-    //count images => 1 original image + (1 tagged * 100) + 1 localhost/podman-pause from pods = 102
-    await playExpect.poll(async () => await images.countRowsFromTable(), { timeout: 10_000 }).toBe(102);
-    for (let imgNum = 1; imgNum <= 100; imgNum++) {
+    //count images => 1 original image + (1 tagged * numberOfObjects) + 1 localhost/podman-pause from pods = numberOfObjects + 2
+    await playExpect.poll(async () => await images.countRowsFromTable(), { timeout: 10_000 }).toBe(numberOfObjects + 2);
+    for (let imgNum = 1; imgNum <= numberOfObjects; imgNum++) {
       await playExpect
         .poll(async () => await images.waitForImageExists(`localhost/my-image-${imgNum}`), { timeout: 5_000 })
         .toBeTruthy();
@@ -58,9 +61,11 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
   test(`Verification of containers`, async ({ navigationBar }) => {
     test.setTimeout(30_000);
     const containers = await navigationBar.openContainers();
-    //count containers => (1 manually created + 2 from creating pods) * 100 = 300
-    await playExpect.poll(async () => await containers.countRowsFromTable(), { timeout: 10_000 }).toBe(300);
-    for (let containerNum = 1; containerNum <= 100; containerNum++) {
+    //count containers => (1 manually created + 2 from creating pods) * numberOfObjects = 3 * numberOfObjects
+    await playExpect
+      .poll(async () => await containers.countRowsFromTable(), { timeout: 10_000 })
+      .toBe(3 * numberOfObjects);
+    for (let containerNum = 1; containerNum <= numberOfObjects; containerNum++) {
       await playExpect
         .poll(async () => await containers.containerExists(`my-container-${containerNum}`), { timeout: 5_000 })
         .toBeTruthy();
@@ -70,9 +75,9 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
   test(`Verification of pods`, async ({ navigationBar }) => {
     test.setTimeout(30_000);
     const pods = await navigationBar.openPods();
-    //count pods => 1 manually created * 100 = 100
-    await playExpect.poll(async () => await pods.countRowsFromTable(), { timeout: 10_000 }).toBe(100);
-    for (let podNum = 1; podNum <= 100; podNum++) {
+    //count pods => 1 manually created * numberOfObjects = numberOfObjects
+    await playExpect.poll(async () => await pods.countRowsFromTable(), { timeout: 10_000 }).toBe(numberOfObjects);
+    for (let podNum = 1; podNum <= numberOfObjects; podNum++) {
       await playExpect.poll(async () => await pods.podExists(`my-pod-${podNum}`), { timeout: 5_000 }).toBeTruthy();
     }
   });

--- a/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
+++ b/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
@@ -42,7 +42,7 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
     await playExpect.poll(async () => await images.countRowsFromTable(), { timeout: 10_000 }).toBe(numberOfObjects + 2);
     for (let imgNum = 1; imgNum <= numberOfObjects; imgNum++) {
       await playExpect
-        .poll(async () => await images.waitForImageExists(`localhost/my-image-${imgNum}`, 60_000), { timeout: 0 })
+        .poll(async () => await images.waitForRowToExists(`localhost/my-image-${imgNum}`), { timeout: 0 })
         .toBeTruthy();
     }
   });
@@ -58,7 +58,7 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
       .toBe(3 * numberOfObjects);
     for (let containerNum = 1; containerNum <= numberOfObjects; containerNum++) {
       await playExpect
-        .poll(async () => await containers.containerExists(`my-container-${containerNum}`), { timeout: 60_000 })
+        .poll(async () => await containers.waitForRowToExists(`my-container-${containerNum}`), { timeout: 0 })
         .toBeTruthy();
     }
   });
@@ -71,7 +71,7 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
     //count pods => 1 manually created * numberOfObjects = numberOfObjects
     await playExpect.poll(async () => await pods.countRowsFromTable(), { timeout: 10_000 }).toBe(numberOfObjects);
     for (let podNum = 1; podNum <= numberOfObjects; podNum++) {
-      await playExpect.poll(async () => await pods.podExists(`my-pod-${podNum}`), { timeout: 60_000 }).toBeTruthy();
+      await playExpect.poll(async () => await pods.waitForRowToExists(`my-pod-${podNum}`), { timeout: 0 }).toBeTruthy();
     }
   });
 });


### PR DESCRIPTION
### What does this PR do?
Modifies the ui-stress.spec.ts file to use a parameterized value from the workflow instead of a hardcoded one

### How to test this PR?
Run `pnpm test:e2e:ui-stress`