### PR TITLE
chore: remove pod kubernetes actions

### DIFF
--- a/packages/renderer/src/lib/pod/PodActions.spec.ts
+++ b/packages/renderer/src/lib/pod/PodActions.spec.ts
@@ -22,8 +22,6 @@ import type { ContainerInfo, Port } from '@podman-desktop/api';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
-import type { V1Route } from '/@api/openshift-types';
-
 import PodActions from './PodActions.svelte';
 import type { PodInfoUI } from './PodInfoUI';
 
@@ -56,20 +54,10 @@ class Pod {
 
 const podmanPod: PodInfoUI = new Pod('pod', [{ Id: 'pod' }], 'RUNNING', 'podman', '') as unknown as PodInfoUI;
 
-const kubernetesPod: PodInfoUI = {
-  id: 'pod',
-  name: 'name',
-  containers: [{ Id: 'pod' }],
-  status: 'RUNNING',
-  kind: 'kubernetes',
-} as PodInfoUI;
-
 const listContainersMock = vi.fn();
 const getContributedMenusMock = vi.fn();
 const updateMock = vi.fn();
 const showMessageBoxMock = vi.fn();
-const kubernetesGetCurrentNamespaceMock = vi.fn();
-const kubernetesReadNamespacedPodMock = vi.fn();
 const openExternalSpy = vi.fn();
 
 class ResizeObserver {
@@ -81,15 +69,11 @@ class ResizeObserver {
 beforeAll(() => {
   Object.defineProperty(window, 'ResizeObserver', { value: ResizeObserver });
   Object.defineProperty(window, 'showMessageBox', { value: showMessageBoxMock });
-  Object.defineProperty(window, 'kubernetesDeletePod', { value: vi.fn() });
   Object.defineProperty(window, 'listContainers', { value: listContainersMock });
   Object.defineProperty(window, 'startPod', { value: vi.fn() });
   Object.defineProperty(window, 'stopPod', { value: vi.fn() });
   Object.defineProperty(window, 'restartPod', { value: vi.fn() });
   Object.defineProperty(window, 'removePod', { value: vi.fn() });
-  Object.defineProperty(window, 'kubernetesGetCurrentNamespace', { value: kubernetesGetCurrentNamespaceMock });
-  Object.defineProperty(window, 'kubernetesReadNamespacedPod', { value: kubernetesReadNamespacedPodMock });
-  Object.defineProperty(window, 'kubernetesListRoutes', { value: vi.fn() });
   Object.defineProperty(window, 'getContributedMenus', { value: getContributedMenusMock });
   Object.defineProperty(window, 'openExternal', { value: openExternalSpy });
 });
@@ -97,14 +81,9 @@ beforeAll(() => {
 beforeEach(() => {
   vi.resetAllMocks();
 
-  vi.mocked(window.kubernetesListRoutes).mockResolvedValue([]);
-
   listContainersMock.mockResolvedValue([
     { Id: 'pod', Ports: [{ PublicPort: 8080 } as Port] as Port[] } as ContainerInfo,
   ]);
-
-  kubernetesGetCurrentNamespaceMock.mockResolvedValue('ns');
-  kubernetesReadNamespacedPodMock.mockResolvedValue({ metadata: { labels: { app: 'foo' } } });
 
   getContributedMenusMock.mockResolvedValue([]);
 });
@@ -170,47 +149,4 @@ test('Expect no error and status deleting pod', async () => {
   expect(podmanPod.status).toEqual('DELETING');
   expect(podmanPod.actionError).toEqual('');
   expect(updateMock).toHaveBeenCalled();
-});
-
-test('Expect kubernetes route to be displayed', async () => {
-  const routeName = 'route.name';
-  const routeHost = 'host.local';
-
-  vi.mocked(window.kubernetesListRoutes).mockResolvedValue([
-    { metadata: { labels: { app: 'foo' }, name: routeName }, spec: { host: routeHost } } as unknown as V1Route,
-  ]);
-
-  render(PodActions, { pod: kubernetesPod });
-
-  const openRouteButton = await screen.findByRole('button', { name: `Open ${routeName}` });
-  expect(openRouteButton).toBeVisible();
-
-  await fireEvent.click(openRouteButton);
-
-  expect(openExternalSpy).toHaveBeenCalledWith(`http://${routeHost}`);
-});
-
-test('Expect kubernetes route to be displayed but disabled', async () => {
-  render(PodActions, { pod: kubernetesPod });
-
-  const openRouteButton = await screen.findByRole('button', { name: `Open Browser` });
-  expect(openRouteButton).toBeVisible();
-  expect(openRouteButton).toBeDisabled();
-});
-
-test('Expect kubernetes routes kebab menu to be displayed', async () => {
-  vi.mocked(window.kubernetesListRoutes).mockResolvedValue([
-    { metadata: { labels: { app: 'foo' }, name: 'route1.name' }, spec: { host: 'host1.local' } } as unknown as V1Route,
-    { metadata: { labels: { app: 'foo' }, name: 'route2.name' }, spec: { host: 'host2.local' } } as unknown as V1Route,
-  ]);
-
-  render(PodActions, { pod: kubernetesPod });
-
-  const openRouteButton = await screen.findByRole('button', { name: 'Open Kubernetes Routes' });
-  expect(openRouteButton).toBeVisible();
-
-  await fireEvent.click(openRouteButton);
-
-  const routesDropDownMenu = await screen.findByTitle('Drop Down Menu Items');
-  expect(routesDropDownMenu).toBeVisible();
 });


### PR DESCRIPTION
### What does this PR do?

Removes the unused Kubernetes code from the Podman Pods page actions.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of #8819.

### How to test this PR?

Test no change to actions on Pods or Pod Details pages.

- [x] Tests are covering the bug fix or the new feature

## Summary by Sourcery

Remove Kubernetes-related code from the Pod actions, as it is no longer needed.