### PR TITLE
refactor(main): move `window-all-closed` listener to main class

### DIFF
--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -56,15 +56,6 @@ app.on('second-instance', (_event, _args, _workingDirectory, additionalData: unk
   });
 });
 
-/**
- * Shout down background process if all windows was closed
- */
-app.on('window-all-closed', () => {
-  if (!isMac()) {
-    app.quit();
-  }
-});
-
 app.once('before-quit', event => {
   if (!extensionLoader) {
     stoppedExtensions.val = true;

--- a/packages/main/src/main.ts
+++ b/packages/main/src/main.ts
@@ -18,7 +18,7 @@
 import type { App as ElectronApp, BrowserWindow } from 'electron';
 
 import { SecurityRestrictions } from '/@/security-restrictions.js';
-import { isWindows } from '/@/util.js';
+import { isMac, isWindows } from '/@/util.js';
 
 import { Deferred } from './plugin/util/deferred.js';
 import { ProtocolLauncher } from './protocol-launcher.js';
@@ -85,6 +85,21 @@ export class Main {
      */
     if (isWindows()) {
       this.app.setAppUserModelId(this.app.name);
+    }
+
+    /**
+     * Setup {@link ElectronApp.on} listeners
+     */
+    this.app.on('window-all-closed', this.onWindowAllClosed.bind(this));
+  }
+
+  /**
+   * Listener for {@link ElectronApp.on('window-all-closed')} event
+   * Shout down background process if all windows was closed
+   */
+  protected onWindowAllClosed(): void {
+    if (!isMac()) {
+      this.app.quit();
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?

Following work on https://github.com/podman-desktop/podman-desktop/issues/10042, moving the `winows-all-close` listener from the `index.ts` to the `main.ts`

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/10042

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
