### PR TITLE
chore: wait for update dialogs to disappear

### DIFF
--- a/tests/playwright/src/special-specs/installation/update-install.spec.ts
+++ b/tests/playwright/src/special-specs/installation/update-install.spec.ts
@@ -132,6 +132,7 @@ test.describe.serial('Podman Desktop Update installation', { tag: '@update-insta
     await sBar.updateButtonTitle.click();
     await playExpect(updateDialog).toBeVisible();
     await handleConfirmationDialog(page, 'Update', true, 'OK', 'Cancel');
+    await playExpect(updateDialog).not.toBeVisible();
   });
 
   test('Update is performed and restart offered', async ({ page }) => {
@@ -140,5 +141,6 @@ test.describe.serial('Podman Desktop Update installation', { tag: '@update-insta
     await playExpect(updateDownloadedDialog).toBeVisible({ timeout: 120000 });
     // some buttons
     await handleConfirmationDialog(page, 'Update Downloaded', false, 'Restart', 'Cancel');
+    await playExpect(updateDownloadedDialog).not.toBeVisible();
   });
 });


### PR DESCRIPTION
### What does this PR do?
Should better handle workflow of the update dialogs during update process.
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#11344
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
