### PR TITLE
feat: display resources count in Kubernetes experimental mode

### DIFF
--- a/packages/renderer/src/lib/kube/KubernetesDashboard.spec.ts
+++ b/packages/renderer/src/lib/kube/KubernetesDashboard.spec.ts
@@ -18,18 +18,23 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import type { KubernetesObject } from '@kubernetes/client-node';
+import type { KubernetesObject, V1Deployment } from '@kubernetes/client-node';
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
-import { readable } from 'svelte/store';
-import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
+import { readable, writable } from 'svelte/store';
+import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 
+import { listenActiveResourcesCount } from '/@/lib/kube/active-resources-count-listen';
 import { kubernetesContexts } from '/@/stores/kubernetes-contexts';
 import * as kubeContextStore from '/@/stores/kubernetes-contexts-state';
+import * as kubernetesExperimental from '/@/stores/kubernetes-experimental';
+import * as kubernetesReourcesCount from '/@/stores/kubernetes-resources-count';
 import type { KubeContext } from '/@api/kubernetes-context';
 import type { ContextGeneralState } from '/@api/kubernetes-contexts-states';
+import type { ResourceCount } from '/@api/kubernetes-resource-count';
 
 import KubernetesDashboard from './KubernetesDashboard.svelte';
+import KubernetesDashboardResourceCard from './KubernetesDashboardResourceCard.svelte';
 
 vi.mock('/@/stores/kubernetes-contexts-state', async () => {
   return {};
@@ -38,6 +43,16 @@ vi.mock('/@/stores/kubernetes-contexts-state', async () => {
 vi.mock('/@/lib/ui/KubernetesCurrentContextConnectionBadge.svelte', () => ({
   default: vi.fn(),
 }));
+
+vi.mock('./KubernetesDashboardResourceCard.svelte', () => ({
+  default: vi.fn(),
+}));
+
+vi.mock('/@/stores/kubernetes-experimental');
+
+vi.mock('/@/stores/kubernetes-resources-count');
+
+vi.mock('/@/lib/kube/active-resources-count-listen');
 
 const openExternalMock = vi.fn();
 
@@ -116,13 +131,229 @@ test('Verify basic page with cluster', async () => {
   const title = screen.getByText('Dashboard');
   expect(title).toBeInTheDocument();
 
-  const metrics = screen.getByText('Metrics');
-  expect(metrics).toBeInTheDocument();
-  expect(metrics.nextElementSibling?.childElementCount).toBe(9);
-
   const guides = screen.getByText('Explore articles and blog posts');
   expect(guides).toBeInTheDocument();
 
   const guideCards = screen.queryAllByRole('button', { name: 'Read more' });
   expect(guideCards).toHaveLength(3);
+
+  expect(KubernetesDashboardResourceCard).toHaveBeenCalledTimes(9);
+});
+
+describe('with current context', () => {
+  beforeEach(() => {
+    vi.mocked(kubeContextStore).kubernetesCurrentContextState = readable<ContextGeneralState>(
+      {} as ContextGeneralState,
+    );
+
+    const mockContext: KubeContext = {
+      name: 'context-name',
+      cluster: 'cluster-name',
+      user: 'user-name',
+      currentContext: true,
+      clusterInfo: {
+        name: 'cluster-name',
+        server: 'https://server-name',
+      },
+    };
+    kubernetesContexts.set([mockContext]);
+  });
+
+  describe('experimental mode', () => {
+    beforeEach(() => {
+      vi.mocked(kubernetesExperimental).isKubernetesExperimentalModeStore = writable<boolean>(true);
+    });
+
+    test('counts and active counts', async () => {
+      vi.mocked(listenActiveResourcesCount).mockImplementation(
+        async (f: (activeResourcesCounts: ResourceCount[]) => void) => {
+          f([
+            {
+              contextName: 'context-name',
+              resourceName: 'deployments',
+              count: 2,
+            },
+            {
+              contextName: 'context-name',
+              resourceName: 'nodes',
+              count: 3,
+            },
+          ]);
+          return {
+            dispose: (): void => {},
+          };
+        },
+      );
+
+      vi.mocked(kubernetesReourcesCount).kubernetesResourcesCount = writable<ResourceCount[]>([
+        {
+          contextName: 'context-name',
+          resourceName: 'pods',
+          count: 11,
+        },
+        {
+          contextName: 'context-name',
+          resourceName: 'deployments',
+          count: 12,
+        },
+        {
+          contextName: 'context-name',
+          resourceName: 'nodes',
+          count: 4,
+        },
+        {
+          contextName: 'context-name',
+          resourceName: 'nodes',
+          count: 4,
+        },
+        {
+          contextName: 'context-name',
+          resourceName: 'ingresses',
+          count: 1,
+        },
+        {
+          contextName: 'context-name',
+          resourceName: 'routes',
+          count: 2,
+        },
+        {
+          contextName: 'context-name',
+          resourceName: 'configmaps',
+          count: 3,
+        },
+        {
+          contextName: 'context-name',
+          resourceName: 'secrets',
+          count: 5,
+        },
+      ]);
+      render(KubernetesDashboard);
+
+      expect(KubernetesDashboardResourceCard).toHaveBeenCalledTimes(9);
+      expect(KubernetesDashboardResourceCard).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          count: 11,
+          kind: 'Pod',
+          type: 'Pods',
+        }),
+      );
+      expect(KubernetesDashboardResourceCard).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          activeCount: 2,
+          count: 12,
+          kind: 'Deployment',
+          type: 'Deployments',
+        }),
+      );
+      expect(KubernetesDashboardResourceCard).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          activeCount: 3,
+          count: 4,
+          kind: 'Node',
+          type: 'Nodes',
+        }),
+      );
+      expect(KubernetesDashboardResourceCard).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          count: 3,
+          kind: 'Ingress',
+          type: 'Ingresses & Routes',
+        }),
+      );
+      expect(KubernetesDashboardResourceCard).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          count: 8,
+          kind: 'ConfigMap',
+          type: 'ConfigMaps & Secrets',
+        }),
+      );
+    });
+  });
+
+  describe('non-experimental mode', () => {
+    beforeEach(() => {
+      vi.mocked(kubernetesExperimental).isKubernetesExperimentalModeStore = writable<boolean>(false);
+    });
+
+    test('counts and active counts', async () => {
+      vi.mocked(kubeContextStore).kubernetesCurrentContextDeployments = readable<KubernetesObject[]>([
+        {
+          spec: { replicas: 1 },
+        } as V1Deployment,
+        {},
+        {},
+      ]);
+      vi.mocked(kubeContextStore).kubernetesCurrentContextNodes = readable<KubernetesObject[]>([{}, {}]);
+      vi.mocked(kubeContextStore).kubernetesCurrentContextPods = readable<KubernetesObject[]>([{}, {}]);
+      vi.mocked(kubeContextStore).kubernetesCurrentContextServices = readable<KubernetesObject[]>([]);
+      vi.mocked(kubeContextStore).kubernetesCurrentContextIngresses = readable<KubernetesObject[]>([{}]);
+      vi.mocked(kubeContextStore).kubernetesCurrentContextRoutes = readable<KubernetesObject[]>([{}, {}]);
+      vi.mocked(kubeContextStore).kubernetesCurrentContextCronJobs = readable<KubernetesObject[]>([]);
+      vi.mocked(kubeContextStore).kubernetesCurrentContextConfigMaps = readable<KubernetesObject[]>([{}, {}]);
+      vi.mocked(kubeContextStore).kubernetesCurrentContextSecrets = readable<KubernetesObject[]>([{}]);
+      vi.mocked(kubeContextStore).kubernetesCurrentContextPersistentVolumeClaims = readable<KubernetesObject[]>([]);
+      vi.mocked(kubeContextStore).kubernetesCurrentContextState = readable<ContextGeneralState>(
+        {} as ContextGeneralState,
+      );
+
+      render(KubernetesDashboard);
+
+      expect(KubernetesDashboardResourceCard).toHaveBeenCalledTimes(9);
+      expect(KubernetesDashboardResourceCard).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          count: 2,
+          kind: 'Pod',
+          type: 'Pods',
+        }),
+      );
+      expect(KubernetesDashboardResourceCard).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          count: 0,
+          kind: 'Service',
+          type: 'Services',
+        }),
+      );
+      expect(KubernetesDashboardResourceCard).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          count: 3,
+          kind: 'Ingress',
+          type: 'Ingresses & Routes',
+        }),
+      );
+      expect(KubernetesDashboardResourceCard).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          count: 3,
+          kind: 'ConfigMap',
+          type: 'ConfigMaps & Secrets',
+        }),
+      );
+      expect(KubernetesDashboardResourceCard).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          activeCount: 1,
+          count: 3,
+          kind: 'Deployment',
+          type: 'Deployments',
+        }),
+      );
+      expect(KubernetesDashboardResourceCard).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          activeCount: 0,
+          count: 2,
+          kind: 'Node',
+          type: 'Nodes',
+        }),
+      );
+    });
+  });
 });

