### PR TITLE
chore: kubernetes icon component

### DIFF
--- a/packages/renderer/src/lib/images/ConfigMapSecretIcon.svelte
+++ b/packages/renderer/src/lib/images/ConfigMapSecretIcon.svelte
@@ -9,6 +9,7 @@ export let size = '40';
   style={$$props.style}
   viewBox="0 0 16.015625 16"
   version="1.1"
+  data-testid="ConfigMap Secret"
   xml:space="preserve"
   xmlns="http://www.w3.org/2000/svg"
   xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/packages/renderer/src/lib/images/CronJobIcon.svelte
+++ b/packages/renderer/src/lib/images/CronJobIcon.svelte
@@ -15,6 +15,7 @@ let style: string = baseStyle + (solid ? 'fill:currentColor' : 'fill:none');
   height={size}
   viewBox="1 1 6.4666665 6.4666666"
   version="1.1"
+  data-testid="CronJob"
   xml:space="preserve"
   xmlns="http://www.w3.org/2000/svg"
   xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/packages/renderer/src/lib/images/DeploymentIcon.svelte
+++ b/packages/renderer/src/lib/images/DeploymentIcon.svelte
@@ -9,6 +9,7 @@ export let solid = false;
   class={$$props.class}
   style={$$props.style}
   version="1.1"
