### PR TITLE
chore: remove no-explicit-any from lib/dashboard

### DIFF
--- a/packages/renderer/src/lib/dashboard/ProviderCard.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ProviderCard.spec.ts
@@ -16,8 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import '@testing-library/jest-dom/vitest';
 
 import type { ProviderImages } from '@podman-desktop/api';

--- a/packages/renderer/src/lib/dashboard/ProviderConfigured.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ProviderConfigured.spec.ts
@@ -16,8 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import '@testing-library/jest-dom/vitest';
 
 import { beforeAll, test, vi } from 'vitest';
@@ -26,25 +24,19 @@ import ProviderConfigured from '/@/lib/dashboard/ProviderConfigured.svelte';
 
 import { verifyStatus } from './ProviderStatusTestHelper.spec';
 
-class ResizeObserver {
-  observe = vi.fn();
-  disconnect = vi.fn();
-  unobserve = vi.fn();
-}
-
 beforeAll(() => {
-  (window as any).ResizeObserver = ResizeObserver;
-  (window as any).startProvider = vi.fn();
-
-  // mock that autostart is configured as true
-  (window.getConfigurationValue as unknown) = (_key: string): boolean => {
-    return true;
-  };
-
+  // Cannot mock with vi.mocked(window.ResizeObserver)
+  // we use "global" similar to PodDetails.spec.ts implementation
+  global.ResizeObserver = vi.fn().mockReturnValue({
+    observe: vi.fn(),
+    unobserve: vi.fn(),
+    disconnect: vi.fn(),
+  });
+  vi.mocked(window.getConfigurationValue).mockResolvedValue(true);
   // fake the window.events object
   (window.events as unknown) = {
-    receive: (_channel: string, func: any): void => {
-      func();
+    receive: (_channel: string, func: unknown): void => {
+      (func as () => void)();
     },
   };
 });

--- a/packages/renderer/src/lib/dashboard/ProviderReady.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ProviderReady.spec.ts
@@ -16,8 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import '@testing-library/jest-dom/vitest';
 
 import { beforeAll, test } from 'vitest';
@@ -29,8 +27,8 @@ import { verifyStatus } from './ProviderStatusTestHelper.spec';
 // fake the window.events object
 beforeAll(() => {
   (window.events as unknown) = {
-    receive: (_channel: string, func: any): void => {
-      func();
+    receive: (_channel: string, func: unknown): void => {
+      (func as () => void)();
     },
   };
 });


### PR DESCRIPTION
chore: remove no-explicit-any from lib/dashboard

### What does this PR do?

Removes no-explicit-any from the lib/dashboard folder.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Part of https://github.com/podman-desktop/podman-desktop/issues/10603

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
