### PR TITLE
chore: remove kubernetesListPods

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022-2024 Red Hat, Inc.
+ * Copyright (C) 2022-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -2430,10 +2430,6 @@ export class PluginSystem {
         return kubernetesClient.createIngress(namespace, ingress);
       },
     );
-
-    this.ipcHandle('kubernetes-client:listPods', async (): Promise<PodInfo[]> => {
-      return kubernetesClient.listPods();
-    });
 
     this.ipcHandle('kubernetes-client:listRoutes', async (): Promise<V1Route[]> => {
       return kubernetesClient.listRoutes();

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1991,10 +1991,6 @@ export function initExposure(): void {
     },
   );
 
-  contextBridge.exposeInMainWorld('kubernetesListPods', async (): Promise<PodInfo[]> => {
-    return ipcInvoke('kubernetes-client:listPods');
-  });
-
   contextBridge.exposeInMainWorld('kubernetesListRoutes', async (): Promise<V1Route[]> => {
     return ipcInvoke('kubernetes-client:listRoutes');
   });

--- a/packages/renderer/src/lib/container/ContainerList.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerList.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2024 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,21 +41,17 @@ const deleteContainerMock = vi.fn();
 const removePodMock = vi.fn();
 const listPodsMock = vi.fn();
 
-const kubernetesListPodsMock = vi.fn();
-
 // fake the window.events object
 beforeAll(() => {
   const onDidUpdateProviderStatusMock = vi.fn();
   (window as any).onDidUpdateProviderStatus = onDidUpdateProviderStatusMock;
   onDidUpdateProviderStatusMock.mockImplementation(() => Promise.resolve());
   listPodsMock.mockImplementation(() => Promise.resolve([]));
-  kubernetesListPodsMock.mockImplementation(() => Promise.resolve([]));
   listViewsMock.mockImplementation(() => Promise.resolve([]));
   getContributedMenusMock.mockImplementation(() => Promise.resolve([]));
   (window as any).listViewsContributions = listViewsMock;
   (window as any).listContainers = listContainersMock;
   (window as any).listPods = listPodsMock;
-  (window as any).kubernetesListPods = kubernetesListPodsMock;
   (window as any).getProviderInfos = getProviderInfosMock;
   (window as any).removePod = removePodMock;
   (window as any).deleteContainer = deleteContainerMock;

--- a/packages/renderer/src/lib/container/ContainerListCompose.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerListCompose.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,8 +38,6 @@ const showMessageBoxMock = vi.fn();
 
 const listPodsMock = vi.fn();
 
-const kubernetesListPodsMock = vi.fn();
-
 const deleteContainersByLabelMock = vi.fn();
 
 // fake the window.events object
@@ -49,10 +47,8 @@ beforeAll(() => {
   (window as any).onDidUpdateProviderStatus = onDidUpdateProviderStatusMock;
   onDidUpdateProviderStatusMock.mockImplementation(() => Promise.resolve());
   listPodsMock.mockImplementation(() => Promise.resolve([]));
-  kubernetesListPodsMock.mockImplementation(() => Promise.resolve([]));
   (window as any).listContainers = listContainersMock;
   (window as any).listPods = listPodsMock;
-  (window as any).kubernetesListPods = kubernetesListPodsMock;
   (window as any).getProviderInfos = getProviderInfosMock;
   (window as any).deleteContainersByLabel = deleteContainersByLabelMock;
   const listViewsContributionsMock = vi.fn();

--- a/packages/renderer/src/lib/pod/PodDetails.spec.ts
+++ b/packages/renderer/src/lib/pod/PodDetails.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,6 @@ vi.mock('@xterm/addon-search');
 
 const listPodsMock = vi.fn();
 const listContainersMock = vi.fn();
-const kubernetesListPodsMock = vi.fn();
 const showMessageBoxMock = vi.fn();
 const getConfigurationValueMock = vi.fn();
 
@@ -66,7 +65,6 @@ beforeAll(() => {
   Object.defineProperty(window, 'showMessageBox', { value: showMessageBoxMock });
   Object.defineProperty(window, 'listPods', { value: listPodsMock });
   Object.defineProperty(window, 'listContainers', { value: listContainersMock.mockResolvedValue([]) });
-  Object.defineProperty(window, 'kubernetesListPods', { value: kubernetesListPodsMock });
   Object.defineProperty(window, 'removePod', { value: removePodMock });
   Object.defineProperty(window, 'getContributedMenus', { value: getContributedMenusMock });
   Object.defineProperty(window, 'getConfigurationValue', { value: getConfigurationValueMock, writable: true });
@@ -92,7 +90,6 @@ test('Expect redirect to previous page if pod is deleted', async () => {
   showMessageBoxMock.mockResolvedValue({ response: 0 });
   const routerGotoSpy = vi.spyOn(router, 'goto');
   listPodsMock.mockResolvedValue([myPod]);
-  kubernetesListPodsMock.mockResolvedValue([]);
   window.dispatchEvent(new CustomEvent('extensions-already-started'));
   while (get(podsInfos).length !== 1) {
     await new Promise(resolve => setTimeout(resolve, 500));
@@ -143,7 +140,6 @@ test('Expect redirect to logs', async () => {
     return (): void => {};
   });
   listPodsMock.mockResolvedValue([myPod]);
-  kubernetesListPodsMock.mockResolvedValue([]);
   window.dispatchEvent(new CustomEvent('extensions-already-started'));
   while (get(podsInfos).length !== 1) {
     await new Promise(resolve => setTimeout(resolve, 500));


### PR DESCRIPTION
### What does this PR do?

Removes the kubernetesListPods function and mocking from renderer, since after #11125 it is no longer used by the Podman pods page.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Another part of #8819.

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature