### PR TITLE
chore: updated wsl check version message

### DIFF
--- a/extensions/podman/packages/extension/src/podman-install.spec.ts
+++ b/extensions/podman/packages/extension/src/podman-install.spec.ts
@@ -376,7 +376,9 @@ test('expect WSLVersion preflight check return fail result if wsl --version comm
   const winWSLCheck = new WSLVersionCheck();
   const result = await winWSLCheck.execute();
   expect(result.description).equal('WSL version should be >= 1.2.5.');
-  expect(result.docLinksDescription).equal(`Call 'wsl --version' in a terminal to check your wsl version.`);
+  expect(result.docLinksDescription).equal(
+    `Call 'wsl --update' and 'wsl --version' in a terminal to check your wsl version.`,
+  );
 });
 
 test('expect WSLVersion preflight check return fail result if first line output do not contain any colon symbol', async () => {
@@ -389,7 +391,9 @@ test('expect WSLVersion preflight check return fail result if first line output 
   const winWSLCheck = new WSLVersionCheck();
   const result = await winWSLCheck.execute();
   expect(result.description).equal('WSL version should be >= 1.2.5.');
-  expect(result.docLinksDescription).equal(`Call 'wsl --version' in a terminal to check your wsl version.`);
+  expect(result.docLinksDescription).equal(
+    `Call 'wsl --update' and 'wsl --version' in a terminal to check your wsl version.`,
+  );
 });
 
 test('expect WSLVersion preflight check return fail result if first line output do not contain any wsl word', async () => {
@@ -402,7 +406,9 @@ test('expect WSLVersion preflight check return fail result if first line output 
   const winWSLCheck = new WSLVersionCheck();
   const result = await winWSLCheck.execute();
   expect(result.description).equal('WSL version should be >= 1.2.5.');
-  expect(result.docLinksDescription).equal(`Call 'wsl --version' in a terminal to check your wsl version.`);
+  expect(result.docLinksDescription).equal(
+    `Call 'wsl --update' and 'wsl --version' in a terminal to check your wsl version.`,
+  );
 });
 
 test('expect WSLVersion preflight check return fail result if first line output contain an invalid version', async () => {

--- a/extensions/podman/packages/extension/src/podman-install.ts
+++ b/extensions/podman/packages/extension/src/podman-install.ts
@@ -842,7 +842,7 @@ export class WSLVersionCheck extends BaseCheck {
     }
     return this.createFailureResult({
       description: `WSL version should be >= ${this.minVersion}.`,
-      docLinksDescription: `Call 'wsl --version' in a terminal to check your wsl version.`,
+      docLinksDescription: `Call 'wsl --update' and 'wsl --version' in a terminal to check your wsl version.`,
     });
   }
 }


### PR DESCRIPTION
### What does this PR do?
Updates message with running `wsl --update` to update the version

### Screenshot / video of UI
![image](https://github.com/user-attachments/assets/151d1509-661f-49ed-8f96-9653f07615d0)


### What issues does this PR fix or reference?
Closes #4982 

### How to test this PR?
Go to Global onboarding (Podman)

- [x] Tests are covering the bug fix or the new feature
