### PR TITLE
feat: handle error when exec command not found

### DIFF
--- a/packages/api/src/kubernetes-contexts-healths.ts
+++ b/packages/api/src/kubernetes-contexts-healths.ts
@@ -24,4 +24,8 @@ export interface ContextHealth {
   reachable: boolean;
   // is one of the informers marked offline (disconnect after being connected, the cache still being populated)
   offline: boolean;
+  // description in case of error (other than health check)
+  // currently detected errors:
+  // - user.exec.command not found
+  errorMessage?: string;
 }

--- a/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.spec.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.spec.ts
@@ -173,13 +173,20 @@ test('getContextsHealths should return the values of the map returned by manager
     checking: false,
     reachable: true,
   };
+  const context3State = {
+    contextName: 'context3',
+    checking: false,
+    reachable: false,
+    errorMessage: 'an error',
+  };
   const value = new Map<string, ContextHealthState>([
     ['context1', { ...context1State, kubeConfig: {} as unknown as KubeConfigSingleContext }],
     ['context2', { ...context2State, kubeConfig: {} as unknown as KubeConfigSingleContext }],
+    ['context3', { ...context3State, kubeConfig: {} as unknown as KubeConfigSingleContext }],
   ]);
   vi.mocked(manager.getHealthCheckersStates).mockReturnValue(value);
   const result = dispatcher.getContextsHealths();
-  expect(result).toEqual([context1State, context2State]);
+  expect(result).toEqual([context1State, context2State, context3State]);
 });
 
 test('updateHealthStates should call apiSender.send with kubernetes-contexts-healths', () => {

--- a/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.ts
@@ -61,6 +61,7 @@ export class ContextsStatesDispatcher {
         checking: health.checking,
         reachable: health.reachable,
         offline: this.manager.isContextOffline(contextName),
+        errorMessage: health.errorMessage,
       });
     }
     return value;

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
@@ -82,6 +82,17 @@ const mockContext4: KubeContext = {
   },
 };
 
+const mockContext5: KubeContext = {
+  name: 'context-name5',
+  cluster: 'cluster-name5',
+  user: 'user-name5',
+  namespace: 'namespace-name5',
+  clusterInfo: {
+    name: 'cluster-name5',
+    server: 'https://server-name5',
+  },
+};
+
 const kubernetesGetCurrentContextNameMock = vi.fn();
 
 const showMessageBoxMock = vi.fn();
@@ -95,7 +106,7 @@ beforeAll(() => {
 });
 
 beforeEach(() => {
-  kubernetesContexts.set([mockContext1, mockContext2, mockContext3, mockContext4]);
+  kubernetesContexts.set([mockContext1, mockContext2, mockContext3, mockContext4, mockContext5]);
   vi.clearAllMocks();
 });
 
