### PR TITLE
feat: add the ability to auto scroll to provider from statusbar

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesPage.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesPage.svelte
@@ -64,8 +64,8 @@ onMount(async () => {
       properties={properties}
       taskId={+meta.params.taskId} />
   </Route>
-  <Route path="/resources" breadcrumb="Resources" navigationHint="root">
-    <PreferencesResourcesRendering />
+  <Route path="/resources" breadcrumb="Resources" navigationHint="root" let:meta>
+    <PreferencesResourcesRendering focus={meta.query.focus}/>
   </Route>
   <Route path="/docker-compatibility" breadcrumb="Docker Compatibility">
     <PreferencesDockerCompatibilityRendering />

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
@@ -333,6 +333,21 @@ describe.each<{
     expect(button).toHaveTextContent('Connect ...');
   });
 
+  test('Expect to scroll to the focused element if focus prop is provided', async () => {
+    window.HTMLElement.prototype.scrollIntoView = vi.fn();
+    const customProviderInfo: ProviderInfo = {
+      ...providerInfo,
+      id: 'test-provider',
+      name: 'Test Provider',
+    };
+    providerInfos.set([customProviderInfo]);
+    render(PreferencesResourcesRendering, { focus: 'test-provider' });
+    await vi.waitFor(() => {
+      // Check if scrollIntoView was called
+      expect(window.HTMLElement.prototype.scrollIntoView).toHaveBeenCalledWith({ behavior: 'auto', block: 'start' });
+    });
+  });
+
   describe('provider connections', () => {
     test('Expect to have two container connection region', () => {
       providerInfos.set([providerInfo]);

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -393,6 +393,13 @@ function hasAnyConfiguration(provider: ProviderInfo): boolean {
   );
 }
 
+export let focus: string | undefined;
+let providerElementMap: Record<string, HTMLElement> = {};
+
+$: if (focus && providerElementMap[focus]) {
+  providerElementMap[focus].scrollIntoView({ behavior: 'auto', block: 'start' });
+}
+
 function handleError(errorMessage: string): void {
   console.error(errorMessage);
 }
@@ -414,6 +421,8 @@ function handleError(errorMessage: string): void {
 
     {#each providers as provider (provider.id)}
       <div
+        id={provider.id}
+        bind:this={providerElementMap[provider.id]}
         class="bg-[var(--pd-invert-content-card-bg)] mb-5 rounded-md p-3 divide-x divide-[var(--pd-content-divider)] flex"
         role="region"
         aria-label={provider.id}>

--- a/packages/renderer/src/lib/statusbar/ProviderWidget.spec.ts
+++ b/packages/renderer/src/lib/statusbar/ProviderWidget.spec.ts
@@ -42,6 +42,7 @@ vi.mock('tinro', () => {
 
 const providerMock = {
   name: 'provider1',
+  id: 'provider1-id',
   containerConnections: [],
   kubernetesConnections: [],
   status: 'ready' as ProviderStatus,
@@ -71,7 +72,7 @@ test('Provider widget takes user to /preferences/resources on click by default',
   expect(widget).toBeInTheDocument();
 
   await userEvent.click(widget);
-  expect(router.goto).toBeCalledWith('/preferences/resources');
+  expect(router.goto).toBeCalledWith(`/preferences/resources?focus=${providerMock.id}`);
 });
 
 test('Expect the prop command to be used when it is passed with the entry', async () => {

--- a/packages/renderer/src/lib/statusbar/ProviderWidget.svelte
+++ b/packages/renderer/src/lib/statusbar/ProviderWidget.svelte
@@ -18,7 +18,7 @@ interface Props {
 
 let {
   entry,
-  command = (): void => router.goto('/preferences/resources'),
+  command = (): void => router.goto(`/preferences/resources?focus=${entry.id}`),
   disableTooltip = false,
   class: className,
   tooltipTopRight = false,


### PR DESCRIPTION
### What does this PR do?

Adds the ability to automatically scroll to the provider in the resource page when clicking on the provider in the statusbar

### What issues does this PR fix or reference?
Fixes https://github.com/podman-desktop/podman-desktop/issues/11061

## Summary by Sourcery

New Features:
- Implement auto-scrolling to a provider in the resources page when the provider is clicked in the status bar.