### PR TITLE
fix: revert lost change to have proper higlight/selected colors

### DIFF
--- a/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
+++ b/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
@@ -356,7 +356,9 @@ async function handleKeydown(e: KeyboardEvent): Promise<void> {
           {/if}
         {:else if mode === 'QuickPick'}
           {#each quickPickFilteredItems as item, i}
-            <div class="flex w-full flex-row hover:bg-[var(--pd-modal-dropdown-highlight)]">
+            <div class="flex w-full flex-row  {i === quickPickSelectedFilteredIndex
+                  ? 'bg-[var(--pd-modal-dropdown-highlight)] selected'
+                  : 'hover:bg-[var(--pd-dropdown-bg)]'}">
               {#if quickPickCanPickMany}
                 <Checkbox class="mx-1 my-auto" bind:checked={item.checkbox} />
               {/if}


### PR DESCRIPTION
### What does this PR do?
fix following
https://github.com/podman-desktop/podman-desktop/pull/8549/files


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/podman-desktop/podman-desktop/issues/11228

### How to test this PR?

on a quickpick, select up down key and hover

- [ ] Tests are covering the bug fix or the new feature

## Summary by Sourcery

Bug Fixes:
- Restores the correct highlight and selected colors for items in the QuickPick component.