### PR TITLE
chore: reuse ingress route utils

### DIFF
--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnBackend.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnBackend.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,18 +19,14 @@
 import '@testing-library/jest-dom/vitest';
 
 import { render, screen } from '@testing-library/svelte';
-import { beforeEach, expect, test } from 'vitest';
+import { expect, test } from 'vitest';
 
 import { IngressRouteUtils } from './ingress-route-utils';
 import IngressRouteColumnBackend from './IngressRouteColumnBackend.svelte';
 import type { IngressUI } from './IngressUI';
 import type { RouteUI } from './RouteUI';
 
-let ingressRouteUtils: IngressRouteUtils;
-
-beforeEach(() => {
-  ingressRouteUtils = new IngressRouteUtils();
-});
+const ingressRouteUtils = new IngressRouteUtils();
 
 test('Expect simple column styling with single path ingress', async () => {
   const ingressUI: IngressUI = {

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnHostPath.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnHostPath.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,18 +19,14 @@
 import '@testing-library/jest-dom/vitest';
 
 import { render, screen } from '@testing-library/svelte';
-import { beforeEach, expect, test } from 'vitest';
+import { expect, test } from 'vitest';
 
 import { IngressRouteUtils } from './ingress-route-utils';
 import IngressRouteColumnHostPath from './IngressRouteColumnHostPath.svelte';
 import type { IngressUI } from './IngressUI';
 import type { RouteUI } from './RouteUI';
 
-let ingressRouteUtils: IngressRouteUtils;
-
-beforeEach(() => {
-  ingressRouteUtils = new IngressRouteUtils();
-});
+const ingressRouteUtils = new IngressRouteUtils();
 
 test('Expect simple column styling with single host/path ingress', async () => {
   const ingressUI: IngressUI = {


### PR DESCRIPTION
### What does this PR do?

These two tests recreate the IngressRouteUtils for each test, but it has no state so this is unnecessary.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Found while reviewing #10903.

### How to test this PR?

Just PR check.

- [x] Tests are covering the bug fix or the new feature