### PR TITLE
chore(test): Update Kubernetes E2E tests to use Kubernetes pods page 

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "test:e2e:ui-stress": "npm run test:e2e:build && npm run test:e2e:ui-stress:run",
     "test:e2e:ui-stress:run": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- npx playwright test tests/playwright/src/special-specs/ui-stress/ -g @ui-stress",
     "test:e2e:k8s": "pnpm run test:e2e:build && pnpm run test:e2e:k8s:run",
-    "test:e2e:k8s:run": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- npx playwright test tests/playwright/src/specs/ -g @k8s_e2e",
+    "test:e2e:k8s:run": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- npx playwright test tests/playwright/src/specs/kubernetes-deployments.spec.ts -g @k8s_e2e",
     "test:e2e:extension": "pnpm run test:e2e:build && pnpm run test:e2e:extension:run",
     "test:e2e:extension:run": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- npx playwright test tests/playwright/src/specs/extension-installation.spec.ts",
     "test:e2e:remote": "pnpm run test:e2e:build && pnpm run test:e2e:remote:run",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "test:e2e:ui-stress": "npm run test:e2e:build && npm run test:e2e:ui-stress:run",
     "test:e2e:ui-stress:run": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- npx playwright test tests/playwright/src/special-specs/ui-stress/ -g @ui-stress",
     "test:e2e:k8s": "pnpm run test:e2e:build && pnpm run test:e2e:k8s:run",
-    "test:e2e:k8s:run": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- npx playwright test tests/playwright/src/specs/kubernetes-deployments.spec.ts -g @k8s_e2e",
+    "test:e2e:k8s:run": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- npx playwright test tests/playwright/src/specs/ -g @k8s_e2e",
     "test:e2e:extension": "pnpm run test:e2e:build && pnpm run test:e2e:extension:run",
     "test:e2e:extension:run": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- npx playwright test tests/playwright/src/specs/extension-installation.spec.ts",
     "test:e2e:remote": "pnpm run test:e2e:build && pnpm run test:e2e:remote:run",

--- a/tests/playwright/src/model/core/types.ts
+++ b/tests/playwright/src/model/core/types.ts
@@ -54,6 +54,7 @@ export enum KubernetesResources {
   PVCs = 'Persistent Volume Claims',
   ConfigMapsSecrets = 'ConfigMaps & Secrets',
   PortForwarding = 'Port Forwarding',
+  Pods = 'Pods',
 }
 
 export const KubernetesResourceAttributes: Record<KubernetesResources, string[]> = {
@@ -64,4 +65,5 @@ export const KubernetesResourceAttributes: Record<KubernetesResources, string[]>
   [KubernetesResources.PVCs]: ['Selected', 'Status', 'Name', 'Environment', 'Age', 'Size', 'Actions'],
   [KubernetesResources.ConfigMapsSecrets]: ['Selected', 'Status', 'Name', 'Type', 'Keys', 'Age', 'Actions'],
   [KubernetesResources.PortForwarding]: ['Status', 'Name', 'Type', 'Local Port', 'Remote Port', 'Actions'],
+  [KubernetesResources.Pods]: ['Selectes', 'Status', 'Name', 'Containers', 'Age', 'Actions'],
 };

--- a/tests/playwright/src/model/pages/pods-page.ts
+++ b/tests/playwright/src/model/pages/pods-page.ts
@@ -105,18 +105,4 @@ export class PodsPage extends MainPage {
       return false;
     });
   }
-
-  public async countPodReplicas(expectedPodName: string): Promise<number> {
-    return test.step(`Count pod replicas: ${expectedPodName}`, async () => {
-      let counter: number = 0;
-      const rows = await this.getAllTableRows();
-      for (let i = rows.length - 1; i > 0; i--) {
-        const podName = await rows[i].getByRole('cell').nth(3).getByRole('button').textContent();
-        if (podName?.includes(expectedPodName)) {
-          counter += 1;
-        }
-      }
-      return counter;
-    });
-  }
 }

