### PR TITLE
feat: restart monitoring on offline context

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
@@ -366,6 +366,29 @@ describe.each([
       expect(within(context4).queryByText('CONNECTION LOST')).toBeInTheDocument();
     }
   });
+
+  test('Connect button is displayed on offline contexts', async () => {
+    if (!implemented.offline) {
+      return;
+    }
+
+    initMocks();
+    render(PreferencesKubernetesContextsRendering, {});
+
+    await vi.waitFor(() => {
+      const context1 = screen.getAllByRole('row')[0];
+      expect(within(context1).queryByText('Connect')).not.toBeInTheDocument(); // reachable and not offline
+    });
+
+    const context2 = screen.getAllByRole('row')[1];
+    expect(within(context2).queryByText('Connect')).toBeInTheDocument(); // not reachable
+
+    const context3 = screen.getAllByRole('row')[2];
+    expect(within(context3).queryByText('Connect')).not.toBeInTheDocument(); // reachable and not offline
+
+    const context4 = screen.getAllByRole('row')[3];
+    expect(within(context4).queryByText('Connect')).toBeInTheDocument(); // reachable and offline
+  });
 });
 
 test('Connect button is displayed on contexts for which state is not known', () => {

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -298,6 +298,9 @@ async function connect(contextName: string): Promise<void> {
                     </div>
                   </div>
                 </div>
+                {#if context.isOffline}
+                  <div><Button on:click={(): Promise<void> => connect(context.name)}>Connect</Button></div>
+                {/if}
                 {#if !context.podsPermitted || !context.deploymentsPermitted}
                   <Tooltip tip={context.notPermittedHelp}><div><Fa size="1x" icon={faQuestionCircle} /></div></Tooltip>
                 {/if}


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

In experimental mode,
In Settings > Kubernetes, display the Connect button for contexts detected as Offline 

### Screenshot / video of UI

https://github.com/user-attachments/assets/c486bda7-2ec2-4a7c-ad50-5d7461692875

### What issues does this PR fix or reference?

Part of #11277 

### How to test this PR?

See video above

- [x] Tests are covering the bug fix or the new feature
