### PR TITLE
chore(test): wait for update dialog to switch instead of closing in e2e

### DIFF
--- a/tests/playwright/src/special-specs/installation/update-install.spec.ts
+++ b/tests/playwright/src/special-specs/installation/update-install.spec.ts
@@ -128,15 +128,11 @@ test.describe.serial('Podman Desktop Update installation', { tag: '@update-insta
     await playExpect(updateAvailableDialog).not.toBeVisible();
   });
 
-  test('Update is in progress', async ({ page }) => {
+  test('Update is progressing until restart is offered', async ({ page }) => {
+    test.setTimeout(150000);
     await sBar.updateButtonTitle.click();
     await playExpect(updateDialog).toBeVisible();
-    await handleConfirmationDialog(page, 'Update', true, 'OK', 'Cancel');
-    await playExpect(updateDialog).not.toBeVisible();
-  });
-
-  test('Update is performed and restart offered', async ({ page }) => {
-    test.setTimeout(150000);
+    // the dialog might change in meantime from Update (in progress) to Update downloaded.
     // now it takes some time to perform, in case of failure, PD gets closed
     await playExpect(updateDownloadedDialog).toBeVisible({ timeout: 120000 });
     // some buttons


### PR DESCRIPTION
### What does this PR do?
Tries to tackle the update of podman desktop in e2e tests where the dialog changes depending on external circumstances.
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#11344 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