--- a/packages/renderer/src/lib/kube/active-resources-count-listen.spec.ts
+++ b/packages/renderer/src/lib/kube/active-resources-count-listen.spec.ts
@@ -1,0 +1,103 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { listenActiveResourcesCount } from './active-resources-count-listen';
+
+const callbacks = new Map<string, () => void>();
+
+const eventEmitter = {
+  receive: (message: string, callback: () => void): void => {
+    callbacks.set(message, callback);
+  },
+};
+
+beforeAll(() => {
+  Object.defineProperty(window, 'events', {
+    value: {
+      receive: (message: string, callback: () => void) => {
+        eventEmitter.receive(message, callback);
+        return {
+          dispose: (): void => {},
+        };
+      },
+    },
+  });
+});
+
+test('listenActiveResourcesCount is undefined in non experimental mode (setting is set to false)', async () => {
+  vi.mocked(window.getConfigurationValue<boolean>).mockResolvedValue(false);
+  const result = await listenActiveResourcesCount((): void => {});
+  expect(result).toBeUndefined();
+});
+
+test('listenActiveResourcesCount is undefined in non experimental mode (setting is undefined)', async () => {
+  vi.mocked(window.getConfigurationValue<boolean>).mockResolvedValue(undefined);
+  const result = await listenActiveResourcesCount((): void => {});
+  expect(result).toBeUndefined();
+});
+
+describe('experimental mode is set', () => {
+  beforeEach(() => {
+    vi.mocked(window.getConfigurationValue<boolean>).mockResolvedValue(true);
+  });
+
+  test('get initial and updated values', async () => {
+    const counts = [
+      {
+        contextName: 'ctx1',
+        resourceName: 'resource1',
+        count: 1,
+      },
+      {
+        contextName: 'ctx2',
+        resourceName: 'resource1',
+        count: 2,
+      },
+      {
+        contextName: 'ctx2',
+        resourceName: 'resource2',
+        count: 3,
+      },
+    ];
+    vi.mocked(window.kubernetesGetActiveResourcesCount).mockResolvedValue(counts);
+
+    const callback = vi.fn();
+    const result = await listenActiveResourcesCount(callback);
+    expect(result).not.toBeUndefined();
+    expect(callback).toHaveBeenCalledWith(counts);
+
+    const newCounts = [
+      {
+        contextName: 'ctx1',
+        resourceName: 'resource1',
+        count: 1,
+      },
+    ];
+    vi.mocked(window.kubernetesGetActiveResourcesCount).mockResolvedValue(newCounts);
+
+    callback.mockClear();
+    const cb = callbacks.get('kubernetes-active-resources-count');
+    expect(cb).toBeDefined();
+    cb!();
+    await vi.waitFor(() => {
+      expect(callback).toHaveBeenCalledWith(newCounts);
+    });
+  });
+});

