### PR TITLE
chore: remove docker compatibility warning from dashboard

### DIFF
--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -29,7 +29,6 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import * as compatibilityModeLib from './compatibility-mode';
 import {
-  checkDisguisedPodmanSocket,
   initCheckAndRegisterUpdate,
   registerOnboardingMachineExistsCommand,
   registerOnboardingUnsupportedPodmanMachineCommand,
@@ -1610,18 +1609,6 @@ test('provider is registered without edit capabilities on Linux', async () => {
   expect(registeredConnection).toBeDefined();
   expect(registeredConnection?.lifecycle).toBeDefined();
   expect(registeredConnection?.lifecycle?.edit).toBeUndefined();
-});
-
-test('checkDisguisedPodmanSocket: does not run updateWarnings when called with Linux', async () => {
-  vi.mocked(extensionApi.env).isLinux = true;
-  await checkDisguisedPodmanSocket(provider);
-  expect(updateWarningsMock).not.toBeCalled();
-});
-
-test('checkDisguisedPodmanSocket: runs updateWarnings when called not on Linux', async () => {
-  vi.mocked(extensionApi.env).isLinux = false;
-  await checkDisguisedPodmanSocket(provider);
-  expect(updateWarningsMock).toBeCalled();
 });
 
 test('Even with getJSONMachineList erroring, do not show setup notification on Linux', async () => {

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -55,7 +55,7 @@ import {
   LoggerDelegator,
   VMTYPE,
 } from './util';
-import { getDisguisedPodmanInformation, getSocketPath, isDisguisedPodman } from './warnings';
+import { getSocketPath, isDisguisedPodman } from './warnings';
 
 type StatusHandler = (name: string, event: extensionApi.ProviderConnectionStatus) => void;
 
@@ -1384,7 +1384,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   const provider = extensionApi.provider.createProvider(providerOptions);
 
   // Check on initial setup
-  await checkDisguisedPodmanSocket(provider);
+  await checkDisguisedPodmanSocket();
 
   // Update the status of the provider if the socket is changed, created or deleted
   disguisedPodmanSocketWatcher = setupDisguisedPodmanSocketWatcher(provider, getSocketPath());
@@ -2262,7 +2262,7 @@ function setupDisguisedPodmanSocketWatcher(
 
   // Add the check to the listeners as well to make sure we check on podman status change as well
   listeners.add(() => {
-    checkDisguisedPodmanSocket(provider).catch((error: unknown) => {
+    checkDisguisedPodmanSocket().catch((error: unknown) => {
       console.error('Error while checking disguised podman socket', error);
     });
   });
@@ -2275,7 +2275,7 @@ function setupDisguisedPodmanSocketWatcher(
   // only trigger if the watched file is the socket file
   const updateSocket = async (uri: extensionApi.Uri): Promise<void> => {
     if (uri.fsPath === socketFile) {
-      await checkDisguisedPodmanSocket(provider);
+      await checkDisguisedPodmanSocket();
     }
   };
 
@@ -2294,7 +2294,7 @@ function setupDisguisedPodmanSocketWatcher(
   return socketWatcher;
 }
 
-export async function checkDisguisedPodmanSocket(provider: extensionApi.Provider): Promise<void> {
+export async function checkDisguisedPodmanSocket(): Promise<void> {
   // Check to see if the socket is disguised or not. If it is, we'll push a warning up
   // to the plugin library to the let the provider know that there is a warning
   const disguisedCheck = await isDisguisedPodman();
@@ -2304,17 +2304,6 @@ export async function checkDisguisedPodmanSocket(provider: extensionApi.Provider
 
   // If it's disguised on startup, set the enable-docker-compatibility setting accordingly
   await extensionApi.configuration.getConfiguration('podman').update(configurationCompatibilityMode, disguisedCheck);
-
-  // If isDisguisedPodmanSocket is true, we'll push a warning up to the plugin library with getDisguisedPodmanWarning()
-  // If isDisguisedPodmanSocket is false, we'll push an empty array up to the plugin library to clear the warning
-  // as we have no other warnings to display (or implemented)
-
-  // NOTE: LINUX SUPPORT
-  // Linux does not support compatibility mode button, so do not sending the warning
-  if (!extensionApi.env.isLinux) {
-    const retrievedWarnings = isDisguisedPodmanSocket ? [] : [getDisguisedPodmanInformation()];
-    provider.updateWarnings(retrievedWarnings);
-  }
 }
 
 // Shortform for getting the compatibility mode setting

--- a/extensions/podman/packages/extension/src/warnings.ts
+++ b/extensions/podman/packages/extension/src/warnings.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022-2023 Red Hat, Inc.
+ * Copyright (C) 2022-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,43 +19,11 @@
 import http from 'node:http';
 import * as os from 'node:os';
 
-import type * as extensionApi from '@podman-desktop/api';
-
 const DEFAULT_TIMEOUT = 5000;
-
-// Explanations
-const detailsExplanation = 'Docker socket is not reachable. Docker specific tools may not work.';
 
 // Default socket paths
 const windowsSocketPath = '//./pipe/docker_engine';
 const defaultSocketPath = '/var/run/docker.sock';
-
-// Return the warning information to the user if the socket is not a disguised Podman socket
-export function getDisguisedPodmanInformation(): extensionApi.ProviderInformation {
-  let details: string;
-
-  // Set the details message based on the OS
-  switch (os.platform()) {
-    case 'win32':
-      details = detailsExplanation;
-      break;
-    case 'darwin':
-      // Due to how `podman-mac-helper` does not (by default) map the emulator to /var/run/docker.sock, we need to explain
-      // that the user must go on the Podman Desktop website for more information. This is because the user must manually
-      // map the socket to /var/run/docker.sock if not done by `podman machine` already (podman machine automatically maps the socket if Docker is not running)
-      details = detailsExplanation.concat(` Press 'Docker Compatibility' button to enable.`);
-      break;
-    default:
-      details = detailsExplanation;
-      break;
-  }
-
-  // Return ProviderInformation with the details message
-  return {
-    name: 'Docker Socket Compatibility',
-    details,
-  };
-}
 
 // Async function that checks to see if the current Docker socket is a disguised Podman socket
 export async function isDisguisedPodman(): Promise<boolean> {


### PR DESCRIPTION
chore: remove docker compatibility warning from dashboard

### What does this PR do?

We now have the new section as well as other parts of PD that displays
the warning.

This code removes the docker compatibility code that puts warns up on
the main dashboard.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A, simply see that it is no longer there.

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/podman-desktop/issues/11432

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

1. Docker installed
2. Open Podman Desktop
3. Disable Docker Compatibility
4. See there is zero warning on the dashboard.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
