### PR TITLE
chore: add backend for k8s jobs

### DIFF
--- a/packages/api/src/kubernetes-contexts-states.ts
+++ b/packages/api/src/kubernetes-contexts-states.ts
@@ -38,6 +38,7 @@ export const secondaryResources = [
   'persistentvolumeclaims',
   'events',
   'cronjobs',
+  'jobs',
 ] as const;
 
 export type SecondaryResourceName = (typeof secondaryResources)[number];

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -31,6 +31,7 @@ import type {
   V1CronJob,
   V1Deployment,
   V1Ingress,
+  V1Job,
   V1NamespaceList,
   V1Node,
   V1PersistentVolumeClaim,
@@ -2460,6 +2461,10 @@ export class PluginSystem {
       return kubernetesClient.deleteCronJob(name);
     });
 
+    this.ipcHandle('kubernetes-client:deleteJob', async (_listener, name: string): Promise<void> => {
+      return kubernetesClient.deleteJob(name);
+    });
+
     this.ipcHandle('kubernetes-client:deleteSecret', async (_listener, name: string): Promise<void> => {
       return kubernetesClient.deleteSecret(name);
     });
@@ -2491,6 +2496,13 @@ export class PluginSystem {
       'kubernetes-client:readNamespacedCronJob',
       async (_listener, name: string, namespace: string): Promise<V1CronJob | undefined> => {
         return kubernetesClient.readNamespacedCronJob(name, namespace);
+      },
+    );
+
+    this.ipcHandle(
+      'kubernetes-client:readNamespacedJob',
+      async (_listener, name: string, namespace: string): Promise<V1Job | undefined> => {
+        return kubernetesClient.readNamespacedJob(name, namespace);
       },
     );
 

--- a/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
@@ -38,6 +38,7 @@ import { CronjobsResourceFactory } from './cronjobs-resource-factory.js';
 import { DeploymentsResourceFactory } from './deployments-resource-factory.js';
 import { EventsResourceFactory } from './events-resource-factory.js';
 import { IngressesResourceFactory } from './ingresses-resource-factory.js';
+import { JobsResourceFactory } from './jobs-resource-factory.js';
 import type { KubeConfigSingleContext } from './kubeconfig-single-context.js';
 import { NodesResourceFactory } from './nodes-resource-factory.js';
 import { PodsResourceFactory } from './pods-resource-factory.js';
@@ -106,6 +107,7 @@ export class ContextsManagerExperimental {
     return [
       new ConfigmapsResourceFactory(),
       new CronjobsResourceFactory(),
+      new JobsResourceFactory(),
       new DeploymentsResourceFactory(),
       new EventsResourceFactory(),
       new IngressesResourceFactory(),

--- a/packages/main/src/plugin/kubernetes/contexts-states-registry.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-states-registry.ts
@@ -63,6 +63,7 @@ export const dispatchAllResources: ResourcesDispatchOptions = {
   routes: true,
   configmaps: true,
   cronjobs: true,
+  jobs: true,
   secrets: true,
   events: true,
   // add new resources here when adding new informers
@@ -215,6 +216,7 @@ export class ContextsStatesRegistry {
           ingresses: [],
           routes: [],
           configmaps: [],
+          jobs: [],
           cronjobs: [],
           secrets: [],
           events: [],

--- a/packages/main/src/plugin/kubernetes/jobs-resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/jobs-resource-factory.ts
@@ -39,6 +39,7 @@ export class JobsResourceFactory extends ResourceFactoryBase implements Resource
           verb: 'watch',
         },
         {
+          group: 'batch',
           verb: 'watch',
           resource: 'jobs',
         },

--- a/packages/main/src/plugin/kubernetes/jobs-resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/jobs-resource-factory.ts
@@ -1,0 +1,59 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1Job, V1JobList } from '@kubernetes/client-node';
+import { BatchV1Api } from '@kubernetes/client-node';
+
+import type { KubeConfigSingleContext } from './kubeconfig-single-context.js';
+import type { ResourceFactory } from './resource-factory.js';
+import { ResourceFactoryBase } from './resource-factory.js';
+import { ResourceInformer } from './resource-informer.js';
+
+export class JobsResourceFactory extends ResourceFactoryBase implements ResourceFactory {
+  constructor() {
+    super({
+      resource: 'jobs',
+    });
+
+    this.setPermissions({
+      isNamespaced: true,
+      permissionsRequests: [
+        {
+          group: '*',
+          resource: '*',
+          verb: 'watch',
+        },
+        {
+          verb: 'watch',
+          resource: 'jobs',
+        },
+      ],
+    });
+    this.setInformer({
+      createInformer: this.createInformer,
+    });
+  }
+
+  createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1Job> {
+    const namespace = kubeconfig.getNamespace();
+    const apiClient = kubeconfig.getKubeConfig().makeApiClient(BatchV1Api);
+    const listFn = (): Promise<V1JobList> => apiClient.listNamespacedJob({ namespace });
+    const path = `/apis/batch/v1/namespaces/${namespace}/jobs`;
+    return new ResourceInformer<V1Job>({ kubeconfig, path, listFn, kind: 'Job', plural: 'jobs' });
+  }
+}

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -30,6 +30,7 @@ import type {
   V1CronJob,
   V1Deployment,
   V1Ingress,
+  V1Job,
   V1NamespaceList,
   V1Node,
   V1PersistentVolumeClaim,
@@ -1969,6 +1970,13 @@ export function initExposure(): void {
     },
   );
 
+  contextBridge.exposeInMainWorld(
+    'kubernetesReadNamespacedJob',
+    async (name: string, namespace: string): Promise<V1Job | undefined> => {
+      return ipcInvoke('kubernetes-client:readNamespacedJob', name, namespace);
+    },
+  );
+
   contextBridge.exposeInMainWorld('kubernetesIsAPIGroupSupported', async (group: string): Promise<boolean> => {
     return ipcInvoke('kubernetes-client:isAPIGroupSupported', group);
   });
@@ -2033,6 +2041,10 @@ export function initExposure(): void {
 
   contextBridge.exposeInMainWorld('kubernetesDeleteCronJob', async (name: string): Promise<void> => {
     return ipcInvoke('kubernetes-client:deleteCronJob', name);
+  });
+
+  contextBridge.exposeInMainWorld('kubernetesDeleteJob', async (name: string): Promise<void> => {
+    return ipcInvoke('kubernetes-client:deleteJob', name);
   });
 
   contextBridge.exposeInMainWorld('kubernetesDeletePersistentVolumeClaim', async (name: string): Promise<void> => {


### PR DESCRIPTION
chore: add backend for k8s jobs

### What does this PR do?

Adds:
* Informers for jobs
* index.ts calls in preload and plugin
* Context manager / kubernetes client calls
* Tests

To add in other PRs:
* Stores
* Main page
* Summary page

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Part of https://github.com/podman-desktop/podman-desktop/issues/11112

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Signed-off-by: Charlie Drage <charlie@charliedrage.com>

## Summary by Sourcery

Adds backend support for Kubernetes Jobs, including informers, context management, and API calls. This change enables the application to monitor and manage Kubernetes Jobs.

New Features:
- Adds informers for Kubernetes Jobs to track their status.
- Exposes new functions via context bridge to allow the frontend to interact with the new Job informers.

Tests:
- Adds unit tests for the new Kubernetes Job functionality, covering scenarios such as deleting a job and reading a namespaced job.