### PR TITLE
fix: group of CronJob for permission checking

### DIFF
--- a/packages/main/src/plugin/kubernetes/cronjobs-resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/cronjobs-resource-factory.ts
@@ -39,6 +39,7 @@ export class CronjobsResourceFactory extends ResourceFactoryBase implements Reso
           verb: 'watch',
         },
         {
+          group: 'batch',
           verb: 'watch',
           resource: 'cronjobs',
         },


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Fix group of CronJob for permission checking

### Screenshot / video of UI

### What issues does this PR fix or reference?

Fixes #11416

### How to test this PR?

- [ ] Tests are covering the bug fix or the new feature

## Summary by Sourcery

Bug Fixes:
- Fixes a permission issue when watching CronJobs by specifying the correct group ('batch') for the CronJob resource.