### PR TITLE
feat: display offline status in Kubernetes Contexts page

### DIFF
--- a/packages/api/src/kubernetes-contexts-healths.ts
+++ b/packages/api/src/kubernetes-contexts-healths.ts
@@ -18,6 +18,10 @@
 
 export interface ContextHealth {
   contextName: string;
+  // is the health of the cluster being checked?
   checking: boolean;
+  // was the health check successful?
   reachable: boolean;
+  // is one of the informers marked offline (disconnect after being connected, the cache still being populated)
+  offline: boolean;
 }

--- a/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
@@ -69,6 +69,9 @@ export class ContextsManagerExperimental {
   #onContextHealthStateChange = new Emitter<ContextHealthState>();
   onContextHealthStateChange: Event<ContextHealthState> = this.#onContextHealthStateChange.event;
 
+  #onOfflineChange = new Emitter<void>();
+  onOfflineChange: Event<void> = this.#onOfflineChange.event;
+
   #onContextPermissionResult = new Emitter<ContextPermissionResult>();
   onContextPermissionResult: Event<ContextPermissionResult> = this.#onContextPermissionResult.event;
 
@@ -325,7 +328,7 @@ export class ContextsManagerExperimental {
               }
             });
             informer.onOffline((_e: OfflineEvent) => {
-              /* send event to dispatcher */
+              this.#onOfflineChange.fire();
             });
             const cache = informer.start();
             this.#objectCaches.set(contextName, resource, cache);
@@ -357,5 +360,12 @@ export class ContextsManagerExperimental {
     }
     this.#informers.removeForContext(contextName);
     this.#objectCaches.removeForContext(contextName);
+  }
+
+  // returns true if at least one informer for the context is 'offline'
+  // meaning that it has lost connection with the cluster (after being connected)
+  isContextOffline(contextName: string): boolean {
+    const informers = this.#informers.getForContext(contextName);
+    return informers.some(informer => informer.isOffline());
   }
 }

