### PR TITLE
feat: display counts in dashboard in experimental mode

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -2682,6 +2682,10 @@ export class PluginSystem {
       return kubernetesClient.getResourcesCount();
     });
 
+    this.ipcHandle('kubernetes:getActiveResourcesCount', async (_listener): Promise<ResourceCount[]> => {
+      return kubernetesClient.getActiveResourcesCount();
+    });
+
     this.ipcHandle(
       'kubernetes:getResources',
       async (_listener, contextNames: string[], resourceName: string): Promise<KubernetesContextResources[]> => {

--- a/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
@@ -176,6 +176,24 @@ export class ContextsManagerExperimental {
     }));
   }
 
+  // getActiveResourcesCount returns the count of filtered resources for each context/resource
+  // when isActive is declared for a resource, and filtered with isActive
+  getActiveResourcesCount(): ResourceCount[] {
+    return this.#objectCaches
+      .getAll()
+      .map(informer => {
+        const isActive = this.#resourceFactoryHandler.getResourceFactoryByResourceName(informer.resourceName)?.isActive;
+        return isActive
+          ? {
+              contextName: informer.contextName,
+              resourceName: informer.resourceName,
+              count: informer.value.list().filter(isActive).length,
+            }
+          : undefined;
+      })
+      .filter(f => !!f);
+  }
+
   getResources(contextNames: string[], resourceName: string): KubernetesContextResources[] {
     return this.#objectCaches.getForContextsAndResource(contextNames, resourceName).map(({ contextName, value }) => {
       return {

--- a/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.ts
@@ -43,7 +43,10 @@ export class ContextsStatesDispatcher {
       this.updatePermissions();
     });
     this.manager.onResourceCountUpdated(() => this.updateResourcesCount());
-    this.manager.onResourceUpdated(event => this.updateResource(event.resourceName));
+    this.manager.onResourceUpdated(event => {
+      this.updateResource(event.resourceName);
+      this.updateActiveResourcesCount();
+    });
   }
 
   updateHealthStates(): void {
@@ -75,8 +78,17 @@ export class ContextsStatesDispatcher {
     this.apiSender.send(`kubernetes-resources-count`);
   }
 
+  updateActiveResourcesCount(): void {
+    // TODO send signal only if frontend has registered
+    this.apiSender.send(`kubernetes-active-resources-count`);
+  }
+
   getResourcesCount(): ResourceCount[] {
     return this.manager.getResourcesCount();
+  }
+
+  getActiveResourcesCount(): ResourceCount[] {
+    return this.manager.getActiveResourcesCount();
   }
 
   updateResource(resourceName: string): void {

--- a/packages/main/src/plugin/kubernetes/deployments-resource-factory.spec.ts
+++ b/packages/main/src/plugin/kubernetes/deployments-resource-factory.spec.ts
@@ -1,0 +1,49 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1Deployment } from '@kubernetes/client-node';
+import { expect, test } from 'vitest';
+
+import { DeploymentsResourceFactory } from './deployments-resource-factory.js';
+
+test('deployment with replica=0 is not active', () => {
+  const factory = new DeploymentsResourceFactory();
+  expect(
+    factory.isActive({
+      spec: {
+        replicas: 0,
+      },
+    } as V1Deployment),
+  ).toBeFalsy();
+});
+
+test('deployment with replica=1 is active', () => {
+  const factory = new DeploymentsResourceFactory();
+  expect(
+    factory.isActive({
+      spec: {
+        replicas: 1,
+      },
+    } as V1Deployment),
+  ).toBeTruthy();
+});
+
+test('deployment with replica undefined is not active', () => {
+  const factory = new DeploymentsResourceFactory();
+  expect(factory.isActive({} as V1Deployment)).toBeFalsy();
+});

--- a/packages/main/src/plugin/kubernetes/deployments-resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/deployments-resource-factory.ts
@@ -48,6 +48,7 @@ export class DeploymentsResourceFactory extends ResourceFactoryBase implements R
     this.setInformer({
       createInformer: this.createInformer,
     });
+    this.setIsActive(this.isDeploymentActive);
   }
 
   createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1Deployment> {
@@ -56,5 +57,9 @@ export class DeploymentsResourceFactory extends ResourceFactoryBase implements R
     const listFn = (): Promise<V1DeploymentList> => apiClient.listNamespacedDeployment({ namespace });
     const path = `/apis/apps/v1/namespaces/${namespace}/deployments`;
     return new ResourceInformer<V1Deployment>({ kubeconfig, path, listFn, kind: 'Deployment', plural: 'deployments' });
+  }
+
+  isDeploymentActive(deployment: V1Deployment): boolean {
+    return (deployment.spec?.replicas ?? 0) > 0;
   }
 }

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.ts
@@ -1688,6 +1688,13 @@ export class KubernetesClient {
     return this.contextsStatesDispatcher.getResourcesCount();
   }
 
