### PR TITLE
fix: add back button cursor pointer

### DIFF
--- a/packages/renderer/src/app.css
+++ b/packages/renderer/src/app.css
@@ -13,3 +13,10 @@ a {
   --spacing-leftnavbar: 48px;
   --spacing-leftsidebar: 170px;
 }
+
+@layer base {
+  button:not(:disabled),
+  [role='button']:not(:disabled) {
+    cursor: pointer;
+  }
+}


### PR DESCRIPTION
### What does this PR do?

Reverts the Tailwind v4 change to remove the default button cursor pointer. (see https://tailwindcss.com/docs/upgrade-guide)

As discussed on the standup, we'll undo this change for the current release to avoid regression (especially on components that have no hover effect), then possibly undo this later and replace with targeted fixes for elements where we have no hover or focus indicator.

### Screenshot / video of UI

N/A (recording isn't capturing cursor correctly)

### What issues does this PR fix or reference?

Fixes #11436.

### How to test this PR?

Hover over the Learning Center title, buttons. Prior to this change there's no change to the cursor (no indication the LC is clickable), with this PR the cursor changes to a pointer like in 1.16.