### PR TITLE
chore(extension-api): adding version property to ContainerProviderConnection

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -401,6 +401,10 @@ declare module '@podman-desktop/api' {
      * the vmTypeDisplayName property cannot be set if vmType is undefined
      */
     vmTypeDisplayName?: string;
+    /**
+     * the remote may be different from the client version
+     */
+    version?(): string | undefined;
   }
 
   export interface PodCreatePortOptions {

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -402,9 +402,13 @@ declare module '@podman-desktop/api' {
      */
     vmTypeDisplayName?: string;
     /**
-     * the remote may be different from the client version
+     * The Container Provider Connection may have a specific version
+     * that differ from the client/host.
+     *
+     * This is common when dealing with remote host, such as Podman Machines.
      */
-    version?(): string | undefined;
+    version?: string;
+    onDidUpdateVersion?: Event<string>;
   }
 
   export interface PodCreatePortOptions {


### PR DESCRIPTION
### What does this PR do?

As per requested in https://github.com/podman-desktop/podman-desktop/pull/10768 splitting it.

### Notes

Why using a function (getter) for the `version` field instead of a string field ?

When the extension `registerContainerProviderConnection` it provide an object, and those object cannot be changed after. To overcome this limitation, the status field is a function, that the core can call to get the status.

Since the version cannot be determine when the podman machine is not running, we would put `undefined` when registering the container connection, and would have no way to update it when finally the machine would be started.

Therefore, in a similar manner, having a function allow the core to call it to be able to get it when the extension notify an update.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/4215

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature

## Summary by Sourcery

Add a `version` property to the `ContainerProviderConnection` interface in the extension API. This property is a function that returns the version of the container provider connection.

Chores:
- Add a `version` property to the `ContainerProviderConnection` interface in the extension API.
- The `version` property is a function that returns the version of the container provider connection, allowing the core to call it to get the version when the extension notifies an update.