### PR TITLE
chore: remove podman pod kubernetes navigation

### DIFF
--- a/packages/api/src/navigation-request.ts
+++ b/packages/api/src/navigation-request.ts
@@ -36,7 +36,7 @@ export interface NavigationParameters {
   [NavigationPage.IMAGE]: { id: string; engineId: string; tag: string };
   [NavigationPage.ONBOARDING]: { extensionId: string };
   [NavigationPage.PODMAN_PODS]: never;
-  [NavigationPage.PODMAN_POD]: { kind: string; name: string; engineId: string };
+  [NavigationPage.PODMAN_POD]: { name: string; engineId: string };
   [NavigationPage.VOLUMES]: never;
   [NavigationPage.VOLUME]: { name: string };
   [NavigationPage.CONTRIBUTION]: { name: string };

--- a/packages/main/src/plugin/extension/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension/extension-loader.spec.ts
@@ -1445,7 +1445,6 @@ describe('Navigation', async () => {
     expect(sendMock).toBeCalledWith('navigate', {
       page: NavigationPage.PODMAN_POD,
       parameters: {
-        kind: 'valid-kind',
         name: 'valid-name',
         engineId: 'valid-engine',
       },

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -1397,6 +1397,9 @@ export class ExtensionLoader {
         await this.navigationManager.navigateToPods();
       },
       navigateToPod: async (kind: string, name: string, engineId: string): Promise<void> => {
+        if (kind === 'kubernetes') {
+          throw new Error(`Use 'kubernetes' route to navigate to Kubernetes pods.`);
+        }
         await this.navigationManager.navigateToPod(kind, name, engineId);
       },
       navigateToContribution: async (name: string): Promise<void> => {

--- a/packages/main/src/plugin/navigation/navigation-manager.ts
+++ b/packages/main/src/plugin/navigation/navigation-manager.ts
@@ -244,7 +244,6 @@ export class NavigationManager {
     this.navigateTo({
       page: NavigationPage.PODMAN_POD,
       parameters: {
-        kind: kind,
         name: name,
         engineId: engineId,
       },

--- a/packages/renderer/src/lib/pod/PodColumnName.svelte
+++ b/packages/renderer/src/lib/pod/PodColumnName.svelte
@@ -13,7 +13,6 @@ function openDetailsPod(pod: PodInfoUI): void {
   handleNavigation({
     page: NavigationPage.PODMAN_POD,
     parameters: {
-      kind: encodeURI(pod.kind),
       name: encodeURI(pod.name),
       engineId: encodeURIComponent(pod.engineId),
     },

--- a/packages/renderer/src/navigation.spec.ts
+++ b/packages/renderer/src/navigation.spec.ts
@@ -140,11 +140,10 @@ test(`Test navigationHandle for ${NavigationPage.PODMAN_POD}`, () => {
     parameters: {
       engineId: 'dummyEngineId',
       name: 'dummyPod',
-      kind: 'kubernetes',
     },
   });
 
-  expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/pods/kubernetes/dummyPod/dummyEngineId/');
+  expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/pods/podman/dummyPod/dummyEngineId/');
 });
 
 test(`Test navigationHandle for ${NavigationPage.VOLUMES}`, () => {

--- a/packages/renderer/src/navigation.ts
+++ b/packages/renderer/src/navigation.ts
@@ -88,7 +88,7 @@ export const handleNavigation = (request: InferredNavigationRequest<NavigationPa
       router.goto(`/pods`);
       break;
     case NavigationPage.PODMAN_POD:
-      router.goto(`/pods/${request.parameters.kind}/${request.parameters.name}/${request.parameters.engineId}/`);
+      router.goto(`/pods/podman/${request.parameters.name}/${request.parameters.engineId}/`);
       break;
     case NavigationPage.VOLUMES:
       router.goto('/volumes');


### PR DESCRIPTION
### What does this PR do?

Since you can no longer have Kubernetes pods in the regular Pods page, you can't navigate to any pod kind other than 'podman'. The kind parameter in the navigation can be removed since it can never have another value.

This affects the extension API, but that is what we want as Kubernetes navigation should be done using the route and not part of the extension API. As far as I can tell the main extensions we have today are not using this yet, so no breakage.

The hard-coded 'podman' in the call to containerRegistry.podExist() and in the navigation.ts url is a bit odd, but: one change, one PR. These could be cleaned up in future PRs.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of #8819.

### How to test this PR?

PR checks (just cleanup, existing tests modified).

- [x] Tests are covering the bug fix or the new feature