### PR TITLE
refactor: create helper functions for tests

### DIFF
--- a/packages/renderer/src/lib/configmaps-secrets/ConfigMapDetails.spec.ts
+++ b/packages/renderer/src/lib/configmaps-secrets/ConfigMapDetails.spec.ts
@@ -21,13 +21,18 @@ import '@testing-library/jest-dom/vitest';
 import type { KubernetesObject, V1ConfigMap } from '@kubernetes/client-node';
 import { render, screen } from '@testing-library/svelte';
 import { writable } from 'svelte/store';
-import { beforeAll, expect, test, vi } from 'vitest';
+import { router } from 'tinro';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-import * as kubeContextStore from '/@/stores/kubernetes-contexts-state';
+import * as states from '/@/stores/kubernetes-contexts-state';
+import type { IDisposable } from '/@api/disposable';
 
+import { isKubernetesExperimentalMode, listenResources } from '../kube/resources-listen';
 import ConfigMapDetails from './ConfigMapDetails.svelte';
 
 const configMap: V1ConfigMap = {
+  apiVersion: 'v1',
+  kind: 'ConfigMap',
   metadata: {
     name: 'my-configmap',
     namespace: 'default',
@@ -35,23 +40,74 @@ const configMap: V1ConfigMap = {
   data: {},
 };
 
-vi.mock('/@/stores/kubernetes-contexts-state', async () => {
+vi.mock(import('../kube/resources-listen'), async importOriginal => {
+  // we want to keep the original nonVerbose
+  const original = await importOriginal();
   return {
-    kubernetesCurrentContextConfigMaps: vi.fn(),
+    ...original,
+    listenResources: vi.fn(),
+    isKubernetesExperimentalMode: vi.fn(),
   };
 });
 
-beforeAll(() => {
-  Object.defineProperty(window, 'kubernetesReadNamespacedConfigMap', { value: vi.fn() });
+vi.mock('/@/stores/kubernetes-contexts-state');
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  router.goto('http://localhost:3000');
 });
 
-test('Confirm renders configmap details', async () => {
-  // mock object store
-  const configMaps = writable<KubernetesObject[]>([configMap]);
-  vi.mocked(kubeContextStore).kubernetesCurrentContextConfigMaps = configMaps;
+type initListsReturnType = {
+  updateDeployments: (objects: KubernetesObject[]) => void;
+};
 
-  render(ConfigMapDetails, { name: 'my-configmap', namespace: 'default' });
+describe.each<{
+  experimental: boolean;
+  initLists: (configmaps: KubernetesObject[]) => initListsReturnType;
+}>([
+  {
+    experimental: false,
+    initLists: (configmaps: KubernetesObject[]): initListsReturnType => {
+      const configmapsStore = writable<KubernetesObject[]>(configmaps);
+      vi.mocked(states).kubernetesCurrentContextConfigMaps = configmapsStore;
+      return {
+        updateDeployments: (configmaps: KubernetesObject[]): void => {
+          configmapsStore.set(configmaps);
+        },
+      };
+    },
+  },
+  {
+    experimental: true,
+    initLists: (configmaps: KubernetesObject[]): initListsReturnType => {
+      let configmapsCallback: (resoures: KubernetesObject[]) => void;
+      vi.mocked(listenResources).mockImplementation(async (resourceName, _options, cb): Promise<IDisposable> => {
+        configmapsCallback = cb;
+        setTimeout(() => configmapsCallback(configmaps));
+        return {
+          dispose: (): void => {},
+        };
+      });
+      return {
+        updateDeployments: (updatedObjects: KubernetesObject[]): void => {
+          configmapsCallback(updatedObjects);
+        },
+      };
+    },
+  },
+])('is experimental: $experimental', ({ experimental, initLists }) => {
+  beforeEach(() => {
+    vi.mocked(isKubernetesExperimentalMode).mockResolvedValue(experimental);
+  });
 
-  expect(screen.getByText('my-configmap')).toBeInTheDocument();
-  expect(screen.getByText('default')).toBeInTheDocument();
+  test('Confirm renders configmap details', async () => {
+    initLists([configMap]);
+
+    render(ConfigMapDetails, { name: 'my-configmap', namespace: 'default' });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('my-configmap')).toBeInTheDocument();
+      expect(screen.getByText('default')).toBeInTheDocument();
+    });
+  });
 });

--- a/packages/renderer/src/lib/configmaps-secrets/ConfigMapDetails.spec.ts
+++ b/packages/renderer/src/lib/configmaps-secrets/ConfigMapDetails.spec.ts
@@ -23,14 +23,14 @@ import { render, screen } from '@testing-library/svelte';
 import { router } from 'tinro';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-import * as states from '/@/stores/kubernetes-contexts-state';
-
-import { isKubernetesExperimentalMode } from '../kube/resources-listen';
+import { isKubernetesExperimentalMode } from '/@/lib/kube/resources-listen';
 import {
   initListExperimental,
   initListsNonExperimental,
   type initListsReturnType,
-} from '../kube/tests-helpers/init-lists';
+} from '/@/lib/kube/tests-helpers/init-lists';
+import * as states from '/@/stores/kubernetes-contexts-state';
+
 import ConfigMapDetails from './ConfigMapDetails.svelte';
 
 const configMap: V1ConfigMap = {
@@ -43,7 +43,7 @@ const configMap: V1ConfigMap = {
   data: {},
 };
 
-vi.mock(import('../kube/resources-listen'), async importOriginal => {
+vi.mock(import('/@/lib/kube/resources-listen'), async importOriginal => {
   // we want to keep the original nonVerbose
   const original = await importOriginal();
   return {

--- a/packages/renderer/src/lib/configmaps-secrets/ConfigMapDetails.svelte
+++ b/packages/renderer/src/lib/configmaps-secrets/ConfigMapDetails.svelte
@@ -1,16 +1,18 @@
 <script lang="ts">
-import type { V1ConfigMap } from '@kubernetes/client-node';
+import type { KubernetesObject, V1ConfigMap } from '@kubernetes/client-node';
 import { StatusIcon, Tab } from '@podman-desktop/ui-svelte';
-import { onMount } from 'svelte';
+import { onDestroy, onMount } from 'svelte';
 import { router } from 'tinro';
 import { stringify } from 'yaml';
 
 import { kubernetesCurrentContextConfigMaps } from '/@/stores/kubernetes-contexts-state';
+import type { IDisposable } from '/@api/disposable';
 
 import Route from '../../Route.svelte';
 import MonacoEditor from '../editor/MonacoEditor.svelte';
 import ConfigMapIcon from '../images/ConfigMapSecretIcon.svelte';
 import KubeEditYAML from '../kube/KubeEditYAML.svelte';
+import { listenResource } from '../kube/resource-listen';
 import DetailsPage from '../ui/DetailsPage.svelte';
 import StateChange from '../ui/StateChange.svelte';
 import { getTabUrl, isTabSelected } from '../ui/Util';
@@ -19,37 +21,54 @@ import ConfigMapDetailsSummary from './ConfigMapDetailsSummary.svelte';
 import ConfigMapSecretActions from './ConfigMapSecretActions.svelte';
 import type { ConfigMapSecretUI } from './ConfigMapSecretUI';
 
-export let name: string;
-export let namespace: string;
+interface Props {
+  name: string;
+  namespace: string;
+}
+let { name, namespace }: Props = $props();
 
-let configMap: ConfigMapSecretUI;
-let detailsPage: DetailsPage;
-let kubeConfigMap: V1ConfigMap | undefined;
-let kubeError: string;
+let configMap: ConfigMapSecretUI | undefined = $state(undefined);
+let detailsPage: DetailsPage | undefined = $state(undefined);
+let kubeConfigMap: V1ConfigMap | undefined = $state(undefined);
+let kubeError: string | undefined = $state(undefined);
 
-onMount(() => {
+let listener: IDisposable | undefined;
+
+onMount(async () => {
   const configMapUtils = new ConfigMapSecretUtils();
-  // loading configMap info
-  return kubernetesCurrentContextConfigMaps.subscribe(configMaps => {
-    const matchingConfigMap = configMaps.find(
-      configMap => configMap.metadata?.name === name && configMap.metadata?.namespace === namespace,
-    );
-    if (matchingConfigMap) {
-      configMap = configMapUtils.getConfigMapSecretUI(matchingConfigMap);
-      loadDetails().catch((err: unknown) => console.error(`Error getting config map ${configMap.name} details`, err));
-    } else if (detailsPage) {
-      // the configMap has been deleted
-      detailsPage.close();
-    }
+  listener = await listenResource({
+    resourceName: 'configmaps',
+    name,
+    namespace,
+    listenEvents: false,
+    legacyResourceStore: kubernetesCurrentContextConfigMaps,
+    onResourceNotFound: () => {
+      if (detailsPage) {
+        // the deployment has been deleted
+        detailsPage.close();
+      }
+    },
+    onResourceUpdated: (resource: KubernetesObject, isExperimental: boolean) => {
+      configMap = configMapUtils.getConfigMapSecretUI(resource);
+      if (isExperimental) {
+        kubeConfigMap = resource;
+      } else {
+        loadDetails().catch((err: unknown) => console.error(`Error getting config map ${name} details`, err));
+      }
+    },
   });
 });
 
+onDestroy(() => {
+  listener?.dispose();
+});
+
 async function loadDetails(): Promise<void> {
-  const getKubeConfigMap = await window.kubernetesReadNamespacedConfigMap(configMap.name, namespace);
+  const getKubeConfigMap = await window.kubernetesReadNamespacedConfigMap(name, namespace);
   if (getKubeConfigMap) {
     kubeConfigMap = getKubeConfigMap;
   } else {
-    kubeError = `Unable to retrieve Kubernetes details for ${configMap.name}`;
+    kubeError = `Unable to retrieve Kubernetes details for ${name}`;
   }
 }
 </script>
@@ -58,7 +77,7 @@ async function loadDetails(): Promise<void> {
   <DetailsPage title={configMap.name} subtitle={configMap.namespace} bind:this={detailsPage}>
     <StatusIcon slot="icon" icon={ConfigMapIcon} size={24} status={configMap.status} />
     <svelte:fragment slot="actions">
-      <ConfigMapSecretActions configMapSecret={configMap} detailed={true} on:update={(): ConfigMapSecretUI => (configMap = configMap)} />
+      <ConfigMapSecretActions configMapSecret={configMap} detailed={true} on:update={(): ConfigMapSecretUI | undefined => (configMap = configMap)} />
     </svelte:fragment>
     <div slot="detail" class="flex py-2 w-full justify-end text-sm text-[var(--pd-content-text)]">
       <StateChange state={configMap.status} />

--- a/packages/renderer/src/lib/configmaps-secrets/ConfigMapDetails.svelte
+++ b/packages/renderer/src/lib/configmaps-secrets/ConfigMapDetails.svelte
@@ -5,6 +5,7 @@ import { onDestroy, onMount } from 'svelte';
 import { router } from 'tinro';
 import { stringify } from 'yaml';
 
+import { listenResource } from '/@/lib/kube/resource-listen';
 import { kubernetesCurrentContextConfigMaps } from '/@/stores/kubernetes-contexts-state';
 import type { IDisposable } from '/@api/disposable';
 
@@ -12,7 +13,6 @@ import Route from '../../Route.svelte';
 import MonacoEditor from '../editor/MonacoEditor.svelte';
 import ConfigMapIcon from '../images/ConfigMapSecretIcon.svelte';
 import KubeEditYAML from '../kube/KubeEditYAML.svelte';
-import { listenResource } from '../kube/resource-listen';
 import DetailsPage from '../ui/DetailsPage.svelte';
 import StateChange from '../ui/StateChange.svelte';
 import { getTabUrl, isTabSelected } from '../ui/Util';

--- a/packages/renderer/src/lib/cronjob/CronJobList.spec.ts
+++ b/packages/renderer/src/lib/cronjob/CronJobList.spec.ts
@@ -23,14 +23,14 @@ import { render, screen } from '@testing-library/svelte';
 import { writable } from 'svelte/store';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
+import * as resourcesListen from '/@/lib/kube/resources-listen';
 import * as states from '/@/stores/kubernetes-contexts-state';
 import type { IDisposable } from '/@api/disposable.js';
 
-import * as resourcesListen from '../kube/resources-listen';
 import CronJobList from './CronJobList.svelte';
 
 vi.mock('/@/stores/kubernetes-contexts-state');
-vi.mock('../kube/resources-listen');
+vi.mock('/@/lib/kube/resources-listen');
 
 beforeEach(() => {
   vi.resetAllMocks();

--- a/packages/renderer/src/lib/deployments/DeploymentDetails.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentDetails.spec.ts
@@ -23,10 +23,10 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { router } from 'tinro';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
+import { isKubernetesExperimentalMode } from '/@/lib/kube/resources-listen';
 import { lastPage } from '/@/stores/breadcrumb';
 import * as states from '/@/stores/kubernetes-contexts-state';
 
-import { isKubernetesExperimentalMode } from '../kube/resources-listen';
 import {
   initListExperimental,
   initListsNonExperimental,
@@ -49,7 +49,7 @@ const deployment: V1Deployment = {
     template: {},
   },
 };
-vi.mock(import('../kube/resources-listen'), async importOriginal => {
+vi.mock(import('/@/lib/kube/resources-listen'), async importOriginal => {
   // we want to keep the original nonVerbose
   const original = await importOriginal();
   return {

--- a/packages/renderer/src/lib/deployments/DeploymentDetails.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentDetails.spec.ts
@@ -20,15 +20,18 @@ import '@testing-library/jest-dom/vitest';
 
 import type { CoreV1Event, KubernetesObject, V1Deployment } from '@kubernetes/client-node';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
-import { writable } from 'svelte/store';
 import { router } from 'tinro';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { lastPage } from '/@/stores/breadcrumb';
 import * as states from '/@/stores/kubernetes-contexts-state';
-import type { IDisposable } from '/@api/disposable.js';
 
-import { isKubernetesExperimentalMode, listenResources } from '../kube/resources-listen';
+import { isKubernetesExperimentalMode } from '../kube/resources-listen';
+import {
+  initListExperimental,
+  initListsNonExperimental,
+  type initListsReturnType,
+} from '../kube/tests-helpers/init-lists';
 import DeploymentDetails from './DeploymentDetails.svelte';
 import * as deploymentDetailsSummary from './DeploymentDetailsSummary.svelte';
 
@@ -63,61 +66,20 @@ beforeEach(() => {
   router.goto('http://localhost:3000');
 });
 
-type initListsReturnType = {
-  updateDeployments: (objects: KubernetesObject[]) => void;
-  updateEvents: (objects: CoreV1Event[]) => void;
-};
-
 describe.each<{
   experimental: boolean;
   initLists: (deployments: KubernetesObject[], events: CoreV1Event[]) => initListsReturnType;
 }>([
   {
     experimental: false,
-    initLists: (deployments: KubernetesObject[], events: CoreV1Event[]): initListsReturnType => {
-      const deploymentsStore = writable<KubernetesObject[]>(deployments);
-      vi.mocked(states).kubernetesCurrentContextDeployments = deploymentsStore;
-      const eventsStore = writable<CoreV1Event[]>(events);
-      vi.mocked(states).kubernetesCurrentContextEvents = eventsStore;
-      return {
-        updateDeployments: (deployments: KubernetesObject[]): void => {
-          deploymentsStore.set(deployments);
-        },
-        updateEvents: (events: CoreV1Event[]): void => {
-          eventsStore.set(events);
-        },
-      };
-    },
+    initLists: initListsNonExperimental({
+      onResourcesStore: store => (vi.mocked(states).kubernetesCurrentContextDeployments = store),
+      onEventsStore: store => (vi.mocked(states).kubernetesCurrentContextEvents = store),
+    }),
   },
   {
     experimental: true,
-    initLists: (deployments: KubernetesObject[], events: CoreV1Event[]): initListsReturnType => {
-      let deploymentsCallback: (resoures: KubernetesObject[]) => void;
-      let eventsCallback: (resoures: CoreV1Event[]) => void;
-      vi.mocked(listenResources).mockImplementation(async (resourceName, _options, cb): Promise<IDisposable> => {
-        if (resourceName === 'deployments') {
-          deploymentsCallback = cb;
-          setTimeout(() => deploymentsCallback(deployments));
-          return {
-            dispose: (): void => {},
-          };
-        } else {
-          eventsCallback = cb;
-          setTimeout(() => eventsCallback(events));
-          return {
-            dispose: (): void => {},
-          };
-        }
-      });
-      return {
-        updateDeployments: (updatedObjects: KubernetesObject[]): void => {
-          deploymentsCallback(updatedObjects);
-        },
-        updateEvents: (updatedObjects: CoreV1Event[]): void => {
-          eventsCallback(updatedObjects);
-        },
-      };
-    },
+    initLists: initListExperimental({ resourceName: 'deployments' }),
   },
 ])('is experimental: $experimental', ({ experimental, initLists }) => {
   beforeEach(() => {
@@ -134,7 +96,7 @@ describe.each<{
 
     // remove deployment from the store when we call delete
     vi.mocked(window.kubernetesDeleteDeployment).mockImplementation(async () => {
-      list.updateDeployments([]);
+      list.updateResources([]);
     });
 
     // define a fake lastPage so we can check where we will be redirected

--- a/packages/renderer/src/lib/deployments/DeploymentDetails.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentDetails.spec.ts
@@ -24,14 +24,14 @@ import { router } from 'tinro';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { isKubernetesExperimentalMode } from '/@/lib/kube/resources-listen';
-import { lastPage } from '/@/stores/breadcrumb';
-import * as states from '/@/stores/kubernetes-contexts-state';
-
 import {
   initListExperimental,
   initListsNonExperimental,
   type initListsReturnType,
-} from '../kube/tests-helpers/init-lists';
+} from '/@/lib/kube/tests-helpers/init-lists';
+import { lastPage } from '/@/stores/breadcrumb';
+import * as states from '/@/stores/kubernetes-contexts-state';
+
 import DeploymentDetails from './DeploymentDetails.svelte';
 import * as deploymentDetailsSummary from './DeploymentDetailsSummary.svelte';
 

--- a/packages/renderer/src/lib/deployments/DeploymentDetails.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentDetails.svelte
@@ -5,6 +5,7 @@ import { onDestroy, onMount } from 'svelte';
 import { router } from 'tinro';
 import { stringify } from 'yaml';
 
+import { listenResource } from '/@/lib/kube/resource-listen';
 import {
   kubernetesCurrentContextDeployments,
   kubernetesCurrentContextEvents,
@@ -16,7 +17,6 @@ import MonacoEditor from '../editor/MonacoEditor.svelte';
 import type { EventUI } from '../events/EventUI';
 import DeploymentIcon from '../images/DeploymentIcon.svelte';
 import KubeEditYAML from '../kube/KubeEditYAML.svelte';
-import { listenResource } from '../kube/resource-listen';
 import DetailsPage from '../ui/DetailsPage.svelte';
 import { getTabUrl, isTabSelected } from '../ui/Util';
 import { DeploymentUtils } from './deployment-utils';

--- a/packages/renderer/src/lib/deployments/DeploymentsList.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentsList.spec.ts
@@ -23,14 +23,14 @@ import { fireEvent, render, screen, within } from '@testing-library/svelte';
 import { writable } from 'svelte/store';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
+import * as resourcesListen from '/@/lib/kube/resources-listen';
 import * as states from '/@/stores/kubernetes-contexts-state';
 import type { IDisposable } from '/@api/disposable.js';
 
-import * as resourcesListen from '../kube/resources-listen';
 import DeploymentsList from './DeploymentsList.svelte';
 
 vi.mock('/@/stores/kubernetes-contexts-state');
-vi.mock('../kube/resources-listen');
+vi.mock('/@/lib/kube/resources-listen');
 
 beforeEach(() => {
   vi.resetAllMocks();

--- a/packages/renderer/src/lib/kube/tests-helpers/init-lists.ts
+++ b/packages/renderer/src/lib/kube/tests-helpers/init-lists.ts
@@ -20,9 +20,8 @@ import type { CoreV1Event, KubernetesObject } from '@kubernetes/client-node';
 import { type Writable, writable } from 'svelte/store';
 import { vi } from 'vitest';
 
+import { listenResources } from '/@/lib/kube/resources-listen';
 import type { IDisposable } from '/@api/disposable';
-
-import { listenResources } from '../resources-listen';
 
 export type initListsReturnType = {
   updateResources: (objects: KubernetesObject[]) => void;

--- a/packages/renderer/src/lib/kube/tests-helpers/init-lists.ts
+++ b/packages/renderer/src/lib/kube/tests-helpers/init-lists.ts
@@ -1,0 +1,82 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { CoreV1Event, KubernetesObject } from '@kubernetes/client-node';
+import { type Writable, writable } from 'svelte/store';
+import { vi } from 'vitest';
+
+import type { IDisposable } from '/@api/disposable';
+
+import { listenResources } from '../resources-listen';
+
+export type initListsReturnType = {
+  updateResources: (objects: KubernetesObject[]) => void;
+  updateEvents: (objects: CoreV1Event[]) => void;
+};
+
+export function initListsNonExperimental(options: {
+  onResourcesStore: (store: Writable<KubernetesObject[]>) => void;
+  onEventsStore: (store: Writable<CoreV1Event[]>) => void;
+}): (resources: KubernetesObject[], events: CoreV1Event[]) => initListsReturnType {
+  return (resources: KubernetesObject[], events: CoreV1Event[]): initListsReturnType => {
+    const resourcesStore = writable<KubernetesObject[]>(resources);
+    options.onResourcesStore(resourcesStore);
+    const eventsStore = writable<CoreV1Event[]>(events);
+    options.onEventsStore(eventsStore);
+    return {
+      updateResources: (resources: KubernetesObject[]): void => {
+        resourcesStore.set(resources);
+      },
+      updateEvents: (events: CoreV1Event[]): void => {
+        eventsStore.set(events);
+      },
+    };
+  };
+}
+
+export function initListExperimental(options: {
+  resourceName: string;
+}): (resources: KubernetesObject[], events: CoreV1Event[]) => initListsReturnType {
+  return (resources: KubernetesObject[], events: CoreV1Event[]): initListsReturnType => {
+    let resourcesCallback: (resources: KubernetesObject[]) => void;
+    let eventsCallback: (resources: CoreV1Event[]) => void;
+    vi.mocked(listenResources).mockImplementation(async (listenedResourceName, _options, cb): Promise<IDisposable> => {
+      if (listenedResourceName === options.resourceName) {
+        resourcesCallback = cb;
+        setTimeout(() => resourcesCallback(resources));
+        return {
+          dispose: (): void => {},
+        };
+      } else {
+        eventsCallback = cb;
+        setTimeout(() => eventsCallback(events));
+        return {
+          dispose: (): void => {},
+        };
+      }
+    });
+    return {
+      updateResources: (updatedObjects: KubernetesObject[]): void => {
+        resourcesCallback(updatedObjects);
+      },
+      updateEvents: (updatedObjects: CoreV1Event[]): void => {
+        eventsCallback(updatedObjects);
+      },
+    };
+  };
+}

--- a/packages/renderer/src/lib/node/NodeDetails.spec.ts
+++ b/packages/renderer/src/lib/node/NodeDetails.spec.ts
@@ -23,13 +23,13 @@ import { router } from 'tinro';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { isKubernetesExperimentalMode } from '/@/lib/kube/resources-listen';
-import * as states from '/@/stores/kubernetes-contexts-state';
-
 import {
   initListExperimental,
   initListsNonExperimental,
   type initListsReturnType,
-} from '../kube/tests-helpers/init-lists';
+} from '/@/lib/kube/tests-helpers/init-lists';
+import * as states from '/@/stores/kubernetes-contexts-state';
+
 import NodeDetails from './NodeDetails.svelte';
 import * as nodeDetailsSummary from './NodeDetailsSummary.svelte';
 

--- a/packages/renderer/src/lib/node/NodeDetails.spec.ts
+++ b/packages/renderer/src/lib/node/NodeDetails.spec.ts
@@ -19,14 +19,17 @@ import '@testing-library/jest-dom/vitest';
 
 import type { CoreV1Event, KubernetesObject, V1Node } from '@kubernetes/client-node';
 import { render, screen } from '@testing-library/svelte';
-import { writable } from 'svelte/store';
 import { router } from 'tinro';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import * as states from '/@/stores/kubernetes-contexts-state';
-import type { IDisposable } from '/@api/disposable.js';
 
-import { isKubernetesExperimentalMode, listenResources } from '../kube/resources-listen';
+import { isKubernetesExperimentalMode } from '../kube/resources-listen';
+import {
+  initListExperimental,
+  initListsNonExperimental,
+  type initListsReturnType,
+} from '../kube/tests-helpers/init-lists';
 import NodeDetails from './NodeDetails.svelte';
 import * as nodeDetailsSummary from './NodeDetailsSummary.svelte';
 
@@ -57,61 +60,20 @@ beforeEach(() => {
   router.goto('http://localhost:3000');
 });
 
-type initListsReturnType = {
-  updateNodes: (objects: KubernetesObject[]) => void;
-  updateEvents: (objects: CoreV1Event[]) => void;
-};
-
 describe.each<{
   experimental: boolean;
-  initLists: (nodes: KubernetesObject[], events: CoreV1Event[]) => initListsReturnType;
+  initLists: (resources: KubernetesObject[], events: CoreV1Event[]) => initListsReturnType;
 }>([
   {
     experimental: false,
-    initLists: (nodes: KubernetesObject[], events: CoreV1Event[]): initListsReturnType => {
-      const nodesStore = writable<KubernetesObject[]>(nodes);
-      vi.mocked(states).kubernetesCurrentContextNodes = nodesStore;
-      const eventsStore = writable<CoreV1Event[]>(events);
-      vi.mocked(states).kubernetesCurrentContextEvents = eventsStore;
-      return {
-        updateNodes: (nodes: KubernetesObject[]): void => {
-          nodesStore.set(nodes);
-        },
-        updateEvents: (events: CoreV1Event[]): void => {
-          eventsStore.set(events);
-        },
-      };
-    },
+    initLists: initListsNonExperimental({
+      onResourcesStore: store => (vi.mocked(states).kubernetesCurrentContextNodes = store),
+      onEventsStore: store => (vi.mocked(states).kubernetesCurrentContextEvents = store),
+    }),
   },
   {
     experimental: true,
-    initLists: (nodes: KubernetesObject[], events: CoreV1Event[]): initListsReturnType => {
-      let nodesCallback: (resources: KubernetesObject[]) => void;
-      let eventsCallback: (resources: CoreV1Event[]) => void;
-      vi.mocked(listenResources).mockImplementation(async (resourceName, _options, cb): Promise<IDisposable> => {
-        if (resourceName === 'nodes') {
-          nodesCallback = cb;
-          setTimeout(() => nodesCallback(nodes));
-          return {
-            dispose: (): void => {},
-          };
-        } else {
-          eventsCallback = cb;
-          setTimeout(() => eventsCallback(events));
-          return {
-            dispose: (): void => {},
-          };
-        }
-      });
-      return {
-        updateNodes: (updatedObjects: KubernetesObject[]): void => {
-          nodesCallback(updatedObjects);
-        },
-        updateEvents: (updatedObjects: CoreV1Event[]): void => {
-          eventsCallback(updatedObjects);
-        },
-      };
-    },
+    initLists: initListExperimental({ resourceName: 'nodes' }),
   },
 ])('is experimental: $experimental', ({ experimental, initLists }) => {
   beforeEach(() => {

--- a/packages/renderer/src/lib/node/NodeDetails.spec.ts
+++ b/packages/renderer/src/lib/node/NodeDetails.spec.ts
@@ -22,9 +22,9 @@ import { render, screen } from '@testing-library/svelte';
 import { router } from 'tinro';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
+import { isKubernetesExperimentalMode } from '/@/lib/kube/resources-listen';
 import * as states from '/@/stores/kubernetes-contexts-state';
 
-import { isKubernetesExperimentalMode } from '../kube/resources-listen';
 import {
   initListExperimental,
   initListsNonExperimental,
@@ -43,7 +43,7 @@ const node: V1Node = {
   },
 } as V1Node;
 
-vi.mock(import('../kube/resources-listen'), async importOriginal => {
+vi.mock(import('/@/lib/kube/resources-listen'), async importOriginal => {
   // we want to keep the original nonVerbose
   const original = await importOriginal();
   return {

--- a/packages/renderer/src/lib/node/NodeDetails.svelte
+++ b/packages/renderer/src/lib/node/NodeDetails.svelte
@@ -5,6 +5,7 @@ import { onDestroy, onMount } from 'svelte';
 import { router } from 'tinro';
 import { stringify } from 'yaml';
 
+import { listenResource } from '/@/lib/kube/resource-listen';
 import { kubernetesCurrentContextEvents, kubernetesCurrentContextNodes } from '/@/stores/kubernetes-contexts-state';
 import type { IDisposable } from '/@api/disposable.js';
 
@@ -13,7 +14,6 @@ import MonacoEditor from '../editor/MonacoEditor.svelte';
 import type { EventUI } from '../events/EventUI';
 import NodeIcon from '../images/NodeIcon.svelte';
 import KubeEditYAML from '../kube/KubeEditYAML.svelte';
-import { listenResource } from '../kube/resource-listen';
 import DetailsPage from '../ui/DetailsPage.svelte';
 import { getTabUrl, isTabSelected } from '../ui/Util';
 import { NodeUtils } from './node-utils';

--- a/packages/renderer/src/lib/objects/KubernetesObjectsList.svelte
+++ b/packages/renderer/src/lib/objects/KubernetesObjectsList.svelte
@@ -6,11 +6,11 @@ import { Button, FilteredEmptyScreen, NavPage, Table } from '@podman-desktop/ui-
 import { onDestroy, onMount, type Snippet } from 'svelte';
 import { type Readable, type Unsubscriber, type Writable } from 'svelte/store';
 
+import { listenResources } from '/@/lib/kube/resources-listen';
 import type { IDisposable } from '/@api/disposable.js';
 
 import { withBulkConfirmation } from '../actions/BulkActions';
 import KubeActions from '../kube/KubeActions.svelte';
-import { listenResources } from '../kube/resources-listen';
 import KubernetesCurrentContextConnectionBadge from '../ui/KubernetesCurrentContextConnectionBadge.svelte';
 import type { KubernetesObjectUI } from './KubernetesObjectUI';
 

--- a/packages/renderer/src/lib/service/ServiceDetails.spec.ts
+++ b/packages/renderer/src/lib/service/ServiceDetails.spec.ts
@@ -24,14 +24,14 @@ import { router } from 'tinro';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import * as resourcesListen from '/@/lib/kube/resources-listen';
-import { lastPage } from '/@/stores/breadcrumb';
-import * as states from '/@/stores/kubernetes-contexts-state';
-
 import {
   initListExperimental,
   initListsNonExperimental,
   type initListsReturnType,
-} from '../kube/tests-helpers/init-lists';
+} from '/@/lib/kube/tests-helpers/init-lists';
+import { lastPage } from '/@/stores/breadcrumb';
+import * as states from '/@/stores/kubernetes-contexts-state';
+
 import ServiceDetails from './ServiceDetails.svelte';
 import * as serviceDetailsSummary from './ServiceDetailsSummary.svelte';
 

--- a/packages/renderer/src/lib/service/ServiceDetails.spec.ts
+++ b/packages/renderer/src/lib/service/ServiceDetails.spec.ts
@@ -20,15 +20,18 @@ import '@testing-library/jest-dom/vitest';
 
 import type { CoreV1Event, KubernetesObject, V1Service } from '@kubernetes/client-node';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
-import { writable } from 'svelte/store';
 import { router } from 'tinro';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { lastPage } from '/@/stores/breadcrumb';
 import * as states from '/@/stores/kubernetes-contexts-state';
-import type { IDisposable } from '/@api/disposable.js';
 
 import * as resourcesListen from '../kube/resources-listen';
+import {
+  initListExperimental,
+  initListsNonExperimental,
+  type initListsReturnType,
+} from '../kube/tests-helpers/init-lists';
 import ServiceDetails from './ServiceDetails.svelte';
 import * as serviceDetailsSummary from './ServiceDetailsSummary.svelte';
 
@@ -59,63 +62,20 @@ beforeEach(() => {
   router.goto('http://localhost:3000');
 });
 
-type initListsReturnType = {
-  updateServices: (objects: KubernetesObject[]) => void;
-  updateEvents: (objects: CoreV1Event[]) => void;
-};
-
 describe.each<{
   experimental: boolean;
   initLists: (services: KubernetesObject[], events: CoreV1Event[]) => initListsReturnType;
 }>([
   {
     experimental: false,
-    initLists: (services: KubernetesObject[], events: CoreV1Event[]): initListsReturnType => {
-      const servciesStore = writable<KubernetesObject[]>(services);
-      vi.mocked(states).kubernetesCurrentContextServices = servciesStore;
-      const eventsStore = writable<CoreV1Event[]>(events);
-      vi.mocked(states).kubernetesCurrentContextEvents = eventsStore;
-      return {
-        updateServices: (services: KubernetesObject[]): void => {
-          servciesStore.set(services);
-        },
-        updateEvents: (events: CoreV1Event[]): void => {
-          eventsStore.set(events);
-        },
-      };
-    },
+    initLists: initListsNonExperimental({
+      onResourcesStore: store => (vi.mocked(states).kubernetesCurrentContextServices = store),
+      onEventsStore: store => (vi.mocked(states).kubernetesCurrentContextEvents = store),
+    }),
   },
   {
     experimental: true,
-    initLists: (services: KubernetesObject[], events: CoreV1Event[]): initListsReturnType => {
-      let servicesCallback: (resoures: KubernetesObject[]) => void;
-      let eventsCallback: (resoures: CoreV1Event[]) => void;
-      vi.mocked(resourcesListen.listenResources).mockImplementation(
-        async (resourceName, _options, cb): Promise<IDisposable> => {
-          if (resourceName === 'services') {
-            servicesCallback = cb;
-            setTimeout(() => servicesCallback(services));
-            return {
-              dispose: (): void => {},
-            };
-          } else {
-            eventsCallback = cb;
-            setTimeout(() => eventsCallback(events));
-            return {
-              dispose: (): void => {},
-            };
-          }
-        },
-      );
-      return {
-        updateServices: (updatedObjects: KubernetesObject[]): void => {
-          servicesCallback(updatedObjects);
-        },
-        updateEvents: (updatedObjects: CoreV1Event[]): void => {
-          eventsCallback(updatedObjects);
-        },
-      };
-    },
+    initLists: initListExperimental({ resourceName: 'services' }),
   },
 ])('is experimental: $experimental', ({ experimental, initLists }) => {
   beforeEach(() => {
@@ -131,7 +91,7 @@ describe.each<{
 
     // remove service from the store when we call delete
     vi.mocked(window.kubernetesDeleteService).mockImplementation(async () => {
-      list.updateServices([]);
+      list.updateResources([]);
     });
 
     // define a fake lastPage so we can check where we will be redirected

--- a/packages/renderer/src/lib/service/ServiceDetails.spec.ts
+++ b/packages/renderer/src/lib/service/ServiceDetails.spec.ts
@@ -23,10 +23,10 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { router } from 'tinro';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
+import * as resourcesListen from '/@/lib/kube/resources-listen';
 import { lastPage } from '/@/stores/breadcrumb';
 import * as states from '/@/stores/kubernetes-contexts-state';
 
-import * as resourcesListen from '../kube/resources-listen';
 import {
   initListExperimental,
   initListsNonExperimental,
@@ -45,7 +45,7 @@ const service: V1Service = {
   status: {},
 };
 
-vi.mock(import('../kube/resources-listen'), async importOriginal => {
+vi.mock(import('/@/lib/kube/resources-listen'), async importOriginal => {
   // we want to keep the original nonVerbose
   const original = await importOriginal();
   return {

--- a/packages/renderer/src/lib/service/ServiceDetails.svelte
+++ b/packages/renderer/src/lib/service/ServiceDetails.svelte
@@ -5,6 +5,7 @@ import { onDestroy, onMount } from 'svelte';
 import { router } from 'tinro';
 import { stringify } from 'yaml';
 
+import { listenResource } from '/@/lib/kube/resource-listen';
 import { kubernetesCurrentContextEvents, kubernetesCurrentContextServices } from '/@/stores/kubernetes-contexts-state';
 import type { IDisposable } from '/@api/disposable.js';
 
@@ -13,7 +14,6 @@ import MonacoEditor from '../editor/MonacoEditor.svelte';
 import type { EventUI } from '../events/EventUI';
 import ServiceIcon from '../images/ServiceIcon.svelte';
 import KubeEditYAML from '../kube/KubeEditYAML.svelte';
-import { listenResource } from '../kube/resource-listen';
 import DetailsPage from '../ui/DetailsPage.svelte';
 import StateChange from '../ui/StateChange.svelte';
 import { getTabUrl, isTabSelected } from '../ui/Util';

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPage.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPage.svelte
@@ -3,10 +3,10 @@ import { Page, Tab } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 import { router } from 'tinro';
 
+import { isKubernetesExperimentalMode } from '/@/lib/kube/resources-listen';
 import Route from '/@/Route.svelte';
 
 import { lastPage } from '../../stores/breadcrumb';
-import { isKubernetesExperimentalMode } from '../kube/resources-listen';
 import { getTabUrl, isTabSelected } from '../ui/Util';
 import TroubleshootingDevToolsConsoleLogs from './TroubleshootingDevToolsConsoleLogs.svelte';
 import TroubleshootingGatherLogs from './TroubleshootingGatherLogs.svelte';


### PR DESCRIPTION
### What does this PR do?

- create helper functions to test the display of Kubernetes resources
- use them for DeploymentDetails, ServiceDetails, NodeDetails and ConfigMapDetails

### Screenshot / video of UI

### What issues does this PR fix or reference?

Part of #11102 

### How to test this PR?

- [ ] Tests are covering the bug fix or the new feature
