### PR TITLE
chore: indicate in provider widget if update is available

### DIFF
--- a/packages/renderer/src/lib/statusbar/ProviderWidget.spec.ts
+++ b/packages/renderer/src/lib/statusbar/ProviderWidget.spec.ts
@@ -130,3 +130,9 @@ test('class props should be propagated to button', async () => {
   const widget = getByRole('button', { name: 'provider1' });
   expect(widget).toHaveClass('potatoes');
 });
+
+test('Epect tooltip to show Update available text if the provider has an update', () => {
+  providerMock.updateInfo = { version: '1.1.0' };
+  render(ProviderWidget, { entry: providerMock });
+  expect(screen.getByText('Update available')).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/statusbar/ProviderWidget.spec.ts
+++ b/packages/renderer/src/lib/statusbar/ProviderWidget.spec.ts
@@ -131,7 +131,7 @@ test('class props should be propagated to button', async () => {
   expect(widget).toHaveClass('potatoes');
 });
 
-test('Epect tooltip to show Update available text if the provider has an update', () => {
+test('Expect tooltip to show Update available text if the provider has an update', () => {
   providerMock.updateInfo = { version: '1.1.0' };
   render(ProviderWidget, { entry: providerMock });
   expect(screen.getByText('Update available')).toBeInTheDocument();

--- a/packages/renderer/src/lib/statusbar/ProviderWidget.svelte
+++ b/packages/renderer/src/lib/statusbar/ProviderWidget.svelte
@@ -36,6 +36,11 @@ let connections = $derived.by(() => {
 <Tooltip top class="mb-[20px]">
   <div slot="tip" class="py-2 px-4" hidden={disableTooltip}>
     <div class="flex flex-col">
+      {#if entry.updateInfo?.version}
+        <div class="flex flex-row h-fit pb-1">
+          Update available
+        </div>
+      {/if}
       {#each connections as connection}
         <div class="flex flex-row items-center h-fit">
           <ProviderWidgetStatus status={connection.status} class="mr-1"/>
@@ -43,12 +48,6 @@ let connections = $derived.by(() => {
           : {connection.name}
         </div>
       {/each}
-      {#if entry.updateInfo?.version}
-        <div class="flex flex-row items-center h-fit">
-          <ProviderWidgetStatus status="Update available" class="mr-1"/>
-          Update available
-        </div>
-      {/if}
     </div>
   </div>
   <button

--- a/packages/renderer/src/lib/statusbar/ProviderWidget.svelte
+++ b/packages/renderer/src/lib/statusbar/ProviderWidget.svelte
@@ -38,11 +38,17 @@ let connections = $derived.by(() => {
     <div class="flex flex-col">
       {#each connections as connection}
         <div class="flex flex-row items-center h-fit">
-          <ProviderWidgetStatus status={connection.status} class="mr-1 mt-1"/>
+          <ProviderWidgetStatus status={connection.status} class="mr-1"/>
           <ProviderWidgetStatusStyle status={connection.status}/>
           : {connection.name}
         </div>
       {/each}
+      {#if entry.updateInfo?.version}
+        <div class="flex flex-row items-center h-fit">
+          <ProviderWidgetStatus status="Update available" class="mr-1"/>
+          Update available
+        </div>
+      {/if}
     </div>
   </div>
   <button

--- a/packages/renderer/src/lib/statusbar/ProviderWidgetStatus.spec.ts
+++ b/packages/renderer/src/lib/statusbar/ProviderWidgetStatus.spec.ts
@@ -58,3 +58,10 @@ test('Expect to have different status icon based on provider status', async () =
     'animate-spin border border-solid border-[var(--pd-action-button-spinner)] border-t-transparent',
   );
 });
+
+test('Expect to have Update available icon status when an Update available status is passed', () => {
+  render(ProviderWidgetStatus, { status: 'Update available' });
+  const statusIcon = screen.getByLabelText('Connection Status Icon');
+  expect(statusIcon).toBeInTheDocument();
+  expect(statusIcon).toHaveClass('fa-regular fa-circle-up');
+});

--- a/packages/renderer/src/lib/statusbar/ProviderWidgetStatus.svelte
+++ b/packages/renderer/src/lib/statusbar/ProviderWidgetStatus.svelte
@@ -6,7 +6,7 @@ import type { ProviderInfo } from '/@api/provider-info';
 
 interface Props {
   entry?: ProviderInfo;
-  status?: ProviderStatus | ProviderConnectionStatus;
+  status?: ProviderStatus | ProviderConnectionStatus | 'Update available';
   class?: string;
 }
 
@@ -14,7 +14,9 @@ let { entry, status, class: className = '' }: Props = $props();
 
 let providerStatus = $derived.by(() => {
   if (entry) {
-    if (entry.containerConnections.length > 0) {
+    if (entry.updateInfo?.version) {
+      return 'Update available';
+    } else if (entry.containerConnections.length > 0) {
       return entry.containerConnections[0].status;
     } else if (entry.kubernetesConnections.length > 0) {
       return entry.kubernetesConnections[0].status;
@@ -28,13 +30,13 @@ let providerStatus = $derived.by(() => {
   }
 });
 
-const faRegularIconStatus: ProviderStatus[] = ['ready', 'started', 'stopped', 'error', 'unknown'];
+const faRegularIconStatus: string[] = ['ready', 'started', 'stopped', 'error', 'unknown', 'Update available'];
 </script>
 
 {#if providerStatus === 'starting' || providerStatus === 'stopping'}
-  <div aria-label="Connection Status Icon" class="w-3 h-3 rounded-full animate-spin border border-solid border-[var(--pd-action-button-spinner)] border-t-transparent {className}"></div>
+  <div aria-label="Connection Status Icon" class="max-h-3 rounded-full animate-spin border border-solid border-[var(--pd-action-button-spinner)] border-t-transparent {className}"></div>
 {:else}
-  <div aria-label="Connection Status Icon" class="w-3 h-3 {className}"
+  <div aria-label="Connection Status Icon" class="max-h-3 {className}"
     class:fa-regular={faRegularIconStatus.includes(providerStatus)}
     class:fa={providerStatus === 'not-installed'}
     class:fa-circle-check={providerStatus === 'ready' || providerStatus === 'started'}
@@ -42,6 +44,7 @@ const faRegularIconStatus: ProviderStatus[] = ['ready', 'started', 'stopped', 'e
     class:fa-circle-xmark={providerStatus === 'error'}
     class:fa-exclamation-triangle={providerStatus === 'not-installed'}
     class:fa-circle-question={providerStatus === 'unknown'}
+    class:fa-circle-up={providerStatus === 'Update available'}
     >
   </div>
 {/if}


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR adds an indication if there is an available update in the ProviderWidget.

Currently, this will only show up for Podman, since most other extensions (especially CLI tools) only include the update information in the registered CLI tool and not the registered provider. https://github.com/podman-desktop/podman-desktop/issues/11557

### Screenshot / video of UI
<img width="238" alt="Screenshot 2025-03-21 at 12 25 06 PM" src="https://github.com/user-attachments/assets/fb5502eb-1b3e-4dcc-be2b-5d4ef0e25817" />


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/podman-desktop/issues/11426

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