--- a/packages/renderer/src/lib/kube/active-resources-count-listen.ts
+++ b/packages/renderer/src/lib/kube/active-resources-count-listen.ts
@@ -1,0 +1,60 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { IDisposable } from '/@api/disposable.js';
+import type { ResourceCount } from '/@api/kubernetes-resource-count';
+
+// listenActiveResourcesCount listens the count of active resources
+export async function listenActiveResourcesCount(
+  callback: (activeResourcesCounts: ResourceCount[]) => void,
+): Promise<IDisposable | undefined> {
+  if (!(await isKubernetesExperimentalMode())) {
+    return;
+  }
+
+  const disposable = window.events.receive('kubernetes-active-resources-count', () => {
+    collectAndSendCount(callback);
+  });
+
+  collectAndSendCount(callback);
+
+  return {
+    dispose: (): void => {
+      disposable.dispose();
+    },
+  };
+}
+
+function collectAndSendCount(callback: (activeResourcesCount: ResourceCount[]) => void): void {
+  window
+    .kubernetesGetActiveResourcesCount()
+    .then(result => {
+      callback(result);
+    })
+    .catch(() => {
+      console.error(`error getting active resources counts`);
+    });
+}
+
+export async function isKubernetesExperimentalMode(): Promise<boolean> {
+  try {
+    return (await window.getConfigurationValue<boolean>('kubernetes.statesExperimental')) ?? false;
+  } catch {
+    return false;
+  }
+}

