### PR TITLE
chore: remove no-explicit-any from dialogs

### DIFF
--- a/packages/renderer/src/lib/dialogs/CommandPalette.spec.ts
+++ b/packages/renderer/src/lib/dialogs/CommandPalette.spec.ts
@@ -16,8 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import '@testing-library/jest-dom/vitest';
 
 import { render, screen } from '@testing-library/svelte';
@@ -43,7 +41,7 @@ beforeAll(() => {
   // mock missing scrollIntoView method
   window.HTMLElement.prototype.scrollIntoView = vi.fn();
 
-  (window as any).executeCommand = executeCommandMock;
+  Object.defineProperty(window, 'executeCommand', { value: executeCommandMock });
 });
 
 beforeEach(() => {

--- a/packages/renderer/src/lib/dialogs/CommandPalette.spec.ts
+++ b/packages/renderer/src/lib/dialogs/CommandPalette.spec.ts
@@ -31,8 +31,6 @@ const receiveFunctionMock = vi.fn();
 
 const COMMAND_PALETTE_ARIA_LABEL = 'Command palette command input';
 
-const executeCommandMock = vi.fn();
-// mock some methods of the window object
 beforeAll(() => {
   (window.events as unknown) = {
     receive: receiveFunctionMock,
@@ -40,8 +38,6 @@ beforeAll(() => {
 
   // mock missing scrollIntoView method
   window.HTMLElement.prototype.scrollIntoView = vi.fn();
-
-  Object.defineProperty(window, 'executeCommand', { value: executeCommandMock });
 });
 
 beforeEach(() => {
@@ -121,7 +117,7 @@ describe('Command Palette', () => {
     // click on the item
     await userEvent.click(secondItem);
 
-    expect(executeCommandMock).toBeCalledWith('my-command-2');
+    expect(window.executeCommand).toBeCalledWith('my-command-2');
   });
 
   test('Check tab key', async () => {
@@ -167,7 +163,7 @@ describe('Command Palette', () => {
     // click on the item
     await userEvent.click(secondItem);
 
-    expect(executeCommandMock).toBeCalledWith('my-command-2');
+    expect(window.executeCommand).toBeCalledWith('my-command-2');
   });
 
   test('Check keyup ⬆️', async () => {
@@ -226,7 +222,7 @@ describe('Command Palette', () => {
     // click on the item
     await userEvent.click(secondItem);
 
-    expect(executeCommandMock).toBeCalledWith('my-command-2');
+    expect(window.executeCommand).toBeCalledWith('my-command-2');
   });
 
   test('Check Enter key', async () => {
@@ -258,7 +254,7 @@ describe('Command Palette', () => {
     // now, press the Enter key
     await userEvent.keyboard('{Enter}');
 
-    expect(executeCommandMock).toBeCalledWith('my-command-1');
+    expect(window.executeCommand).toBeCalledWith('my-command-1');
   });
 
   test('Check filtering', async () => {
@@ -318,7 +314,7 @@ describe('Command Palette', () => {
     // now, press the Enter key
     await userEvent.keyboard('{Enter}');
 
-    expect(executeCommandMock).toBeCalledWith('my-command-1');
+    expect(window.executeCommand).toBeCalledWith('my-command-1');
   });
 
   test('Check enablement', async () => {
@@ -377,6 +373,6 @@ describe('Command Palette', () => {
     // now, press the Enter key
     await userEvent.keyboard('{Enter}');
 
-    expect(executeCommandMock).toBeCalledWith('my-command-enabled-1');
+    expect(window.executeCommand).toBeCalledWith('my-command-enabled-1');
   });
 });

--- a/packages/renderer/src/lib/dialogs/CustomPick.spec.ts
+++ b/packages/renderer/src/lib/dialogs/CustomPick.spec.ts
@@ -16,8 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import '@testing-library/jest-dom/vitest';
 
 import { render, screen } from '@testing-library/svelte';
@@ -36,8 +34,8 @@ beforeAll(() => {
   (window.events as unknown) = {
     receive: receiveFunctionMock,
   };
-  (window as any).sendCustomPickItemsOnConfirmation = sendCustomPickItemsOnConfirmation;
-  (window as any).closeCustomPick = closeCustomPick;
+  Object.defineProperty(window, 'sendCustomPickItemsOnConfirmation', { value: sendCustomPickItemsOnConfirmation });
+  Object.defineProperty(window, 'closeCustomPick', { value: closeCustomPick });
 });
 
 describe('CustomPick', () => {

--- a/packages/renderer/src/lib/dialogs/CustomPick.spec.ts
+++ b/packages/renderer/src/lib/dialogs/CustomPick.spec.ts
@@ -25,8 +25,6 @@ import { beforeAll, describe, expect, test, vi } from 'vitest';
 import CustomPick from './CustomPick.svelte';
 import type { CustomPickOptions } from './quickpick-input';
 
-const sendCustomPickItemsOnConfirmation = vi.fn();
-const closeCustomPick = vi.fn();
 const receiveFunctionMock = vi.fn();
 
 // mock some methods of the window object
@@ -34,8 +32,6 @@ beforeAll(() => {
   (window.events as unknown) = {
     receive: receiveFunctionMock,
   };
-  Object.defineProperty(window, 'sendCustomPickItemsOnConfirmation', { value: sendCustomPickItemsOnConfirmation });
-  Object.defineProperty(window, 'closeCustomPick', { value: closeCustomPick });
 });
 
 describe('CustomPick', () => {
@@ -138,7 +134,7 @@ describe('CustomPick', () => {
 
     await userEvent.click(button);
 
-    expect(closeCustomPick).toHaveBeenCalled();
+    expect(window.closeCustomPick).toHaveBeenCalled();
   });
 
   test('Expect that by clicking the next button it calls the senditemms and close command', async () => {
@@ -174,7 +170,7 @@ describe('CustomPick', () => {
     expect(button).toBeInTheDocument();
 
     await userEvent.click(button);
-    expect(sendCustomPickItemsOnConfirmation).toHaveBeenCalled();
-    expect(closeCustomPick).toHaveBeenCalled();
+    expect(window.sendCustomPickItemsOnConfirmation).toHaveBeenCalled();
+    expect(window.closeCustomPick).toHaveBeenCalled();
   });
 });

--- a/packages/renderer/src/lib/dialogs/MessageBox.spec.ts
+++ b/packages/renderer/src/lib/dialogs/MessageBox.spec.ts
@@ -16,8 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen } from '@testing-library/svelte';
@@ -36,8 +34,8 @@ beforeAll(() => {
   (window.events as unknown) = {
     receive: receiveFunctionMock,
   };
-  (window as any).sendShowMessageBoxValues = sendShowMessageBoxValuesMock;
-  (window as any).sendShowMessageBoxOnSelect = sendShowMessageBoxOnSelect;
+  Object.defineProperty(window, 'sendShowMessageBoxValues', { value: sendShowMessageBoxValuesMock });
+  Object.defineProperty(window, 'sendShowMessageBoxOnSelect', { value: sendShowMessageBoxOnSelect });
 });
 
 describe('MessageBox', () => {

--- a/packages/renderer/src/lib/dialogs/MessageBox.spec.ts
+++ b/packages/renderer/src/lib/dialogs/MessageBox.spec.ts
@@ -25,8 +25,6 @@ import { beforeAll, describe, expect, test, vi } from 'vitest';
 import MessageBox from './MessageBox.svelte';
 import type { MessageBoxOptions } from './messagebox-input';
 
-const sendShowMessageBoxValuesMock = vi.fn();
-const sendShowMessageBoxOnSelect = vi.fn();
 const receiveFunctionMock = vi.fn();
 
 // mock some methods of the window object
@@ -34,8 +32,6 @@ beforeAll(() => {
   (window.events as unknown) = {
     receive: receiveFunctionMock,
   };
-  Object.defineProperty(window, 'sendShowMessageBoxValues', { value: sendShowMessageBoxValuesMock });
-  Object.defineProperty(window, 'sendShowMessageBoxOnSelect', { value: sendShowMessageBoxOnSelect });
 });
 
 describe('MessageBox', () => {
@@ -93,7 +89,7 @@ describe('MessageBox', () => {
     const ok = await screen.findByText('OK');
     expect(ok).toBeInTheDocument();
     await fireEvent.click(ok);
-    expect(sendShowMessageBoxOnSelect).toBeCalledWith(idRequest, 0, undefined);
+    expect(window.sendShowMessageBoxOnSelect).toBeCalledWith(idRequest, 0, undefined);
   });
 
   test('Expect that Esc closes', async () => {
@@ -114,7 +110,7 @@ describe('MessageBox', () => {
     render(MessageBox, {});
 
     await userEvent.keyboard('{Escape}');
-    expect(sendShowMessageBoxOnSelect).toBeCalledWith(idRequest, undefined);
+    expect(window.sendShowMessageBoxOnSelect).toBeCalledWith(idRequest, undefined);
   });
 
   test('Expect that tabbing works', async () => {
@@ -188,7 +184,7 @@ describe('MessageBox', () => {
     const title1 = await screen.findByText(messageBoxOptions1.title);
     expect(title1).toBeInTheDocument();
     await fireEvent.click(ok1);
-    await vi.waitFor(() => expect(sendShowMessageBoxOnSelect).toBeCalledWith(idRequest1, 0, undefined));
+    await vi.waitFor(() => expect(window.sendShowMessageBoxOnSelect).toBeCalledWith(idRequest1, 0, undefined));
     eventCallback?.(messageBoxOptions2);
 
     const ok2 = await screen.findByText('OK');

--- a/packages/renderer/src/lib/dialogs/QuickPickInput.spec.ts
+++ b/packages/renderer/src/lib/dialogs/QuickPickInput.spec.ts
@@ -28,17 +28,14 @@ import type { InputBoxOptions, QuickPickOptions } from './quickpick-input';
 import QuickPickInput from './QuickPickInput.svelte';
 
 const receiveFunctionMock = vi.fn();
-const sendShowQuickPickOnSelectMock = vi.fn().mockResolvedValue(undefined);
-const sendShowQuickPickValuesMock = vi.fn().mockResolvedValue(undefined);
-
 // mock some methods of the window object
 beforeAll(() => {
   (window.events as unknown) = {
     receive: receiveFunctionMock,
   };
 
-  (window.sendShowQuickPickOnSelect as unknown) = sendShowQuickPickOnSelectMock;
-  (window.sendShowQuickPickValues as unknown) = sendShowQuickPickValuesMock;
+  vi.mocked(window.sendShowQuickPickOnSelect).mockResolvedValue(undefined);
+  vi.mocked(window.sendShowQuickPickValues).mockResolvedValue(undefined);
 });
 
 describe('QuickPickInput', () => {
@@ -240,9 +237,8 @@ describe('QuickPickInput', () => {
     const itemB1 = await screen.findByText('itemB');
     expect(itemB1).toBeInTheDocument();
 
-    expect(sendShowQuickPickOnSelectMock).toHaveBeenCalled();
-    expect(sendShowQuickPickOnSelectMock).toHaveBeenCalledWith(123, 0);
-    sendShowQuickPickOnSelectMock.mockClear();
+    expect(window.sendShowQuickPickOnSelect).toHaveBeenCalled();
+    expect(window.sendShowQuickPickOnSelect).toHaveBeenCalledWith(123, 0);
 
     await userEvent.type(input, 'B');
 
@@ -251,9 +247,8 @@ describe('QuickPickInput', () => {
     const itemB2 = await screen.findByText('itemB');
     expect(itemB2).toBeInTheDocument();
 
-    expect(sendShowQuickPickOnSelectMock).toHaveBeenCalled();
-    expect(sendShowQuickPickOnSelectMock).toHaveBeenCalledWith(123, 1);
-    sendShowQuickPickOnSelectMock.mockClear();
+    expect(window.sendShowQuickPickOnSelect).toHaveBeenCalled();
+    expect(window.sendShowQuickPickOnSelect).toHaveBeenCalledWith(123, 1);
   });
 
   test('Expect that filtering is case insensitive', async () => {
@@ -285,9 +280,8 @@ describe('QuickPickInput', () => {
     const itemB1 = await screen.findByText('itemB');
     expect(itemB1).toBeInTheDocument();
 
-    expect(sendShowQuickPickOnSelectMock).toHaveBeenCalled();
-    expect(sendShowQuickPickOnSelectMock).toHaveBeenCalledWith(123, 0);
-    sendShowQuickPickOnSelectMock.mockClear();
+    expect(window.sendShowQuickPickOnSelect).toHaveBeenCalled();
+    expect(window.sendShowQuickPickOnSelect).toHaveBeenCalledWith(123, 0);
 
     await userEvent.type(input, 'a');
 
@@ -295,9 +289,8 @@ describe('QuickPickInput', () => {
     expect(itemA2).toBeInTheDocument();
     const itemB2 = screen.queryByText('itemB');
     expect(itemB2).not.toBeInTheDocument();
-    expect(sendShowQuickPickOnSelectMock).toHaveBeenCalled();
-    expect(sendShowQuickPickOnSelectMock).toHaveBeenCalledWith(123, 0);
-    sendShowQuickPickOnSelectMock.mockClear();
+    expect(window.sendShowQuickPickOnSelect).toHaveBeenCalled();
+    expect(window.sendShowQuickPickOnSelect).toHaveBeenCalledWith(123, 0);
   });
 
   test('Expect that invalid filter clears selection', async () => {
@@ -329,9 +322,8 @@ describe('QuickPickInput', () => {
     const itemB1 = await screen.findByText('itemB');
     expect(itemB1).toBeInTheDocument();
 
-    expect(sendShowQuickPickOnSelectMock).toHaveBeenCalled();
-    expect(sendShowQuickPickOnSelectMock).toHaveBeenCalledWith(123, 0);
-    sendShowQuickPickOnSelectMock.mockClear();
+    expect(window.sendShowQuickPickOnSelect).toHaveBeenCalled();
+    expect(window.sendShowQuickPickOnSelect).toHaveBeenCalledWith(123, 0);
 
     await userEvent.type(input, 'q');
 
@@ -340,8 +332,8 @@ describe('QuickPickInput', () => {
     const itemB3 = screen.queryByText('itemB');
     expect(itemB3).not.toBeInTheDocument();
 
-    expect(sendShowQuickPickOnSelectMock).toHaveBeenCalled();
-    expect(sendShowQuickPickOnSelectMock).toHaveBeenCalledWith(123, -1);
+    expect(window.sendShowQuickPickOnSelect).toHaveBeenCalled();
+    expect(window.sendShowQuickPickOnSelect).toHaveBeenCalledWith(123, -1);
   });
 
   test('Expect item label to have ellipsis class', async () => {

--- a/packages/renderer/src/lib/dialogs/QuickPickInput.spec.ts
+++ b/packages/renderer/src/lib/dialogs/QuickPickInput.spec.ts
@@ -37,9 +37,11 @@ beforeAll(() => {
   (window.events as unknown) = {
     receive: receiveFunctionMock,
   };
-  (window as any).sendShowQuickPickValues = sendShowQuickPickValuesMock;
-  (window as any).sendShowInputBoxValue = sendShowInputBoxValueMock;
-  (window as any).sendShowQuickPickOnSelect = sendShowQuickPickOnSelectMock.mockResolvedValue(undefined);
+  Object.defineProperty(window, 'sendShowQuickPickValues', { value: sendShowQuickPickValuesMock });
+  Object.defineProperty(window, 'sendShowInputBoxValue', { value: sendShowInputBoxValueMock });
+  Object.defineProperty(window, 'sendShowQuickPickOnSelect', {
+    value: sendShowQuickPickOnSelectMock.mockResolvedValue(undefined),
+  });
 });
 
 describe('QuickPickInput', () => {

--- a/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
+++ b/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
@@ -150,7 +150,6 @@ async function onInputChange(event: Event): Promise<void> {
 
   // Verify that target is an HTMLInputElement or HTMLTextAreaElement
   if (!(target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement)) {
-    console.warn('Unexpected event target:', target);
     return;
   }
 

--- a/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
+++ b/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
@@ -146,7 +146,14 @@ const onClose = async (): Promise<void> => {
 };
 
 async function onInputChange(event: Event): Promise<void> {
-  const target = event.target as HTMLInputElement | HTMLTextAreaElement;
+  const target = event.target;
+
+  // Verify that target is an HTMLInputElement or HTMLTextAreaElement
+  if (!(target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement)) {
+    console.warn('Unexpected event target:', target);
+    return;
+  }
+
   // in case of quick pick, filter the items
   if (mode === 'QuickPick') {
     let val = target.value.toLowerCase();

--- a/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
+++ b/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
@@ -145,11 +145,11 @@ const onClose = async (): Promise<void> => {
   }
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function onInputChange(event: any): Promise<void> {
+async function onInputChange(event: Event): Promise<void> {
+  const target = event.target as HTMLInputElement | HTMLTextAreaElement;
   // in case of quick pick, filter the items
   if (mode === 'QuickPick') {
-    let val = event.target.value.toLowerCase();
+    let val = target.value.toLowerCase();
     quickPickFilteredItems = quickPickItems.filter(item => item.value.toLowerCase().includes(val));
     quickPickSelectedFilteredIndex = 0;
     if (quickPickFilteredItems.length > 0) {
@@ -168,7 +168,7 @@ async function onInputChange(event: any): Promise<void> {
     return;
   }
   validationError = undefined;
-  const value = event.target.value;
+  const value = target.value;
   const result = await window.sendShowInputBoxValidate(currentId, value);
   if (result) {
     validationError = result.toString();


### PR DESCRIPTION
chore: remove no-explicit-any from dialogs

### What does this PR do?

Removes the no explicit any from dialog folder

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/podman-desktop/issues/10603

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
