### PR TITLE
feat: display Ingress details in experimental mode

### DIFF
--- a/packages/renderer/src/lib/ingresses-routes/IngressDetails.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressDetails.spec.ts
@@ -20,18 +20,23 @@ import '@testing-library/jest-dom/vitest';
 
 import type { KubernetesObject, V1Ingress } from '@kubernetes/client-node';
 import { fireEvent, render, screen } from '@testing-library/svelte';
-import { writable } from 'svelte/store';
 import { router } from 'tinro';
-import { beforeAll, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
+import { isKubernetesExperimentalMode } from '/@/lib/kube/resources-listen';
+import {
+  initListExperimental,
+  initListsNonExperimental,
+  type initListsReturnType,
+} from '/@/lib/kube/tests-helpers/init-lists';
 import { lastPage } from '/@/stores/breadcrumb';
-import * as kubeContextStore from '/@/stores/kubernetes-contexts-state';
+import * as states from '/@/stores/kubernetes-contexts-state';
 
 import IngressRouteDetails from './IngressDetails.svelte';
 
-const kubernetesDeleteIngressMock = vi.fn();
-
 const ingress: V1Ingress = {
+  apiVersion: 'networking.k8s.io/v1',
+  kind: 'Ingress',
   metadata: {
     name: 'my-ingress',
     namespace: 'default',
@@ -39,52 +44,80 @@ const ingress: V1Ingress = {
   status: {},
 };
 
-vi.mock('/@/stores/kubernetes-contexts-state', async () => {
+vi.mock(import('/@/lib/kube/resources-listen'), async importOriginal => {
+  // we want to keep the original nonVerbose
+  const original = await importOriginal();
   return {
-    kubernetesCurrentContextIngresses: vi.fn(),
+    ...original,
+    listenResources: vi.fn(),
+    isKubernetesExperimentalMode: vi.fn(),
   };
 });
 
-beforeAll(() => {
-  Object.defineProperty(window, 'kubernetesDeleteIngress', { value: kubernetesDeleteIngressMock });
-  Object.defineProperty(window, 'kubernetesReadNamespacedIngress', { value: vi.fn() });
+vi.mock('/@/stores/kubernetes-contexts-state');
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  router.goto('http://localhost:3000');
 });
 
-test('Expect redirect to previous page if ingress is deleted', async () => {
-  const routerGotoSpy = vi.spyOn(router, 'goto');
-
-  // mock object store
-  const ingresses = writable<KubernetesObject[]>([ingress]);
-  vi.mocked(kubeContextStore).kubernetesCurrentContextIngresses = ingresses;
-
-  // remove ingress from the store when we call delete
-  kubernetesDeleteIngressMock.mockImplementation(() => {
-    ingresses.set([]);
+describe.each<{
+  experimental: boolean;
+  initLists: (configmaps: KubernetesObject[]) => initListsReturnType;
+}>([
+  {
+    experimental: false,
+    initLists: initListsNonExperimental({
+      onResourcesStore: store => (vi.mocked(states).kubernetesCurrentContextIngresses = store),
+    }),
+  },
+  {
+    experimental: true,
+    initLists: initListExperimental({ resourceName: 'ingresses' }),
+  },
+])('is experimental: $experimental', ({ experimental, initLists }) => {
+  beforeEach(() => {
+    vi.mocked(isKubernetesExperimentalMode).mockResolvedValue(experimental);
   });
 
-  // define a fake lastPage so we can check where we will be redirected
-  lastPage.set({ name: 'Fake Previous', path: '/last' });
+  test('Expect redirect to previous page if ingress is deleted', async () => {
+    const routerGotoSpy = vi.spyOn(router, 'goto');
 
-  // render the component
-  render(IngressRouteDetails, { name: 'my-ingress', namespace: 'default' });
-  expect(screen.getByText('my-ingress')).toBeInTheDocument();
+    // mock object store
+    const list = initLists([ingress]);
 
-  // grab current route
-  const currentRoute = window.location;
-  expect(currentRoute.href).toBe('http://localhost:3000/');
+    // remove ingress from the store when we call delete
+    vi.mocked(window.kubernetesDeleteIngress).mockImplementation(async () => {
+      list.updateResources([]);
+    });
 
-  // click on delete button
-  const deleteButton = screen.getByRole('button', { name: 'Delete Ingress' });
-  await fireEvent.click(deleteButton);
+    // define a fake lastPage so we can check where we will be redirected
+    lastPage.set({ name: 'Fake Previous', path: '/last' });
 
-  // check that delete method has been called
-  expect(kubernetesDeleteIngressMock).toHaveBeenCalled();
+    // render the component
+    render(IngressRouteDetails, { name: 'my-ingress', namespace: 'default' });
 
-  // expect that we have called the router when page has been removed
-  // to jump to the previous page
-  expect(routerGotoSpy).toBeCalledWith('/last');
+    await vi.waitFor(() => {
+      expect(screen.getByText('my-ingress')).toBeInTheDocument();
+    });
 
-  // confirm updated route
-  const afterRoute = window.location;
-  expect(afterRoute.href).toBe('http://localhost:3000/last');
+    // grab current route
+    const currentRoute = window.location;
+    expect(currentRoute.href).toBe('http://localhost:3000/');
+
+    // click on delete button
+    const deleteButton = screen.getByRole('button', { name: 'Delete Ingress' });
+    await fireEvent.click(deleteButton);
+
+    // check that delete method has been called
+    expect(window.kubernetesDeleteIngress).toHaveBeenCalled();
+
+    // expect that we have called the router when page has been removed
+    // to jump to the previous page
+    expect(routerGotoSpy).toBeCalledWith('/last');
+
+    // confirm updated route
+    const afterRoute = window.location;
+    expect(afterRoute.href).toBe('http://localhost:3000/last');
+  });
 });


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Display Ingress details in experimental mode

### Screenshot / video of UI

### What issues does this PR fix or reference?

Part of #10657 

### How to test this PR?

Test in experimental and non experimental mode:

- create ingress (1)
- go to Kubernetes > Ingresses/Routes > Details
- check that the summary of ingress is displayed
- check that Inspect tab displays YAML
- check that the ingress can be updated from the Kube tab (add annotation, etc)

(1) example of ingress

```
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: ingress1
  namespace: default
spec:
  rules:
  - host: localhost
```

- [x] Tests are covering the bug fix or the new feature
