### PR TITLE
fix: button focus outline

### DIFF
--- a/packages/ui/src/lib/button/Button.spec.ts
+++ b/packages/ui/src/lib/button/Button.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2024 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,8 @@ test('Check primary button styling', async () => {
   expect(button).toHaveClass('border-none');
   expect(button).toHaveClass('py-[5px]');
   expect(button).toHaveClass('text-[var(--pd-button-text)]');
+  expect(button).toHaveClass('focus:outline-[var(--pd-button-primary-hover-bg)]');
+  expect(button).toHaveClass('outline-transparent');
 });
 
 test('Check disabled/in-progress primary button styling', async () => {
@@ -74,6 +76,8 @@ test('Check secondary button styling', async () => {
   expect(button).toHaveClass('hover:bg-[var(--pd-button-secondary-hover)]');
   expect(button).toHaveClass('hover:border-[var(--pd-button-secondary-hover)]');
   expect(button).toHaveClass('hover:text-[var(--pd-button-text)]');
+  expect(button).toHaveClass('focus:outline-[var(--pd-button-primary-hover-bg)]');
+  expect(button).toHaveClass('outline-transparent');
 });
 
 test('Check danger button styling', async () => {
@@ -90,6 +94,8 @@ test('Check danger button styling', async () => {
   expect(button).toHaveClass('text-[var(--pd-button-danger-text)]');
   expect(button).toHaveClass('hover:bg-[var(--pd-button-danger-hover-bg)]');
   expect(button).toHaveClass('hover:text-[var(--pd-button-danger-hover-text)]');
+  expect(button).toHaveClass('focus:outline-[var(--pd-button-primary-hover-bg)]');
+  expect(button).toHaveClass('outline-transparent');
 });
 
 test('Check disabled/in-progress secondary button styling', async () => {
@@ -117,6 +123,8 @@ test('Check link button styling', async () => {
   expect(button).toHaveClass('py-[5px]');
   expect(button).toHaveClass('hover:bg-[var(--pd-button-link-hover-bg)]');
   expect(button).toHaveClass('text-[var(--pd-button-link-text)]');
+  expect(button).toHaveClass('focus:outline-[var(--pd-button-primary-hover-bg)]');
+  expect(button).toHaveClass('outline-transparent');
 });
 
 test('Check disabled/in-progress link button styling', async () => {
@@ -140,6 +148,8 @@ test('Check tab button styling', async () => {
   expect(button).toHaveClass('border-[var(--pd-button-tab-border)]');
   expect(button).toHaveClass('pb-1');
   expect(button).toHaveClass('text-[var(--pd-button-tab-text)]');
+  expect(button).toHaveClass('focus:outline-[var(--pd-button-primary-hover-bg)]');
+  expect(button).toHaveClass('outline-transparent');
 });
 
 test('Check selected tab button styling', async () => {

--- a/packages/ui/src/lib/button/Button.svelte
+++ b/packages/ui/src/lib/button/Button.svelte
@@ -69,7 +69,8 @@ $: {
 
 <button
   type="button"
-  class="relative {padding} box-border whitespace-nowrap select-none transition-all {classes} {$$props.class ?? ''}"
+  class="relative {padding} box-border whitespace-nowrap select-none transition-all outline-transparent focus:outline-[var(--pd-button-primary-hover-bg)] {classes} {$$props.class ??
+    ''}"
   class:border-[var(--pd-button-tab-border-selected)]={type === 'tab' && selected}
   class:hover:border-[var(--pd-button-tab-hover-border)]={type === 'tab' && !selected}
   class:text-[var(--pd-button-tab-text-selected)]={type === 'tab' && selected}

--- a/packages/ui/src/lib/button/CloseButton.spec.ts
+++ b/packages/ui/src/lib/button/CloseButton.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,8 @@ test('Check button styling', async () => {
   expect(button).toHaveClass('p-1');
   expect(button).toHaveClass('no-underline');
   expect(button).toHaveClass('cursor-pointer');
+  expect(button).toHaveClass('outline-transparent');
+  expect(button).toHaveClass('focus:outline-[var(--pd-button-primary-hover-bg)]');
 
   const img = within(button).getByRole('img', { hidden: true });
   expect(img).toBeInTheDocument();

--- a/packages/ui/src/lib/button/CloseButton.svelte
+++ b/packages/ui/src/lib/button/CloseButton.svelte
@@ -12,7 +12,7 @@ function click(): void {
 
 <button
   type="button"
-  class="hover:bg-[var(--pd-button-close-hover-bg)] hover:bg-opacity-10 transition-all rounded-[4px] p-1 no-underline cursor-pointer {$$props.class ||
+  class="hover:bg-[var(--pd-button-close-hover-bg)] hover:bg-opacity-10 transition-all rounded-[4px] p-1 no-underline cursor-pointer outline-transparent focus:outline-[var(--pd-button-primary-hover-bg)] {$$props.class ||
     ''}"
   on:click={click}
   title="Close"

--- a/packages/ui/src/lib/tab/Tab.spec.ts
+++ b/packages/ui/src/lib/tab/Tab.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ test('check link element is created by using url and title and correct class whe
   expect((item as HTMLAnchorElement).href.endsWith('/url')).toBeTruthy();
   expect(item.textContent).equals('title');
   expect(item.parentElement).not.toHaveClass('border-transparent');
+  expect(item.parentElement).toHaveClass('focus:outline-[var(--pd-tab-highlight)]');
 });
 
 test('check link element is created by using url and title and correct class when not selected', async () => {

--- a/packages/ui/src/lib/tab/Tab.svelte
+++ b/packages/ui/src/lib/tab/Tab.svelte
@@ -5,7 +5,7 @@ export let title: string;
 </script>
 
 <div
-  class="pb-1 border-b-[3px] whitespace-nowrap hover:cursor-pointer"
+  class="pb-1 border-b-[3px] whitespace-nowrap hover:cursor-pointer focus:outline-[var(--pd-tab-highlight)]"
   class:border-[var(--pd-tab-highlight)]={selected}
   class:border-transparent={!selected}
   class:hover:border-[var(--pd-tab-hover)]={!selected}>


### PR DESCRIPTION
### What does this PR do?

Most of our components do not have an outline border set, so when you tab to them they have a default blue outline. This changes Button, CloseButton, and Tab to use their hover colors (purple) instead. Button/close button also require outline-transparent to avoid a white outline flash on entry.

This fixes the specific issue (buttons), but there are >10 other controls to fix as well. It's not always clear what the correct behaviour should be, so I've opened #11482 to track the overall design.

### Screenshot / video of UI

Before:

<img width="185" alt="Screenshot 2025-03-03 at 4 11 02 PM" src="https://github.com/user-attachments/assets/044f337c-2af2-46b4-a251-ba765cd3a0d3" />

<img width="185" alt="Screenshot 2025-03-03 at 4 11 55 PM" src="https://github.com/user-attachments/assets/9729f62b-3d51-4409-86e1-e5a052f78e8b" />

<img width="65" alt="Screenshot 2025-03-03 at 4 10 33 PM" src="https://github.com/user-attachments/assets/faf47e46-6fd6-4b3a-a1c9-5d1b94d8ad2e" />

After:

<img width="185" alt="Screenshot 2025-03-03 at 4 11 19 PM" src="https://github.com/user-attachments/assets/fc72023b-fbbb-41d4-ae78-f72698880435" />

<img width="185" alt="Screenshot 2025-03-03 at 4 11 39 PM" src="https://github.com/user-attachments/assets/c3804943-62ce-44be-914e-d882926bcb8b" />

<img width="65" alt="Screenshot 2025-03-03 at 4 10 15 PM" src="https://github.com/user-attachments/assets/93df5118-c6f8-4e9a-8ead-a970120545a4" />

### What issues does this PR fix or reference?

Fixes #6379.

### How to test this PR?

Find instances of these controls and tab to them. You'll see lots of other components that have the same problem, but this fix is specifically for Buttons and #11482 will track the general issue.

- [x] Tests are covering the bug fix or the new feature