### PR TITLE
fix: make labels in create new connection form resize properly and update form components width

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
@@ -577,7 +577,7 @@ function preventDefault(handler: (e: SubmitEvent) => Promise<void>): (e: SubmitE
             aria-label="Properties Information">
             {#each configurationKeys as configurationKey}
               <div class="mb-2.5">
-                <div class="flex flex-row items-center h-[30px]">
+                <div class="flex flex-row items-center h-fit">
                   {#if configurationKey.description}
                     {configurationKey.description}:
                   {:else if configurationKey.markdownDescription && configurationKey.type !== 'markdown'}

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
@@ -532,7 +532,7 @@ function preventDefault(handler: (e: SubmitEvent) => Promise<void>): (e: SubmitE
         </div>
       {:else}
         {#if operationStarted || errorMessage}
-          <div class="w-4/5">
+          <div class="w-full">
             <div class="mt-2 mb-8">
               <div class="mt-2 float-right">
                 <button
@@ -560,12 +560,12 @@ function preventDefault(handler: (e: SubmitEvent) => Promise<void>): (e: SubmitE
           </div>
         {/if}
         {#if errorMessage}
-          <div class="pt-3 mt-2 w-4/5 h-fit">
+          <div class="pt-3 mt-2 w-full h-fit">
             <ErrorMessage error={errorMessage} />
           </div>
         {/if}
 
-        <div class="p-3 mt-2 w-4/5 h-fit {inProgress ? 'opacity-40 pointer-events-none' : ''}">
+        <div class="p-3 mt-2 w-full h-fit {inProgress ? 'opacity-40 pointer-events-none' : ''}">
           {#if connectionAuditResult && (connectionAuditResult.records?.length ?? 0) > 0}
             <AuditMessageBox auditResult={connectionAuditResult} />
           {/if}


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR ensures that the create new connection form labels adjust correctly when resizing the window

### Screenshot / video of UI
![Screenshot from 2025-03-06 15-03-19](https://github.com/user-attachments/assets/f8c5b8b3-1994-490a-8ecf-616baefafda1)
![Screenshot from 2025-03-06 15-02-54](https://github.com/user-attachments/assets/4100c912-0efe-44a4-bb23-2f810ff7ecbe)



<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Fixes https://github.com/crc-org/crc-extension/issues/564
Fixes https://github.com/podman-desktop/podman-desktop/issues/11531

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

1. Go to resources, "Create new..." in any provider card
2. Resize the window horizontally to be as small as possible
3. Check that there isn't any overlapping between the labels and other components

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