@@ -188,6 +199,7 @@ describe.each([
       undefinedCounts: true,
       permissions: true,
       offline: true,
+      errorMessage: true,
     },
     initMocks: (): void => {
       Object.defineProperty(global, 'window', {
@@ -235,6 +247,13 @@ describe.each([
           checking: false,
           offline: true,
         },
+        {
+          contextName: 'context-name5',
+          reachable: false,
+          checking: false,
+          offline: false,
+          errorMessage: 'an error',
+        },
       ]);
       kubernetesContextsPermissions.set([
         {
@@ -278,6 +297,7 @@ describe.each([
       undefinedCounts: false,
       permissions: false,
       offline: false,
+      errorMessage: false,
     },
     initMocks: (): void => {
       const state: Map<string, ContextGeneralState> = new Map();
@@ -364,6 +384,13 @@ describe.each([
 
     if (implemented.offline) {
       expect(within(context4).queryByText('CONNECTION LOST')).toBeInTheDocument();
+    }
+
+    if (implemented.errorMessage) {
+      const context5 = screen.getAllByRole('row')[4];
+      expect(within(context5).queryByText('ERROR')).toBeInTheDocument();
+      expect(within(context5).queryByText('PODS')).not.toBeInTheDocument();
+      expect(within(context5).queryByText('DEPLOYMENTS')).not.toBeInTheDocument();
     }
   });
 

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -201,10 +201,6 @@ async function connect(contextName: string): Promise<void> {
     }
   });
 }
-
-function toHtmlParagraphs(s: string): string {
-  return '<p>' + s.replaceAll('\n', '</p><p>') + '</p>';
-}
 </script>
 
 <SettingsPage title="Kubernetes Contexts">
@@ -324,8 +320,10 @@ function toHtmlParagraphs(s: string): string {
                       <div class="ml-1 text-xs text-[var(--pd-status-dead)]" aria-label="Error">
                         <Tooltip>
                           <div>ERROR</div>
-                          <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-                          <div slot="tip" class="p-2">{@html toHtmlParagraphs(context.errorMessage)}</div>
+                          <div slot="tip" class="p-2">
+                            {#each context.errorMessage.split('\n').filter(l => l) as line}
+                              <p>{line}</p>
+                            {/each}
                         </Tooltip>
                       </div>
                     {:else}

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -32,6 +32,7 @@ interface KubeContextWithStates extends KubeContext {
   podsPermitted: boolean;
   deploymentsPermitted: boolean;
   notPermittedHelp?: string;
+  errorMessage?: string;
 }
 
 const currentContextName = $derived($kubernetesContexts.find(c => c.currentContext)?.name);
@@ -51,6 +52,7 @@ const kubernetesContextsWithStates: KubeContextWithStates[] = $derived(
       deploymentsCount: getResourcesCount(kubeContext.name, 'deployments', experimentalStates),
       podsPermitted: getResourcePermitted(kubeContext.name, 'pods', experimentalStates),
       deploymentsPermitted: getResourcePermitted(kubeContext.name, 'deployments', experimentalStates),
+      errorMessage: getErrorMessage(kubeContext.name, experimentalStates),
     }))
     .map(kubeContext => ({
       ...kubeContext,
@@ -117,6 +119,12 @@ function isContextReachable(contextName: string, experimental: boolean): boolean
     );
   }
   return $kubernetesContextsState.get(contextName)?.reachable ?? false;
+}
+
+function getErrorMessage(contextName: string, experimental: boolean): string | undefined {
+  if (experimental) {
+    return $kubernetesContextsHealths.find(contextHealth => contextHealth.contextName === contextName)?.errorMessage;
+  }
 }
 
 function isContextOffline(contextName: string, experimental: boolean): boolean {
@@ -192,6 +200,10 @@ async function connect(contextName: string): Promise<void> {
       $kubernetesContexts = setKubeUIContextError($kubernetesContexts, contextName, e);
     }
   });
+}
+
+function toHtmlParagraphs(s: string): string {
+  return '<p>' + s.replaceAll('\n', '</p><p>') + '</p>';
 }
 </script>
 
@@ -307,14 +319,25 @@ async function connect(contextName: string): Promise<void> {
               {:else}
                 <div class="flex flex-col space-y-2">
                   <div class="flex flex-row pt-2">
-                    <div class="w-3 h-3 rounded-full bg-[var(--pd-status-disconnected)]"></div>
-                    <div class="ml-1 text-xs text-[var(--pd-status-disconnected)]" aria-label="Context Unreachable">
-                      {#if context.isKnown}
-                        UNREACHABLE
-                      {:else}
-                        UNKNOWN
-                      {/if}
-                    </div>
+                    {#if context.errorMessage}
+                      <div class="w-3 h-3 rounded-full bg-[var(--pd-status-dead)]"></div>
+                      <div class="ml-1 text-xs text-[var(--pd-status-dead)]" aria-label="Error">
+                        <Tooltip>
+                          <div>ERROR</div>
+                          <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+                          <div slot="tip" class="p-2">{@html toHtmlParagraphs(context.errorMessage)}</div>
+                        </Tooltip>
+                      </div>
+                    {:else}
+                      <div class="w-3 h-3 rounded-full bg-[var(--pd-status-disconnected)]"></div>
+                      <div class="ml-1 text-xs text-[var(--pd-status-disconnected)]" aria-label="Context Unreachable">
+                        {#if context.isKnown}
+                          UNREACHABLE
+                        {:else}
+                          UNKNOWN
+                        {/if}
+                      </div>
+                    {/if}
                     {#if context.isBeingChecked}
                       <div class="ml-1"><Spinner size="12px"></Spinner></div>
                     {/if}                    


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Check if user auth exec command is in the path, during the health check.

If such an error occurs, a message is displayed to the user

### Screenshot / video of UI

![enoent](https://github.com/user-attachments/assets/7e3d1766-305b-4218-8b49-ec160932644b)

### What issues does this PR fix or reference?

Fixes podman-desktop/podman-desktop#10081 
Fixes podman-desktop/podman-desktop#10479 
### How to test this PR?

Have a user defiing an exec section in `~/.kube/config` (see podman-desktop/extension-kubernetes-contexts#398 for an example), and declare a command found/not found in your syatem

- [x] Tests are covering the bug fix or the new feature
