### PR TITLE
chore(test): skip kind tests that run on rootless mode machines

### DIFF
--- a/tests/playwright/src/setupFiles/setup-kind.ts
+++ b/tests/playwright/src/setupFiles/setup-kind.ts
@@ -1,0 +1,33 @@
+/**********************************************************************
+ * Copyright (C) 2024-2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { isLinux, isMac, isWindows } from '../utility/platform';
+
+export function setupKind(): boolean[] {
+  const rootfulMode = process.env.ROOTFUL_MODE === 'true'; // undefined or "false" => false
+  const runKindTests = process.env.RUN_KIND_TESTS === 'true';
+  return [rootfulMode, runKindTests];
+}
+
+export function canRunKindTests(): boolean {
+  const [rootfulMode, runKindTests] = setupKind();
+  // to run the kind tests there are 2 options:
+  // 1-the OS is linux or mac + runKindTests == true
+  // 2-the OS is windows, the podman machine is rootful
+  return ((isLinux || isMac) && runKindTests) || (isWindows && rootfulMode);
+}

--- a/tests/playwright/src/setupFiles/setup-kind.ts
+++ b/tests/playwright/src/setupFiles/setup-kind.ts
@@ -26,8 +26,9 @@ export function setupKind(): boolean[] {
 
 export function canRunKindTests(): boolean {
   const [rootfulMode, runKindTests] = setupKind();
-  // to run the kind tests there are 2 options:
-  // 1-the OS is linux or mac + runKindTests == true
-  // 2-the OS is windows, the podman machine is rootful
-  return ((isLinux || isMac) && runKindTests) || (isWindows && rootfulMode);
+  // to run the kind tests there are 3 options:
+  // 1-the runKindTest envvar is defined and true
+  // 2-the OS is linux or mac
+  // 3-the OS is windows + the podman machine is rootful
+  return runKindTests || isLinux || isMac || (isWindows && rootfulMode);
 }

--- a/tests/playwright/src/specs/deploy-to-kubernetes.spec.ts
+++ b/tests/playwright/src/specs/deploy-to-kubernetes.spec.ts
@@ -41,6 +41,8 @@ const CONTAINER_START_PARAMS: ContainerInteractiveParams = {
 const skipKindInstallation = process.env.SKIP_KIND_INSTALL === 'true';
 const providerTypeGHA = process.env.KIND_PROVIDER_GHA ?? '';
 
+test.skip(!canRunKindTests, `This test can't run on a windows rootless machine`);
+
 test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
   test.setTimeout(350_000);
   runner.setVideoAndTraceName('deploy-to-k8s-e2e');
@@ -77,7 +79,6 @@ test.afterAll(async ({ runner, page }) => {
 });
 
 test.describe.serial('Deploy a container to the Kind cluster', { tag: '@k8s_e2e' }, () => {
-  test.skip(!canRunKindTests, `This test can't run on a windows rootless machine`);
   test('Pull an image and start a container', async ({ navigationBar }) => {
     const imagesPage = await navigationBar.openImages();
     const pullImagePage = await imagesPage.openPullImage();

--- a/tests/playwright/src/specs/deploy-to-kubernetes.spec.ts
+++ b/tests/playwright/src/specs/deploy-to-kubernetes.spec.ts
@@ -77,7 +77,7 @@ test.afterAll(async ({ runner, page }) => {
 });
 
 test.describe.serial('Deploy a container to the Kind cluster', { tag: '@k8s_e2e' }, () => {
-  test.skip(!canRunKindTests, "This test can't run on a windows rootless machine");
+  test.skip(!canRunKindTests, `This test can't run on a windows rootless machine`);
   test('Pull an image and start a container', async ({ navigationBar }) => {
     const imagesPage = await navigationBar.openImages();
     const pullImagePage = await imagesPage.openPullImage();

--- a/tests/playwright/src/specs/deploy-to-kubernetes.spec.ts
+++ b/tests/playwright/src/specs/deploy-to-kubernetes.spec.ts
@@ -76,6 +76,7 @@ test.afterAll(async ({ runner, page }) => {
 });
 
 test.describe.serial('Deploy a container to the Kind cluster', { tag: '@k8s_e2e' }, () => {
+  test.skip(process.env.ROOTFUL_MODE !== 'true', 'This test should only run on a rootful machine');
   test('Pull an image and start a container', async ({ navigationBar }) => {
     const imagesPage = await navigationBar.openImages();
     const pullImagePage = await imagesPage.openPullImage();

--- a/tests/playwright/src/specs/deploy-to-kubernetes.spec.ts
+++ b/tests/playwright/src/specs/deploy-to-kubernetes.spec.ts
@@ -18,6 +18,7 @@
 
 import { ContainerState } from '../model/core/states';
 import type { ContainerInteractiveParams } from '../model/core/types';
+import { canRunKindTests } from '../setupFiles/setup-kind';
 import { createKindCluster, deleteCluster } from '../utility/cluster-operations';
 import { expect as playExpect, test } from '../utility/fixtures';
 import { deployContainerToCluster } from '../utility/kubernetes';
@@ -76,7 +77,7 @@ test.afterAll(async ({ runner, page }) => {
 });
 
 test.describe.serial('Deploy a container to the Kind cluster', { tag: '@k8s_e2e' }, () => {
-  test.skip(process.env.ROOTFUL_MODE !== 'true', 'This test should only run on a rootful machine');
+  test.skip(!canRunKindTests, "This test can't run on a windows rootless machine");
   test('Pull an image and start a container', async ({ navigationBar }) => {
     const imagesPage = await navigationBar.openImages();
     const pullImagePage = await imagesPage.openPullImage();

--- a/tests/playwright/src/specs/kind.spec.ts
+++ b/tests/playwright/src/specs/kind.spec.ts
@@ -54,7 +54,9 @@ test.beforeAll(async ({ runner, page, welcomePage }) => {
 
 test.afterAll(async ({ runner, page }) => {
   try {
-    await deleteCluster(page, RESOURCE_NAME, KIND_NODE, CLUSTER_NAME);
+    if (process.env.ROOTFUL_MODE === 'true')
+      //This is only needed on a rootful machine
+      await deleteCluster(page, RESOURCE_NAME, KIND_NODE, CLUSTER_NAME);
   } finally {
     await runner.close();
   }

--- a/tests/playwright/src/specs/kind.spec.ts
+++ b/tests/playwright/src/specs/kind.spec.ts
@@ -45,6 +45,8 @@ let kindResourceCard: ResourceConnectionCardPage;
 const skipKindInstallation = process.env.SKIP_KIND_INSTALL === 'true';
 const providerTypeGHA = process.env.KIND_PROVIDER_GHA ?? '';
 
+test.skip(!canRunKindTests, `This test can't run on a windows rootless machine`);
+
 test.beforeAll(async ({ runner, page, welcomePage }) => {
   runner.setVideoAndTraceName('kind-e2e');
   await welcomePage.handleWelcomePage(true);
@@ -55,9 +57,7 @@ test.beforeAll(async ({ runner, page, welcomePage }) => {
 
 test.afterAll(async ({ runner, page }) => {
   try {
-    if (!canRunKindTests)
-      //This is not needed on a windows rootless machine
-      await deleteCluster(page, RESOURCE_NAME, KIND_NODE, CLUSTER_NAME);
+    await deleteCluster(page, RESOURCE_NAME, KIND_NODE, CLUSTER_NAME);
   } finally {
     await runner.close();
   }
@@ -91,7 +91,6 @@ test.describe.serial('Kind End-to-End Tests', { tag: '@k8s_e2e' }, () => {
       });
     });
   test.describe('Kind cluster validation tests', () => {
-    test.skip(!canRunKindTests, `This test can't run on a windows rootless machine`);
     test('Create a Kind cluster', async ({ page }) => {
       test.setTimeout(CLUSTER_CREATION_TIMEOUT);
       if (process.env.GITHUB_ACTIONS && process.env.RUNNER_OS === 'Linux') {
@@ -135,7 +134,6 @@ test.describe.serial('Kind End-to-End Tests', { tag: '@k8s_e2e' }, () => {
     });
   });
   test.describe('Kind cluster operations - Details', () => {
-    test.skip(!canRunKindTests, `This test can't run on a windows rootless machine`);
     test('Create a Kind cluster', async ({ page }) => {
       test.setTimeout(CLUSTER_CREATION_TIMEOUT);
       if (process.env.GITHUB_ACTIONS && process.env.RUNNER_OS === 'Linux') {

--- a/tests/playwright/src/specs/kind.spec.ts
+++ b/tests/playwright/src/specs/kind.spec.ts
@@ -88,6 +88,7 @@ test.describe.serial('Kind End-to-End Tests', { tag: '@k8s_e2e' }, () => {
       });
     });
   test.describe('Kind cluster validation tests', () => {
+    test.skip(process.env.ROOTFUL_MODE !== 'true', 'This test should only run on a rootful machine');
     test('Create a Kind cluster', async ({ page }) => {
       test.setTimeout(CLUSTER_CREATION_TIMEOUT);
       if (process.env.GITHUB_ACTIONS && process.env.RUNNER_OS === 'Linux') {
@@ -131,6 +132,7 @@ test.describe.serial('Kind End-to-End Tests', { tag: '@k8s_e2e' }, () => {
     });
   });
   test.describe('Kind cluster operations - Details', () => {
+    test.skip(process.env.ROOTFUL_MODE !== 'true', 'This test should only run on a rootful machine');
     test('Create a Kind cluster', async ({ page }) => {
       test.setTimeout(CLUSTER_CREATION_TIMEOUT);
       if (process.env.GITHUB_ACTIONS && process.env.RUNNER_OS === 'Linux') {

--- a/tests/playwright/src/specs/kind.spec.ts
+++ b/tests/playwright/src/specs/kind.spec.ts
@@ -20,6 +20,7 @@ import { ResourceElementActions } from '../model/core/operations';
 import { ResourceElementState } from '../model/core/states';
 import { ResourceConnectionCardPage } from '../model/pages/resource-connection-card-page';
 import { ResourcesPage } from '../model/pages/resources-page';
+import { canRunKindTests } from '../setupFiles/setup-kind';
 import {
   checkClusterResources,
   createKindCluster,
@@ -54,8 +55,8 @@ test.beforeAll(async ({ runner, page, welcomePage }) => {
 
 test.afterAll(async ({ runner, page }) => {
   try {
-    if (process.env.ROOTFUL_MODE === 'true')
-      //This is only needed on a rootful machine
+    if (!canRunKindTests)
+      //This is not needed on a windows rootless machine
       await deleteCluster(page, RESOURCE_NAME, KIND_NODE, CLUSTER_NAME);
   } finally {
     await runner.close();
@@ -90,7 +91,7 @@ test.describe.serial('Kind End-to-End Tests', { tag: '@k8s_e2e' }, () => {
       });
     });
   test.describe('Kind cluster validation tests', () => {
-    test.skip(process.env.ROOTFUL_MODE !== 'true', 'This test should only run on a rootful machine');
+    test.skip(!canRunKindTests, "This test can't run on a windows rootless machine");
     test('Create a Kind cluster', async ({ page }) => {
       test.setTimeout(CLUSTER_CREATION_TIMEOUT);
       if (process.env.GITHUB_ACTIONS && process.env.RUNNER_OS === 'Linux') {
@@ -134,7 +135,7 @@ test.describe.serial('Kind End-to-End Tests', { tag: '@k8s_e2e' }, () => {
     });
   });
   test.describe('Kind cluster operations - Details', () => {
-    test.skip(process.env.ROOTFUL_MODE !== 'true', 'This test should only run on a rootful machine');
+    test.skip(!canRunKindTests, "This test can't run on a windows rootless machine");
     test('Create a Kind cluster', async ({ page }) => {
       test.setTimeout(CLUSTER_CREATION_TIMEOUT);
       if (process.env.GITHUB_ACTIONS && process.env.RUNNER_OS === 'Linux') {

--- a/tests/playwright/src/specs/kind.spec.ts
+++ b/tests/playwright/src/specs/kind.spec.ts
@@ -91,7 +91,7 @@ test.describe.serial('Kind End-to-End Tests', { tag: '@k8s_e2e' }, () => {
       });
     });
   test.describe('Kind cluster validation tests', () => {
-    test.skip(!canRunKindTests, "This test can't run on a windows rootless machine");
+    test.skip(!canRunKindTests, `This test can't run on a windows rootless machine`);
     test('Create a Kind cluster', async ({ page }) => {
       test.setTimeout(CLUSTER_CREATION_TIMEOUT);
       if (process.env.GITHUB_ACTIONS && process.env.RUNNER_OS === 'Linux') {
@@ -135,7 +135,7 @@ test.describe.serial('Kind End-to-End Tests', { tag: '@k8s_e2e' }, () => {
     });
   });
   test.describe('Kind cluster operations - Details', () => {
-    test.skip(!canRunKindTests, "This test can't run on a windows rootless machine");
+    test.skip(!canRunKindTests, `This test can't run on a windows rootless machine`);
     test('Create a Kind cluster', async ({ page }) => {
       test.setTimeout(CLUSTER_CREATION_TIMEOUT);
       if (process.env.GITHUB_ACTIONS && process.env.RUNNER_OS === 'Linux') {

--- a/tests/playwright/src/specs/kubernetes-context-smoke.spec.ts
+++ b/tests/playwright/src/specs/kubernetes-context-smoke.spec.ts
@@ -46,7 +46,6 @@ test.afterAll(async ({ runner }) => {
 });
 
 test.describe.serial('Verification of kube context management', { tag: '@smoke' }, () => {
-  test.skip(process.env.ROOTFUL_MODE !== 'true', 'This test should only run on a rootful machine');
   test('Load custom kubeconfig in Preferences', async ({ navigationBar }) => {
     // open preferences page
     const settingsBar = await navigationBar.openSettings();

--- a/tests/playwright/src/specs/kubernetes-context-smoke.spec.ts
+++ b/tests/playwright/src/specs/kubernetes-context-smoke.spec.ts
@@ -46,6 +46,7 @@ test.afterAll(async ({ runner }) => {
 });
 
 test.describe.serial('Verification of kube context management', { tag: '@smoke' }, () => {
+  test.skip(process.env.ROOTFUL_MODE !== 'true', 'This test should only run on a rootful machine');
   test('Load custom kubeconfig in Preferences', async ({ navigationBar }) => {
     // open preferences page
     const settingsBar = await navigationBar.openSettings();

--- a/tests/playwright/src/specs/kubernetes-deployments.spec.ts
+++ b/tests/playwright/src/specs/kubernetes-deployments.spec.ts
@@ -55,6 +55,8 @@ const DEPLOYMENT_YAML_PATH = path.resolve(__dirname, '..', '..', 'resources', 'k
 const skipKindInstallation = process.env.SKIP_KIND_INSTALL === 'true';
 const providerTypeGHA = process.env.KIND_PROVIDER_GHA ?? '';
 
+test.skip(!canRunKindTests, `This test can't run on a windows rootless machine`);
+
 test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
   test.setTimeout(350_000);
   runner.setVideoAndTraceName('kubernetes-edit-yaml');
@@ -74,9 +76,7 @@ test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
       useIngressController: false,
     });
   } else {
-    if (!canRunKindTests)
-      //This test can't run on a windows rootless machine
-      await createKindCluster(page, CLUSTER_NAME, true, CLUSTER_CREATION_TIMEOUT);
+    await createKindCluster(page, CLUSTER_NAME, true, CLUSTER_CREATION_TIMEOUT);
   }
 });
 
@@ -90,7 +90,6 @@ test.afterAll(async ({ runner, page }) => {
 });
 
 test.describe.serial('Kubernetes deployment resource E2E Test', { tag: '@k8s_e2e' }, () => {
-  test.skip(!canRunKindTests, `This test can't run on a windows rootless machine`);
   test('Kubernetes Pods page should be empty', async ({ navigationBar }) => {
     const kubernetesBar = await navigationBar.openKubernetes();
     const kubernetesPodsPage = await kubernetesBar.openTabPage(KubernetesResources.Pods);

--- a/tests/playwright/src/specs/kubernetes-deployments.spec.ts
+++ b/tests/playwright/src/specs/kubernetes-deployments.spec.ts
@@ -73,7 +73,9 @@ test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
       useIngressController: false,
     });
   } else {
-    await createKindCluster(page, CLUSTER_NAME, true, CLUSTER_CREATION_TIMEOUT);
+    if (process.env.ROOTFUL_MODE === 'true')
+      //Only possible on a rootful machine
+      await createKindCluster(page, CLUSTER_NAME, true, CLUSTER_CREATION_TIMEOUT);
   }
 });
 
@@ -87,6 +89,7 @@ test.afterAll(async ({ runner, page }) => {
 });
 
 test.describe.serial('Kubernetes deployment resource E2E Test', { tag: '@k8s_e2e' }, () => {
+  test.skip(process.env.ROOTFUL_MODE !== 'true', 'This test should only run on a rootful machine');
   test('Kubernetes Pods page should be empty', async ({ navigationBar }) => {
     const kubernetesBar = await navigationBar.openKubernetes();
     const kubernetesPodsPage = await kubernetesBar.openTabPage(KubernetesResources.Pods);

--- a/tests/playwright/src/specs/kubernetes-deployments.spec.ts
+++ b/tests/playwright/src/specs/kubernetes-deployments.spec.ts
@@ -22,6 +22,7 @@ import { fileURLToPath } from 'node:url';
 import { PlayYamlRuntime } from '../model/core/operations';
 import { KubernetesResourceState } from '../model/core/states';
 import { KubernetesResources } from '../model/core/types';
+import { canRunKindTests } from '../setupFiles/setup-kind';
 import { createKindCluster, deleteCluster } from '../utility/cluster-operations';
 import { expect as playExpect, test } from '../utility/fixtures';
 import {
@@ -73,8 +74,8 @@ test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
       useIngressController: false,
     });
   } else {
-    if (process.env.ROOTFUL_MODE === 'true')
-      //Only possible on a rootful machine
+    if (!canRunKindTests)
+      //This test can't run on a windows rootless machine
       await createKindCluster(page, CLUSTER_NAME, true, CLUSTER_CREATION_TIMEOUT);
   }
 });
@@ -89,7 +90,7 @@ test.afterAll(async ({ runner, page }) => {
 });
 
 test.describe.serial('Kubernetes deployment resource E2E Test', { tag: '@k8s_e2e' }, () => {
-  test.skip(process.env.ROOTFUL_MODE !== 'true', 'This test should only run on a rootful machine');
+  test.skip(!canRunKindTests, "This test can't run on a windows rootless machine");
   test('Kubernetes Pods page should be empty', async ({ navigationBar }) => {
     const kubernetesBar = await navigationBar.openKubernetes();
     const kubernetesPodsPage = await kubernetesBar.openTabPage(KubernetesResources.Pods);

--- a/tests/playwright/src/specs/kubernetes-deployments.spec.ts
+++ b/tests/playwright/src/specs/kubernetes-deployments.spec.ts
@@ -90,7 +90,7 @@ test.afterAll(async ({ runner, page }) => {
 });
 
 test.describe.serial('Kubernetes deployment resource E2E Test', { tag: '@k8s_e2e' }, () => {
-  test.skip(!canRunKindTests, "This test can't run on a windows rootless machine");
+  test.skip(!canRunKindTests, `This test can't run on a windows rootless machine`);
   test('Kubernetes Pods page should be empty', async ({ navigationBar }) => {
     const kubernetesBar = await navigationBar.openKubernetes();
     const kubernetesPodsPage = await kubernetesBar.openTabPage(KubernetesResources.Pods);

--- a/tests/playwright/src/specs/kubernetes-port-forwarding.spec.ts
+++ b/tests/playwright/src/specs/kubernetes-port-forwarding.spec.ts
@@ -63,7 +63,9 @@ test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
       useIngressController: false,
     });
   } else {
-    await createKindCluster(page, clusterName, true, 300_000);
+    if (process.env.ROOTFUL_MODE === 'true')
+      //Only possible on a rootful machine
+      await createKindCluster(page, clusterName, true, 300_000);
   }
 });
 
@@ -79,6 +81,7 @@ test.afterAll(async ({ runner, page }) => {
 });
 
 test.describe.serial('Port forwarding workflow verification', { tag: '@k8s_e2e' }, () => {
+  test.skip(process.env.ROOTFUL_MODE !== 'true', 'This test should only run on a rootful machine');
   test('Prepare deployment on the cluster', async ({ navigationBar }) => {
     test.setTimeout(120_000);
     //Pull image

--- a/tests/playwright/src/specs/kubernetes-port-forwarding.spec.ts
+++ b/tests/playwright/src/specs/kubernetes-port-forwarding.spec.ts
@@ -45,6 +45,8 @@ const localPort: number = 50000;
 const forwardAddress: string = `http://localhost:${localPort}/`;
 const responseMessage: string = 'Welcome to nginx!';
 
+test.skip(!canRunKindTests, `This test can't run on a windows rootless machine`);
+
 test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
   test.setTimeout(200_000);
   runner.setVideoAndTraceName('kubernetes-port-forwarding');
@@ -64,9 +66,7 @@ test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
       useIngressController: false,
     });
   } else {
-    if (!canRunKindTests)
-      //This test can't run on a windows rootless machine
-      await createKindCluster(page, clusterName, true, 300_000);
+    await createKindCluster(page, clusterName, true, 300_000);
   }
 });
 
@@ -82,7 +82,6 @@ test.afterAll(async ({ runner, page }) => {
 });
 
 test.describe.serial('Port forwarding workflow verification', { tag: '@k8s_e2e' }, () => {
-  test.skip(!canRunKindTests, `This test can't run on a windows rootless machine`);
   test('Prepare deployment on the cluster', async ({ navigationBar }) => {
     test.setTimeout(120_000);
     //Pull image

--- a/tests/playwright/src/specs/kubernetes-port-forwarding.spec.ts
+++ b/tests/playwright/src/specs/kubernetes-port-forwarding.spec.ts
@@ -82,7 +82,7 @@ test.afterAll(async ({ runner, page }) => {
 });
 
 test.describe.serial('Port forwarding workflow verification', { tag: '@k8s_e2e' }, () => {
-  test.skip(!canRunKindTests, "This test can't run on a windows rootless machine");
+  test.skip(!canRunKindTests, `This test can't run on a windows rootless machine`);
   test('Prepare deployment on the cluster', async ({ navigationBar }) => {
     test.setTimeout(120_000);
     //Pull image

--- a/tests/playwright/src/specs/kubernetes-port-forwarding.spec.ts
+++ b/tests/playwright/src/specs/kubernetes-port-forwarding.spec.ts
@@ -18,6 +18,7 @@
 
 import { KubernetesResources } from '../model/core/types';
 import { KubernetesResourcePage } from '../model/pages/kubernetes-resource-page';
+import { canRunKindTests } from '../setupFiles/setup-kind';
 import { createKindCluster, deleteCluster } from '../utility/cluster-operations';
 import { expect as playExpect, test } from '../utility/fixtures';
 import {
@@ -63,8 +64,8 @@ test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
       useIngressController: false,
     });
   } else {
-    if (process.env.ROOTFUL_MODE === 'true')
-      //Only possible on a rootful machine
+    if (!canRunKindTests)
+      //This test can't run on a windows rootless machine
       await createKindCluster(page, clusterName, true, 300_000);
   }
 });
@@ -81,7 +82,7 @@ test.afterAll(async ({ runner, page }) => {
 });
 
 test.describe.serial('Port forwarding workflow verification', { tag: '@k8s_e2e' }, () => {
-  test.skip(process.env.ROOTFUL_MODE !== 'true', 'This test should only run on a rootful machine');
+  test.skip(!canRunKindTests, "This test can't run on a windows rootless machine");
   test('Prepare deployment on the cluster', async ({ navigationBar }) => {
     test.setTimeout(120_000);
     //Pull image

--- a/tests/playwright/src/specs/kubernetes.spec.ts
+++ b/tests/playwright/src/specs/kubernetes.spec.ts
@@ -22,6 +22,7 @@ import { fileURLToPath } from 'node:url';
 import { PlayYamlRuntime } from '../model/core/operations';
 import { KubernetesResourceState, PodState } from '../model/core/states';
 import { KubernetesResources } from '../model/core/types';
+import { canRunKindTests } from '../setupFiles/setup-kind';
 import { createKindCluster, deleteCluster } from '../utility/cluster-operations';
 import { expect as playExpect, test } from '../utility/fixtures';
 import {
@@ -80,8 +81,8 @@ test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
       useIngressController: false,
     });
   } else {
-    if (process.env.ROOTFUL_MODE === 'true')
-      //Only possible on a rootful machine
+    if (!canRunKindTests)
+      //This test can't run on a windows rootless machine
       await createKindCluster(page, CLUSTER_NAME, true, CLUSTER_CREATION_TIMEOUT);
   }
 });
@@ -96,7 +97,7 @@ test.afterAll(async ({ runner, page }) => {
 });
 
 test.describe('Kubernetes resources End-to-End test', { tag: '@k8s_e2e' }, () => {
-  test.skip(process.env.ROOTFUL_MODE !== 'true', 'This test should only run on a rootful machine');
+  test.skip(!canRunKindTests, "This test can't run on a windows rootless machine");
   test('Kubernetes Nodes test', async ({ page }) => {
     await checkKubernetesResourceState(page, KubernetesResources.Nodes, KIND_NODE, KubernetesResourceState.Running);
   });

--- a/tests/playwright/src/specs/kubernetes.spec.ts
+++ b/tests/playwright/src/specs/kubernetes.spec.ts
@@ -97,7 +97,7 @@ test.afterAll(async ({ runner, page }) => {
 });
 
 test.describe('Kubernetes resources End-to-End test', { tag: '@k8s_e2e' }, () => {
-  test.skip(!canRunKindTests, "This test can't run on a windows rootless machine");
+  test.skip(!canRunKindTests, `This test can't run on a windows rootless machine`);
   test('Kubernetes Nodes test', async ({ page }) => {
     await checkKubernetesResourceState(page, KubernetesResources.Nodes, KIND_NODE, KubernetesResourceState.Running);
   });

--- a/tests/playwright/src/specs/kubernetes.spec.ts
+++ b/tests/playwright/src/specs/kubernetes.spec.ts
@@ -80,7 +80,9 @@ test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
       useIngressController: false,
     });
   } else {
-    await createKindCluster(page, CLUSTER_NAME, true, CLUSTER_CREATION_TIMEOUT);
+    if (process.env.ROOTFUL_MODE === 'true')
+      //Only possible on a rootful machine
+      await createKindCluster(page, CLUSTER_NAME, true, CLUSTER_CREATION_TIMEOUT);
   }
 });
 
@@ -94,6 +96,7 @@ test.afterAll(async ({ runner, page }) => {
 });
 
 test.describe('Kubernetes resources End-to-End test', { tag: '@k8s_e2e' }, () => {
+  test.skip(process.env.ROOTFUL_MODE !== 'true', 'This test should only run on a rootful machine');
   test('Kubernetes Nodes test', async ({ page }) => {
     await checkKubernetesResourceState(page, KubernetesResources.Nodes, KIND_NODE, KubernetesResourceState.Running);
   });

--- a/tests/playwright/src/specs/kubernetes.spec.ts
+++ b/tests/playwright/src/specs/kubernetes.spec.ts
@@ -62,6 +62,8 @@ const SECRET_POD_YAML_PATH = path.resolve(__dirname, '..', '..', 'resources', 'k
 const skipKindInstallation = process.env.SKIP_KIND_INSTALL === 'true';
 const providerTypeGHA = process.env.KIND_PROVIDER_GHA ?? '';
 
+test.skip(!canRunKindTests, `This test can't run on a windows rootless machine`);
+
 test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
   test.setTimeout(350_000);
   runner.setVideoAndTraceName('kubernetes-e2e');
@@ -81,9 +83,7 @@ test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
       useIngressController: false,
     });
   } else {
-    if (!canRunKindTests)
-      //This test can't run on a windows rootless machine
-      await createKindCluster(page, CLUSTER_NAME, true, CLUSTER_CREATION_TIMEOUT);
+    await createKindCluster(page, CLUSTER_NAME, true, CLUSTER_CREATION_TIMEOUT);
   }
 });
 
@@ -97,7 +97,6 @@ test.afterAll(async ({ runner, page }) => {
 });
 
 test.describe('Kubernetes resources End-to-End test', { tag: '@k8s_e2e' }, () => {
-  test.skip(!canRunKindTests, `This test can't run on a windows rootless machine`);
   test('Kubernetes Nodes test', async ({ page }) => {
     await checkKubernetesResourceState(page, KubernetesResources.Nodes, KIND_NODE, KubernetesResourceState.Running);
   });


### PR DESCRIPTION
### What does this PR do?
Adds an skip condition to the kind tests so that they are not run on rootless machines. Fixes partially [#315 ](https://github.com/podman-desktop/e2e/issues/315).

### What issues does this PR fix or reference?
[Kind E2E tests on windows rootless should be expected to fail, but aren't #315 ](https://github.com/podman-desktop/e2e/issues/315)
Related PR: [chore(e2e): add ROOTFUL_MODE envvar for kind tests #16](https://github.com/odockal/pde2e-runner/pull/16)

### How to test this PR?
Run `pnpm test:e2e:all`

## Summary by Sourcery

Skip Kind E2E tests on rootless machines. This change ensures that Kind E2E tests are only executed on rootful machines by adding a skip condition based on the `ROOTFUL_MODE` environment variable.