### PR TITLE
feat: kubernetes experimental backend provides active resources count

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -2682,6 +2682,10 @@ export class PluginSystem {
       return kubernetesClient.getResourcesCount();
     });
 
+    this.ipcHandle('kubernetes:getActiveResourcesCount', async (_listener): Promise<ResourceCount[]> => {
+      return kubernetesClient.getActiveResourcesCount();
+    });
+
     this.ipcHandle(
       'kubernetes:getResources',
       async (_listener, contextNames: string[], resourceName: string): Promise<KubernetesContextResources[]> => {

--- a/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
@@ -176,6 +176,24 @@ export class ContextsManagerExperimental {
     }));
   }
 
+  // getActiveResourcesCount returns the count of filtered resources for each context/resource
+  // when isActive is declared for a resource, and filtered with isActive
+  getActiveResourcesCount(): ResourceCount[] {
+    return this.#objectCaches
+      .getAll()
+      .map(informer => {
+        const isActive = this.#resourceFactoryHandler.getResourceFactoryByResourceName(informer.resourceName)?.isActive;
+        return isActive
+          ? {
+              contextName: informer.contextName,
+              resourceName: informer.resourceName,
+              count: informer.value.list().filter(isActive).length,
+            }
+          : undefined;
+      })
+      .filter(f => !!f);
+  }
+
   getResources(contextNames: string[], resourceName: string): KubernetesContextResources[] {
     return this.#objectCaches.getForContextsAndResource(contextNames, resourceName).map(({ contextName, value }) => {
       return {

--- a/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.spec.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.spec.ts
@@ -117,6 +117,38 @@ test('ContextsStatesDispatcher should call updateHealthStates and updatePermissi
   expect(updatePermissionsSpy).toHaveBeenCalled();
 });
 
+test('ContextsStatesDispatcher should call updateResource and updateActiveResourcesCount when onResourceUpdated event is fired', () => {
+  const manager: ContextsManagerExperimental = {
+    onContextHealthStateChange: vi.fn(),
+    onOfflineChange: vi.fn(),
+    onContextPermissionResult: vi.fn(),
+    onContextDelete: vi.fn(),
+    getHealthCheckersStates: vi.fn(),
+    getPermissions: vi.fn(),
+    onResourceCountUpdated: vi.fn(),
+    onResourceUpdated: vi.fn(),
+    isContextOffline: vi.fn(),
+  } as unknown as ContextsManagerExperimental;
+  const apiSender: ApiSenderType = {
+    send: vi.fn(),
+  } as unknown as ApiSenderType;
+  vi.mocked(manager.getPermissions).mockReturnValue([]);
+  const dispatcher = new ContextsStatesDispatcher(manager, apiSender);
+  const updateResourceSpy = vi.spyOn(dispatcher, 'updateResource');
+  const updateActiveResourcesCountSpy = vi.spyOn(dispatcher, 'updateActiveResourcesCount');
+  vi.mocked(manager.getHealthCheckersStates).mockReturnValue(new Map<string, ContextHealthState>());
+  dispatcher.init();
+  expect(updateResourceSpy).not.toHaveBeenCalled();
+  expect(updateActiveResourcesCountSpy).not.toHaveBeenCalled();
+
+  vi.mocked(manager.onResourceUpdated).mockImplementation(
+    f => f({} as { contextName: string; resourceName: string }) as IDisposable,
+  );
+  dispatcher.init();
+  expect(updateResourceSpy).toHaveBeenCalled();
+  expect(updateActiveResourcesCountSpy).toHaveBeenCalled();
+});
+
 test('getContextsHealths should return the values of the map returned by manager.getHealthCheckersStates without kubeConfig', () => {
   const manager: ContextsManagerExperimental = {
     onContextHealthStateChange: vi.fn(),

--- a/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.ts
@@ -43,7 +43,10 @@ export class ContextsStatesDispatcher {
       this.updatePermissions();
     });
     this.manager.onResourceCountUpdated(() => this.updateResourcesCount());
-    this.manager.onResourceUpdated(event => this.updateResource(event.resourceName));
+    this.manager.onResourceUpdated(event => {
+      this.updateResource(event.resourceName);
+      this.updateActiveResourcesCount();
+    });
   }
 
   updateHealthStates(): void {
@@ -75,8 +78,16 @@ export class ContextsStatesDispatcher {
     this.apiSender.send(`kubernetes-resources-count`);
   }
 
+  updateActiveResourcesCount(): void {
+    this.apiSender.send(`kubernetes-active-resources-count`);
+  }
+
   getResourcesCount(): ResourceCount[] {
     return this.manager.getResourcesCount();
+  }
+
+  getActiveResourcesCount(): ResourceCount[] {
+    return this.manager.getActiveResourcesCount();
   }
 
   updateResource(resourceName: string): void {

--- a/packages/main/src/plugin/kubernetes/deployments-resource-factory.spec.ts
+++ b/packages/main/src/plugin/kubernetes/deployments-resource-factory.spec.ts
@@ -1,0 +1,58 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1Deployment } from '@kubernetes/client-node';
+import { expect, test } from 'vitest';
+
+import { DeploymentsResourceFactory } from './deployments-resource-factory.js';
+
+test('deployment with replica=0 is not active', () => {
+  const factory = new DeploymentsResourceFactory();
+  if (!factory.isActive) {
+    throw new Error('isActive should not be undefined');
+  }
+  expect(
+    factory.isActive({
+      spec: {
+        replicas: 0,
+      },
+    } as V1Deployment),
+  ).toBeFalsy();
+});
+
+test('deployment with replica=1 is active', () => {
+  const factory = new DeploymentsResourceFactory();
+  if (!factory.isActive) {
+    throw new Error('isActive should not be undefined');
+  }
+  expect(
+    factory.isActive({
+      spec: {
+        replicas: 1,
+      },
+    } as V1Deployment),
+  ).toBeTruthy();
+});
+
+test('deployment with replica undefined is not active', () => {
+  const factory = new DeploymentsResourceFactory();
+  if (!factory.isActive) {
+    throw new Error('isActive should not be undefined');
+  }
+  expect(factory.isActive({} as V1Deployment)).toBeFalsy();
+});

--- a/packages/main/src/plugin/kubernetes/deployments-resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/deployments-resource-factory.ts
@@ -48,6 +48,7 @@ export class DeploymentsResourceFactory extends ResourceFactoryBase implements R
     this.setInformer({
       createInformer: this.createInformer,
     });
+    this.setIsActive(this.isDeploymentActive);
   }
 
   createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1Deployment> {
@@ -56,5 +57,9 @@ export class DeploymentsResourceFactory extends ResourceFactoryBase implements R
     const listFn = (): Promise<V1DeploymentList> => apiClient.listNamespacedDeployment({ namespace });
     const path = `/apis/apps/v1/namespaces/${namespace}/deployments`;
     return new ResourceInformer<V1Deployment>({ kubeconfig, path, listFn, kind: 'Deployment', plural: 'deployments' });
+  }
+
+  isDeploymentActive(deployment: V1Deployment): boolean {
+    return (deployment.spec?.replicas ?? 0) > 0;
   }
 }

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.ts
@@ -1688,6 +1688,13 @@ export class KubernetesClient {
     return this.contextsStatesDispatcher.getResourcesCount();
   }
 
+  public getActiveResourcesCount(): ResourceCount[] {
+    if (!this.contextsStatesDispatcher) {
+      throw new Error('contextsStatesDispatcher is undefined. This should not happen in Kubernetes experimental');
+    }
+    return this.contextsStatesDispatcher.getActiveResourcesCount();
+  }
+
   public getResources(contextNames: string[], resourceName: string): KubernetesContextResources[] {
     if (!this.contextsStatesDispatcher) {
       throw new Error(

--- a/packages/main/src/plugin/kubernetes/nodes-resource-factory.spec.ts
+++ b/packages/main/src/plugin/kubernetes/nodes-resource-factory.spec.ts
@@ -1,0 +1,74 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { V1Node } from '@kubernetes/client-node';
+import { expect, test } from 'vitest';
+
+import { NodesResourceFactory } from './nodes-resource-factory.js';
+
+test('node with no status is not active', () => {
+  const factory = new NodesResourceFactory();
+  if (!factory.isActive) {
+    throw new Error('isActive should not be undefined');
+  }
+  expect(
+    factory.isActive({
+      spec: {
+        replicas: 0,
+      },
+    } as V1Node),
+  ).toBeFalsy();
+});
+
+test('node with "Ready" condition set to true is active', () => {
+  const factory = new NodesResourceFactory();
+  if (!factory.isActive) {
+    throw new Error('isActive should not be undefined');
+  }
+  expect(
+    factory.isActive({
+      status: {
+        conditions: [
+          {
+            type: 'Ready',
+            status: 'True',
+          },
+        ],
+      },
+    } as V1Node),
+  ).toBeTruthy();
+});
+
+test('node with "Ready" condition set to false is not active', () => {
+  const factory = new NodesResourceFactory();
+  if (!factory.isActive) {
+    throw new Error('isActive should not be undefined');
+  }
+  expect(
+    factory.isActive({
+      status: {
+        conditions: [
+          {
+            type: 'Ready',
+            status: 'False',
+          },
+        ],
+      },
+    } as V1Node),
+  ).toBeFalsy();
+});

--- a/packages/main/src/plugin/kubernetes/nodes-resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/nodes-resource-factory.ts
@@ -47,6 +47,7 @@ export class NodesResourceFactory extends ResourceFactoryBase implements Resourc
     this.setInformer({
       createInformer: this.createInformer,
     });
+    this.setIsActive(this.isNodeActive);
   }
 
   createInformer(kubeconfig: KubeConfigSingleContext): ResourceInformer<V1Node> {
@@ -54,5 +55,11 @@ export class NodesResourceFactory extends ResourceFactoryBase implements Resourc
     const listFn = (): Promise<V1NodeList> => apiClient.listNode();
     const path = `/api/v1/nodes`;
     return new ResourceInformer<V1Node>({ kubeconfig, path, listFn, kind: 'Node', plural: 'nodes' });
+  }
+
+  isNodeActive(node: V1Node): boolean {
+    return (
+      node.status?.conditions?.some(condition => condition.type === 'Ready' && condition.status === 'True') ?? false
+    );
   }
 }

--- a/packages/main/src/plugin/kubernetes/resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/resource-factory.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024 - 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ export class ResourceFactoryBase {
   #resource: string;
   #permissions: ResourcePermissionsFactory | undefined;
   #informer: ResourceInformerFactory | undefined;
+  #isActive: undefined | ((resource: KubernetesObject) => boolean);
 
   constructor(options: {
     resource: string;
@@ -60,6 +61,11 @@ export class ResourceFactoryBase {
     return this;
   }
 
+  setIsActive(isActive: (resource: KubernetesObject) => boolean): ResourceFactoryBase {
+    this.#isActive = isActive;
+    return this;
+  }
+
   get resource(): string {
     return this.#resource;
   }
@@ -70,6 +76,10 @@ export class ResourceFactoryBase {
 
   get informer(): ResourceInformerFactory | undefined {
     return this.#informer;
+  }
+
+  get isActive(): undefined | ((resource: KubernetesObject) => boolean) {
+    return this.#isActive;
   }
 
   copyWithSlicedPermissions(): ResourceFactory {
@@ -89,6 +99,8 @@ export interface ResourceFactory {
   get resource(): string;
   permissions?: ResourcePermissionsFactory;
   informer?: ResourceInformerFactory;
+  // isActive returns true if `resource` is considered active
+  isActive?: (resource: KubernetesObject) => boolean;
   copyWithSlicedPermissions(): ResourceFactory;
 }
 

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1883,6 +1883,10 @@ export function initExposure(): void {
     return ipcInvoke('kubernetes:getResourcesCount');
   });
 
+  contextBridge.exposeInMainWorld('kubernetesGetActiveResourcesCount', async (): Promise<ResourceCount[]> => {
+    return ipcInvoke('kubernetes:getActiveResourcesCount');
+  });
+
   contextBridge.exposeInMainWorld(
     'kubernetesGetResources',
     async (contextNames: string[], resourceName: string): Promise<KubernetesContextResources[]> => {


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Kubernetes experimental backend provides active resources count


### What issues does this PR fix or reference?

Part of #11106 (server part)

### How to test this PR?


- [x] Tests are covering the bug fix or the new feature
