### PR TITLE
fix(tests): svelte 5.22.5

### DIFF
--- a/packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.spec.ts
+++ b/packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.spec.ts
@@ -123,7 +123,7 @@ test('install button should always be disable when extensionInstallFromImage is 
 
   const progressBar = screen.getByRole('progressbar', { name: 'Installation progress' });
   await vi.waitFor(() => {
-    expect(progressBar.getAttribute('style')).toBe('width: 100%');
+    expect(progressBar).toHaveStyle({ width: '100%' });
   });
 
   // expect button done to be disabled
@@ -179,7 +179,9 @@ test('progressbar should match latest log', async () => {
     logCallback(`Downloading sha256:random-sha256.tar - ${i}% - (${i}/64)`);
 
     await vi.waitFor(() => {
-      expect(progressBar.getAttribute('style')).toBe(`width: ${i}%`);
+      expect(progressBar).toHaveStyle({
+        width: `${i}%`,
+      });
     });
   }
 });
@@ -206,7 +208,9 @@ test('install button should be enable while extensionInstallFromImage is resolve
   logCallback('Downloading sha256:random-sha256.tar - 100% - (521578/521578)');
   const progressBar = screen.getByRole('progressbar', { name: 'Installation progress' });
   await vi.waitFor(() => {
-    expect(progressBar.getAttribute('style')).toBe('width: 100%');
+    expect(progressBar).toHaveStyle({
+      width: `100%`,
+    });
   });
 
   // resolve extensionInstallFromImage

--- a/packages/renderer/src/lib/image/ImagesList.spec.ts
+++ b/packages/renderer/src/lib/image/ImagesList.spec.ts
@@ -423,8 +423,12 @@ describe('Contributions', () => {
       const fedoraOld = screen.getByRole('cell', { name: 'fedora my-custom-badge 123456789012 old' });
       expect(fedoraOld).toBeInTheDocument();
 
+      const badge = within(fedoraOld).getByText('my-custom-badge');
+
       // check background color
-      expect(fedoraOld.innerHTML).contain('background-color: #ff00ff');
+      expect(badge).toHaveStyle({
+        'background-color': '#ff00ff',
+      });
     },
   );
 });

--- a/packages/renderer/src/lib/recommendation/ExtensionBanner.spec.ts
+++ b/packages/renderer/src/lib/recommendation/ExtensionBanner.spec.ts
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import '@testing-library/jest-dom/vitest';
+
 import { render, screen, waitFor } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
@@ -108,7 +110,10 @@ describe('backgrounds', () => {
 
     const card = screen.getByLabelText('Recommended extension');
     expect(card).toBeDefined();
-    expect(card.attributes.getNamedItem('style')?.value).toBe('background: linear-gradient(#fff, #000);');
+
+    expect(card).toHaveStyle({
+      'background-image': 'linear-gradient(#fff, #000)',
+    });
   });
 
   test('expect image background for dark theme', async () => {
@@ -120,9 +125,9 @@ describe('backgrounds', () => {
 
     const card = screen.getByLabelText('Recommended extension');
     expect(card).toBeDefined();
-    expect(card.attributes.getNamedItem('style')?.value).toBe(
-      'background-image: url("data:image/png;base64-image-dark");',
-    );
+    expect(card).toHaveStyle({
+      'background-image': 'url("data:image/png;base64-image-dark")',
+    });
   });
 
   test('expect image background for light theme', async () => {
@@ -134,9 +139,9 @@ describe('backgrounds', () => {
 
     const card = screen.getByLabelText('Recommended extension');
     expect(card).toBeDefined();
-    expect(card.attributes.getNamedItem('style')?.value).toBe(
-      'background-image: url("data:image/png;base64-image-light");',
-    );
+    expect(card).toHaveStyle({
+      'background-image': 'url("data:image/png;base64-image-light")',
+    });
   });
 });
 


### PR DESCRIPTION
### What does this PR do?

Fixes the tests failing when upgrading to svelte 5.22.5. The fixes mainly consist of applying the code guidelines talked in https://github.com/podman-desktop/podman-desktop/issues/9821#issuecomment-2706019975.

We were checking manually the style attribute: which is a problem, and we should instead use `toHaveStyle` jest function.

> :information_source: this PR does not include the svelte bump, the depandabot PR will have to be rebased after this PR is merged.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/11566

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
