### PR TITLE
fix: display empty screen only when received data

### DIFF
--- a/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretList.spec.ts
+++ b/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretList.spec.ts
@@ -42,8 +42,10 @@ test('Expect configmap empty screen', async () => {
   vi.mocked(states).kubernetesCurrentContextConfigMapsFiltered = writable<KubernetesObject[]>([]);
   vi.mocked(states).kubernetesCurrentContextSecretsFiltered = writable<KubernetesObject[]>([]);
   render(ConfigMapSecretList);
-  const noNodes = screen.getByRole('heading', { name: 'No configmaps or secrets' });
-  expect(noNodes).toBeInTheDocument();
+  await vi.waitFor(() => {
+    const noNodes = screen.getByRole('heading', { name: 'No configmaps or secrets' });
+    expect(noNodes).toBeInTheDocument();
+  });
 });
 
 test('Expect configmap and secrets list', async () => {

--- a/packages/renderer/src/lib/cronjob/CronJobList.spec.ts
+++ b/packages/renderer/src/lib/cronjob/CronJobList.spec.ts
@@ -90,8 +90,10 @@ describe.each<{
   test('Expect cronjob empty screen', async () => {
     initObjectsList([]);
     render(CronJobList);
-    const noCronJobs = screen.getByRole('heading', { name: 'No cronjobs' });
-    expect(noCronJobs).toBeInTheDocument();
+    await vi.waitFor(() => {
+      const noCronJobs = screen.getByRole('heading', { name: 'No cronjobs' });
+      expect(noCronJobs).toBeInTheDocument();
+    });
   });
 
   test('Expect cronjobs list', async () => {
@@ -130,8 +132,10 @@ describe.each<{
 
     render(CronJobList, { searchTerm: 'No match' });
 
-    const filterButton = screen.getByRole('button', { name: 'Clear filter' });
-    expect(filterButton).toBeInTheDocument();
+    await vi.waitFor(() => {
+      const filterButton = screen.getByRole('button', { name: 'Clear filter' });
+      expect(filterButton).toBeInTheDocument();
+    });
   });
 
   test('Expect cronjob list is updated when kubernetesCurrentContextCronJobsFiltered changes', async () => {

--- a/packages/renderer/src/lib/deployments/DeploymentsList.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentsList.spec.ts
@@ -43,19 +43,21 @@ beforeEach(() => {
 describe.each<{
   experimental: boolean;
   initMocks: () => void;
-  initObjectsList: (objects: KubernetesObject[]) => { update: (objects: KubernetesObject[]) => void };
+  initObjectsList: (objects?: KubernetesObject[]) => { update: (objects: KubernetesObject[]) => void };
 }>([
   {
     experimental: true,
     initMocks: (): void => {
       vi.mocked(states).kubernetesCurrentContextDeploymentsFiltered = writable();
     },
-    initObjectsList: (objects: KubernetesObject[]): { update: (objects: KubernetesObject[]) => void } => {
+    initObjectsList: (objects?: KubernetesObject[]): { update: (objects: KubernetesObject[]) => void } => {
       let callback: (resoures: KubernetesObject[]) => void;
       vi.mocked(resourcesListen.listenResources).mockImplementation(
         async (_resources, _options, cb): Promise<IDisposable> => {
           callback = cb;
-          setTimeout(() => callback(objects));
+          if (objects) {
+            setTimeout(() => callback(objects));
+          }
           return {
             dispose: (): void => {},
           };
@@ -73,7 +75,7 @@ describe.each<{
     initMocks: (): void => {
       vi.mocked(resourcesListen.listenResources).mockResolvedValue(undefined);
     },
-    initObjectsList: (objects: KubernetesObject[]): { update: (objects: KubernetesObject[]) => void } => {
+    initObjectsList: (objects?: KubernetesObject[]): { update: (objects: KubernetesObject[]) => void } => {
       const store = writable<KubernetesObject[]>(objects);
       vi.mocked(states).kubernetesCurrentContextDeploymentsFiltered = store;
       return {
@@ -91,8 +93,25 @@ describe.each<{
   test('Expect deployment empty screen', async () => {
     initObjectsList([]);
     render(DeploymentsList);
+
     await vi.waitFor(() => {
       const noDeployments = screen.getByRole('heading', { name: 'No deployments' });
+      expect(noDeployments).toBeInTheDocument();
+    });
+  });
+
+  test('Expect no deployment empty screen before received data', async () => {
+    const list = initObjectsList();
+    render(DeploymentsList);
+
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    let noDeployments = screen.queryByRole('heading', { name: 'No deployments' });
+    expect(noDeployments).not.toBeInTheDocument();
+
+    list.update([]);
+    await vi.waitFor(() => {
+      noDeployments = screen.queryByRole('heading', { name: 'No deployments' });
       expect(noDeployments).toBeInTheDocument();
     });
   });

--- a/packages/renderer/src/lib/deployments/DeploymentsList.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentsList.spec.ts
@@ -91,8 +91,10 @@ describe.each<{
   test('Expect deployment empty screen', async () => {
     initObjectsList([]);
     render(DeploymentsList);
-    const noDeployments = screen.getByRole('heading', { name: 'No deployments' });
-    expect(noDeployments).toBeInTheDocument();
+    await vi.waitFor(() => {
+      const noDeployments = screen.getByRole('heading', { name: 'No deployments' });
+      expect(noDeployments).toBeInTheDocument();
+    });
   });
 
   test('Expect deployments list', async () => {
@@ -158,8 +160,10 @@ describe.each<{
     initObjectsList([]);
 
     render(DeploymentsList, { searchTerm: 'No match' });
-    const filterButton = screen.getByRole('button', { name: 'Clear filter' });
-    expect(filterButton).toBeInTheDocument();
+    await vi.waitFor(() => {
+      const filterButton = screen.getByRole('button', { name: 'Clear filter' });
+      expect(filterButton).toBeInTheDocument();
+    });
   });
 
   test('Expect user confirmation to pop up when preferences require', async () => {

--- a/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.spec.ts
@@ -43,8 +43,10 @@ test('Expect ingress&routes empty screen', async () => {
   vi.mocked(states).kubernetesCurrentContextIngressesFiltered = readable<KubernetesObject[]>([]);
   vi.mocked(states).kubernetesCurrentContextRoutesFiltered = readable<KubernetesObject[]>([]);
   render(IngressesRoutesList);
-  const noIngressesNorRoutes = screen.getByRole('heading', { name: 'No ingresses or routes' });
-  expect(noIngressesNorRoutes).toBeInTheDocument();
+  await vi.waitFor(() => {
+    const noIngressesNorRoutes = screen.getByRole('heading', { name: 'No ingresses or routes' });
+    expect(noIngressesNorRoutes).toBeInTheDocument();
+  });
 });
 
 test('Expect element in ingresses list', async () => {
@@ -113,8 +115,10 @@ test('Expect filter empty screen if no match', async () => {
 
   render(IngressesRoutesList, { searchTerm: 'No match' });
 
-  const filterButton = screen.getByRole('button', { name: 'Clear filter' });
-  expect(filterButton).toBeInTheDocument();
+  await vi.waitFor(() => {
+    const filterButton = screen.getByRole('button', { name: 'Clear filter' });
+    expect(filterButton).toBeInTheDocument();
+  });
 });
 
 test('Expect status column name to be clickable / sortable', async () => {

--- a/packages/renderer/src/lib/kube/pods/PodsList.spec.ts
+++ b/packages/renderer/src/lib/kube/pods/PodsList.spec.ts
@@ -91,8 +91,10 @@ describe.each<{
   test('Expect pod empty screen', async () => {
     initObjectsList([]);
     render(PodsList);
-    const noPods = screen.getByRole('heading', { name: 'No pods' });
-    expect(noPods).toBeInTheDocument();
+    await vi.waitFor(() => {
+      const noPods = screen.getByRole('heading', { name: 'No pods' });
+      expect(noPods).toBeInTheDocument();
+    });
   });
 
   test('Expect pods list', async () => {
@@ -156,8 +158,10 @@ describe.each<{
     initObjectsList([]);
 
     render(PodsList, { searchTerm: 'No match' });
-    const filterButton = screen.getByRole('button', { name: 'Clear filter' });
-    expect(filterButton).toBeInTheDocument();
+    await vi.waitFor(() => {
+      const filterButton = screen.getByRole('button', { name: 'Clear filter' });
+      expect(filterButton).toBeInTheDocument();
+    });
   });
 
   test('Expect user confirmation to pop up when preferences require', async () => {

--- a/packages/renderer/src/lib/node/NodesList.spec.ts
+++ b/packages/renderer/src/lib/node/NodesList.spec.ts
@@ -41,8 +41,10 @@ test('Expect node empty screen', async () => {
   vi.mocked(states).kubernetesCurrentContextNodesFiltered = writable<KubernetesObject[]>([]);
 
   render(NodesList);
-  const noNodes = screen.getByRole('heading', { name: 'No nodes' });
-  expect(noNodes).toBeInTheDocument();
+  await vi.waitFor(() => {
+    const noNodes = screen.getByRole('heading', { name: 'No nodes' });
+    expect(noNodes).toBeInTheDocument();
+  });
 });
 
 test('Expect nodes list', async () => {

--- a/packages/renderer/src/lib/objects/KubernetesObjectsList.svelte
+++ b/packages/renderer/src/lib/objects/KubernetesObjectsList.svelte
@@ -72,6 +72,9 @@ onMount(async () => {
 
     legacyUnsubscribers.push(
       kind.legacyObjectStore.subscribe(o => {
+        if (o === undefined) {
+          return;
+        }
         started = true;
         resources[kind.resource] = o;
       }),

--- a/packages/renderer/src/lib/objects/KubernetesObjectsList.svelte
+++ b/packages/renderer/src/lib/objects/KubernetesObjectsList.svelte
@@ -39,6 +39,8 @@ interface Props {
   emptySnippet: Snippet;
 }
 
+let started = $state<boolean>(false);
+
 let { kinds, singular, plural, icon, searchTerm, columns, row, emptySnippet }: Props = $props();
 
 let resources = $state<{ [key: string]: KubernetesObject[] | undefined }>({});
@@ -62,6 +64,7 @@ onMount(async () => {
           searchTermStore: kind.legacySearchPatternStore,
         },
         (updatedResources: KubernetesObject[]) => {
+          started = true;
           resources[kind.resource] = updatedResources;
         },
       ),
@@ -69,6 +72,7 @@ onMount(async () => {
 
     legacyUnsubscribers.push(
       kind.legacyObjectStore.subscribe(o => {
+        started = true;
         resources[kind.resource] = o;
       }),
     );
@@ -150,7 +154,7 @@ let table: Table;
       defaultSortColumn="Name">
     </Table>
 
-    {#if objects.length === 0}
+    {#if started && objects.length === 0}
       {#if searchTerm}
         <FilteredEmptyScreen
           icon={icon}

--- a/packages/renderer/src/lib/pvc/PVCList.spec.ts
+++ b/packages/renderer/src/lib/pvc/PVCList.spec.ts
@@ -40,8 +40,10 @@ beforeEach(() => {
 test('Expect PVC empty screen', async () => {
   vi.mocked(states).kubernetesCurrentContextPersistentVolumeClaimsFiltered = writable<KubernetesObject[]>([]);
   render(PVCList);
-  const noPVCS = screen.getByRole('heading', { name: 'No PVCs' });
-  expect(noPVCS).toBeInTheDocument();
+  await vi.waitFor(() => {
+    const noPVCS = screen.getByRole('heading', { name: 'No PVCs' });
+    expect(noPVCS).toBeInTheDocument();
+  });
 });
 
 test('Expect PVC list', async () => {

--- a/packages/renderer/src/lib/service/ServicesList.spec.ts
+++ b/packages/renderer/src/lib/service/ServicesList.spec.ts
@@ -40,8 +40,10 @@ beforeEach(() => {
 test('Expect service empty screen', async () => {
   vi.mocked(states).kubernetesCurrentContextServicesFiltered = writable<KubernetesObject[]>([]);
   render(ServicesList);
-  const noServices = screen.getByRole('heading', { name: 'No services' });
-  expect(noServices).toBeInTheDocument();
+  await vi.waitFor(() => {
+    const noServices = screen.getByRole('heading', { name: 'No services' });
+    expect(noServices).toBeInTheDocument();
+  });
 });
 
 test('Expect services list', async () => {
@@ -73,8 +75,10 @@ test('Expect filter empty screen', async () => {
 
   render(ServicesList, { searchTerm: 'No match' });
 
-  const filterButton = screen.getByRole('button', { name: 'Clear filter' });
-  expect(filterButton).toBeInTheDocument();
+  await vi.waitFor(() => {
+    const filterButton = screen.getByRole('button', { name: 'Clear filter' });
+    expect(filterButton).toBeInTheDocument();
+  });
 });
 
 test('Expect user confirmation to pop up when preferences require', async () => {


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

On Kubernetes lists, display empty screen only when received data.

### Screenshot / video of UI


### What issues does this PR fix or reference?

Fixes #11437

### How to test this PR?



- [x] Tests are covering the bug fix or the new feature

## Summary by Sourcery

This PR fixes an issue where the empty screen was displayed before data was received. The empty screen is now only displayed after data has been received from the Kubernetes API.

Bug Fixes:
- Fixes an issue where the empty screen was displayed before data was received, causing a flicker.

Tests:
- Updates tests to wait for the 'No resources' message to be displayed before asserting that it is visible.