### PR TITLE
fix: do not use ResourceName for experimental kubernetes

### DIFF
--- a/packages/renderer/src/lib/kube/resource-permission.ts
+++ b/packages/renderer/src/lib/kube/resource-permission.ts
@@ -20,10 +20,9 @@ import { kubernetesContextsPermissions } from '/@/stores/kubernetes-context-perm
 import { kubernetesContexts } from '/@/stores/kubernetes-contexts';
 import type { IDisposable } from '/@api/disposable';
 import type { ContextPermission } from '/@api/kubernetes-contexts-permissions';
-import type { ResourceName } from '/@api/kubernetes-contexts-states';
 
 export async function listenResourcePermitted(
-  resourceName: ResourceName,
+  resourceName: string,
   callback: (permitted: boolean) => void,
 ): Promise<IDisposable> {
   const experimental = (await window.getConfigurationValue<boolean>('kubernetes.statesExperimental')) ?? false;


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

The type ResourceName is defined in 'legacy' kubernetes, but in experimental mode, the resource name is using the `string` type.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
