### PR TITLE
refactor: get events from PodDetails component

### DIFF
--- a/packages/renderer/src/lib/kube/pods/PodDetails.svelte
+++ b/packages/renderer/src/lib/kube/pods/PodDetails.svelte
@@ -5,7 +5,7 @@ import { onMount } from 'svelte';
 import { router } from 'tinro';
 import { stringify } from 'yaml';
 
-import { kubernetesCurrentContextPods } from '/@/stores/kubernetes-contexts-state';
+import { kubernetesCurrentContextEvents, kubernetesCurrentContextPods } from '/@/stores/kubernetes-contexts-state';
 
 import Route from '../../../Route.svelte';
 import MonacoEditor from '../../editor/MonacoEditor.svelte';
@@ -31,6 +31,8 @@ let pod = $state<PodUI>();
 let detailsPage = $state<DetailsPage>();
 let kubePod = $state<V1Pod>();
 let kubeError = $state<string>();
+
+let events = $derived($kubernetesCurrentContextEvents.filter(ev => ev.involvedObject.uid === kubePod?.metadata?.uid));
 
 onMount(() => {
   const podUtils = new PodUtils();
@@ -82,7 +84,7 @@ async function loadDetails(): Promise<void> {
     </svelte:fragment>
     <svelte:fragment slot="content">
       <Route path="/summary" breadcrumb="Summary" navigationHint="tab">
-        <PodDetailsSummary pod={kubePod} kubeError={kubeError} />
+        <PodDetailsSummary pod={kubePod} kubeError={kubeError} events={events} />
       </Route>
       <Route path="/logs" breadcrumb="Logs" navigationHint="tab">
         <PodDetailsLogs pod={pod} />

--- a/packages/renderer/src/lib/kube/pods/PodDetailsSummary.spec.ts
+++ b/packages/renderer/src/lib/kube/pods/PodDetailsSummary.spec.ts
@@ -30,10 +30,7 @@ import type {
   V1Volume,
 } from '@kubernetes/client-node';
 import { render, screen } from '@testing-library/svelte';
-import { writable } from 'svelte/store';
 import { beforeEach, expect, test, vi } from 'vitest';
-
-import * as states from '/@/stores/kubernetes-contexts-state';
 
 import * as eventsTable from '../details/EventsTable.svelte';
 import PodDetailsSummary from './PodDetailsSummary.svelte';
@@ -133,8 +130,7 @@ beforeEach(() => {
 });
 
 test('expect summary renders with V1Pod object', async () => {
-  vi.mocked(states).kubernetesCurrentContextEvents = writable<CoreV1Event[]>([]);
-  render(PodDetailsSummary, { props: { pod: fakePod } });
+  render(PodDetailsSummary, { props: { pod: fakePod, events: [] } });
 
   // Check that the rendered text is correct
   expect(screen.getByText('fakepod')).toBeInTheDocument();
@@ -156,8 +152,7 @@ test('expect summary renders with V1Pod object', async () => {
 
 test('expect EventsTable is called with events', async () => {
   const eventsTableSpy = vi.spyOn(eventsTable, 'default');
-  vi.mocked(states).kubernetesCurrentContextEvents = writable<CoreV1Event[]>(events);
-  render(PodDetailsSummary, { props: { pod: fakePod } });
+  render(PodDetailsSummary, { props: { pod: fakePod, events } });
 
   expect(eventsTableSpy).toHaveBeenCalledWith(expect.anything(), { events: events });
 });

--- a/packages/renderer/src/lib/kube/pods/PodDetailsSummary.svelte
+++ b/packages/renderer/src/lib/kube/pods/PodDetailsSummary.svelte
@@ -3,8 +3,8 @@ import type { V1Pod } from '@kubernetes/client-node';
 import { ErrorMessage } from '@podman-desktop/ui-svelte';
 
 import Table from '/@/lib/details/DetailsTable.svelte';
-import { kubernetesCurrentContextEvents } from '/@/stores/kubernetes-contexts-state';
 
+import type { EventUI } from '../../events/EventUI';
 import KubeEventsArtifact from '../details/KubeEventsArtifact.svelte';
 import KubeObjectMetaArtifact from '../details/KubeObjectMetaArtifact.svelte';
 import KubePodSpecArtifact from '../details/KubePodSpecArtifact.svelte';
@@ -12,11 +12,10 @@ import KubePodStatusArtifact from '../details/KubePodStatusArtifact.svelte';
 
 interface Props {
   pod: V1Pod | undefined;
+  events: EventUI[];
   kubeError?: string;
 }
-let { pod, kubeError = undefined }: Props = $props();
-
-let events = $derived($kubernetesCurrentContextEvents.filter(ev => ev.involvedObject.uid === pod?.metadata?.uid));
+let { pod, events, kubeError = undefined }: Props = $props();
 </script>
 
 <!-- Show the kube error if we're unable to retrieve the data correctly, but we still want to show the


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Get events from PodDetails component, to be able to use `listenResource` for experimental mode

### Screenshot / video of UI

### What issues does this PR fix or reference?

Part of #10657

### How to test this PR?

Events should still be visible and reactive for Kubernetes pods in non experimental mode

- [x] Tests are covering the bug fix or the new feature
