### PR TITLE
feat: display secret details in experimental mode

### DIFF
--- a/packages/renderer/src/lib/configmaps-secrets/SecretDetails.spec.ts
+++ b/packages/renderer/src/lib/configmaps-secrets/SecretDetails.spec.ts
@@ -20,14 +20,22 @@ import '@testing-library/jest-dom/vitest';
 
 import type { KubernetesObject, V1Secret } from '@kubernetes/client-node';
 import { render, screen } from '@testing-library/svelte';
-import { writable } from 'svelte/store';
-import { beforeAll, expect, test, vi } from 'vitest';
+import { router } from 'tinro';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-import * as kubeContextStore from '/@/stores/kubernetes-contexts-state';
+import { isKubernetesExperimentalMode } from '/@/lib/kube/resources-listen';
+import {
+  initListExperimental,
+  initListsNonExperimental,
+  type initListsReturnType,
+} from '/@/lib/kube/tests-helpers/init-lists';
+import * as states from '/@/stores/kubernetes-contexts-state';
 
 import SecretDetails from './SecretDetails.svelte';
 
 const secret: V1Secret = {
+  apiVersion: 'v1',
+  kind: 'Secret',
   metadata: {
     name: 'my-secret',
     namespace: 'default',
@@ -35,23 +43,51 @@ const secret: V1Secret = {
   data: {},
 };
 
-vi.mock('/@/stores/kubernetes-contexts-state', async () => {
+vi.mock(import('/@/lib/kube/resources-listen'), async importOriginal => {
+  // we want to keep the original nonVerbose
+  const original = await importOriginal();
   return {
-    kubernetesCurrentContextSecrets: vi.fn(),
+    ...original,
+    listenResources: vi.fn(),
+    isKubernetesExperimentalMode: vi.fn(),
   };
 });
 
-beforeAll(() => {
-  Object.defineProperty(window, 'kubernetesReadNamespacedSecret', { value: vi.fn() });
+vi.mock('/@/stores/kubernetes-contexts-state');
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  router.goto('http://localhost:3000');
 });
 
-test('Confirm renders secret details', async () => {
-  // mock object store
-  const secrets = writable<KubernetesObject[]>([secret]);
-  vi.mocked(kubeContextStore).kubernetesCurrentContextSecrets = secrets;
+describe.each<{
+  experimental: boolean;
+  initLists: (secrets: KubernetesObject[]) => initListsReturnType;
+}>([
+  {
+    experimental: false,
+    initLists: initListsNonExperimental({
+      onResourcesStore: store => (vi.mocked(states).kubernetesCurrentContextSecrets = store),
+    }),
+  },
+  {
+    experimental: true,
+    initLists: initListExperimental({ resourceName: 'secrets' }),
+  },
+])('is experimental: $experimental', ({ experimental, initLists }) => {
+  beforeEach(() => {
+    vi.mocked(isKubernetesExperimentalMode).mockResolvedValue(experimental);
+  });
 
-  render(SecretDetails, { name: 'my-secret', namespace: 'default' });
+  test('Confirm renders secret details', async () => {
+    // mock object store
+    initLists([secret]);
 
-  expect(screen.getByText('my-secret')).toBeInTheDocument();
-  expect(screen.getByText('default')).toBeInTheDocument();
+    render(SecretDetails, { name: 'my-secret', namespace: 'default' });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('my-secret')).toBeInTheDocument();
+      expect(screen.getByText('default')).toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Display secret details in experimental mode

### Screenshot / video of UI


### What issues does this PR fix or reference?

Part of #10657 

### How to test this PR?

Test in experimental and non experimental mode:
- create secrets
- go to Kubernetes > Secrets > Details
- check that the summary of secrets is displayed
- check that Inspect tab displays YAML
- check that the secret can be updated from the Kube tab (add data, etc)

- [x] Tests are covering the bug fix or the new feature
