### PR TITLE
chore: reduce default gap in expandable

### DIFF
--- a/packages/renderer/src/lib/kube/KubernetesDashboard.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesDashboard.svelte
@@ -112,7 +112,7 @@ async function openKubernetesDocumentation(): Promise<void> {
                 <Expandable>
                   <!-- eslint-disable-next-line sonarjs/no-unused-vars -->
                   {#snippet title()}<div class="text-xl">Explore articles and blog posts</div>{/snippet}
-                  <div class="grid grid-cols-3 gap-4">
+                  <div class="grid grid-cols-3 gap-4 pt-2">
                     <KubernetesDashboardGuideCard title='Deploy and test Kubernetes containers using Podman Desktop' image={deployAndTestKubernetesImage} link='https://developers.redhat.com/articles/2023/06/09/deploy-and-test-kubernetes-containers-using-podman-desktop'/>
                     <KubernetesDashboardGuideCard title='Working with Kubernetes in Podman Desktop' image={workingWithKubernetesImage} link='https://developers.redhat.com/articles/2023/11/06/working-kubernetes-podman-desktop'/>
                     <KubernetesDashboardGuideCard title='Share your local podman images with the Kubernetes cluster' image={shareYourLocalProdmanImagesWithTheKubernetesImage} link='https://podman-desktop.io/blog/sharing-podman-images-with-kubernetes-cluster'/>

--- a/packages/ui/src/lib/button/Expandable.spec.ts
+++ b/packages/ui/src/lib/button/Expandable.spec.ts
@@ -61,6 +61,7 @@ test('Check title and content are visible by default', async () => {
   const title = screen.getByText('Title');
   expect(title).toBeVisible();
   expect(title.parentElement?.parentElement).toHaveAttribute('aria-expanded', 'true');
+  expect(title.parentElement?.parentElement?.parentElement).toHaveClass('gap-2');
 
   expect(screen.queryByText('Content')).toBeInTheDocument();
 });

--- a/packages/ui/src/lib/button/Expandable.svelte
+++ b/packages/ui/src/lib/button/Expandable.svelte
@@ -25,7 +25,7 @@ function toggle(): void {
 }
 </script>
 
-<div class="flex flex-col w-full">
+<div class="flex flex-col w-full gap-2">
   <button onclick={(): void => toggle()} aria-expanded="{expanded}">
     <div class="flex flex-row space-x-1 items-center">
       {#if expanded}
@@ -38,7 +38,7 @@ function toggle(): void {
   </button>
 {#if initialized}
 {#if expanded}
-  <div role="region" class="pt-5" transition:slide={{ duration: 250 }}>
+  <div role="region" transition:slide={{ duration: 250 }}>
     <div transition:fade={{ duration: 250 }}>
       {@render children?.()}
     </div>


### PR DESCRIPTION
### What does this PR do?

When I created the Expandable component I used the standard pt-5 that we use everywhere as a gap between the control/title and content. This is fine as a default in Podman Desktop where we tend to use the control with big headers, but isn't a good default for a component - e.g. when I tried it on the bootc build page where it would be used for smaller section expanders.

This just uses a more standard gap-2 instead, and adds a pt to the Kubernetes dashboard to compensate.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Related to #11364.

### How to test this PR?

Just confirm no visual change to Kubernetes dashboard guide section.

- [x] Tests are covering the bug fix or the new feature