### PR TITLE
chore(test): fix kubernetes e2e tests

### DIFF
--- a/tests/playwright/src/model/pages/image-details-page.ts
+++ b/tests/playwright/src/model/pages/image-details-page.ts
@@ -113,9 +113,6 @@ export class ImageDetailsPage extends DetailsPage {
     await playExpect(pushToKindButton).toBeVisible();
     await pushToKindButton.click();
 
-    const confirmationDialog = this.page.getByRole('dialog', { name: 'Kind' });
-    await playExpect(confirmationDialog).toBeVisible({ timeout: 10000 });
-    const okButton = confirmationDialog.getByRole('button', { name: 'OK' });
-    await okButton.click();
+    await handleConfirmationDialog(this.page, 'Kind', true, 'OK', '', 15_000);
   }
 }

--- a/tests/playwright/src/specs/deploy-to-kubernetes.spec.ts
+++ b/tests/playwright/src/specs/deploy-to-kubernetes.spec.ts
@@ -32,8 +32,7 @@ const RESOURCE_NAME: string = 'kind';
 const IMAGE_TO_PULL: string = 'ghcr.io/linuxcontainers/alpine';
 const IMAGE_TAG: string = 'latest';
 const CONTAINER_NAME: string = 'alpine-container';
-const NAMESPACE: string = 'default';
-const DEPLOYED_POD_NAME: string = `${CONTAINER_NAME} ${KIND_NODE} ${NAMESPACE}`;
+const DEPLOYED_POD_NAME: string = CONTAINER_NAME;
 const CONTAINER_START_PARAMS: ContainerInteractiveParams = {
   attachTerminal: false,
 };

--- a/tests/playwright/src/utility/operations.ts
+++ b/tests/playwright/src/utility/operations.ts
@@ -168,11 +168,12 @@ export async function handleConfirmationDialog(
   confirm = true,
   confirmationButton = 'Yes',
   cancelButton = 'Cancel',
+  timeout = 10_000,
 ): Promise<void> {
   return test.step('Handle confirmation dialog', async () => {
     // wait for dialog to appear using waitFor
     const dialog = page.getByRole('dialog', { name: dialogTitle, exact: true });
-    await waitUntil(async () => await dialog.isVisible());
+    await waitUntil(async () => await dialog.isVisible(), { timeout: timeout });
     const button = confirm
       ? dialog.getByRole('button', { name: confirmationButton })
       : dialog.getByRole('button', { name: cancelButton });


### PR DESCRIPTION
Signed-off-by: Anton Misskii <amisskii@redhat.com>

### What does this PR do?

Fixes the new Kubernetes port forwarding E2E test. Refactors deployed pod name in the deploy-to-kubernetes E2E test.


### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature

## Summary by Sourcery

Bug Fixes:
- Fixes the Kubernetes port forwarding E2E test by adjusting the pod name and improving the handling of confirmation dialogs.