### PR TITLE
chore: provide a new entry to configure registry configuration

### DIFF
--- a/extensions/podman/packages/extension/package.json
+++ b/extensions/podman/packages/extension/package.json
@@ -387,6 +387,15 @@
         }
       ],
       "enablement": "(isLinux && onboardingContext:podmanIsNotInstalled) || (!isLinux && !onboardingContext:podmanMachineExists) || podman.needPodmanMachineCleanup"
+    },
+    "menus": {
+      "dashboard/container-connection": [
+        {
+          "command": "podman.setupRegistry",
+          "title": "Setup registry configuration",
+          "when": "selectedProviderConnectionType === 'podman' && selectedProviderConnectionStatus === 'started'"
+        }
+      ]
     }
   },
   "scripts": {


### PR DESCRIPTION
### What does this PR do?
add podman entry in the podman provider card to setup registries

depends on:
- https://github.com/podman-desktop/podman-desktop/pull/11404
- https://github.com/podman-desktop/podman-desktop/pull/11390


### Screenshot / video of UI


### What issues does this PR fix or reference?

fixes https://github.com/podman-desktop/podman-desktop/issues/10673

### How to test this PR?

having the two other PRs in, go the settings/resources, click on the 'more actions' kebab menu of podman machine and see the 'configure registries' item

- [ ] Tests are covering the bug fix or the new feature

## Summary by Sourcery

New Features:
- Adds a 'Configure Registries' option to the Podman connection menu, allowing users to set up registry configurations.