### PR TITLE
chore: allow to contribute 3rd party actions for container provider connection

### DIFF
--- a/packages/main/src/plugin/menu-registry.ts
+++ b/packages/main/src/plugin/menu-registry.ts
@@ -31,6 +31,7 @@ export enum MenuContext {
   DASHBOARD_CONTAINER = 'dashboard/container',
   DASHBOARD_POD = 'dashboard/pod',
   DASHBOARD_COMPOSE = 'dashboard/compose',
+  DASHBOARD_CONTAINER_CONNECTION = 'dashboard/container-connection',
 }
 
 export class MenuRegistry {


### PR DESCRIPTION
### What does this PR do?
allow to plug new menu items in the provider connection page

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/issues/10673

### How to test this PR?

unit test covering

- [x] Tests are covering the bug fix or the new feature

## Summary by Sourcery

This pull request introduces the ability to contribute third-party actions to the container provider connection menu, enhancing extensibility. It also adds a new `MenuContext` for `DASHBOARD_CONTAINER_CONNECTION`.

New Features:
- Allows third-party actions to be contributed and displayed within the container provider connection menu.
- Adds a new `MenuContext` for `DASHBOARD_CONTAINER_CONNECTION` to register contributed menu items.

Tests:
- Adds a unit test to verify that custom actions are displayed in the container provider connection menu based on their defined conditions.