### PR TITLE
chore: add a method to check if playbook is a command supported on podman CLI

### DIFF
--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -2403,6 +2403,29 @@ test('isLibkrunSupported should return false with previous 5.1.2 version', async
   expect(enabled).toBeFalsy();
 });
 
+describe('isPlaybookMachineInitSupported', () => {
+  test('isPlaybookMachineInitSupported should return false with 5.3.0', async () => {
+    vi.mocked(extensionApi.env).isMac = true;
+    vi.mocked(arch).mockReturnValue('x64');
+    const enabled = extension.isPlaybookMachineInitSupported('5.3.0');
+    expect(enabled).toBeFalsy();
+  });
+
+  test('isLibkrunSupported should return true with 5.4.0 version on Windows/amd', async () => {
+    vi.mocked(arch).mockReturnValue('amd64');
+    vi.mocked(extensionApi.env).isWindows = true;
+    const enabled = extension.isPlaybookMachineInitSupported('5.4.0');
+    expect(enabled).toBeTruthy();
+  });
+
+  test('isLibkrunSupported should return true with 5.4.0 version on arm/mac', async () => {
+    vi.mocked(arch).mockReturnValue('arm64');
+    vi.mocked(extensionApi.env).isMac = true;
+    const enabled = extension.isPlaybookMachineInitSupported('5.4.0');
+    expect(enabled).toBeTruthy();
+  });
+});
+
 describe('sendTelemetryRecords', () => {
   test('krunkit found', async () => {
     vi.mocked(extensionApi.env).isMac = true;

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -2411,14 +2411,14 @@ describe('isPlaybookMachineInitSupported', () => {
     expect(enabled).toBeFalsy();
   });
 
-  test('isLibkrunSupported should return true with 5.4.0 version on Windows/amd', async () => {
+  test('isPlaybookMachineInitSupported should return true with 5.4.0 version on Windows/amd', async () => {
     vi.mocked(arch).mockReturnValue('amd64');
     vi.mocked(extensionApi.env).isWindows = true;
     const enabled = extension.isPlaybookMachineInitSupported('5.4.0');
     expect(enabled).toBeTruthy();
   });
 
-  test('isLibkrunSupported should return true with 5.4.0 version on arm/mac', async () => {
+  test('isPlaybookMachineInitSupported should return true with 5.4.0 version on arm/mac', async () => {
     vi.mocked(arch).mockReturnValue('arm64');
     vi.mocked(extensionApi.env).isMac = true;
     const enabled = extension.isPlaybookMachineInitSupported('5.4.0');

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -1921,6 +1921,13 @@ export function isRootfulMachineInitSupported(podmanVersion: string): boolean {
   return compareVersions(podmanVersion, PODMAN_MINIMUM_VERSION_FOR_ROOTFUL_MACHINE_INIT) >= 0;
 }
 
+const PODMAN_MINIMUM_VERSION_FOR_PLAYBOOK_MACHINE_INIT = '5.4.0';
+
+// Checks if playbook option is supported.
+export function isPlaybookMachineInitSupported(podmanVersion: string): boolean {
+  return compareVersions(podmanVersion, PODMAN_MINIMUM_VERSION_FOR_PLAYBOOK_MACHINE_INIT) >= 0;
+}
+
 const PODMAN_MINIMUM_VERSION_FOR_NEW_SOCKET_LOCATION = '4.5.0';
 
 export function isPodmanSocketLocationMoved(podmanVersion: string): boolean {


### PR DESCRIPTION
### What does this PR do?
add a helper method

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/issues/10673

### How to test this PR?

unit test provided

- [x] Tests are covering the bug fix or the new feature
