### PR TITLE
chore: use kube icon on dashboard

### DIFF
--- a/packages/renderer/src/lib/kube/KubernetesDashboard.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesDashboard.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 import type { KubernetesObject } from '@kubernetes/client-node';
 import { Link } from '@podman-desktop/ui-svelte';
-import type { Component } from 'svelte';
 
 import KubernetesCurrentContextConnectionBadge from '/@/lib/ui/KubernetesCurrentContextConnectionBadge.svelte';
 import { containersInfos } from '/@/stores/containers';
@@ -21,14 +20,6 @@ import {
 import { NO_CURRENT_CONTEXT_ERROR } from '/@api/kubernetes-contexts-states';
 
 import { kubernetesContexts } from '../../stores/kubernetes-contexts';
-import ConfigMapSecretIcon from '../images/ConfigMapSecretIcon.svelte';
-import CronJobIcon from '../images/CronJobIcon.svelte';
-import DeploymentIcon from '../images/DeploymentIcon.svelte';
-import IngressRouteIcon from '../images/IngressRouteIcon.svelte';
-import NodeIcon from '../images/NodeIcon.svelte';
-import PodIcon from '../images/PodIcon.svelte';
-import PvcIcon from '../images/PVCIcon.svelte';
-import ServiceIcon from '../images/ServiceIcon.svelte';
 import { fadeSlide } from '../ui/animations';
 import deployAndTestKubernetesImage from './DeployAndTestKubernetes.png';
 import KubernetesDashboardGuideCard from './KubernetesDashboardGuideCard.svelte';
@@ -123,14 +114,14 @@ async function openKubernetesDocumentation(): Promise<void> {
                 <!-- Metrics - non-collapsible -->
                 <div class="text-xl pt-2">Metrics</div>
                 <div class="grid grid-cols-4 gap-4">
-                    <KubernetesDashboardResourceCard type='Nodes' Icon={NodeIcon} activeCount={activeNodeCount} count={nodeCount} kind='Node'/>
-                    <KubernetesDashboardResourceCard type='Deployments' Icon={DeploymentIcon} activeCount={activeDeploymentsCount} count={deploymentCount} kind='Deployment'/>
-                    <KubernetesDashboardResourceCard type='Pods' Icon={PodIcon} count={podCount} kind='Pod'/>
-                    <KubernetesDashboardResourceCard type='Services' Icon={ServiceIcon} count={serviceCount} kind='Service'/>
-                    <KubernetesDashboardResourceCard type='Ingresses & Routes' Icon={IngressRouteIcon} count={ingressRouteCount} kind='Ingress'/>
-                    <KubernetesDashboardResourceCard type='Persistent Volume Claims' Icon={PvcIcon} count={pvcCount} kind='PersistentVolumeClaim'/>
-                    <KubernetesDashboardResourceCard type='ConfigMaps & Secrets' Icon={ConfigMapSecretIcon} count={configMapSecretCount} kind='ConfigMap'/>
-                    <KubernetesDashboardResourceCard type='CronJobs' Icon={CronJobIcon as Component} count={cronjobCount} kind='CronJob'/>
+                    <KubernetesDashboardResourceCard type='Nodes' activeCount={activeNodeCount} count={nodeCount} kind='Node'/>
+                    <KubernetesDashboardResourceCard type='Deployments' activeCount={activeDeploymentsCount} count={deploymentCount} kind='Deployment'/>
+                    <KubernetesDashboardResourceCard type='Pods' count={podCount} kind='Pod'/>
+                    <KubernetesDashboardResourceCard type='Services' count={serviceCount} kind='Service'/>
+                    <KubernetesDashboardResourceCard type='Ingresses & Routes' count={ingressRouteCount} kind='Ingress'/>
+                    <KubernetesDashboardResourceCard type='Persistent Volume Claims' count={pvcCount} kind='PersistentVolumeClaim'/>
+                    <KubernetesDashboardResourceCard type='ConfigMaps & Secrets' count={configMapSecretCount} kind='ConfigMap'/>
+                    <KubernetesDashboardResourceCard type='CronJobs' count={cronjobCount} kind='CronJob'/>
                 </div>
                 <!-- Graphs -->
                 

--- a/packages/renderer/src/lib/kube/KubernetesDashboardResourceCard.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesDashboardResourceCard.svelte
@@ -1,15 +1,14 @@
 <script lang="ts">
-import type { Component } from 'svelte';
+import KubernetesIcon from './KubernetesIcon.svelte';
 
 interface Props {
   type: string;
-  Icon: Component;
   activeCount?: number;
   count: number;
   kind: string;
 }
 
-let { type, Icon, activeCount, count, kind }: Props = $props();
+let { type, activeCount, count, kind }: Props = $props();
 
 async function openLink(): Promise<void> {
   try {
@@ -23,7 +22,7 @@ async function openLink(): Promise<void> {
 <button class="flex flex-col gap-4 p-4 bg-[var(--pd-content-card-carousel-card-bg)] hover:bg-[var(--pd-content-card-carousel-card-hover-bg)] rounded-md" onclick={openLink}>
   <div class="text-[var(--pd-invert-content-card-text)] font-semibold text-start">{type}</div>
   <div class="grid grid-cols-{activeCount !== undefined ? '3' : '2'} gap-4 w-full grow items-end">
-    <div class="justify-self-center text-[var(--pd-button-primary-bg)]"><Icon size={40}/></div>
+    <div class="justify-self-center text-[var(--pd-button-primary-bg)]"><KubernetesIcon kind={kind} size='40'/></div>
     {#if activeCount !== undefined}
     <div class="flex flex-col">
       <span class="text-[var(--pd-invert-content-card-text)]">Active</span>


### PR DESCRIPTION
### What does this PR do?

Uses the new KubernetesIcon component in the Kube dashboard resource card. Since we already know the kind, it means we can remove the Icon property and imports from the dashboard.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Related to #11035.

### How to test this PR?

Just ensure resource cards on Kube dashboard still appear.