### PR TITLE
fix: pass only added env vars to process.exec in Kind and Lima

### DIFF
--- a/extensions/kind/src/create-cluster.spec.ts
+++ b/extensions/kind/src/create-cluster.spec.ts
@@ -24,7 +24,7 @@ import type { Mock } from 'vitest';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { connectionAuditor, createCluster, getKindClusterConfig } from './create-cluster';
-import { getMemTotalInfo } from './util';
+import { getKindPath, getMemTotalInfo } from './util';
 
 vi.mock('node:fs', () => ({
   promises: {
@@ -85,6 +85,7 @@ test('expect error is cli returns non zero exit code', async () => {
 });
 
 test('expect cluster to be created', async () => {
+  vi.mocked(getKindPath).mockReturnValue('/kind/path');
   (extensionApi.process.exec as Mock).mockReturnValue({} as extensionApi.RunResult);
   await createCluster({}, '', telemetryLoggerMock);
   expect(telemetryLogUsageMock).toHaveBeenNthCalledWith(
@@ -94,6 +95,10 @@ test('expect cluster to be created', async () => {
   );
   expect(telemetryLogErrorMock).not.toBeCalled();
   expect(extensionApi.kubernetes.createResources).not.toBeCalled();
+  const props = (extensionApi.process.exec as Mock).mock.calls[0][2];
+  expect(props).to.have.property('env');
+  const env = props.env;
+  expect(env).toStrictEqual({ PATH: '/kind/path' });
 });
 
 test('expect cluster to be created using config file', async () => {

--- a/extensions/kind/src/create-cluster.ts
+++ b/extensions/kind/src/create-cluster.ts
@@ -133,7 +133,7 @@ export async function createCluster(
     provider = String(params['kind.cluster.creation.provider']);
   }
 
-  const env = { ...process.env } as { [key: string]: string };
+  const env: { [key: string]: string } = {};
   // add KIND_EXPERIMENTAL_PROVIDER env variable if needed
   if (provider === 'podman') {
     env['KIND_EXPERIMENTAL_PROVIDER'] = 'podman';

--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -211,7 +211,7 @@ async function updateClusters(
           await extensionApi.containerEngine.stopContainer(cluster.engineId, cluster.id);
         },
         delete: async (logger): Promise<void> => {
-          const env = { ...process.env } as { [key: string]: string };
+          const env: { [key: string]: string } = {};
           if (cluster.engineType === 'podman') {
             env['KIND_EXPERIMENTAL_PROVIDER'] = 'podman';
           }

--- a/extensions/kind/src/image-handler.spec.ts
+++ b/extensions/kind/src/image-handler.spec.ts
@@ -128,6 +128,5 @@ test('expect cli is called with right PATH', async () => {
   const props = (extensionApi.process.exec as Mock).mock.calls[0][2];
   expect(props).to.have.property('env');
   const env = props.env;
-  expect(env).to.have.property('PATH');
-  expect(env.PATH).toBe('my-custom-path');
+  expect(env).toStrictEqual({ KIND_EXPERIMENTAL_PROVIDER: 'podman', PATH: 'my-custom-path' });
 });

--- a/extensions/kind/src/image-handler.ts
+++ b/extensions/kind/src/image-handler.ts
@@ -57,7 +57,7 @@ export class ImageHandler {
     if (selectedCluster) {
       let name = image.name;
       let filename: string | undefined;
-      const env = { ...process.env } as { [key: string]: string };
+      const env: { [key: string]: string } = {};
 
       // Create a name:tag string for the image
       if (image.tag) {

--- a/extensions/lima/src/image-handler.ts
+++ b/extensions/lima/src/image-handler.ts
@@ -37,7 +37,7 @@ export class ImageHandler {
     if (instanceName) {
       let name = image.name;
       let filename: string | undefined;
-      const env = { ...process.env } as { [key: string]: string };
+      const env: { [key: string]: string } = {};
 
       // Create a name:tag string for the image
       if (image.tag) {


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Instead of passing the entire env configuration to process.exec, now it only pass the new additional env variables that have been added in the code.
The entire env configuration and the env that is passed to process.exec are merged in https://github.com/podman-desktop/podman-desktop/blob/7f89f7d90a5d4f8ea889061e4cfec5ee351349f1/packages/main/src/plugin/util/exec.ts#L52-L54

(Part 1 of the fix, 2nd part is https://github.com/podman-desktop/podman-desktop/pull/11370)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Fixes https://github.com/podman-desktop/podman-desktop/issues/10953

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