+  public getActiveResourcesCount(): ResourceCount[] {
+    if (!this.contextsStatesDispatcher) {
+      throw new Error('contextsStatesDispatcher is undefined. This should not happen in Kubernetes experimental');
+    }
+    return this.contextsStatesDispatcher.getActiveResourcesCount();
+  }
+
   public getResources(contextNames: string[], resourceName: string): KubernetesContextResources[] {
     if (!this.contextsStatesDispatcher) {
       throw new Error(

--- a/packages/main/src/plugin/kubernetes/nodes-resource-factory.spec.ts
+++ b/packages/main/src/plugin/kubernetes/nodes-resource-factory.spec.ts
@@ -1,0 +1,65 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1Node } from '@kubernetes/client-node';
+import { expect, test } from 'vitest';
+
+import { NodesResourceFactory } from './nodes-resource-factory.js';
+
+test('node with no status is not active', () => {
+  const factory = new NodesResourceFactory();
+  expect(
+    factory.isActive({
+      spec: {
+        replicas: 0,
+      },
+    } as V1Node),
+  ).toBeFalsy();
+});
+
+test('node with "Ready" condition set to true is active', () => {
+  const factory = new NodesResourceFactory();
+  expect(
+    factory.isActive({
+      status: {
+        conditions: [
+          {
+            type: 'Ready',
+            status: 'True',
+          },
+        ],
+      },
+    } as V1Node),
+  ).toBeTruthy();
+});
+
+test('node with "Ready" condition set to false is not active', () => {
+  const factory = new NodesResourceFactory();
+  expect(
+    factory.isActive({
+      status: {
+        conditions: [
+          {
+            type: 'Ready',
+            status: 'False',
+          },
+        ],
+      },
+    } as V1Node),
+  ).toBeFalsy();
+});

--- a/packages/main/src/plugin/kubernetes/nodes-resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/nodes-resource-factory.ts
@@ -47,6 +47,7 @@ export class NodesResourceFactory extends ResourceFactoryBase implements Resourc
     this.setInformer({
       createInformer: this.createInformer,
     });
+    this.setIsActive(this.isNodeActive);
   }
 
   createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1Node> {
@@ -54,5 +55,11 @@ export class NodesResourceFactory extends ResourceFactoryBase implements Resourc
     const listFn = (): Promise<V1NodeList> => apiClient.listNode();
     const path = `/api/v1/nodes`;
     return new ResourceInformer<V1Node>({ kubeconfig, path, listFn, kind: 'Node', plural: 'nodes' });
+  }
+
+  isNodeActive(node: V1Node): boolean {
+    return (
+      node.status?.conditions?.some(condition => condition.type === 'Ready' && condition.status === 'True') ?? false
+    );
   }
 }

