### PR TITLE
chore: clean up PodInfoUI kind

### DIFF
--- a/packages/renderer/src/lib/container/ContainerColumnActionsPod.svelte
+++ b/packages/renderer/src/lib/container/ContainerColumnActionsPod.svelte
@@ -22,7 +22,6 @@ export let object: ContainerGroupInfoUI;
         Names: container.name,
         Status: container.state,
       })),
-      kind: 'podman',
     }}
     dropdownMenu={true}
     on:update />

--- a/packages/renderer/src/lib/pod/PodColumnActions.spec.ts
+++ b/packages/renderer/src/lib/pod/PodColumnActions.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,7 +58,6 @@ test('Expect action buttons', async () => {
     created: '',
     selected: false,
     containers: [],
-    kind: 'podman',
   };
 
   render(PodColumnActions, { object: pod });
@@ -79,7 +78,6 @@ test('Expect error message', async () => {
     created: '',
     selected: false,
     containers: [],
-    kind: 'podman',
     actionError: 'Pod failed',
   };
 

--- a/packages/renderer/src/lib/pod/PodColumnContainers.spec.ts
+++ b/packages/renderer/src/lib/pod/PodColumnContainers.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,6 @@ const pod: PodInfoUI = {
       Status: 'RUNNING',
     },
   ],
-  kind: 'podman',
 };
 
 test('Expect simple column styling', async () => {

--- a/packages/renderer/src/lib/pod/PodColumnName.spec.ts
+++ b/packages/renderer/src/lib/pod/PodColumnName.spec.ts
@@ -37,7 +37,6 @@ const pod: PodInfoUI = {
   created: '',
   selected: false,
   containers: [],
-  kind: 'podman',
   node: 'node1',
   namespace: 'default',
 };

--- a/packages/renderer/src/lib/pod/PodColumnStatus.spec.ts
+++ b/packages/renderer/src/lib/pod/PodColumnStatus.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2024 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,6 @@ const pod: PodInfoUI = {
   created: '',
   selected: false,
   containers: [],
-  kind: 'podman',
 };
 
 test('Expect simple column styling', async () => {

--- a/packages/renderer/src/lib/pod/PodDetailsLogs.spec.ts
+++ b/packages/renderer/src/lib/pod/PodDetailsLogs.spec.ts
@@ -49,7 +49,6 @@ const PODMAN_POD: PodInfoUI = {
       Status: 'Running',
     },
   ],
-  kind: 'podman',
 };
 
 test('Podman pod should use window#logsContainer', async () => {

--- a/packages/renderer/src/lib/pod/PodInfoUI.ts
+++ b/packages/renderer/src/lib/pod/PodInfoUI.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022 Red Hat, Inc.
+ * Copyright (C) 2022-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-export enum PodGroupInfoTypeUI {
-  KUBERNETES = 'kubernetes',
-  PODMAN = 'podman',
-}
 export interface PodInfoContainerUI {
   Id: string;
   Names: string;
@@ -49,5 +45,4 @@ export interface PodInfoUI {
   actionError?: string;
   node?: string;
   namespace?: string;
-  kind: 'kubernetes' | 'podman';
 }

--- a/packages/renderer/src/lib/pod/PodmanPodDetailsSummary.spec.ts
+++ b/packages/renderer/src/lib/pod/PodmanPodDetailsSummary.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,6 @@ const fakePod: PodInfoUI = {
       Status: 'running',
     },
   ],
-  kind: 'podman',
 };
 
 // Test render PodmanPodDetailsSummary with the PodInfoUI object

--- a/packages/renderer/src/lib/pod/pod-utils.ts
+++ b/packages/renderer/src/lib/pod/pod-utils.ts
@@ -69,7 +69,6 @@ export class PodUtils {
       engineName: this.getEngineName(podinfo),
       containers: podinfo.Containers,
       selected: false,
-      kind: podinfo.kind,
       node: podinfo.node,
       namespace: podinfo.Namespace,
     };

--- a/packages/renderer/src/lib/ui/ProviderInfo.svelte
+++ b/packages/renderer/src/lib/ui/ProviderInfo.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 import { ContainerGroupInfoTypeUI } from '../container/ContainerInfoUI';
-import { PodGroupInfoTypeUI } from '../pod/PodInfoUI';
 import Label from './Label.svelte';
 import ProviderInfoCircle from './ProviderInfoCircle.svelte';
 
@@ -19,7 +18,7 @@ function getProviderName(providerName: string): ProviderNameType {
       return 'podman';
     case ContainerGroupInfoTypeUI.DOCKER:
       return 'docker';
-    case PodGroupInfoTypeUI.KUBERNETES:
+    case 'kubernetes':
       return 'kubernetes';
     default:
       return undefined;


### PR DESCRIPTION
### What does this PR do?

The kind property in PodInfoUI can only be 'podman', so remove it.

Likewise, PodGroupInfoTypeUI is only used by ProviderInfo and can only be 'podman' too.

ProviderInfo could probably remove all Kubernetes support at this point, but since the 'kubernetes' string is already used in the file and the file is used in lots of other places I'm just doing the basic removal of the type here.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of #8819.

### How to test this PR?

Just code review.

- [x] Tests are covering the bug fix or the new feature