### PR TITLE
refactor(main): classify protocol launcher logic

### DIFF
--- a/packages/main/src/main.ts
+++ b/packages/main/src/main.ts
@@ -21,6 +21,7 @@ import { SecurityRestrictions } from '/@/security-restrictions.js';
 import { isWindows } from '/@/util.js';
 
 import { Deferred } from './plugin/util/deferred.js';
+import { ProtocolLauncher } from './protocol-launcher.js';
 
 export type AdditionalData = {
   argv: string[];
@@ -34,10 +35,13 @@ export class Main {
   public app: ElectronApp;
   // TODO: should be renamed to #mainWindowDeferred
   public mainWindowDeferred: Deferred<BrowserWindow>;
+  // TODO: should be renamed to #protocolLauncher
+  public protocolLauncher: ProtocolLauncher;
 
   constructor(app: ElectronApp) {
     this.app = app;
     this.mainWindowDeferred = new Deferred<BrowserWindow>();
+    this.protocolLauncher = new ProtocolLauncher(this.mainWindowDeferred);
   }
 
   main(args: string[]): void {

--- a/packages/main/src/protocol-launcher.spec.ts
+++ b/packages/main/src/protocol-launcher.spec.ts
@@ -1,0 +1,124 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { BrowserWindow } from 'electron';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { Deferred } from '/@/plugin/util/deferred.js';
+import { isWindows } from '/@/util.js';
+
+import { ProtocolLauncher } from './protocol-launcher.js';
+
+// mock modules
+vi.mock(import('/@/util.js'));
+
+const BROWSER_WINDOW_MOCK: BrowserWindow = {
+  isDestroyed: vi.fn(),
+  webContents: {
+    send: vi.fn(),
+  },
+} as unknown as BrowserWindow;
+
+function getProtocolLauncher(): ProtocolLauncher {
+  // create deferred promise
+  const deferred = new Deferred<BrowserWindow>();
+  deferred.resolve(BROWSER_WINDOW_MOCK);
+
+  // create protocol launcher
+  return new ProtocolLauncher(deferred);
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('should send the URL to open when mainWindow is created', async () => {
+  const protocol = getProtocolLauncher();
+  protocol.handleOpenUrl('podman-desktop:extension/my.extension');
+
+  // wait sendMock being called
+  await vi.waitFor(() => expect(BROWSER_WINDOW_MOCK.webContents.send).toHaveBeenCalled());
+
+  expect(BROWSER_WINDOW_MOCK.webContents.send).toHaveBeenCalledWith(
+    'podman-desktop-protocol:install-extension',
+    'my.extension',
+  );
+});
+
+test('should send the URL to open when mainWindow is created with :// format', async () => {
+  const protocol = getProtocolLauncher();
+  protocol.handleOpenUrl('podman-desktop://extension/my.extension');
+
+  // wait sendMock being called
+  await vi.waitFor(() =>
+    expect(BROWSER_WINDOW_MOCK.webContents.send).toHaveBeenCalledWith(
+      'podman-desktop-protocol:install-extension',
+      'my.extension',
+    ),
+  );
+});
+
+test('should not send the URL for invalid URLs', async () => {
+  const protocol = getProtocolLauncher();
+  protocol.handleOpenUrl('podman-desktop:foobar');
+
+  // expect an error
+  expect(vi.mocked(BROWSER_WINDOW_MOCK.webContents.send)).not.toHaveBeenCalled();
+});
+
+test('should handle podman-desktop:extension/ URL on Windows', async () => {
+  vi.mocked(isWindows).mockReturnValue(true);
+
+  const protocol = getProtocolLauncher();
+  protocol.handleAdditionalProtocolLauncherArgs(['podman-desktop:extension/my.extension']);
+
+  // expect handleOpenUrl not be called
+  await vi.waitFor(() =>
+    expect(BROWSER_WINDOW_MOCK.webContents.send).toHaveBeenCalledWith(
+      'podman-desktop-protocol:install-extension',
+      'my.extension',
+    ),
+  );
+});
+
+test('should not do anything with podman-desktop:extension/ URL on OS different than Windows', async () => {
+  vi.mocked(isWindows).mockReturnValue(false);
+
+  const protocol = getProtocolLauncher();
+
+  protocol.handleAdditionalProtocolLauncherArgs(['podman-desktop:extension/my.extension']);
+
+  // no called on it
+  expect(BROWSER_WINDOW_MOCK.webContents.send).not.toHaveBeenCalled();
+});
+
+describe('sanitizeProtocolForExtension', () => {
+  test('handle sanitizeProtocolForExtension', () => {
+    const protocol = getProtocolLauncher();
+
+    const fakeLink = 'podman-desktop://extension/my.extension';
+    const sanitizedLink = 'podman-desktop:extension/my.extension';
+    expect(protocol.sanitizeProtocolForExtension(fakeLink)).toEqual(sanitizedLink);
+  });
+
+  test('handle sanitizeProtocolForExtension noop', () => {
+    const protocol = getProtocolLauncher();
+
+    const sanitizedLink = 'podman-desktop:extension/my.extension';
+    expect(protocol.sanitizeProtocolForExtension(sanitizedLink)).toEqual(sanitizedLink);
+  });
+});

--- a/packages/main/src/protocol-launcher.ts
+++ b/packages/main/src/protocol-launcher.ts
@@ -1,0 +1,75 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { BrowserWindow } from 'electron';
+
+import type { Deferred } from '/@/plugin/util/deferred.js';
+import { isWindows } from '/@/util.js';
+
+export class ProtocolLauncher {
+  constructor(private browserWindow: Deferred<BrowserWindow>) {}
+
+  /**
+   * if arg starts with 'podman-desktop://extension', replace it with 'podman-desktop:extension'
+   * @param url
+   */
+  sanitizeProtocolForExtension(url: string): string {
+    if (url.startsWith('podman-desktop://extension/')) {
+      url = url.replace('podman-desktop://extension/', 'podman-desktop:extension/');
+    }
+
+    return url;
+  }
+
+  handleAdditionalProtocolLauncherArgs(args: ReadonlyArray<string>): void {
+    // On Windows protocol handler will call the app with '<url>' args
+    // on macOS it's done with 'open-url' event
+    if (isWindows()) {
+      // now search if we have 'open-url' in the list of args and give it to the handler
+      for (const arg of args) {
+        const analyzedArg = this.sanitizeProtocolForExtension(arg);
+        if (analyzedArg.startsWith('podman-desktop:extension/')) {
+          this.handleOpenUrl(analyzedArg);
+        }
+      }
+    }
+  }
+
+  handleOpenUrl(url: string): void {
+    // if the url starts with podman-desktop:extension/<id>
+    // we need to install the extension
+
+    // if url starts with 'podman-desktop://extension', replace it with 'podman-desktop:extension'
+    url = this.sanitizeProtocolForExtension(url);
+
+    if (!url.startsWith('podman-desktop:extension/')) {
+      console.log(`url ${url} does not start with podman-desktop:extension/, skipping.`);
+      return;
+    }
+    // grab the extension id
+    const extensionId = url.substring('podman-desktop:extension/'.length);
+
+    // wait that the window is ready
+    this.browserWindow.promise
+      .then(w => {
+        w.webContents.send('podman-desktop-protocol:install-extension', extensionId);
+      })
+      .catch((error: unknown) => {
+        console.error('Error sending open-url event to webcontents', error);
+      });
+  }
+}


### PR DESCRIPTION
-### What does this PR do?

Moving out of the `index.ts` the functions handling the protocol launcher

### Notes

- _Classifying_ the protocol launchers method
- Exposing temporary the protocol launcher instance as public in the main, to avoid too much noise in the index.ts
- Moving related tests from `index.spec.ts` to the `protocol-launcher.spec.ts`

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/10042

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

**Testing manually**

> :warning: Does not work on Linux (ref https://github.com/podman-desktop/podman-desktop/issues/9807)

1. Open https://podman-desktop.io/extensions
2. Select any extension
3. Click on `Install`
4. assert it opened Podman Desktop to the extension details page

## Summary by Sourcery

Refactor the main process to encapsulate protocol launching logic within a dedicated `ProtocolLauncher` class. This change improves code modularity and separation of concerns by extracting the protocol handling functionality from the main `index.ts` file.

Enhancements:
- Move protocol launcher logic into a dedicated class to improve code organization and maintainability.

Tests:
- Move protocol launcher tests to a dedicated test file to improve test organization and discoverability.