### PR TITLE
chore: update the description of empty forwards configuration

### DIFF
--- a/packages/renderer/src/lib/kubernetes-port-forward/PortForwardingList.spec.ts
+++ b/packages/renderer/src/lib/kubernetes-port-forward/PortForwardingList.spec.ts
@@ -37,6 +37,8 @@ beforeEach(() => {
 test('empty kubernetesCurrentContextPortForwards store should display empty screen', async () => {
   const { getByText } = render(PortForwardList);
 
-  const text = getByText('Start forwarding ports from the Pod Details > Summary tab');
+  const text = getByText(
+    'To forward ports, open the Summary tab on the relevant resource (Pod, Service, or Deployment)',
+  );
   expect(text).toBeDefined();
 });

--- a/packages/renderer/src/lib/kubernetes-port-forward/PortForwardingList.svelte
+++ b/packages/renderer/src/lib/kubernetes-port-forward/PortForwardingList.svelte
@@ -54,7 +54,7 @@ const row = new TableRow<ForwardConfig>({});
         defaultSortColumn="Name">
       </Table>
     {:else}
-      <EmptyScreen message="Start forwarding ports from the Pod Details > Summary tab" icon={faEthernet} title="No port forwarding configured"/>
+      <EmptyScreen message="To forward ports, open the Summary tab on the relevant resource (Pod, Service, or Deployment)" icon={faEthernet} title="No port forwarding configured"/>
     {/if}
   </div>
 </NavPage>


### PR DESCRIPTION
### What does this PR do?

Updates the description on Port forwarding page.

### Screenshot / video of UI

<img width="1162" alt="Снимок экрана 2025-02-25 в 16 22 36" src="https://github.com/user-attachments/assets/9a50d382-1728-4f99-9967-872e8d1f85a4" />

### What issues does this PR fix or reference?

#10350 

### How to test this PR?

Navigate to the Port forwarding page and be sure that there isn't any forwarding configured. Make sure that description says, that user should navigate to the Summary tab for the relevant resource to be able to forward a particular port.

- [ ] Tests are covering the bug fix or the new feature
