### PR TITLE
fix(ui): dropdown menu overlap

### DIFF
--- a/packages/renderer/src/lib/authentication/AuthActions.svelte
+++ b/packages/renderer/src/lib/authentication/AuthActions.svelte
@@ -10,7 +10,6 @@ import { authenticationProviders } from '../../stores/authenticationProviders';
 export let onBeforeToggle = (): void => {};
 let showMenu = false;
 
-let clientY: number;
 let clientX: number;
 export let outsideWindow: HTMLDivElement;
 
@@ -31,7 +30,6 @@ function onWindowClick(e: Event): void {
 
 export function onButtonClick(e: MouseEvent): void {
   // keep track of the cursor position
-  clientY = e.clientY;
   clientX = e.clientX;
   toggleMenu();
 }
@@ -40,7 +38,7 @@ export function onButtonClick(e: MouseEvent): void {
 <svelte:window on:keyup={handleEscape} on:click={onWindowClick} />
 
 {#if showMenu}
-  <DropdownMenu.Items clientY={clientY} clientX={clientX}>
+  <DropdownMenu.Items clientX={clientX}>
     <DropdownMenu.Item
       title="Manage authentication"
       icon={faKey}

--- a/packages/ui/src/lib/dropdownMenu/DropDownMenuItems.spec.ts
+++ b/packages/ui/src/lib/dropdownMenu/DropDownMenuItems.spec.ts
@@ -44,22 +44,9 @@ afterEach(() => {
   vi.resetAllMocks();
 });
 
-test('Expect DropDownMenuItems to open on the above the button', async () => {
-  render(DropDownMenuItems, {
-    clientX: 200,
-    clientY: 400,
-  });
-  const dropDownMenuItems = screen.getByTitle('Drop Down Menu Items', {});
-
-  expect(dropDownMenuItems).toBeVisible();
-  expect(dropDownMenuItems).toBeInTheDocument();
-  expect(dropDownMenuItems).toHaveStyle('top: -100px');
-});
-
 test('Expect DropDownMenuItems to open on the under the button', async () => {
   render(DropDownMenuItems, {
     clientX: 200,
-    clientY: 50,
   });
   const dropDownMenuItems = screen.getByTitle('Drop Down Menu Items', {});
 
@@ -71,7 +58,6 @@ test('Expect DropDownMenuItems to open on the under the button', async () => {
 test('Expect DropDownMenuItems to open on the right of the button', async () => {
   render(DropDownMenuItems, {
     clientX: 650,
-    clientY: 200,
   });
   const dropDownMenuItems = screen.getByTitle('Drop Down Menu Items', {});
 
@@ -84,7 +70,6 @@ test('Expect DropDownMenuItems to open on the right of the button', async () => 
 test('Expect DropDownMenuItems to open on the left of the button', async () => {
   render(DropDownMenuItems, {
     clientX: 50,
-    clientY: 200,
   });
   const dropDownMenuItems = screen.getByTitle('Drop Down Menu Items', {});
 

--- a/packages/ui/src/lib/dropdownMenu/DropDownMenuItems.svelte
+++ b/packages/ui/src/lib/dropdownMenu/DropDownMenuItems.svelte
@@ -1,25 +1,16 @@
 <script lang="ts">
 import { onDestroy, onMount } from 'svelte';
 
-let dropDownHeight: number;
 let dropDownWidth: number;
 let dropDownElement: HTMLElement;
 let sideAlign: string;
 
-export let clientY: number;
 export let clientX: number;
-
-const STATUS_BAR_HEIGHT = 24;
 
 // When initializing the widget, set the placement on top or on bottom
 // depending on the clientY position (cursor position) and the height of the dropdown menu to display
 onMount(() => {
-  const innerHeight = window.innerHeight;
-  if (innerHeight - clientY - STATUS_BAR_HEIGHT < dropDownHeight) {
-    dropDownElement.style.top = `-${dropDownHeight}px`;
-  } else {
-    dropDownElement.style.top = '20px';
-  }
+  dropDownElement.style.top = '20px';
 
   // When initializing the widget, set the placement on left or right
   // depending on the clientX position (cursor position) and the width of the dropdown menu to display
@@ -38,7 +29,6 @@ onDestroy(() => {
 
 <div
   title="Drop Down Menu Items"
-  bind:clientHeight={dropDownHeight}
   bind:clientWidth={dropDownWidth}
   bind:this={dropDownElement}
   class="{sideAlign} absolute z-10 m-2 rounded-md shadow-lg bg-[var(--pd-dropdown-bg)] ring-2 ring-[var(--pd-dropdown-ring)] hover:ring-[var(--pd-dropdown-hover-ring)] divide-y divide-[var(--pd-dropdown-divider)] focus:outline-hidden">

--- a/packages/ui/src/lib/dropdownMenu/DropdownMenu.svelte
+++ b/packages/ui/src/lib/dropdownMenu/DropdownMenu.svelte
@@ -24,7 +24,6 @@ function handleEscape({ key }: KeyboardEvent): void {
   }
 }
 
-let clientY: number;
 let clientX: number;
 
 function toggleMenu(): void {
@@ -40,7 +39,6 @@ function onWindowClick(e: any): void {
 
 function onButtonClick(e: MouseEvent): void {
   // keep track of the cursor position
-  clientY = e.clientY;
   clientX = e.clientX;
   toggleMenu();
 }
@@ -66,7 +64,7 @@ function onButtonClick(e: MouseEvent): void {
 
     <!-- Dropdown menu for all other actions -->
     {#if showMenu}
-      <DropDownMenuItems clientY={clientY} clientX={clientX}><slot /></DropDownMenuItems>
+      <DropDownMenuItems clientX={clientX}><slot /></DropDownMenuItems>
     {/if}
   </div>
 {/if}


### PR DESCRIPTION
### What does this PR do?

I was not able to found a _nice_ solution to fix the positioning of the DropdownItem. The solution brought here is just to force it to always be placed on the bottom position.

Some references for the problem
- Can't have both an `overflow: visible` and an `overflow: scroll` at the same time[^1]
- Playground minimal problem reproducable[^2]

[^1]: https://www.reddit.com/r/learnprogramming/comments/1b993a0/css_overflowx_visible_and_overflowy_scroll_why/?rdt=41032
[^2]: https://codepen.io/jessearon/pen/abxdmRV

### Screenshot / video of UI

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/7b63bca4-ecdc-4c34-9548-30c241206581) | ![image](https://github.com/user-attachments/assets/c406a312-999f-432b-8fe2-01019a2b8654) |

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/10850

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Existing tests ensure no regression

## Summary by Sourcery

Fixes an issue where the dropdown menu was overlapping with other UI elements by forcing the dropdown to always be placed on the bottom position.

Bug Fixes:
- Fixes an issue where the dropdown menu was overlapping with other UI elements.

Tests:
- Removes a test that was checking if the dropdown menu was opening above the button, as the dropdown menu is now always placed on the bottom.