### PR TITLE
feat: added visual indicator for kubernetes permissions - apply button

### DIFF
--- a/packages/renderer/src/lib/kube/KubeActions.svelte
+++ b/packages/renderer/src/lib/kube/KubeActions.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
 import KubeApplyYamlButton from '/@/lib/kube/KubeApplyYAMLButton.svelte';
+
+interface Props {
+  disabled?: boolean;
+}
+
+let { disabled = false }: Props = $props();
 </script>
 
-<KubeApplyYamlButton />
+<KubeApplyYamlButton {disabled}/>

--- a/packages/renderer/src/lib/kube/KubeApplyYAMLButton.spec.ts
+++ b/packages/renderer/src/lib/kube/KubeApplyYAMLButton.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -145,4 +145,12 @@ test('Verify failure will open an error dialog', async () => {
 
   expect(showMessageBoxMock).toHaveBeenCalled();
   expect(showMessageBoxMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+});
+
+test('Verify that the button is disabled', () => {
+  render(KubeApplyYamlButton, { disabled: true });
+
+  const button = screen.getByRole('button', { name: 'Apply YAML' });
+  expect(button).toBeInTheDocument();
+  expect(button).toBeDisabled();
 });

--- a/packages/renderer/src/lib/kube/KubeApplyYAMLButton.svelte
+++ b/packages/renderer/src/lib/kube/KubeApplyYAMLButton.svelte
@@ -4,7 +4,13 @@ import { Button } from '@podman-desktop/ui-svelte';
 
 import SolidKubeIcon from '../images/SolidKubeIcon.svelte';
 
-let inProgress = false;
+interface Props {
+  disabled?: boolean;
+}
+
+let { disabled = false }: Props = $props();
+
+let inProgress = $state(false);
 
 async function kubeApply(): Promise<void> {
   let contextName = await window.kubernetesGetCurrentContextName();
@@ -76,4 +82,4 @@ async function kubeApply(): Promise<void> {
 }
 </script>
 
-<Button on:click={kubeApply} title="Apply YAML" icon={SolidKubeIcon} inProgress={inProgress}>Apply YAML</Button>
+<Button on:click={kubeApply} {disabled} title="Apply YAML" icon={SolidKubeIcon} inProgress={inProgress}>Apply YAML</Button>

--- a/packages/renderer/src/lib/kube/resource-permission.ts
+++ b/packages/renderer/src/lib/kube/resource-permission.ts
@@ -1,0 +1,66 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { kubernetesContextsPermissions } from '/@/stores/kubernetes-context-permission';
+import { kubernetesContexts } from '/@/stores/kubernetes-contexts';
+import type { IDisposable } from '/@api/disposable';
+import type { ContextPermission } from '/@api/kubernetes-contexts-permissions';
+import type { ResourceName } from '/@api/kubernetes-contexts-states';
+
+export async function listenResourcePermitted(
+  resourceName: ResourceName,
+  callback: (permitted: boolean) => void,
+): Promise<IDisposable> {
+  const experimental = (await window.getConfigurationValue<boolean>('kubernetes.statesExperimental')) ?? false;
+  let contextName = '';
+  let permissions: ContextPermission[] = [];
+
+  const computePermission = (): void => {
+    const permission = permissions.find(
+      permission => permission.contextName === contextName && permission.resourceName === resourceName,
+    );
+
+    if (!permission) {
+      callback(true);
+      return;
+    }
+    callback(permission.permitted);
+  };
+
+  if (!experimental) {
+    callback(true);
+    return { dispose: (): void => {} };
+  }
+
+  const unsubscribeContexts = kubernetesContexts.subscribe(value => {
+    contextName = value.find(c => c.currentContext)?.name ?? '';
+    computePermission();
+  });
+
+  const unsubscribePermissions = kubernetesContextsPermissions.subscribe(newPermissions => {
+    permissions = newPermissions;
+    computePermission();
+  });
+
+  return {
+    dispose: (): void => {
+      unsubscribeContexts();
+      unsubscribePermissions();
+    },
+  };
+}

--- a/packages/renderer/src/lib/objects/KubernetesObjectsList.svelte
+++ b/packages/renderer/src/lib/objects/KubernetesObjectsList.svelte
@@ -8,9 +8,11 @@ import { type Readable, type Unsubscriber, type Writable } from 'svelte/store';
 
 import { listenResources } from '/@/lib/kube/resources-listen';
 import type { IDisposable } from '/@api/disposable.js';
+import type { ResourceName } from '/@api/kubernetes-contexts-states';
 
 import { withBulkConfirmation } from '../actions/BulkActions';
 import KubeActions from '../kube/KubeActions.svelte';
+import { listenResourcePermitted } from '../kube/resource-permission';
 import KubernetesCurrentContextConnectionBadge from '../ui/KubernetesCurrentContextConnectionBadge.svelte';
 import type { KubernetesObjectUI } from './KubernetesObjectUI';
 
@@ -45,6 +47,9 @@ let resources = $state<{ [key: string]: KubernetesObject[] | undefined }>({});
 let resourceListeners: (IDisposable | undefined)[] = [];
 let legacyUnsubscribers: Unsubscriber[] = [];
 
+let kubeActionsDisabled: boolean = $state(false);
+let selectedResource: ResourceName = $state('deployments');
+
 const objects = $derived(
   kinds.flatMap(kind => resources[kind.resource]?.map(object => kind.transformer(object)) ?? []),
 );
@@ -73,6 +78,12 @@ onMount(async () => {
       }),
     );
   }
+
+  resourceListeners.push(
+    await listenResourcePermitted(selectedResource, (permitted: boolean) => {
+      kubeActionsDisabled = !permitted;
+    }),
+  );
 });
 
 onDestroy(() => {
@@ -118,7 +129,7 @@ let table: Table;
 
 <NavPage bind:searchTerm={searchTerm} title={plural}>
   <svelte:fragment slot="additional-actions">
-    <KubeActions />
+    <KubeActions disabled={kubeActionsDisabled}/>
   </svelte:fragment>
 
   <svelte:fragment slot="bottom-additional-actions">


### PR DESCRIPTION
### What does this PR do?
Adds visual indicator for users to differentiate between permissions to kubernetes deployments - just APPLY button in upper right corner

This is just for deployments - apply button

### Screenshot / video of UI
Mockup (only for deployments): 
![Image](https://github.com/user-attachments/assets/28154725-367a-4a63-a8a2-b9cf666c26fc)

### What issues does this PR fix or reference?
Required for #11107 
Required for #11307 - needs to be merged first

### How to test this PR?
Create an user with not all permissions: 
https://github.com/podman-desktop/podman-desktop/issues/10655

- [x] Tests are covering the bug fix or the new feature