+  data-testid="Deployment"
   xml:space="preserve"
   viewBox="0 0 16 16">
   {#if solid}

--- a/packages/renderer/src/lib/images/IngressRouteIcon.svelte
+++ b/packages/renderer/src/lib/images/IngressRouteIcon.svelte
@@ -9,6 +9,7 @@ export let solid = false;
   class={$$props.class}
   style={$$props.style}
   version="1.1"
+  data-testid="Ingress Route"
   xml:space="preserve"
   viewBox="-0.3 -0.3 16.6 16.6">
   {#if solid}

--- a/packages/renderer/src/lib/images/JobIcon.svelte
+++ b/packages/renderer/src/lib/images/JobIcon.svelte
@@ -15,6 +15,7 @@ let style: string = baseStyle + (solid ? 'fill:currentColor' : 'fill:none');
   height={size}
   viewBox="1 1 6.4666665 6.4666666"
   version="1.1"
+  data-testid="Job"
   xml:space="preserve"
   xmlns="http://www.w3.org/2000/svg"
   xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/packages/renderer/src/lib/images/NodeIcon.svelte
+++ b/packages/renderer/src/lib/images/NodeIcon.svelte
@@ -10,6 +10,7 @@ export let solid = false;
   style={$$props.style}
   viewBox="0 0 0.66666667 0.66666667"
   version="1.1"
+  data-testid="Node"
   xml:space="preserve"
   xmlns="http://www.w3.org/2000/svg"
   xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/packages/renderer/src/lib/images/PVCIcon.svelte
+++ b/packages/renderer/src/lib/images/PVCIcon.svelte
@@ -10,6 +10,7 @@ export let solid = false;
   style={$$props.style}
   viewBox="0.926 0.926 15.999999 15.999999"
   version="1.1"
+  data-testid="PersistentVolumeClaim"
   xml:space="preserve"
   xmlns="http://www.w3.org/2000/svg"
   xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/packages/renderer/src/lib/images/PodIcon.svelte
+++ b/packages/renderer/src/lib/images/PodIcon.svelte
@@ -10,6 +10,7 @@ export let solid = false;
   style={$$props.style}
   viewBox="0.557 0.555 5.24 5.24"
   version="1.1"
+  data-testid="Pod"
   xml:space="preserve"
   xmlns="http://www.w3.org/2000/svg"
   xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/packages/renderer/src/lib/images/ServiceIcon.svelte
+++ b/packages/renderer/src/lib/images/ServiceIcon.svelte
@@ -14,6 +14,7 @@ if (!solid) {
   class={$$props.class}
   style={$$props.style}
   version="1.1"
+  data-testid="Service"
   xml:space="preserve"
   viewBox="-0.5 -0.5 20.03 15">
   <!-- four boxes -->

--- a/packages/renderer/src/lib/kube/KubernetesDashboard.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesDashboard.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 import type { KubernetesObject } from '@kubernetes/client-node';
 import { Link } from '@podman-desktop/ui-svelte';
-import type { Component } from 'svelte';
 
 import KubernetesCurrentContextConnectionBadge from '/@/lib/ui/KubernetesCurrentContextConnectionBadge.svelte';
 import { containersInfos } from '/@/stores/containers';
@@ -21,14 +20,6 @@ import {
 import { NO_CURRENT_CONTEXT_ERROR } from '/@api/kubernetes-contexts-states';
 
 import { kubernetesContexts } from '../../stores/kubernetes-contexts';
-import ConfigMapSecretIcon from '../images/ConfigMapSecretIcon.svelte';
-import CronJobIcon from '../images/CronJobIcon.svelte';
-import DeploymentIcon from '../images/DeploymentIcon.svelte';
-import IngressRouteIcon from '../images/IngressRouteIcon.svelte';
-import NodeIcon from '../images/NodeIcon.svelte';
-import PodIcon from '../images/PodIcon.svelte';
-import PvcIcon from '../images/PVCIcon.svelte';
-import ServiceIcon from '../images/ServiceIcon.svelte';
 import { fadeSlide } from '../ui/animations';
 import deployAndTestKubernetesImage from './DeployAndTestKubernetes.png';
 import KubernetesDashboardGuideCard from './KubernetesDashboardGuideCard.svelte';
@@ -123,14 +114,14 @@ async function openKubernetesDocumentation(): Promise<void> {
                 <!-- Metrics - non-collapsible -->
                 <div class="text-xl pt-2">Metrics</div>
                 <div class="grid grid-cols-4 gap-4">
-                    <KubernetesDashboardResourceCard type='Nodes' Icon={NodeIcon} activeCount={activeNodeCount} count={nodeCount} kind='Node'/>
-                    <KubernetesDashboardResourceCard type='Deployments' Icon={DeploymentIcon} activeCount={activeDeploymentsCount} count={deploymentCount} kind='Deployment'/>
-                    <KubernetesDashboardResourceCard type='Pods' Icon={PodIcon} count={podCount} kind='Pod'/>
-                    <KubernetesDashboardResourceCard type='Services' Icon={ServiceIcon} count={serviceCount} kind='Service'/>
-                    <KubernetesDashboardResourceCard type='Ingresses & Routes' Icon={IngressRouteIcon} count={ingressRouteCount} kind='Ingress'/>
-                    <KubernetesDashboardResourceCard type='Persistent Volume Claims' Icon={PvcIcon} count={pvcCount} kind='PersistentVolumeClaim'/>
-                    <KubernetesDashboardResourceCard type='ConfigMaps & Secrets' Icon={ConfigMapSecretIcon} count={configMapSecretCount} kind='ConfigMap'/>
-                    <KubernetesDashboardResourceCard type='CronJobs' Icon={CronJobIcon as Component} count={cronjobCount} kind='CronJob'/>
+                    <KubernetesDashboardResourceCard type='Nodes' activeCount={activeNodeCount} count={nodeCount} kind='Node'/>
+                    <KubernetesDashboardResourceCard type='Deployments' activeCount={activeDeploymentsCount} count={deploymentCount} kind='Deployment'/>
+                    <KubernetesDashboardResourceCard type='Pods' count={podCount} kind='Pod'/>
+                    <KubernetesDashboardResourceCard type='Services' count={serviceCount} kind='Service'/>
+                    <KubernetesDashboardResourceCard type='Ingresses & Routes' count={ingressRouteCount} kind='Ingress'/>
+                    <KubernetesDashboardResourceCard type='Persistent Volume Claims' count={pvcCount} kind='PersistentVolumeClaim'/>
+                    <KubernetesDashboardResourceCard type='ConfigMaps & Secrets' count={configMapSecretCount} kind='ConfigMap'/>
+                    <KubernetesDashboardResourceCard type='CronJobs' count={cronjobCount} kind='CronJob'/>
                 </div>
                 <!-- Graphs -->
                 

--- a/packages/renderer/src/lib/kube/KubernetesDashboardResourceCard.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesDashboardResourceCard.svelte
@@ -1,15 +1,14 @@
 <script lang="ts">
-import type { Component } from 'svelte';
+import KubernetesIcon from './KubernetesIcon.svelte';
 
 interface Props {
   type: string;
-  Icon: Component;
   activeCount?: number;
   count: number;
   kind: string;
 }
 
-let { type, Icon, activeCount, count, kind }: Props = $props();
+let { type, activeCount, count, kind }: Props = $props();
 
 async function openLink(): Promise<void> {
   try {
@@ -23,7 +22,7 @@ async function openLink(): Promise<void> {
 <button class="flex flex-col gap-4 p-4 bg-[var(--pd-content-card-carousel-card-bg)] hover:bg-[var(--pd-content-card-carousel-card-hover-bg)] rounded-md" onclick={openLink}>
   <div class="text-[var(--pd-invert-content-card-text)] font-semibold text-start">{type}</div>
   <div class="grid grid-cols-{activeCount !== undefined ? '3' : '2'} gap-4 w-full grow items-end">
-    <div class="justify-self-center text-[var(--pd-button-primary-bg)]"><Icon size={40}/></div>
+    <div class="justify-self-center text-[var(--pd-button-primary-bg)]"><KubernetesIcon kind={kind} size='40'/></div>
     {#if activeCount !== undefined}
     <div class="flex flex-col">
       <span class="text-[var(--pd-invert-content-card-text)]">Active</span>

--- a/packages/renderer/src/lib/kube/KubernetesIcon.spec.ts
+++ b/packages/renderer/src/lib/kube/KubernetesIcon.spec.ts
@@ -1,0 +1,45 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, test } from 'vitest';
+
+import KubernetesIcon from './KubernetesIcon.svelte';
+
+describe.each([
+  'Node',
+  'Deployment',
+  'Pod',
+  'Service',
+  'Ingress',
+  'Route',
+  'ConfigMap',
+  'Secret',
+  'PersistentVolumeClaim',
+  'CronJob',
+  'Job',
+])('Check Kubernetes icon is correct', kind => {
+  test(kind, async () => {
+    render(KubernetesIcon, { kind: `${kind}` });
+
+    const label = screen.getByTestId(kind, { exact: false });
+    expect(label).toBeInTheDocument();
+  });
+});

--- a/packages/renderer/src/lib/kube/KubernetesIcon.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesIcon.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+import type { Component } from 'svelte';
+
+import ConfigMapSecretIcon from '../images/ConfigMapSecretIcon.svelte';
+import CronJobIcon from '../images/CronJobIcon.svelte';
+import DeploymentIcon from '../images/DeploymentIcon.svelte';
+import IngressRouteIcon from '../images/IngressRouteIcon.svelte';
+import JobIcon from '../images/JobIcon.svelte';
+import KubeIcon from '../images/KubeIcon.svelte';
+import NodeIcon from '../images/NodeIcon.svelte';
+import PodIcon from '../images/PodIcon.svelte';
+import PvcIcon from '../images/PVCIcon.svelte';
+import ServiceIcon from '../images/ServiceIcon.svelte';
+
+interface Props {
+  kind: string;
+  size?: string;
+}
+let { kind, size }: Props = $props();
+
+let Icon = $derived.by(() => {
+  switch (kind) {
+    case 'Node':
+      return NodeIcon;
+    case 'Deployment':
+      return DeploymentIcon;
+    case 'Pod':
+      return PodIcon;
+    case 'Service':
+      return ServiceIcon;
+    case 'Ingress':
+      return IngressRouteIcon;
+    case 'Route':
+      return IngressRouteIcon;
+    case 'ConfigMap':
+      return ConfigMapSecretIcon;
+    case 'Secret':
+      return ConfigMapSecretIcon;
+    case 'PersistentVolumeClaim':
+      return PvcIcon;
+    case 'CronJob':
+      return CronJobIcon as Component;
+    case 'Job':
+      return JobIcon as Component;
+    default:
+      return KubeIcon;
+  }
+});
+</script>
+
+<Icon size={size}/>


### PR DESCRIPTION
### What does this PR do?

Every Kubernetes resource kind has an associated icon, so when we know the kind why not look it up vs having to specify the icon everywhere? This creates a utility function in kube-utils to return the icon based on kind, and uses that in the dashboard resource card to remove the property.

Isn't this just moving this function? Sure. But it means we can now look up the icon *anywhere* we know the kind, e.g. anywhere the UI objects exist. The next PR can create a shared status column and remove the individual status columns from all lists. We might be able to do something similar with the empty pages.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of #11035.

### How to test this PR?

Verify Kubernetes dashboard resource card icons are unchanged.

- [x] Tests are covering the bug fix or the new feature