--- a/packages/renderer/src/stores/kubernetes-experimental.spec.ts
+++ b/packages/renderer/src/stores/kubernetes-experimental.spec.ts
@@ -1,0 +1,54 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { get } from 'svelte/store';
+import { expect, test, vi } from 'vitest';
+
+import { configurationProperties } from './configurationProperties';
+import { isKubernetesExperimentalModeStore } from './kubernetes-experimental';
+
+test('experimental mode is set', async () => {
+  vi.mocked(window.getConfigurationValue).mockImplementation(async () => {
+    return true;
+  });
+  configurationProperties.set([]);
+  await vi.waitFor(() => {
+    const result = get(isKubernetesExperimentalModeStore);
+    expect(result).toEqual(true);
+  });
+});
+
+test('experimental mode is set to false', async () => {
+  vi.mocked(window.getConfigurationValue).mockImplementation(async () => {
+    return false;
+  });
+  configurationProperties.set([]);
+  await vi.waitFor(() => {
+    const result = get(isKubernetesExperimentalModeStore);
+    expect(result).toEqual(false);
+  });
+});
+
+test('experimental mode is not defined', async () => {
+  vi.mocked(window.getConfigurationValue).mockRejectedValue(new Error('an error'));
+  configurationProperties.set([]);
+  await vi.waitFor(() => {
+    const result = get(isKubernetesExperimentalModeStore);
+    expect(result).toEqual(false);
+  });
+});

--- a/packages/renderer/src/stores/kubernetes-experimental.ts
+++ b/packages/renderer/src/stores/kubernetes-experimental.ts
@@ -1,0 +1,34 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { type Writable, writable } from 'svelte/store';
+
+import { configurationProperties } from './configurationProperties';
+
+export const isKubernetesExperimentalModeStore: Writable<boolean | undefined> = writable();
+
+configurationProperties.subscribe(() => {
+  if (window?.getConfigurationValue) {
+    window
+      ?.getConfigurationValue<boolean>('kubernetes.statesExperimental')
+      ?.then(value => isKubernetesExperimentalModeStore.set(value ?? false))
+      ?.catch((err: unknown) =>
+        console.error(`Error getting configuration value 'kubernetes.statesExperimental'}`, err),
+      );
+  }
+});

--- a/packages/renderer/src/stores/kubernetes-resources-count.ts
+++ b/packages/renderer/src/stores/kubernetes-resources-count.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024 - 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,4 +59,4 @@ export const kubernetesResourcesCountStore = new EventStore<ResourceCount[]>(
   windowListeners,
   listResourcesCount,
 );
-kubernetesResourcesCountStore.setup();
+kubernetesResourcesCountStore.setupWithDebounce(100, 100);


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Display resources count in Kubernetes experimental mode (frontend part)

`KubernetesDashboard` implementation is optimized for experimental mode.

Active counts are listened by a listener created when the KubernetesDashboard is created, and disposed when the page is destroyed. As the computing of the active resources can be quite heavy in the backend, this computing is called only when the Dashboard is displayed.

### Screenshot / video of UI


### What issues does this PR fix or reference?

Fixes #11106 

### How to test this PR?

In experimental and non experimental mode, check the resources counts in the Kubernetes dashboard

- [x] Tests are covering the bug fix or the new feature
