### PR TITLE
chore: add jobs store function

### DIFF
--- a/packages/renderer/src/stores/kubernetes-contexts-state.spec.ts
+++ b/packages/renderer/src/stores/kubernetes-contexts-state.spec.ts
@@ -28,6 +28,7 @@ import type { ResourceName } from '/@api/kubernetes-contexts-states';
 import {
   kubernetesCurrentContextCronJobs,
   kubernetesCurrentContextDeployments,
+  kubernetesCurrentContextJobs,
   kubernetesCurrentContextNodes,
   kubernetesCurrentContextPods,
   kubernetesCurrentContextServices,
@@ -87,6 +88,10 @@ test.each(['nodes', 'pods', 'deployments', 'services', 'cronjobs'])(
       }
       case 'cronjobs': {
         await testKubernetesStore(resourceName, kubernetesCurrentContextCronJobs);
+        break;
+      }
+      case 'jobs': {
+        await testKubernetesStore(resourceName, kubernetesCurrentContextJobs);
         break;
       }
     }

--- a/packages/renderer/src/stores/kubernetes-contexts-state.ts
+++ b/packages/renderer/src/stores/kubernetes-contexts-state.ts
@@ -167,6 +167,30 @@ export const kubernetesCurrentContextCronJobsFiltered = derived(
     $cronJobs.filter(cronJob => findMatchInLeaves(cronJob, $searchPattern.toLowerCase())),
 );
 
+// Jobs
+export const kubernetesCurrentContextJobs = readable<KubernetesObject[]>([], set => {
+  window
+    .kubernetesRegisterGetCurrentContextResources('jobs')
+    .then(value => set(value))
+    .catch((err: unknown) => console.log('Error registering Kubernetes jobs', err));
+  window.events?.receive('kubernetes-current-context-jobs-update', (value: unknown) => {
+    set(value as KubernetesObject[]);
+  });
+  return (): void => {
+    window
+      .kubernetesUnregisterGetCurrentContextResources('jobs')
+      .catch((err: unknown) => console.log('Error unregistering Kubernetes jobs', err));
+  };
+});
+
+export const jobSearchPattern = writable('');
+
+// Current context of jobs
+export const kubernetesCurrentContextJobsFiltered = derived(
+  [jobSearchPattern, kubernetesCurrentContextJobs],
+  ([$searchPattern, $jobs]) => $jobs.filter(job => findMatchInLeaves(job, $searchPattern.toLowerCase())),
+);
+
 // Nodes
 
 export const kubernetesCurrentContextNodes = readable<KubernetesObject[]>([], set => {


### PR DESCRIPTION
chore: add jobs store function

### What does this PR do?

Adds the store function for jobs

Rebased against https://github.com/podman-desktop/podman-desktop/pull/11402

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Part of https://github.com/podman-desktop/podman-desktop/issues/11112

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Signed-off-by: Charlie Drage <charlie@charliedrage.com>

## Summary by Sourcery

Adds a store function for Kubernetes Jobs, including a readable store `kubernetesCurrentContextJobs` that provides Kubernetes Job resources, a writable store `jobSearchPattern` for filtering, and a derived store `kubernetesCurrentContextJobsFiltered` for the filtered list of jobs.