### PR TITLE
chore: add custom env variables to flatpak-spawn command with env flag 

### DIFF
--- a/packages/main/src/plugin/util/exec.spec.ts
+++ b/packages/main/src/plugin/util/exec.spec.ts
@@ -409,7 +409,7 @@ describe('exec', () => {
     expect(stdout).toContain('Hello, World!');
   });
 
-  test('should run the command with privileges on flatpak Linux', async () => {
+  test('should run the command with privileges and set env variables on flatpak Linux', async () => {
     const command = 'echo';
     const args = ['Hello, World!'];
 
@@ -431,12 +431,15 @@ describe('exec', () => {
     } as unknown as ChildProcess);
 
     // emulate flatpak environment
-    const { stdout } = await exec.exec(command, args, { env: { FLATPAK_ID: 'true' }, isAdmin: true });
+    const { stdout } = await exec.exec(command, args, {
+      env: { FLATPAK_ID: 'true', var1: 'value1', var2: 'value2' },
+      isAdmin: true,
+    });
 
     // caller should contains the cwd provided
     expect(spawnMock).toHaveBeenCalledWith(
       'flatpak-spawn',
-      expect.arrayContaining(['--host', 'pkexec', 'echo', 'Hello, World!']),
+      expect.arrayContaining(['--host', '--env=var1=value1', '--env=var2=value2', 'pkexec', 'echo', 'Hello, World!']),
       expect.anything(),
     );
     expect(stdout).toBeDefined();

--- a/packages/main/src/plugin/util/exec.ts
+++ b/packages/main/src/plugin/util/exec.ts
@@ -137,7 +137,11 @@ export class Exec {
     }
 
     if (env['FLATPAK_ID']) {
-      args = ['--host', command, ...(args ?? [])];
+      const customEnvVariables: string[] = [];
+      for (const envVar in options?.env) {
+        customEnvVariables.push(`--env=${envVar}=${options.env[envVar]}`);
+      }
+      args = ['--host', ...customEnvVariables, command, ...(args ?? [])];
       command = 'flatpak-spawn';
     }
 


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
When custom env variables are passed to process.exec, in the case of Flatpak, those variables will be added to the flatpak-spawn command with the `--env` flag.
(Part 2 of the fix, needs to be merged after https://github.com/podman-desktop/podman-desktop/pull/11369)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Fixes https://github.com/podman-desktop/podman-desktop/issues/10953

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

## Summary by Sourcery

Tests:
- Adds a test case to verify that environment variables are correctly passed to the `flatpak-spawn` command.