### PR TITLE
feat: add a command to configure registries of Podman

### DIFF
--- a/extensions/podman/packages/extension/package.json
+++ b/extensions/podman/packages/extension/package.json
@@ -40,6 +40,10 @@
       {
         "command": "podman.onboarding.removeUnsupportedMachines",
         "title": "Podman: Remove unsupported podman machines"
+      },
+      {
+        "command": "podman.setupRegistry",
+        "title": "Podman: Setup registry"
       }
     ],
     "configuration": {

--- a/extensions/podman/packages/extension/src/configuration/registry-configuration.ts
+++ b/extensions/podman/packages/extension/src/configuration/registry-configuration.ts
@@ -16,18 +16,52 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { mkdir, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { homedir, tmpdir } from 'node:os';
 import { dirname, resolve } from 'node:path';
 
-import { env } from '@podman-desktop/api';
+import type { Disposable, QuickPickItem } from '@podman-desktop/api';
+import { commands, env, window } from '@podman-desktop/api';
 import mustache from 'mustache';
+import * as toml from 'smol-toml';
 
+import { getJSONMachineList } from '../extension';
+import { execPodman } from '../util';
 import playbookRegistryConfFileTemplate from './playbook-setup-registry-conf-file.mustache?raw';
 
+interface RegistryEntryQuickPickItem extends QuickPickItem {
+  entry: RegistryConfigurationEntry;
+}
+
+export enum ActionEnum {
+  ADD_REGISTRY_ACTION = 'addRegistry',
+  END_REGISTRY_ACTION = 'endConfiguringRegistry',
+}
+
+interface ActionQuickPickItem extends QuickPickItem {
+  actionName: ActionEnum;
+}
+
+interface RegistryConfigurationEntry {
+  prefix?: string;
+  insecure?: boolean;
+  blocked?: boolean;
+  location?: string;
+  mirror?: RegistryConfigurationMirrorEntry[];
+}
+
+interface RegistryConfigurationMirrorEntry {
+  location?: string;
+  insecure?: boolean;
+}
+
+export interface RegistryConfigurationFile {
+  registry: RegistryConfigurationEntry[];
+}
+
 export interface RegistryConfiguration {
-  getRegistryConfFilePath(): string;
-  getPathToRegistriesConfInsideVM(): string;
+  init(): Promise<Disposable[]>;
   getPlaybookScriptPath(): Promise<string>;
 }
 
@@ -35,7 +69,176 @@ export interface RegistryConfiguration {
  * Manages the registry configuration file (inside the Podman VM for macOS/Windows)
  */
 export class RegistryConfigurationImpl implements RegistryConfiguration {
-  // provides the path to the file being on the host
+  async init(): Promise<Disposable[]> {
+    const disposables: Disposable[] = [];
+    disposables.push(this.registerSetupRegistryCommand());
+    return disposables;
+  }
+
+  registerSetupRegistryCommand(): Disposable {
+    return commands.registerCommand('podman.setupRegistry', async () => this.setupRegistryCommandCallback());
+  }
+
+  async checkRegistryConfFileExistsInVm(): Promise<boolean> {
+    // check if the podman machine has the file being mounted inside the VM or then says it can't continue
+    const machineList = await getJSONMachineList();
+
+    // check if the machine is running
+    if (!machineList || machineList.list.length === 0) {
+      await window.showErrorMessage('No Podman machine running');
+      return false;
+    }
+
+    // filter all machines that are running
+    const runningMachines = machineList.list.filter(machine => machine.Running === true);
+
+    // execute a command to check if the registries conf file is mounted inside the /etc/containers/registries.conf.d folder
+    // if not, display an error
+    const machineRegistriesConfPathOnHost = this.getPathToRegistriesConfInsideVM();
+
+    // use podman machine ssh command
+    for (const machine of runningMachines) {
+      const commandLineArgs = [
+        'machine',
+        'ssh',
+        machine.Name,
+        `find /etc/containers/registries.conf.d/ -lname "${machineRegistriesConfPathOnHost}"`,
+      ];
+
+      // check if the file is mounted
+      const result = await execPodman(commandLineArgs, machine.VMType);
+      if (!result.stdout) {
+        // display an error message if the link is not found
+        await window.showErrorMessage(
+          `The registries configuration file is not mounted in the Podman VM ${machine.Name} in /etc/containers/registries.conf.d/ folder. Cannot continue. Recreate the machine using Podman Desktop.`,
+        );
+        return false;
+      }
+    }
+    return true;
+  }
+
+  async setupRegistryCommandCallback(): Promise<void> {
+    // on Linux the file is accessible directly
+    if (env.isMac || env.isWindows) {
+      const checked = await this.checkRegistryConfFileExistsInVm();
+      if (!checked) {
+        return;
+      }
+    }
+
+    // continue
+    return this.displayRegistryQuickPick();
+  }
+
+  async displayRegistryQuickPick(): Promise<void> {
+    let keepConfiguring = true;
+    const configFileContent = await this.readRegistriesConfContent();
+
+    while (keepConfiguring) {
+      const quickPickItems = this.buildQuickPickItems(configFileContent);
+      const response = await window.showQuickPick(quickPickItems, {
+        title: 'Registry configuration',
+        placeHolder: 'Select a registry to configure',
+      });
+
+      if (!response) break;
+
+      if ('actionName' in response) {
+        keepConfiguring = await this.handleAction(response, configFileContent);
+      } else if (response.entry?.location) {
+        await this.handleEditMirror(response.entry, configFileContent);
+      }
+    }
+  }
+
+  buildQuickPickItems(
+    configFileContent: RegistryConfigurationFile,
+  ): (RegistryEntryQuickPickItem | ActionQuickPickItem)[] {
+    const items: (RegistryEntryQuickPickItem | ActionQuickPickItem)[] = configFileContent.registry
+      .filter(entry => !!entry.location)
+      .map(entry => {
+        const description = entry.mirror ? `mirroring: [${entry.mirror.map(m => m.location).join(', ')}]` : '';
+        return {
+          label: entry.location ?? '',
+          description,
+          entry,
+        } as RegistryEntryQuickPickItem;
+      });
+    items.push(
+      { label: '⚙️ Add registry configuration', actionName: ActionEnum.ADD_REGISTRY_ACTION },
+      { label: '↩ End configuring registries', actionName: ActionEnum.END_REGISTRY_ACTION },
+    );
+    return items;
+  }
+
+  async handleAction(response: ActionQuickPickItem, configFileContent: RegistryConfigurationFile): Promise<boolean> {
+    if (response.actionName === ActionEnum.ADD_REGISTRY_ACTION) {
+      const registryName = await window.showInputBox({
+        title: 'Add location of the registry',
+        placeHolder: 'Enter a registry location',
+      });
+      if (registryName) {
+        configFileContent.registry.push({ location: registryName });
+        await this.saveRegistriesConfContent(configFileContent);
+      }
+    } else if (response.actionName === ActionEnum.END_REGISTRY_ACTION) {
+      return false; // end configuration
+    }
+    return true;
+  }
+
+  async handleEditMirror(
+    entry: RegistryConfigurationEntry,
+    configFileContent: RegistryConfigurationFile,
+  ): Promise<void> {
+    const initialValue = entry.mirror?.[0]?.location ?? '';
+    const mirrorRegistry = await window.showInputBox({
+      title: 'Define mirror location for the registry',
+      placeHolder: `Enter the mirror for ${entry.location}`,
+      value: initialValue,
+    });
+    const matchingRegistry = configFileContent.registry.find(e => e.location === entry.location);
+    if (matchingRegistry) {
+      matchingRegistry.mirror = mirrorRegistry ? [{ location: mirrorRegistry }] : undefined;
+      await this.saveRegistriesConfContent(configFileContent);
+    }
+  }
+
+  async saveRegistriesConfContent(content: RegistryConfigurationFile): Promise<void> {
+    const tomlContent = toml.stringify(content);
+
+    await writeFile(this.getRegistryConfFilePath(), tomlContent, 'utf-8');
+  }
+
+  async readRegistriesConfContent(): Promise<RegistryConfigurationFile> {
+    const EMPTY_CONFIG_FILE = { registry: [] };
+    const registryConfFilePath = this.getRegistryConfFilePath();
+    if (!existsSync(registryConfFilePath)) {
+      return EMPTY_CONFIG_FILE;
+    }
+
+    // get the content of the file
+    const content = await readFile(registryConfFilePath, 'utf-8');
+    const tomlConfigFile = toml.parse(content);
+
+    // read all the '[[registry]]' entries
+    const registry: RegistryConfigurationEntry[] = [];
+    if (!tomlConfigFile?.registry || !Array.isArray(tomlConfigFile?.registry)) {
+      return EMPTY_CONFIG_FILE;
+    }
+    const registries: RegistryConfigurationEntry[] = tomlConfigFile.registry as RegistryConfigurationEntry[];
+
+    for (const registryEntry of registries) {
+      registry.push(registryEntry);
+    }
+
+    const configurationFile = { registry };
+
+    await this.saveRegistriesConfContent(configurationFile);
+    return configurationFile;
+  }
+
   // $HOME/.config/containers/registries.conf
   getRegistryConfFilePath(): string {
     return resolve(homedir(), '.config/containers/registries.conf');

--- a/extensions/podman/packages/extension/src/configuration/registry-configuration.ts
+++ b/extensions/podman/packages/extension/src/configuration/registry-configuration.ts
@@ -76,7 +76,7 @@ export class RegistryConfigurationImpl implements RegistryConfiguration {
   }
 
   registerSetupRegistryCommand(): Disposable {
-    return commands.registerCommand('podman.setupRegistry', async () => this.setupRegistryCommandCallback());
+    return commands.registerCommand('podman.setupRegistry', this.setupRegistryCommandCallback);
   }
 
   async checkRegistryConfFileExistsInVm(): Promise<boolean> {

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -2331,7 +2331,7 @@ test('isIncompatibleMachineOutput', () => {
 });
 
 describe('calcPodmanMachineSetting', () => {
-  const podmanConfiguration = new PodmanConfiguration();
+  const podmanConfiguration = new PodmanConfiguration({} as unknown as extensionApi.ExtensionContext);
   let originalProvider: string | undefined;
   beforeEach(() => {
     originalProvider = process.env.CONTAINERS_MACHINE_PROVIDER;

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -1378,7 +1378,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
     },
   ];
 
-  const podmanConfiguration = new PodmanConfiguration();
+  const podmanConfiguration = new PodmanConfiguration(extensionContext);
   await podmanConfiguration.init();
 
   const provider = extensionApi.provider.createProvider(providerOptions);

--- a/extensions/podman/packages/extension/src/podman-configuration.spec.ts
+++ b/extensions/podman/packages/extension/src/podman-configuration.spec.ts
@@ -18,7 +18,7 @@
 
 import * as fs from 'node:fs';
 
-import type { ProxySettings } from '@podman-desktop/api';
+import type { ExtensionContext, ProxySettings } from '@podman-desktop/api';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { PodmanConfiguration } from './podman-configuration';
@@ -37,6 +37,8 @@ vi.mock('@podman-desktop/api', async () => {
   };
 });
 
+const extensionContext: ExtensionContext = {} as unknown as ExtensionContext;
+
 // allows to call protected methods
 class TestPodmanConfiguration extends PodmanConfiguration {
   readContainersConfigFile(): Promise<string> {
@@ -47,7 +49,7 @@ class TestPodmanConfiguration extends PodmanConfiguration {
 let podmanConfiguration: TestPodmanConfiguration;
 
 beforeEach(() => {
-  podmanConfiguration = new TestPodmanConfiguration();
+  podmanConfiguration = new TestPodmanConfiguration(extensionContext);
 });
 
 afterEach(() => {

--- a/extensions/podman/packages/extension/src/podman-configuration.ts
+++ b/extensions/podman/packages/extension/src/podman-configuration.ts
@@ -36,9 +36,11 @@ const configurationRosetta = 'setting.rosetta';
 export class PodmanConfiguration {
   private mutex: Mutex = new Mutex();
 
+  #extensionContext: extensionApi.ExtensionContext;
   #registryConfiguration: RegistryConfiguration;
 
-  constructor() {
+  constructor(extensionContext: extensionApi.ExtensionContext) {
+    this.#extensionContext = extensionContext;
     this.#registryConfiguration = new RegistryConfigurationImpl();
   }
 
@@ -46,6 +48,9 @@ export class PodmanConfiguration {
     let httpProxy = undefined;
     let httpsProxy = undefined;
     let noProxy = undefined;
+
+    const disposables = await this.#registryConfiguration.init();
+    this.#extensionContext.subscriptions.push(...disposables);
 
     // we receive an update for the current proxy settings
     extensionApi.proxy.onDidUpdateProxy(async (proxySettings: ProxySettings) => {


### PR DESCRIPTION
### What does this PR do?
Add a command to be able to configure podman registries

### Screenshot / video of UI

https://github.com/user-attachments/assets/151b7f6d-0366-4075-b549-3e83d02eed45


### What issues does this PR fix or reference?

fixes https://github.com/podman-desktop/podman-desktop/issues/10673

### How to test this PR?

1. recreate the machine assuming you're on macOS (on Windows it seems you need to manually tweak the mount)
1. bring command palette and select "podman registry setup" command as in the recording

then enter the registry and then the mirror and check the command using the cli inside the VM to get the right answer

```
podman pull docker.io/invalidddd
Trying to pull docker.io/library/invalidddd:latest...
Error: initializing source docker://invalidddd:latest: (Mirrors also failed: [ghcr.io/library/invalidddd:latest: Requesting bearer token: invalid status code from registry 403 (Forbidden)]): docker.io/library/invalidddd:latest: reading manifest latest in docker.io/library/invalidddd: requested access to the resource is denied
```

see it tries a mirror

- [x] Tests are covering the bug fix or the new feature

## Summary by Sourcery

Adds a new command `podman.setupRegistry` to configure registries for Podman. The command allows users to add registry locations and configure mirrors. The configuration is persisted in a TOML file.

New Features:
- Adds a command to configure Podman registries, allowing users to add registry locations and configure mirrors via a quick pick interface.
- The registry configuration is persisted in a TOML file.