### PR TITLE
feat: display deployment details in experimental mode

### DIFF
--- a/packages/renderer/src/lib/deployments/DeploymentDetails.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentDetails.spec.ts
@@ -22,15 +22,15 @@ import type { CoreV1Event, KubernetesObject, V1Deployment } from '@kubernetes/cl
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { writable } from 'svelte/store';
 import { router } from 'tinro';
-import { beforeAll, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { lastPage } from '/@/stores/breadcrumb';
-import * as kubeContextStore from '/@/stores/kubernetes-contexts-state';
+import * as states from '/@/stores/kubernetes-contexts-state';
 
+import type { IDisposable } from '../../../../main/src/plugin/types/disposable';
+import * as resourcesListen from '../kube/resources-listen';
 import DeploymentDetails from './DeploymentDetails.svelte';
 import * as deploymentDetailsSummary from './DeploymentDetailsSummary.svelte';
-
-const kubernetesDeleteDeploymentMock = vi.fn();
 
 const deployment: V1Deployment = {
   apiVersion: 'apps/v1',
@@ -46,106 +46,171 @@ const deployment: V1Deployment = {
     template: {},
   },
 };
-
-vi.mock('/@/stores/kubernetes-contexts-state', async () => {
+vi.mock(import('../kube/resources-listen'), async importOriginal => {
+  // we want to keep the original nonVerbose
+  const original = await importOriginal();
   return {
-    kubernetesCurrentContextDeployments: vi.fn(),
-    kubernetesCurrentContextEvents: vi.fn(),
+    ...original,
+    listenResources: vi.fn(),
+    isKubernetesExperimentalMode: vi.fn(),
   };
 });
 
-const showMessageBoxMock = vi.fn();
+vi.mock('/@/stores/kubernetes-contexts-state');
 
-beforeAll(() => {
-  Object.defineProperty(window, 'kubernetesDeleteDeployment', { value: kubernetesDeleteDeploymentMock });
-  Object.defineProperty(window, 'kubernetesReadNamespacedDeployment', { value: vi.fn() });
-  Object.defineProperty(window, 'showMessageBox', { value: showMessageBoxMock });
+beforeEach(() => {
+  vi.resetAllMocks();
+  router.goto('http://localhost:3000');
 });
 
-test('Expect redirect to previous page if deployment is deleted', async () => {
-  showMessageBoxMock.mockResolvedValue({ response: 0 });
+type initListsReturnType = {
+  updateDeployments: (objects: KubernetesObject[]) => void;
+  updateEvents: (objects: CoreV1Event[]) => void;
+};
 
-  const routerGotoSpy = vi.spyOn(router, 'goto');
-
-  // mock object stores
-  const deployments = writable<KubernetesObject[]>([deployment]);
-  vi.mocked(kubeContextStore).kubernetesCurrentContextDeployments = deployments;
-  const events = writable<CoreV1Event[]>([]);
-  vi.mocked(kubeContextStore).kubernetesCurrentContextEvents = events;
-
-  // remove deployment from the store when we call delete
-  kubernetesDeleteDeploymentMock.mockImplementation(() => {
-    deployments.set([]);
+describe.each<{
+  experimental: boolean;
+  initLists: (deployments: KubernetesObject[], events: CoreV1Event[]) => initListsReturnType;
+}>([
+  {
+    experimental: false,
+    initLists: (deployments: KubernetesObject[], events: CoreV1Event[]): initListsReturnType => {
+      const deploymentsStore = writable<KubernetesObject[]>(deployments);
+      vi.mocked(states).kubernetesCurrentContextDeployments = deploymentsStore;
+      const eventsStore = writable<CoreV1Event[]>(events);
+      vi.mocked(states).kubernetesCurrentContextEvents = eventsStore;
+      return {
+        updateDeployments: (deployments: KubernetesObject[]): void => {
+          deploymentsStore.set(deployments);
+        },
+        updateEvents: (events: CoreV1Event[]): void => {
+          eventsStore.set(events);
+        },
+      };
+    },
+  },
+  {
+    experimental: true,
+    initLists: (deployments: KubernetesObject[], events: CoreV1Event[]): initListsReturnType => {
+      let deploymentsCallback: (resoures: KubernetesObject[]) => void;
+      let eventsCallback: (resoures: CoreV1Event[]) => void;
+      vi.mocked(resourcesListen.listenResources).mockImplementation(
+        async (resourceName, _options, cb): Promise<IDisposable> => {
+          if (resourceName === 'deployments') {
+            deploymentsCallback = cb;
+            setTimeout(() => deploymentsCallback(deployments));
+            return {
+              dispose: (): void => {},
+            };
+          } else {
+            eventsCallback = cb;
+            setTimeout(() => eventsCallback(events));
+            return {
+              dispose: (): void => {},
+            };
+          }
+        },
+      );
+      return {
+        updateDeployments: (updatedObjects: KubernetesObject[]): void => {
+          deploymentsCallback(updatedObjects);
+        },
+        updateEvents: (updatedObjects: CoreV1Event[]): void => {
+          eventsCallback(updatedObjects);
+        },
+      };
+    },
+  },
+])('is experimental: $experimental', ({ experimental, initLists }) => {
+  beforeEach(() => {
+    vi.mocked(resourcesListen.isKubernetesExperimentalMode).mockResolvedValue(experimental);
   });
 
-  // define a fake lastPage so we can check where we will be redirected
-  lastPage.set({ name: 'Fake Previous', path: '/last' });
+  test('Expect redirect to previous page if deployment is deleted', async () => {
+    vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
 
-  // render the component
-  render(DeploymentDetails, { name: 'my-deployment', namespace: 'default' });
-  expect(screen.getByText('my-deployment')).toBeInTheDocument();
+    const routerGotoSpy = vi.spyOn(router, 'goto');
 
-  // grab current route
-  const currentRoute = window.location;
-  expect(currentRoute.href).toBe('http://localhost:3000/');
+    // mock object stores
+    const list = initLists([deployment], []);
 
-  // click on delete button
-  const deleteButton = screen.getByRole('button', { name: 'Delete Deployment' });
-  await fireEvent.click(deleteButton);
-  expect(showMessageBoxMock).toHaveBeenCalledOnce();
+    // remove deployment from the store when we call delete
+    vi.mocked(window.kubernetesDeleteDeployment).mockImplementation(async () => {
+      list.updateDeployments([]);
+    });
 
-  // Wait for confirmation modal to disappear after clicking on delete
-  await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    // define a fake lastPage so we can check where we will be redirected
+    lastPage.set({ name: 'Fake Previous', path: '/last' });
 
-  // check that delete method has been called
-  expect(kubernetesDeleteDeploymentMock).toHaveBeenCalled();
+    // render the component
+    render(DeploymentDetails, { name: 'my-deployment', namespace: 'default' });
 
-  // expect that we have called the router when page has been removed
-  // to jump to the previous page
-  expect(routerGotoSpy).toBeCalledWith('/last');
+    await vi.waitFor(() => {
+      expect(screen.getByText('my-deployment')).toBeInTheDocument();
+    });
 
-  // confirm updated route
-  const afterRoute = window.location;
-  expect(afterRoute.href).toBe('http://localhost:3000/last');
-});
+    // grab current route
+    const currentRoute = window.location;
+    expect(currentRoute.href).toBe('http://localhost:3000/');
 
-test('Expect DeploymentDetails to be called with related events only', async () => {
-  const deploymentDetailsSummarySpy = vi.spyOn(deploymentDetailsSummary, 'default');
-  // mock object stores
-  const deploymentsStore = writable<KubernetesObject[]>([deployment]);
-  vi.mocked(kubeContextStore).kubernetesCurrentContextDeployments = deploymentsStore;
+    // click on delete button
+    const deleteButton = screen.getByRole('button', { name: 'Delete Deployment' });
+    await fireEvent.click(deleteButton);
+    expect(window.showMessageBox).toHaveBeenCalledOnce();
 
-  const events: CoreV1Event[] = [
-    {
-      metadata: {
-        name: 'event1',
+    // Wait for confirmation modal to disappear after clicking on delete
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+
+    // check that delete method has been called
+    expect(window.kubernetesDeleteDeployment).toHaveBeenCalled();
+
+    // expect that we have called the router when page has been removed
+    // to jump to the previous page
+    expect(routerGotoSpy).toBeCalledWith('/last');
+
+    // confirm updated route
+    const afterRoute = window.location;
+    expect(afterRoute.href).toBe('http://localhost:3000/last');
+  });
+
+  test('Expect DeploymentDetails to be called with related events only', async () => {
+    const deploymentDetailsSummarySpy = vi.spyOn(deploymentDetailsSummary, 'default');
+
+    const events: CoreV1Event[] = [
+      {
+        kind: 'Event',
+        metadata: {
+          name: 'event1',
+        },
+        involvedObject: { uid: '12345678' },
       },
-      involvedObject: { uid: '12345678' },
-    },
-    {
-      metadata: {
-        name: 'event2',
+      {
+        kind: 'Event',
+        metadata: {
+          name: 'event2',
+        },
+        involvedObject: { uid: '12345678' },
       },
-      involvedObject: { uid: '12345678' },
-    },
-    {
-      metadata: {
-        name: 'event3',
+      {
+        kind: 'Event',
+        metadata: {
+          name: 'event3',
+        },
+        involvedObject: { uid: '1234' },
       },
-      involvedObject: { uid: '1234' },
-    },
-  ];
-  const eventsStore = writable<CoreV1Event[]>(events);
-  vi.mocked(kubeContextStore).kubernetesCurrentContextEvents = eventsStore;
+    ];
 
-  vi.mocked(window.kubernetesReadNamespacedDeployment).mockResolvedValue(deployment);
+    initLists([deployment], events);
 
-  render(DeploymentDetails, { name: 'my-deployment', namespace: 'default' });
-  router.goto('summary');
-  await waitFor(() => {
-    expect(deploymentDetailsSummarySpy).toHaveBeenCalledWith(expect.anything(), {
-      deployment: deployment,
-      events: [events[0], events[1]],
+    vi.mocked(window.kubernetesReadNamespacedDeployment).mockResolvedValue(deployment);
+
+    render(DeploymentDetails, { name: 'my-deployment', namespace: 'default' });
+    router.goto('summary');
+    await vi.waitFor(() => {
+      expect(deploymentDetailsSummarySpy).toHaveBeenCalledWith(expect.anything(), {
+        deployment: deployment,
+        events: [events[0], events[1]],
+      });
     });
   });
 });


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Display deployment details in experimental mode

### Screenshot / video of UI

### What issues does this PR fix or reference?

Part of #10657 

### How to test this PR?

Test in experimental and non experimental mode:
- create a deployment 
- go to Kubernetes > Deployments > Details
- check that the summary of deployment is displayed
- check that Inspect tab displays YAML
- check that the deployemnt can be updated from the Kube tab
- change replicas count from terminal (`kubectl scale deployment/my-deployment --replicas 1`) and check that the related events are displayed reactively in the Summary page 

- [x] Tests are covering the bug fix or the new feature
