### PR TITLE
chore(settings): change navigation appearance to icon plus title by default

### DIFF
--- a/packages/main/src/plugin/appearance-init.spec.ts
+++ b/packages/main/src/plugin/appearance-init.spec.ts
@@ -145,5 +145,7 @@ test('Icon should be default if not in dev env', () => {
   expect(configurationRegistry.registerConfigurations).toBeCalled();
   const configurationNode = vi.mocked(configurationRegistry.registerConfigurations).mock.calls[0]?.[0][0];
 
-  expect(configurationNode?.properties?.['preferences.navigationBarLayout']?.default).toBe('icon');
+  expect(configurationNode?.properties?.['preferences.navigationBarLayout']?.default).toBe(
+    AppearanceSettings.IconAndTitle,
+  );
 });

--- a/packages/main/src/plugin/appearance-init.spec.ts
+++ b/packages/main/src/plugin/appearance-init.spec.ts
@@ -132,17 +132,6 @@ test('should register a configuration', async () => {
   expect(configurationNode?.properties?.['preferences.navigationBarLayout']).toBeDefined();
   expect(configurationNode?.properties?.['preferences.navigationBarLayout']?.description).toBeDefined();
   expect(configurationNode?.properties?.['preferences.navigationBarLayout']?.type).toBe('string');
-  expect(configurationNode?.properties?.['preferences.navigationBarLayout']?.default).toBe('icon + title');
-});
-
-test('Icon + Title should be default', () => {
-  vi.resetAllMocks();
-  const appearanceInit = new AppearanceInit(configurationRegistry);
-  appearanceInit.init();
-
-  expect(configurationRegistry.registerConfigurations).toBeCalled();
-  const configurationNode = vi.mocked(configurationRegistry.registerConfigurations).mock.calls[0]?.[0][0];
-
   expect(configurationNode?.properties?.['preferences.navigationBarLayout']?.default).toBe(
     AppearanceSettings.IconAndTitle,
   );

--- a/packages/main/src/plugin/appearance-init.spec.ts
+++ b/packages/main/src/plugin/appearance-init.spec.ts
@@ -114,7 +114,6 @@ test('Expect unknown theme to be set to system', async () => {
 });
 
 test('should register a configuration', async () => {
-  vi.stubEnv('DEV', true);
   const appearanceInit = new AppearanceInit(configurationRegistry);
   appearanceInit.init();
 
@@ -136,9 +135,8 @@ test('should register a configuration', async () => {
   expect(configurationNode?.properties?.['preferences.navigationBarLayout']?.default).toBe('icon + title');
 });
 
-test('Icon should be default if not in dev env', () => {
+test('Icon + Title should be default', () => {
   vi.resetAllMocks();
-  vi.stubEnv('DEV', false);
   const appearanceInit = new AppearanceInit(configurationRegistry);
   appearanceInit.init();
 

--- a/packages/main/src/plugin/appearance-init.ts
+++ b/packages/main/src/plugin/appearance-init.ts
@@ -51,7 +51,7 @@ export class AppearanceInit {
           description: 'Select icon and title or just icon for navigation icons',
           type: 'string',
           enum: [AppearanceSettings.IconAndTitle, AppearanceSettings.Icon],
-          default: import.meta.env.DEV ? AppearanceSettings.IconAndTitle : AppearanceSettings.Icon,
+          default: AppearanceSettings.IconAndTitle,
         },
       },
     };


### PR DESCRIPTION
### What does this PR do?

As per discussion in the UX call, changing the default navigation appearance settings to `icon + title` by default.

### Screenshot / video of UI

New users will see the following from now

![image](https://github.com/user-attachments/assets/11a42b9c-5ae8-42f4-872c-e9987395b7d9)

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/11543

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
