### PR TITLE
chore: pods name column cleanup

### DIFF
--- a/packages/renderer/src/lib/pod/PodColumnName.spec.ts
+++ b/packages/renderer/src/lib/pod/PodColumnName.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,36 +66,4 @@ test('Expect clicking works', async () => {
   fireEvent.click(text);
 
   expect(routerGotoSpy).toBeCalledWith('/pods/podman/my-pod/podman/');
-});
-
-test('Expect kubernetes pod information', async () => {
-  const fakeKubernetesInfo: PodInfoUI = {
-    id: 'pod-id',
-    shortId: 'short-id',
-    name: 'my-pod',
-    engineId: 'kubernetes',
-    engineName: '',
-    status: '',
-    age: '',
-    created: '',
-    selected: false,
-    containers: [],
-    kind: 'kubernetes',
-    node: 'node1',
-    namespace: 'customnamespace',
-  };
-
-  render(PodColumnName, { object: fakeKubernetesInfo });
-
-  const id = screen.getByText('customnamespace');
-  expect(id).toBeInTheDocument();
-
-  const node = screen.getByText('node1');
-  expect(node).toBeInTheDocument();
-});
-
-test('Do not expect undefined anywhere on the page', async () => {
-  render(PodColumnName, { object: pod });
-
-  expect(screen.queryByText('undefined')).not.toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/pod/PodColumnName.svelte
+++ b/packages/renderer/src/lib/pod/PodColumnName.svelte
@@ -2,12 +2,9 @@
 import { handleNavigation } from '/@/navigation';
 import { NavigationPage } from '/@api/navigation-page';
 
-import { PodUtils } from './pod-utils';
 import type { PodInfoUI } from './PodInfoUI';
 
 export let object: PodInfoUI;
-
-const podUtils = new PodUtils();
 
 function openDetailsPod(pod: PodInfoUI): void {
   handleNavigation({
@@ -25,17 +22,8 @@ function openDetailsPod(pod: PodInfoUI): void {
     {object.name}
   </div>
   <div class="flex flex-row text-sm gap-1">
-    {#if podUtils.isKubernetesPod(object)}
-      {#if object.node}
-        <div class="text-[var(--pd-table-body-text-sub-secondary)]">
-          {object.node}
-        </div>
-      {/if}
-      <div class="font-extra-light text-[var(--pd-table-body-text)]">{object.namespace}</div>
-    {:else}
-      <div class="text-[var(--pd-table-body-text)]">
-        {object.shortId}
-      </div>
-    {/if}
+    <div class="text-[var(--pd-table-body-text)]">
+      {object.shortId}
+    </div>
   </div>
 </button>

--- a/packages/renderer/src/lib/pod/pod-utils.ts
+++ b/packages/renderer/src/lib/pod/pod-utils.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022-2024 Red Hat, Inc.
+ * Copyright (C) 2022-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,10 +73,6 @@ export class PodUtils {
       node: podinfo.node,
       namespace: podinfo.Namespace,
     };
-  }
-
-  isKubernetesPod(pod: PodInfoUI): boolean {
-    return pod.kind === 'kubernetes';
   }
 
   calculateNewPodName(existedPods?: PodInfo[]): string {


### PR DESCRIPTION
### What does this PR do?

The Pods page name column will only ever show pods from Podman, so we can remove support for Kubernetes and simplify it. This was the only use of podUtils.isKubernetesPod() so removing that at the same time.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of #8819.

### How to test this PR?

Just confirm the name column shows no difference.

- [x] Tests are covering the bug fix or the new feature