### PR TITLE
chore: use expandable on kubernetes dashboard

### DIFF
--- a/packages/renderer/src/lib/kube/KubernetesDashboard.spec.ts
+++ b/packages/renderer/src/lib/kube/KubernetesDashboard.spec.ts
@@ -120,8 +120,7 @@ test('Verify basic page with cluster', async () => {
 
   const guides = screen.getByText('Explore articles and blog posts');
   expect(guides).toBeInTheDocument();
-  expect(
-    guides.parentElement?.parentElement?.parentElement?.nextElementSibling?.firstElementChild?.firstElementChild
-      ?.childElementCount,
-  ).toBe(3);
+
+  const guideCards = screen.queryAllByRole('button', { name: 'Read more' });
+  expect(guideCards).toHaveLength(3);
 });

--- a/packages/renderer/src/lib/kube/KubernetesDashboard.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesDashboard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import type { KubernetesObject } from '@kubernetes/client-node';
-import { Link } from '@podman-desktop/ui-svelte';
+import { Expandable, Link } from '@podman-desktop/ui-svelte';
 
 import KubernetesCurrentContextConnectionBadge from '/@/lib/ui/KubernetesCurrentContextConnectionBadge.svelte';
 import { containersInfos } from '/@/stores/containers';
@@ -20,7 +20,6 @@ import {
 import { NO_CURRENT_CONTEXT_ERROR } from '/@api/kubernetes-contexts-states';
 
 import { kubernetesContexts } from '../../stores/kubernetes-contexts';
-import { fadeSlide } from '../ui/animations';
 import deployAndTestKubernetesImage from './DeployAndTestKubernetes.png';
 import KubernetesDashboardGuideCard from './KubernetesDashboardGuideCard.svelte';
 import KubernetesDashboardResourceCard from './KubernetesDashboardResourceCard.svelte';
@@ -58,8 +57,6 @@ let configMapSecretCount = $derived(
   $kubernetesCurrentContextConfigMaps.length + $kubernetesCurrentContextSecrets.length,
 );
 let cronjobCount = $derived($kubernetesCurrentContextCronJobs.length);
-let expandedDetails: boolean = $state(true);
-let expandedGuide: boolean = $state(true);
 
 async function openKubernetesDocumentation(): Promise<void> {
   await window.openExternal('https://podman-desktop.io/docs/kubernetes');
@@ -72,39 +69,23 @@ async function openKubernetesDocumentation(): Promise<void> {
       <KubernetesEmptyPage />
     {:else}
       <!-- Details - collapsible -->
-      <div class="flex flex-1 flex-col">
-        <div class="flex flex-row w-full px-5 pb-2">
-          <button onclick={(): boolean => (expandedDetails = !expandedDetails)}>
-            <div class="flex flex-row space-x-2 items-center text-[var(--pd-content-card-header-text)]">
-              <div class="flex w-full" role="region" aria-label="header">
-                <h1 class="text-xl font-bold capitalize text-[var(--pd-content-header)]">
-                  {#if expandedDetails}
-                  <i class="fas fa-chevron-down"></i>
-                {:else}
-                  <i class="fas fa-chevron-right"></i>
-                {/if}
-                  Dashboard
-                </h1>
-              </div>
+      <div class="flex flex-row w-full px-5 pb-2">
+        <Expandable>
+          <!-- eslint-disable-next-line sonarjs/no-unused-vars -->
+          {#snippet title()}
+            <div class="flex flex-row w-full items-center">
+              <div class="text-xl font-bold capitalize text-[var(--pd-content-header)]">Dashboard</div>
+              <div class="flex grow justify-end"><KubernetesCurrentContextConnectionBadge /></div>
             </div>
-          </button>
-          <div class="flex grow justify-end">
-            <KubernetesCurrentContextConnectionBadge />
+          {/snippet}
+          <div class="flex flex-col gap-4">
+            <div>Here you can manage and interact with Kubernetes clusters with features like connecting to clusters, and
+              viewing workloads like deployments and services.</div>
+            <div>Get up and running by clicking one of the menu items!</div>
+            <div><Link class="place-self-start" on:click={openKubernetesDocumentation}>Kubernetes documentation</Link></div>
           </div>
-        </div>
-      </div>
-      <div class="flex flex-col pl-5 pr-5 border-[var(--pd-global-nav-bg-border)] border-b-[1px]">
-        {#if expandedDetails}
-          <div role="region" class="flex flex-col py-2">
-            <div transition:fadeSlide={{ duration: 500 }} class="flex flex-col gap-4">
-              <div>Here you can manage and interact with Kubernetes clusters with features like connecting to clusters, and
-                viewing workloads like deployments and services.</div>
-              <div>Get up and running by clicking one of the menu items!</div>
-              <div><Link class="place-self-start" on:click={openKubernetesDocumentation}>Kubernetes documentation</Link></div>
-            </div>
-          </div>
-        {/if}
-      </div>
+        </Expandable>
+       </div>
 
       <div class="flex w-full h-full overflow-auto">
         <div class="flex min-w-full h-full justify-center">
@@ -128,29 +109,15 @@ async function openKubernetesDocumentation(): Promise<void> {
               {/if}
               <!-- Articles and blog posts - collapsible -->
               <div class="flex flex-1 flex-col pt-2">
-                <div>
-                  <button onclick={(): boolean => (expandedGuide = !expandedGuide)}>
-                    <div class="flex flex-row space-x-2 items-center text-[var(--pd-content-card-header-text)]">
-                      {#if expandedGuide}
-                        <i class="fas fa-chevron-down"></i>
-                      {:else}
-                        <i class="fas fa-chevron-right"></i>
-                      {/if}
-                      <p class="text-xl">Explore articles and blog posts</p>
-                    </div>
-                  </button>
-                </div>
-                {#if expandedGuide}
-                  <div role="region" class="mt-5">
-                    <div transition:fadeSlide={{ duration: 500 }}>
-                      <div class="grid grid-cols-3 gap-4">
-                        <KubernetesDashboardGuideCard title='Deploy and test Kubernetes containers using Podman Desktop' image={deployAndTestKubernetesImage} link='https://developers.redhat.com/articles/2023/06/09/deploy-and-test-kubernetes-containers-using-podman-desktop'/>
-                        <KubernetesDashboardGuideCard title='Working with Kubernetes in Podman Desktop' image={workingWithKubernetesImage} link='https://developers.redhat.com/articles/2023/11/06/working-kubernetes-podman-desktop'/>
-                        <KubernetesDashboardGuideCard title='Share your local podman images with the Kubernetes cluster' image={shareYourLocalProdmanImagesWithTheKubernetesImage} link='https://podman-desktop.io/blog/sharing-podman-images-with-kubernetes-cluster'/>
-                      </div>
-                    </div>
+                <Expandable>
+                  <!-- eslint-disable-next-line sonarjs/no-unused-vars -->
+                  {#snippet title()}<div class="text-xl">Explore articles and blog posts</div>{/snippet}
+                  <div class="grid grid-cols-3 gap-4">
+                    <KubernetesDashboardGuideCard title='Deploy and test Kubernetes containers using Podman Desktop' image={deployAndTestKubernetesImage} link='https://developers.redhat.com/articles/2023/06/09/deploy-and-test-kubernetes-containers-using-podman-desktop'/>
+                    <KubernetesDashboardGuideCard title='Working with Kubernetes in Podman Desktop' image={workingWithKubernetesImage} link='https://developers.redhat.com/articles/2023/11/06/working-kubernetes-podman-desktop'/>
+                    <KubernetesDashboardGuideCard title='Share your local podman images with the Kubernetes cluster' image={shareYourLocalProdmanImagesWithTheKubernetesImage} link='https://podman-desktop.io/blog/sharing-podman-images-with-kubernetes-cluster'/>
                   </div>
-                {/if}
+                </Expandable>
               </div>
             </div>
           </div>


### PR DESCRIPTION
### What does this PR do?

Uses the new Expandable component on the Kubernetes dashboard. Just reduces code a little and fixes the animations.

### Screenshot / video of UI

https://github.com/user-attachments/assets/347b9837-9016-43ae-a167-b7add98d4ea4

### What issues does this PR fix or reference?

Related to #11363.

### How to test this PR?

Open Kubernetes dashboard and use the toggles.

- [x] Tests are covering the bug fix or the new feature

## Summary by Sourcery

Enhancements:
- Replaces custom expandable logic in the Kubernetes dashboard with the new Expandable component from `@podman-desktop/ui-svelte`.