### PR TITLE
chore(podman): `module` property missing in tsconfig

### DIFF
--- a/extensions/podman/packages/extension/tsconfig.json
+++ b/extensions/podman/packages/extension/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "strict": true,
     "lib": ["ES2017"],
+    "module": "esnext",
     "sourceMap": true,
     "rootDir": "src",
     "outDir": "dist",


### PR DESCRIPTION
### What does this PR do?

While working on https://github.com/podman-desktop/podman-desktop/issues/10327 I noticed that the `module` was missing in the tsconfig of the podman extension.

We use `"module": "esnext"` everywhere, so this should not be a big deal.

https://github.com/podman-desktop/podman-desktop/blob/6b69ae4d5488545f7ef535fb16a005bbe8ea5d55/extensions/compose/tsconfig.json#L5

https://github.com/podman-desktop/podman-desktop/blob/9b9a15c8ee1c2aeecf8ea866599699498784e70c/extensions/kind/tsconfig.json#L5

https://github.com/podman-desktop/podman-desktop/blob/6b69ae4d5488545f7ef535fb16a005bbe8ea5d55/extensions/kubectl-cli/tsconfig.json#L5

etc.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Pipeline should be green