### PR TITLE
fix: use correct css variable name

### DIFF
--- a/packages/renderer/src/lib/onboarding/Onboarding.svelte
+++ b/packages/renderer/src/lib/onboarding/Onboarding.svelte
@@ -485,7 +485,7 @@ $: globalOnboarding = global;
         <div
           class="flex flex-row-reverse p-6 bg-[var(--pd-content-bg)] fixed {globalOnboarding
             ? 'w-full'
-            : 'w-[calc(100%-(var(--width-leftnavbar))-(var(--width-leftsidebar)))] mb-5'} bottom-0 pr-10 max-h-20 bg-opacity-90 z-20"
+            : 'w-[calc(100%-(var(--spacing-leftnavbar))-(var(--spacing-leftsidebar)))] mb-5'} bottom-0 pr-10 max-h-20 bg-opacity-90 z-20"
           role="group"
           aria-label="Step Buttons">
           <Button


### PR DESCRIPTION
### What does this PR do?

The following changes request fixes the layout of button's panel on onboarding page.

### Screenshot / video of UI

<img width="1126" alt="Снимок экрана 2025-02-25 в 17 04 34" src="https://github.com/user-attachments/assets/aa1f88f7-b0a7-48dd-bb6d-6dd15df23293" />


### What issues does this PR fix or reference?

#10984 

### How to test this PR?

Navigate to the Compose setup onboarding page and make sure that lower panel displays correctly.

- [ ] Tests are covering the bug fix or the new feature
