### PR TITLE
chore: remove kube badge from pods page

### DIFF
--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -12,8 +12,6 @@ import {
 } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 
-import KubernetesCurrentContextConnectionBadge from '/@/lib/ui/KubernetesCurrentContextConnectionBadge.svelte';
-
 import type { PodInfo } from '../../../../main/src/plugin/api/pod-info';
 import { filtered, podsInfos, searchPattern } from '../../stores/pods';
 import { providerInfos } from '../../stores/providers';
@@ -185,9 +183,6 @@ const row = new TableRow<PodInfoUI>({ selectable: (_pod): boolean => true });
         icon={faTrash} />
       <span>On {selectedItemsNumber} selected items.</span>
     {/if}
-    <div class="flex grow justify-end">
-      <KubernetesCurrentContextConnectionBadge />
-    </div>
   </svelte:fragment>
 
   <svelte:fragment slot="tabs">


### PR DESCRIPTION
### What does this PR do?

No Kubernetes content: we can remove the Kubernetes context badge from the Pods page.

### Screenshot / video of UI

N/A (imagine the badge not there :))

### What issues does this PR fix or reference?

Part of #8819.

### How to test this PR?

No badge in Pods page.

## Summary by Sourcery

Chores:
- Remove the Kubernetes context badge from the Pods page, as it is no longer relevant.