### PR TITLE
feat: set Kubernetes experimental as experimental feature

### DIFF
--- a/packages/main/src/plugin/kubernetes/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.ts
@@ -207,10 +207,12 @@ export class KubernetesClient {
           readonly: false,
         },
         ['kubernetes.statesExperimental']: {
-          description: 'Use new version of Kubernetes states',
+          description: 'Use new version of Kubernetes contexts monitoring (needs restart)',
           type: 'boolean',
           default: false,
-          hidden: true,
+          experimental: {
+            githubDiscussionLink: 'https://github.com/podman-desktop/podman-desktop/discussions/11424',
+          },
         },
       },
     };


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Set Kubernetes experimental as experimental feature

### Screenshot / video of UI

### What issues does this PR fix or reference?

Fixes #11423 

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature

## Summary by Sourcery

Marks the Kubernetes contexts monitoring feature as experimental, and adds a link to a GitHub discussion for user feedback.