### PR TITLE
feat: display connection lost on resources pages

### DIFF
--- a/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.spec.ts
+++ b/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.spec.ts
@@ -129,19 +129,22 @@ describe.each<{
     });
   });
 
-  test('expect badges to show as there is an offline context', async () => {
-    if (!experimental) {
-      return;
-    }
-    setState({ reachable: true, offline: true });
-    render(KubernetesCurrentContextConnectionBadge);
+  test(
+    'expect badges to show as there is an offline context',
+    {
+      skip: !experimental,
+    },
+    async () => {
+      setState({ reachable: true, offline: true });
+      render(KubernetesCurrentContextConnectionBadge);
 
-    await vi.waitFor(() => {
-      const status = screen.getByRole('status');
-      expect(status).toBeInTheDocument();
-      expect(status).toHaveTextContent('Connection lost');
-    });
-  });
+      await vi.waitFor(() => {
+        const status = screen.getByRole('status');
+        expect(status).toBeInTheDocument();
+        expect(status).toHaveTextContent('Connection lost');
+      });
+    },
+  );
 
   test('expect badges to be green when reachable', async () => {
     setState({ reachable: true });
@@ -163,18 +166,21 @@ describe.each<{
     });
   });
 
-  test('expect badges to be orange when offline', async () => {
-    if (!experimental) {
-      return;
-    }
-    setState({ reachable: true, offline: true });
-    render(KubernetesCurrentContextConnectionBadge);
+  test(
+    'expect badges to be orange when offline',
+    {
+      skip: !experimental,
+    },
+    async () => {
+      setState({ reachable: true, offline: true });
+      render(KubernetesCurrentContextConnectionBadge);
 
-    await vi.waitFor(() => {
-      const status = screen.getByRole('status');
-      expect(status.firstChild).toHaveClass('bg-[var(--pd-status-paused)]');
-    });
-  });
+      await vi.waitFor(() => {
+        const status = screen.getByRole('status');
+        expect(status.firstChild).toHaveClass('bg-[var(--pd-status-paused)]');
+      });
+    },
+  );
 
   test('expect no tooltip when no error', async () => {
     setState({ reachable: true });
@@ -198,19 +204,22 @@ describe.each<{
     });
   });
 
-  test('expect tooltip when offline', async () => {
-    if (!experimental) {
-      return;
-    }
-    setState({ reachable: true, offline: true });
-    render(KubernetesCurrentContextConnectionBadge);
+  test(
+    'expect tooltip when offline',
+    {
+      skip: !experimental,
+    },
+    async () => {
+      setState({ reachable: true, offline: true });
+      render(KubernetesCurrentContextConnectionBadge);
 
-    await vi.waitFor(() => {
-      const tooltip = screen.getByLabelText('tooltip');
-      expect(tooltip).toBeInTheDocument();
-      expect(tooltip).toHaveTextContent('connection lost, resources may be out of sync');
-    });
-  });
+      await vi.waitFor(() => {
+        const tooltip = screen.getByLabelText('tooltip');
+        expect(tooltip).toBeInTheDocument();
+        expect(tooltip).toHaveTextContent('connection lost, resources may be out of sync');
+      });
+    },
+  );
 
   test('spinner should be displayed when and only when the context connectivity is being checked', async () => {
     contexts.set([

--- a/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.svelte
+++ b/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.svelte
@@ -37,7 +37,7 @@ onMount(async () => {
       info = {
         text: getTextExperimental(health),
         classColor: getClassColorExperimental(health),
-        tip: health.reachable ? '' : 'health check not responding',
+        tip: getTipExperimental(health),
       };
     });
   } else {
@@ -66,13 +66,21 @@ function getClassColorNonExperimental(state?: ContextGeneralState): string {
 }
 
 function getTextExperimental(health: ContextHealth): string {
+  if (health.offline) return 'Connection lost';
   if (health.reachable) return 'Connected';
   return 'Cluster not reachable';
 }
 
 function getClassColorExperimental(health: ContextHealth): string {
+  if (health.offline) return 'bg-[var(--pd-status-paused)]';
   if (health.reachable) return 'bg-[var(--pd-status-connected)]';
   return 'bg-[var(--pd-status-disconnected)]';
+}
+
+function getTipExperimental(health: ContextHealth): string {
+  if (health.offline) return 'connection lost, resources may be out of sync';
+  if (health.reachable) return '';
+  return 'health check not responding';
 }
 </script>
 


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Display connection lost on resources pages

### Screenshot / video of UI


https://github.com/user-attachments/assets/b16d5631-f094-4bdd-83bb-3a6696042426



### What issues does this PR fix or reference?

Fixes #11277 

### How to test this PR?

In experimental mode:
- start Podman Desktop with a running cluster, check that the context is detected as reachable
- stop the cluster
- in the Kubernetes section pages (dashboard, deployments list, etc), the badge should indicate 'Connection lost'

In non experimental mode, offline is not implemented

- [x] Tests are covering the bug fix or the new feature

## Summary by Sourcery

Display a 'Connection lost' badge on resource pages when the connection to the cluster is lost in experimental mode. This improves the user experience by providing a clear indication of the connection status.

New Features:
- Display a 'Connection lost' badge on resource pages when the connection to the cluster is lost in experimental mode.

Tests:
- Add tests to verify the 'Connection lost' badge is displayed when the connection to the cluster is lost.