--- a/tests/playwright/src/specs/kubernetes-deployments.spec.ts
+++ b/tests/playwright/src/specs/kubernetes-deployments.spec.ts
@@ -23,7 +23,7 @@ import { PlayYamlRuntime } from '../model/core/operations';
 import { KubernetesResourceState } from '../model/core/states';
 import { KubernetesResources } from '../model/core/types';
 import { createKindCluster, deleteCluster } from '../utility/cluster-operations';
-import { test } from '../utility/fixtures';
+import { expect as playExpect, test } from '../utility/fixtures';
 import {
   checkDeploymentReplicasInfo,
   checkKubernetesResourceState,
@@ -87,6 +87,12 @@ test.afterAll(async ({ runner, page }) => {
 });
 
 test.describe.serial('Kubernetes deployment resource E2E Test', { tag: '@k8s_e2e' }, () => {
+  test('Kubernetes Pods page should be empty', async ({ navigationBar }) => {
+    const kubernetesBar = await navigationBar.openKubernetes();
+    const kubernetesPodsPage = await kubernetesBar.openTabPage(KubernetesResources.Pods);
+
+    await playExpect.poll(async () => kubernetesPodsPage.content.textContent()).toContain('No pods');
+  });
   test('Create a Kubernetes deployment resource', async ({ page }) => {
     test.setTimeout(80_000);
     await createKubernetesResource(

--- a/tests/playwright/src/specs/kubernetes.spec.ts
+++ b/tests/playwright/src/specs/kubernetes.spec.ts
@@ -108,7 +108,7 @@ test.describe('Kubernetes resources End-to-End test', { tag: '@k8s_e2e' }, () =>
         await checkKubernetesResourceState(page, KubernetesResources.PVCs, PVC_NAME, KubernetesResourceState.Running);
       });
       test('Delete the PVC resource', async ({ page }) => {
-        await deletePod(page, PVC_POD_NAME);
+        await deleteKubernetesResource(page, KubernetesResources.Pods, PVC_POD_NAME);
         await deleteKubernetesResource(page, KubernetesResources.PVCs, PVC_NAME);
       });
     });
@@ -144,16 +144,16 @@ test.describe('Kubernetes resources End-to-End test', { tag: '@k8s_e2e' }, () =>
           KubernetesResourceState.Running,
         );
       });
-      test('Can load config and secrets via env. var in pod', async ({ page }) => {
-        const podsPage = await applyYamlFileToCluster(page, SECRET_POD_YAML_PATH, KUBERNETES_RUNTIME);
+      test('Can load config and secrets via env. var in pod', async ({ page, navigationBar }) => {
+        await applyYamlFileToCluster(page, SECRET_POD_YAML_PATH, KUBERNETES_RUNTIME);
 
-        await playExpect(podsPage.heading).toBeVisible();
+        const kubernetesBar = await navigationBar.openKubernetes();
+        const kubernetesPodsPage = await kubernetesBar.openTabPage(KubernetesResources.Pods);
         await playExpect
-          .poll(async () => podsPage.getPodRowByName(SECRET_POD_NAME), {
-            timeout: 25_000,
-          })
+          .poll(async () => kubernetesPodsPage.getResourceRowByName(SECRET_POD_NAME), { timeout: 25_000 })
           .toBeTruthy();
-        const podsDetailsPage = await podsPage.openPodDetails(SECRET_POD_NAME);
+
+        const podsDetailsPage = await kubernetesPodsPage.openResourceDetails(SECRET_POD_NAME, KubernetesResources.Pods);
         await playExpect(podsDetailsPage.heading).toBeVisible();
         await playExpect.poll(async () => podsDetailsPage.getState(), { timeout: 50_000 }).toEqual(PodState.Running);
       });

--- a/tests/playwright/src/utility/kubernetes.ts
+++ b/tests/playwright/src/utility/kubernetes.ts
@@ -172,7 +172,7 @@ export async function editDeploymentYamlFile(
   });
 }
 
-export async function countKubernetesPodReplicas(page: Page, expectedPodName: string): Promise<void> {
+export async function countKubernetesPodReplicas(page: Page, expectedPodName: string): Promise<number> {
   return test.step(`Count pod replicas: ${expectedPodName}`, async () => {
     const navigationBar = new NavigationBar(page);
     const kubernetesBar = await navigationBar.openKubernetes();

--- a/tests/playwright/src/utility/kubernetes.ts
+++ b/tests/playwright/src/utility/kubernetes.ts
@@ -20,7 +20,8 @@ import type { Page } from '@playwright/test';
 import test, { expect as playExpect } from '@playwright/test';
 
 import type { KubernetesResourceState } from '../model/core/states';
-import type { KubernetesResources, PlayKubernetesOptions } from '../model/core/types';
+import type { PlayKubernetesOptions } from '../model/core/types';
+import { KubernetesResources } from '../model/core/types';
 import { ContainerDetailsPage } from '../model/pages/container-details-page';
 import type { PodsPage } from '../model/pages/pods-page';
 import { NavigationBar } from '../model/workbench/navigation';
@@ -40,9 +41,10 @@ export async function deployContainerToCluster(
     const deployToKubernetesPage = await containerDetailsPage.openDeployToKubernetesPage();
     await deployToKubernetesPage.deployPod(containerName, { useKubernetesServices: true }, kubernetesContext);
 
-    const podsPage = await navigationBar.openPods();
+    const kubernetesBar = await navigationBar.openKubernetes();
+    const kubernetesPodsPage = await kubernetesBar.openTabPage(KubernetesResources.Pods);
     await playExpect
-      .poll(async () => podsPage.deployedPodExists(deployedPodName, 'kubernetes'), { timeout: 15_000 })
+      .poll(async () => kubernetesPodsPage.getResourceRowByName(deployedPodName), { timeout: 15_000 })
       .toBeTruthy();
   });
 }
@@ -145,14 +147,13 @@ export async function editDeploymentYamlFile(
 ): Promise<void> {
   return test.step(`Change deployment kubernetes cluster resource`, async () => {
     const navigationBar = new NavigationBar(page);
-    const podsPage = await navigationBar.openPods();
+    const kubernetesBar = await navigationBar.openKubernetes();
     await playExpect
-      .poll(async () => await podsPage.countPodReplicas(deploymentName), {
+      .poll(async () => await countKubernetesPodReplicas(page, deploymentName), {
         timeout: 60_000,
       })
       .toBe(currentReplicaCount);
 
-    const kubernetesBar = await navigationBar.openKubernetes();
     const deploymentsPage = await kubernetesBar.openTabPage(resourceType);
     await playExpect(deploymentsPage.heading).toBeVisible();
     await playExpect(deploymentsPage.getResourceRowByName(deploymentName)).toBeVisible();
@@ -163,11 +164,28 @@ export async function editDeploymentYamlFile(
       `replicas: ${updatedReplicaCount}`,
     );
 
-    await navigationBar.openPods();
     await playExpect
-      .poll(async () => await podsPage.countPodReplicas(deploymentName), {
+      .poll(async () => await countKubernetesPodReplicas(page, deploymentName), {
         timeout: 60_000,
       })
       .toBe(updatedReplicaCount);
+  });
+}
+
+export async function countKubernetesPodReplicas(page: Page, expectedPodName: string): Promise<void> {
+  return test.step(`Count pod replicas: ${expectedPodName}`, async () => {
+    const navigationBar = new NavigationBar(page);
+    const kubernetesBar = await navigationBar.openKubernetes();
+    const kubernetesPodsPage = await kubernetesBar.openTabPage(KubernetesResources.Pods);
+
+    let counter: number = 0;
+    const rows = await kubernetesPodsPage.getAllTableRows();
+    for (let i = rows.length - 1; i > 0; i--) {
+      const podName = await rows[i].getByRole('cell').nth(3).getByRole('button').textContent();
+      if (podName?.includes(expectedPodName)) {
+        counter += 1;
+      }
+    }
+    return counter;
   });
 }


### PR DESCRIPTION
### What does this PR do?
Updates Kubernetes E2E tests to use the Kubernetes Pods page. Adds a new test case for Kubernetes Pods page. 

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/11313
### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