--- a/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.spec.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.spec.ts
@@ -32,12 +32,14 @@ import type { KubeConfigSingleContext } from './kubeconfig-single-context.js';
 test('ContextsStatesDispatcher should call updateHealthStates when onContextHealthStateChange event is fired', () => {
   const manager: ContextsManagerExperimental = {
     onContextHealthStateChange: vi.fn(),
+    onOfflineChange: vi.fn(),
     onContextPermissionResult: vi.fn(),
     onContextDelete: vi.fn(),
     getHealthCheckersStates: vi.fn(),
     getPermissions: vi.fn(),
     onResourceCountUpdated: vi.fn(),
     onResourceUpdated: vi.fn(),
+    isContextOffline: vi.fn(),
   } as unknown as ContextsManagerExperimental;
   const apiSender: ApiSenderType = {
     send: vi.fn(),
@@ -59,12 +61,14 @@ test('ContextsStatesDispatcher should call updateHealthStates when onContextHeal
 test('ContextsStatesDispatcher should call updatePermissions when onContextPermissionResult event is fired', () => {
   const manager: ContextsManagerExperimental = {
     onContextHealthStateChange: vi.fn(),
+    onOfflineChange: vi.fn(),
     onContextPermissionResult: vi.fn(),
     onContextDelete: vi.fn(),
     getHealthCheckersStates: vi.fn(),
     getPermissions: vi.fn(),
     onResourceCountUpdated: vi.fn(),
     onResourceUpdated: vi.fn(),
+    isContextOffline: vi.fn(),
   } as unknown as ContextsManagerExperimental;
   const apiSender: ApiSenderType = {
     send: vi.fn(),
@@ -86,12 +90,14 @@ test('ContextsStatesDispatcher should call updatePermissions when onContextPermi
 test('ContextsStatesDispatcher should call updateHealthStates and updatePermissions when onContextDelete event is fired', () => {
   const manager: ContextsManagerExperimental = {
     onContextHealthStateChange: vi.fn(),
+    onOfflineChange: vi.fn(),
     onContextPermissionResult: vi.fn(),
     onContextDelete: vi.fn(),
     getHealthCheckersStates: vi.fn(),
     getPermissions: vi.fn(),
     onResourceCountUpdated: vi.fn(),
     onResourceUpdated: vi.fn(),
+    isContextOffline: vi.fn(),
   } as unknown as ContextsManagerExperimental;
   const apiSender: ApiSenderType = {
     send: vi.fn(),
@@ -114,10 +120,12 @@ test('ContextsStatesDispatcher should call updateHealthStates and updatePermissi
 test('getContextsHealths should return the values of the map returned by manager.getHealthCheckersStates without kubeConfig', () => {
   const manager: ContextsManagerExperimental = {
     onContextHealthStateChange: vi.fn(),
+    onOfflineChange: vi.fn(),
     onContextPermissionResult: vi.fn(),
     onContextDelete: vi.fn(),
     getHealthCheckersStates: vi.fn(),
     getPermissions: vi.fn(),
+    isContextOffline: vi.fn(),
   } as unknown as ContextsManagerExperimental;
   const apiSender: ApiSenderType = {
     send: vi.fn(),

--- a/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.ts
@@ -36,6 +36,7 @@ export class ContextsStatesDispatcher {
 
   init(): void {
     this.manager.onContextHealthStateChange((_state: ContextHealthState) => this.updateHealthStates());
+    this.manager.onOfflineChange(() => this.updateHealthStates());
     this.manager.onContextPermissionResult((_permissions: ContextPermissionResult) => this.updatePermissions());
     this.manager.onContextDelete((_state: DispatcherEvent) => {
       this.updateHealthStates();
@@ -56,6 +57,7 @@ export class ContextsStatesDispatcher {
         contextName,
         checking: health.checking,
         reachable: health.reachable,
+        offline: this.manager.isContextOffline(contextName),
       });
     }
     return value;

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
@@ -187,6 +187,7 @@ describe.each([
       resourcesCount: true,
       undefinedCounts: true,
       permissions: true,
+      offline: true,
     },
     initMocks: (): void => {
       Object.defineProperty(global, 'window', {
@@ -214,21 +215,25 @@ describe.each([
           contextName: 'context-name',
           reachable: true,
           checking: false,
+          offline: false,
         },
         {
           contextName: 'context-name2',
           reachable: false,
           checking: false,
+          offline: false,
         },
         {
           contextName: 'context-name3',
           reachable: true,
           checking: false,
+          offline: false,
         },
         {
           contextName: 'context-name4',
           reachable: true,
           checking: false,
+          offline: true,
         },
       ]);
       kubernetesContextsPermissions.set([
@@ -272,6 +277,7 @@ describe.each([
       resourcesCount: true,
       undefinedCounts: false,
       permissions: false,
+      offline: false,
     },
     initMocks: (): void => {
       const state: Map<string, ContextGeneralState> = new Map();
@@ -354,6 +360,10 @@ describe.each([
       expect(within(context4).queryByText('DEPLOYMENTS')).toBeInTheDocument();
       checkNotPermitted(context4, 'Context Pods Count');
       checkNotPermitted(context4, 'Context Deployments Count');
+    }
+
+    if (implemented.offline) {
+      expect(within(context4).queryByText('CONNECTION LOST')).toBeInTheDocument();
     }
   });
 });

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -20,6 +20,10 @@ import ListItemButtonIcon from '../ui/ListItemButtonIcon.svelte';
 import SettingsPage from './SettingsPage.svelte';
 
 interface KubeContextWithStates extends KubeContext {
+  // some informers have been disconnected, and their caches are still populated with the last seen resources
+  isOffline: boolean;
+  // the context has been marked as reachable (during health check in experimental mode)
+  // the context will still be marked as reachable even if it is offline
   isReachable: boolean;
   isKnown: boolean;
   isBeingChecked: boolean;
@@ -40,6 +44,7 @@ const kubernetesContextsWithStates: KubeContextWithStates[] = $derived(
     .map(kubeContext => ({
       ...kubeContext,
       isReachable: isContextReachable(kubeContext.name, experimentalStates),
+      isOffline: isContextOffline(kubeContext.name, experimentalStates),
       isKnown: isContextKnown(kubeContext.name, experimentalStates),
       isBeingChecked: isContextBeingChecked(kubeContext.name, experimentalStates),
       podsCount: getResourcesCount(kubeContext.name, 'pods', experimentalStates),
@@ -112,6 +117,15 @@ function isContextReachable(contextName: string, experimental: boolean): boolean
     );
   }
   return $kubernetesContextsState.get(contextName)?.reachable ?? false;
+}
+
+function isContextOffline(contextName: string, experimental: boolean): boolean {
+  if (experimental) {
+    return $kubernetesContextsHealths.some(
+      contextHealth => contextHealth.contextName === contextName && contextHealth.offline,
+    );
+  }
+  return false; // not implement in non-experimental mode
 }
 
 function isContextKnown(contextName: string, experimental: boolean): boolean {
@@ -243,14 +257,25 @@ async function connect(contextName: string): Promise<void> {
         <div class="grow flex-column divide-gray-900 text-[var(--pd-invert-content-card-text)]">
           <div class="flex flex-row">
             <div class="flex-none w-36">
-              {#if context.isReachable}
+              {#if context.isReachable || context.isOffline}
                 <div class="flex flex-row pt-2">
-                  <div class="w-3 h-3 rounded-full bg-[var(--pd-status-connected)]"></div>
-                  <div
-                    class="ml-1 font-bold text-[9px] text-[var(--pd-status-connected)]"
-                    aria-label="Context Reachable">
-                    REACHABLE
-                  </div>
+                  {#if context.isOffline}
+                    <Tooltip class="flex flex-row" tip="connection to the cluster lost, the resources displayed can be out of date">
+                      <div class="w-3 h-3 rounded-full bg-[var(--pd-status-paused)]"></div>
+                      <div
+                        class="ml-1 font-bold text-[9px] text-[var(--pd-status-paused)]"
+                        aria-label="Context connection lost">
+                        CONNECTION LOST
+                      </div>
+                    </Tooltip>
+                  {:else}
+                    <div class="w-3 h-3 rounded-full bg-[var(--pd-status-connected)]"></div>
+                    <div
+                      class="ml-1 font-bold text-[9px] text-[var(--pd-status-connected)]"
+                      aria-label="Context Reachable">
+                      REACHABLE
+                    </div>
+                  {/if}
                 </div>
                 <div class="flex flex-row gap-4 mt-4">
                   <div class="text-center">

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -260,7 +260,7 @@ async function connect(contextName: string): Promise<void> {
               {#if context.isReachable || context.isOffline}
                 <div class="flex flex-row pt-2">
                   {#if context.isOffline}
-                    <Tooltip class="flex flex-row" tip="connection to the cluster lost, the resources displayed can be out of date">
+                    <Tooltip class="flex flex-row" tip="connection lost, resources may be out of sync">
                       <div class="w-3 h-3 rounded-full bg-[var(--pd-status-paused)]"></div>
                       <div
                         class="ml-1 font-bold text-[9px] text-[var(--pd-status-paused)]"

--- a/packages/renderer/src/stores/kubernetes-context-health-experimental.spec.ts
+++ b/packages/renderer/src/stores/kubernetes-context-health-experimental.spec.ts
@@ -48,11 +48,13 @@ test('kubernetesContextsHealths in experimental states mode', async () => {
       contextName: 'context1',
       checking: true,
       reachable: false,
+      offline: false,
     },
     {
       contextName: 'context2',
       checking: false,
       reachable: true,
+      offline: false,
     },
   ];
 
@@ -61,11 +63,13 @@ test('kubernetesContextsHealths in experimental states mode', async () => {
       contextName: 'context1',
       checking: false,
       reachable: true,
+      offline: false,
     },
     {
       contextName: 'context2',
       checking: false,
       reachable: true,
+      offline: false,
     },
   ];
 

--- a/packages/renderer/src/stores/kubernetes-context-health-non-experimental.spec.ts
+++ b/packages/renderer/src/stores/kubernetes-context-health-non-experimental.spec.ts
@@ -52,11 +52,13 @@ test('kubernetesContextsHealths not in experimental states mode', async () => {
       contextName: 'context1',
       checking: true,
       reachable: false,
+      offline: false,
     },
     {
       contextName: 'context2',
       checking: false,
       reachable: true,
+      offline: false,
     },
   ];
 


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Display offline status in Kubernetes Contexts page

(see details in #11277)

### Screenshot / video of UI

https://github.com/user-attachments/assets/421e4d62-0f95-4e57-872d-c0d46f2a5d9f

### What issues does this PR fix or reference?

Part of #11277 

### How to test this PR?

Start Podman Desktop with the current context accessible, then stop the cluster

- [x] Tests are covering the bug fix or the new feature