--- a/packages/main/src/plugin/kubernetes/resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/resource-factory.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024 - 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ export class ResourceFactoryBase {
   #resource: string;
   #permissions: ResourcePermissionsFactory | undefined;
   #informer: ResourceInformerFactory | undefined;
+  #isActive: undefined | ((resource: KubernetesObject) => boolean);
 
   constructor(options: {
     resource: string;
@@ -60,6 +61,11 @@ export class ResourceFactoryBase {
     return this;
   }
 
+  setIsActive(isActive: (resource: KubernetesObject) => boolean): ResourceFactoryBase {
+    this.#isActive = isActive;
+    return this;
+  }
+
   get resource(): string {
     return this.#resource;
   }
@@ -70,6 +76,10 @@ export class ResourceFactoryBase {
 
   get informer(): ResourceInformerFactory | undefined {
     return this.#informer;
+  }
+
+  get isActive(): undefined | ((resource: KubernetesObject) => boolean) {
+    return this.#isActive;
   }
 
   copyWithSlicedPermissions(): ResourceFactory {
@@ -89,6 +99,8 @@ export interface ResourceFactory {
   get resource(): string;
   permissions?: ResourcePermissionsFactory;
   informer?: ResourceInformerFactory;
+  // isActive returns true if `resource` is considered active
+  isActive?: (resource: KubernetesObject) => boolean;
   copyWithSlicedPermissions(): ResourceFactory;
 }
 

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1883,6 +1883,10 @@ export function initExposure(): void {
     return ipcInvoke('kubernetes:getResourcesCount');
   });
 
+  contextBridge.exposeInMainWorld('kubernetesGetActiveResourcesCount', async (): Promise<ResourceCount[]> => {
+    return ipcInvoke('kubernetes:getActiveResourcesCount');
+  });
+
   contextBridge.exposeInMainWorld(
     'kubernetesGetResources',
     async (contextNames: string[], resourceName: string): Promise<KubernetesContextResources[]> => {

--- a/packages/renderer/src/lib/kube/KubernetesDashboard.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesDashboard.svelte
@@ -4,6 +4,7 @@ import { Expandable, Link } from '@podman-desktop/ui-svelte';
 
 import KubernetesCurrentContextConnectionBadge from '/@/lib/ui/KubernetesCurrentContextConnectionBadge.svelte';
 import { containersInfos } from '/@/stores/containers';
+import { kubernetesActiveResourcesCount } from '/@/stores/kubernetes-active-resources-count';
 import {
   kubernetesCurrentContextConfigMaps,
   kubernetesCurrentContextCronJobs,
@@ -17,7 +18,10 @@ import {
   kubernetesCurrentContextServices,
   kubernetesCurrentContextState,
 } from '/@/stores/kubernetes-contexts-state';
+import { isKubernetesExperimentalModeStore } from '/@/stores/kubernetes-experimental';
+import { kubernetesResourcesCount } from '/@/stores/kubernetes-resources-count';
 import { NO_CURRENT_CONTEXT_ERROR } from '/@api/kubernetes-contexts-states';
+import type { ResourceCount } from '/@api/kubernetes-resource-count';
 
 import { kubernetesContexts } from '../../stores/kubernetes-contexts';
 import deployAndTestKubernetesImage from './DeployAndTestKubernetes.png';
@@ -51,12 +55,79 @@ let activeDeploymentsCount = $derived(
 );
 let podCount = $derived($kubernetesCurrentContextPods.length);
 let serviceCount = $derived($kubernetesCurrentContextServices.length);
-let ingressRouteCount = $derived($kubernetesCurrentContextIngresses.length + $kubernetesCurrentContextRoutes.length);
+let ingressCount = $derived($kubernetesCurrentContextIngresses.length);
+let routeCount = $derived($kubernetesCurrentContextRoutes.length);
 let pvcCount = $derived($kubernetesCurrentContextPersistentVolumeClaims.length);
-let configMapSecretCount = $derived(
-  $kubernetesCurrentContextConfigMaps.length + $kubernetesCurrentContextSecrets.length,
-);
+let configMapCount = $derived($kubernetesCurrentContextConfigMaps.length);
+let secretCount = $derived($kubernetesCurrentContextSecrets.length);
 let cronjobCount = $derived($kubernetesCurrentContextCronJobs.length);
+
+const initialCounts: { [key: string]: number } = {
+  nodes: 0,
+  deployments: 0,
+  pods: 0,
+  services: 0,
+  ingresses: 0,
+  routes: 0,
+  persistentvolumeclaims: 0,
+  configmaps: 0,
+  secrets: 0,
+  cronjobs: 0,
+};
+
+function getCountsForContext(
+  contextName: string | undefined,
+  storeValue: ResourceCount[],
+  initialValue: { [key: string]: number },
+): { [key: string]: number } {
+  return storeValue.reduce(
+    (acc, resourceCount) => {
+      if (resourceCount.contextName === contextName) {
+        acc[resourceCount.resourceName] = resourceCount.count;
+      }
+      return acc;
+    },
+    { ...initialValue },
+  );
+}
+
+const counts = $derived.by(() => {
+  if ($isKubernetesExperimentalModeStore === undefined) {
+    return initialCounts;
+  } else if ($isKubernetesExperimentalModeStore) {
+    return getCountsForContext(currentContextName, $kubernetesResourcesCount, initialCounts);
+  } else {
+    return {
+      nodes: nodeCount,
+      deployments: deploymentCount,
+      pods: podCount,
+      services: serviceCount,
+      ingresses: ingressCount,
+      routes: routeCount,
+      persistentvolumeclaims: pvcCount,
+      configmaps: configMapCount,
+      secrets: secretCount,
+      cronjobs: cronjobCount,
+    };
+  }
+});
+
+const initialActiveCounts: { [key: string]: number } = {
+  nodes: 0,
+  deployments: 0,
+};
+const activeCounts = $derived.by(() => {
+  if ($isKubernetesExperimentalModeStore === undefined) {
+    return initialActiveCounts;
+  } else if ($isKubernetesExperimentalModeStore) {
+    return getCountsForContext(currentContextName, $kubernetesActiveResourcesCount, initialActiveCounts);
+  } else {
+    return {
+      nodes: activeNodeCount,
+      deployments: activeDeploymentsCount,
+    };
+  }
+});
 
 async function openKubernetesDocumentation(): Promise<void> {
   await window.openExternal('https://podman-desktop.io/docs/kubernetes');
@@ -95,14 +166,14 @@ async function openKubernetesDocumentation(): Promise<void> {
                 <!-- Metrics - non-collapsible -->
                 <div class="text-xl pt-2">Metrics</div>
                 <div class="grid grid-cols-4 gap-4">
-                    <KubernetesDashboardResourceCard type='Nodes' activeCount={activeNodeCount} count={nodeCount} kind='Node'/>
-                    <KubernetesDashboardResourceCard type='Deployments' activeCount={activeDeploymentsCount} count={deploymentCount} kind='Deployment'/>
-                    <KubernetesDashboardResourceCard type='Pods' count={podCount} kind='Pod'/>
-                    <KubernetesDashboardResourceCard type='Services' count={serviceCount} kind='Service'/>
-                    <KubernetesDashboardResourceCard type='Ingresses & Routes' count={ingressRouteCount} kind='Ingress'/>
-                    <KubernetesDashboardResourceCard type='Persistent Volume Claims' count={pvcCount} kind='PersistentVolumeClaim'/>
-                    <KubernetesDashboardResourceCard type='ConfigMaps & Secrets' count={configMapSecretCount} kind='ConfigMap'/>
-                    <KubernetesDashboardResourceCard type='CronJobs' count={cronjobCount} kind='CronJob'/>
+                    <KubernetesDashboardResourceCard type='Nodes' activeCount={activeCounts.nodes} count={counts.nodes} kind='Node'/>
+                    <KubernetesDashboardResourceCard type='Deployments' activeCount={activeCounts.deployments} count={counts.deployments} kind='Deployment'/>
+                    <KubernetesDashboardResourceCard type='Pods' count={counts.pods} kind='Pod'/>
+                    <KubernetesDashboardResourceCard type='Services' count={counts.services} kind='Service'/>
+                    <KubernetesDashboardResourceCard type='Ingresses & Routes' count={counts.ingresses + counts.routes} kind='Ingress'/>
+                    <KubernetesDashboardResourceCard type='Persistent Volume Claims' count={counts.persistentvolumeclaims} kind='PersistentVolumeClaim'/>
+                    <KubernetesDashboardResourceCard type='ConfigMaps & Secrets' count={counts.configmaps + counts.secrets} kind='ConfigMap'/>
+                    <KubernetesDashboardResourceCard type='CronJobs' count={counts.cronjobs} kind='CronJob'/>
                 </div>
                 <!-- Graphs -->
                 

--- a/packages/renderer/src/stores/kubernetes-active-resources-count-experimental.spec.ts
+++ b/packages/renderer/src/stores/kubernetes-active-resources-count-experimental.spec.ts
@@ -1,0 +1,93 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { get } from 'svelte/store';
+import { beforeAll, expect, test, vi } from 'vitest';
+
+import type { ResourceCount } from '/@api/kubernetes-resource-count';
+
+import {
+  kubernetesActiveResourcesCount,
+  kubernetesActiveResourcesCountStore,
+} from './kubernetes-active-resources-count';
+
+const callbacks = new Map<string, () => Promise<void>>();
+const eventEmitter = {
+  receive: (message: string, callback: () => Promise<void>): void => {
+    callbacks.set(message, callback);
+  },
+};
+
+beforeAll(() => {
+  Object.defineProperty(global, 'window', {
+    value: {
+      kubernetesGetActiveResourcesCount: vi.fn(),
+      getConfigurationValue: vi.fn(),
+      addEventListener: eventEmitter.receive,
+      events: {
+        receive: eventEmitter.receive,
+      },
+    },
+  });
+});
+
+test('kubernetesResourcesCount in experimental states mode', async () => {
+  vi.mocked(window.getConfigurationValue).mockResolvedValue(true);
+
+  const initialValues: ResourceCount[] = [];
+  const nextValues: ResourceCount[] = [
+    {
+      contextName: 'context1',
+      resourceName: 'pods',
+      count: 1,
+    },
+    {
+      contextName: 'context2',
+      resourceName: 'deployments',
+      count: 2,
+    },
+  ];
+  vi.mocked(window.kubernetesGetActiveResourcesCount).mockResolvedValue(initialValues);
+
+  kubernetesActiveResourcesCountStore.setup();
+
+  // send 'extensions-already-started' event
+  const callbackExtensionsStarted = callbacks.get('extensions-already-started');
+  expect(callbackExtensionsStarted).toBeDefined();
+  await callbackExtensionsStarted!();
+
+  await vi.waitFor(() => {
+    const currentValue = get(kubernetesActiveResourcesCount);
+    expect(currentValue).toEqual(initialValues);
+  }, 500);
+
+  // data has been updated in the backend
+  vi.mocked(window.kubernetesGetActiveResourcesCount).mockResolvedValue(nextValues);
+
+  // send an event indicating the data is updated
+  const event = 'kubernetes-active-resources-count';
+  const callback = callbacks.get(event);
+  expect(callback).toBeDefined();
+  await callback!();
+
+  await vi.waitFor(() => {
+    // check received data is updated
+    const currentValue = get(kubernetesActiveResourcesCount);
+    expect(currentValue).toEqual(nextValues);
+  }, 500);
+});

--- a/packages/renderer/src/stores/kubernetes-active-resources-count-non-experimental.spec.ts
+++ b/packages/renderer/src/stores/kubernetes-active-resources-count-non-experimental.spec.ts
@@ -1,0 +1,78 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { get } from 'svelte/store';
+import { beforeAll, expect, test, vi } from 'vitest';
+
+import type { ResourceCount } from '/@api/kubernetes-resource-count';
+
+import {
+  kubernetesActiveResourcesCount,
+  kubernetesActiveResourcesCountStore,
+} from './kubernetes-active-resources-count';
+
+const callbacks = new Map<string, () => Promise<void>>();
+const eventEmitter = {
+  receive: (message: string, callback: () => Promise<void>): void => {
+    callbacks.set(message, callback);
+  },
+};
+
+beforeAll(() => {
+  Object.defineProperty(global, 'window', {
+    value: {
+      kubernetesGetActiveResourcesCount: vi.fn(),
+      getConfigurationValue: vi.fn(),
+      addEventListener: eventEmitter.receive,
+      events: {
+        receive: eventEmitter.receive,
+      },
+    },
+  });
+});
+
+test('kubernetesResourcesCount in non experimental states mode', async () => {
+  vi.mocked(window.getConfigurationValue).mockResolvedValue(false);
+
+  const initialValues: ResourceCount[] = [
+    {
+      contextName: 'context1',
+      resourceName: 'pods',
+      count: 1,
+    },
+    {
+      contextName: 'context2',
+      resourceName: 'deployments',
+      count: 2,
+    },
+  ];
+  vi.mocked(window.kubernetesGetActiveResourcesCount).mockResolvedValue(initialValues);
+
+  kubernetesActiveResourcesCountStore.setup();
+
+  // send 'extensions-already-started' event
+  const callbackExtensionsStarted = callbacks.get('extensions-already-started');
+  expect(callbackExtensionsStarted).toBeDefined();
+  await callbackExtensionsStarted!();
+
+  // values are never fetched
+  await new Promise(resolve => setTimeout(resolve, 500));
+  const currentValue = get(kubernetesActiveResourcesCount);
+  expect(currentValue).toEqual([]);
+  expect(vi.mocked(window.kubernetesGetActiveResourcesCount)).not.toHaveBeenCalled();
+});

--- a/packages/renderer/src/stores/kubernetes-active-resources-count.ts
+++ b/packages/renderer/src/stores/kubernetes-active-resources-count.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 - 2025 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import type { ResourceCount } from '/@api/kubernetes-resource-count';
 
 import { EventStore } from './event-store';
 
-const windowEvents = ['kubernetes-resources-count', 'extension-stopped', 'extensions-started'];
+const windowEvents = ['kubernetes-active-resources-count', 'extension-stopped', 'extensions-started'];
 const windowListeners = ['extensions-already-started'];
 
 let experimentalStates: boolean | undefined = undefined;
@@ -44,19 +44,19 @@ export async function checkForUpdate(eventName: string): Promise<boolean> {
   return readyToUpdate;
 }
 
-export const kubernetesResourcesCount: Writable<ResourceCount[]> = writable([]);
+export const kubernetesActiveResourcesCount: Writable<ResourceCount[]> = writable([]);
 
 // use helper here as window methods are initialized after the store in tests
-const listResourcesCount = (): Promise<ResourceCount[]> => {
-  return window.kubernetesGetResourcesCount();
+const listActiveResourcesCount = (): Promise<ResourceCount[]> => {
+  return window.kubernetesGetActiveResourcesCount();
 };
 
-export const kubernetesResourcesCountStore = new EventStore<ResourceCount[]>(
-  'kubernetes resources count',
-  kubernetesResourcesCount,
+export const kubernetesActiveResourcesCountStore = new EventStore<ResourceCount[]>(
+  'kubernetes active resources count',
+  kubernetesActiveResourcesCount,
   checkForUpdate,
   windowEvents,
   windowListeners,
-  listResourcesCount,
+  listActiveResourcesCount,
 );
-kubernetesResourcesCountStore.setupWithDebounce(100, 100);
+kubernetesActiveResourcesCountStore.setupWithDebounce(100, 100);

--- a/packages/renderer/src/stores/kubernetes-experimental.spec.ts
+++ b/packages/renderer/src/stores/kubernetes-experimental.spec.ts
@@ -1,0 +1,54 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { get } from 'svelte/store';
+import { expect, test, vi } from 'vitest';
+
+import { configurationProperties } from './configurationProperties';
+import { isKubernetesExperimentalModeStore } from './kubernetes-experimental';
+
+test('experimental mode is set', async () => {
+  vi.mocked(window.getConfigurationValue).mockImplementation(async () => {
+    return true;
+  });
+  configurationProperties.set([]);
+  await vi.waitFor(() => {
+    const result = get(isKubernetesExperimentalModeStore);
+    expect(result).toEqual(true);
+  });
+});
+
+test('experimental mode is set to false', async () => {
+  vi.mocked(window.getConfigurationValue).mockImplementation(async () => {
+    return false;
+  });
+  configurationProperties.set([]);
+  await vi.waitFor(() => {
+    const result = get(isKubernetesExperimentalModeStore);
+    expect(result).toEqual(false);
+  });
+});
+
+test('experimental mode is not defined', async () => {
+  vi.mocked(window.getConfigurationValue).mockRejectedValue(new Error('an error'));
+  configurationProperties.set([]);
+  await vi.waitFor(() => {
+    const result = get(isKubernetesExperimentalModeStore);
+    expect(result).toEqual(false);
+  });
+});

--- a/packages/renderer/src/stores/kubernetes-experimental.ts
+++ b/packages/renderer/src/stores/kubernetes-experimental.ts
@@ -1,0 +1,34 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { type Writable, writable } from 'svelte/store';
+
+import { configurationProperties } from './configurationProperties';
+
+export const isKubernetesExperimentalModeStore: Writable<boolean | undefined> = writable();
+
+configurationProperties.subscribe(() => {
+  if (window?.getConfigurationValue) {
+    window
+      ?.getConfigurationValue<boolean>('kubernetes.statesExperimental')
+      ?.then(value => isKubernetesExperimentalModeStore.set(value))
+      ?.catch((err: unknown) =>
+        console.error(`Error getting configuration value 'kubernetes.statesExperimental'}`, err),
+      );
+  }
+});


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Display counts in dashboard in experimental mode

There is a remaining todo, to limit the computing of 'active' resources only when the frontend is registered (as the computing would be heavy for nothing the rest of the time).

In non experimental mode, the computing of active resources is (still) done in the svelte component.

In experimental mode, the computing of active resources is done in the backend, and the function to filter active resources is provided by the 'ResourceFactory'.

The computing of the counts in `KubernetesDashboard` is quite verbose... It is optimized for experimental mode.

### Screenshot / video of UI


### What issues does this PR fix or reference?

Fixes #11106 

### How to test this PR?

Test in experimental and non experimental mode

- go to Kubernetes dashboard
- check that counts are correct 
- change current context

- [ ] Tests are covering the bug fix or the new feature (TODO)

## Summary by Sourcery

Implements experimental mode for the Kubernetes dashboard to display resource counts fetched from the backend. This includes displaying the number of active resources when the experimental mode is enabled. The changes involve modifying the KubernetesDashboard component to conditionally render counts based on the experimental mode and introducing new stores and API endpoints to manage and retrieve resource counts from the backend.

New Features:
- Introduces experimental mode for displaying counts in the Kubernetes dashboard, fetching resource counts from the backend to improve performance.
- Adds the ability to filter and display active resources in the Kubernetes dashboard when in experimental mode.