### PR TITLE
chore: remove explicit-any from config map empty screen

### DIFF
--- a/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretEmptyScreen.spec.ts
+++ b/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretEmptyScreen.spec.ts
@@ -16,8 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import '@testing-library/jest-dom/vitest';
 
 import { render, screen } from '@testing-library/svelte';


### PR DESCRIPTION
chore: remove explicit-any from config map empty screen

### What does this PR do?

Removes no-explicit-any

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Part of https://github.com/podman-desktop/podman-desktop/issues/10603

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Signed-off-by: Charlie Drage <charlie@charliedrage.com>

## Summary by Sourcery

Chores:
- Removes the usage of `explicit-any` in the `ConfigMapSecretEmptyScreen.spec.ts` file.