### PR TITLE
feat: represent not permitted resources in Kubernetes dashboard

### DIFF
--- a/packages/renderer/src/lib/kube/KubernetesDashboardResourceCard.spec.ts
+++ b/packages/renderer/src/lib/kube/KubernetesDashboardResourceCard.spec.ts
@@ -25,8 +25,8 @@ import { expect, test } from 'vitest';
 import NodeIcon from '../images/NodeIcon.svelte';
 import KubernetesDashboardResourceCard from './KubernetesDashboardResourceCard.svelte';
 
-test('Verify basic card format', async () => {
-  const params = { type: 'a type', Icon: NodeIcon, count: 4, kind: 'Pod' };
+test('Verify basic card format when resource permitted', async () => {
+  const params = { type: 'a type', Icon: NodeIcon, count: 4, kind: 'Pod', permitted: true };
   render(KubernetesDashboardResourceCard, params);
 
   const type = screen.getByText(params.type);
@@ -40,8 +40,20 @@ test('Verify basic card format', async () => {
   expect(count).toHaveClass('text-[var(--pd-invert-content-card-text)]');
 });
 
-test('Expect clicking works', async () => {
-  const params = { type: 'a type', Icon: NodeIcon, count: 4, kind: 'Service' };
+test('Verify basic card format when resource not permitted', async () => {
+  const params = { type: 'a type', Icon: NodeIcon, count: 0, kind: 'Pod', permitted: false };
+  render(KubernetesDashboardResourceCard, params);
+
+  const button = screen.getByRole('button');
+  expect(button).toBeInTheDocument();
+  expect(button).toHaveClass('opacity-60');
+
+  const count = screen.queryByText(params.count);
+  expect(count).not.toBeInTheDocument();
+});
+
+test.each([true, false])('Expect clicking works when permitted is %s', async permitted => {
+  const params = { type: 'a type', Icon: NodeIcon, count: 4, kind: 'Service', permitted };
   render(KubernetesDashboardResourceCard, params);
 
   const type = screen.getByText(params.type);

--- a/packages/renderer/src/lib/kube/KubernetesDashboardResourceCard.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesDashboardResourceCard.svelte
@@ -1,4 +1,8 @@
 <script lang="ts">
+import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons';
+import { Tooltip } from '@podman-desktop/ui-svelte';
+import Fa from 'svelte-fa';
+
 import KubernetesIcon from './KubernetesIcon.svelte';
 
 interface Props {
@@ -6,9 +10,10 @@ interface Props {
   activeCount?: number;
   count: number;
   kind: string;
+  permitted: boolean;
 }
 
-let { type, activeCount, count, kind }: Props = $props();
+let { type, activeCount, count, kind, permitted }: Props = $props();
 
 async function openLink(): Promise<void> {
   try {
@@ -19,19 +24,24 @@ async function openLink(): Promise<void> {
 }
 </script>
 
-<button class="flex flex-col gap-4 p-4 bg-[var(--pd-content-card-carousel-card-bg)] hover:bg-[var(--pd-content-card-carousel-card-hover-bg)] rounded-md" onclick={openLink}>
-  <div class="text-[var(--pd-invert-content-card-text)] font-semibold text-start">{type}</div>
+<button class="flex flex-col gap-4 p-4 bg-[var(--pd-content-card-carousel-card-bg)] hover:bg-[var(--pd-content-card-carousel-card-hover-bg)] rounded-md" class:opacity-60={!permitted} onclick={openLink}>
+  <div class="text-start">
+    <span class="text-[var(--pd-invert-content-card-text)] font-semibold">{type}</span>
+    {#if !permitted}
+      <span class="ml-1"><Tooltip class="" tip={`${type} are not accessible`}><div><Fa size="1x" icon={faQuestionCircle} /></div></Tooltip></span>
+    {/if}
+  </div>
   <div class="grid grid-cols-{activeCount !== undefined ? '3' : '2'} gap-4 w-full grow items-end">
     <div class="justify-self-center text-[var(--pd-button-primary-bg)]"><KubernetesIcon kind={kind} size='40'/></div>
     {#if activeCount !== undefined}
     <div class="flex flex-col">
       <span class="text-[var(--pd-invert-content-card-text)]">Active</span>
-      <div class="text-2xl text-[var(--pd-invert-content-card-text)]" aria-label="{type} active count">{activeCount}</div>
+      <div class="text-2xl text-[var(--pd-invert-content-card-text)]" aria-label="{type} active count">{#if permitted}{activeCount}{:else}-{/if}</div>
     </div>
     {/if}
     <div class="flex flex-col">
       <span class="text-[var(--pd-invert-content-card-text)]">Total</span>
-      <div class="text-2xl text-[var(--pd-invert-content-card-text)]" aria-label="{type} count">{count}</div>
+      <div class="text-2xl text-[var(--pd-invert-content-card-text)]" aria-label="{type} count">{#if permitted}{count}{:else}-{/if}</div>
     </div>
   </div>
 </button>

--- a/packages/renderer/src/lib/kube/KubernetesDashboardResourceCard.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesDashboardResourceCard.svelte
@@ -25,10 +25,10 @@ async function openLink(): Promise<void> {
 </script>
 
 <button class="flex flex-col gap-4 p-4 bg-[var(--pd-content-card-carousel-card-bg)] hover:bg-[var(--pd-content-card-carousel-card-hover-bg)] rounded-md" class:opacity-60={!permitted} onclick={openLink}>
-  <div class="text-start">
-    <span class="text-[var(--pd-invert-content-card-text)] font-semibold">{type}</span>
+  <div class="text-start flex">
+    <span class="text-[var(--pd-invert-content-card-text)] font-semibold grow">{type}</span>
     {#if !permitted}
-      <span class="ml-1"><Tooltip class="" tip={`${type} are not accessible`}><div><Fa size="1x" icon={faQuestionCircle} /></div></Tooltip></span>
+      <span class="ml-1"><Tooltip bottom={true} class="" tip={`${type} are not accessible`}><div><Fa size="1x" icon={faQuestionCircle} /></div></Tooltip></span>
     {/if}
   </div>
   <div class="grid grid-cols-{activeCount !== undefined ? '3' : '2'} gap-4 w-full grow items-end">


### PR DESCRIPTION
### What does this PR do?

Represent not permitted resources in Kubernetes dashboard, in experimental mode

### Screenshot / video of UI

https://github.com/user-attachments/assets/241bf11e-6fa9-4438-bee3-8440d1bb6962

### What issues does this PR fix or reference?

Fixes #10655 
Fixes #11490 

### How to test this PR?

In experimental mode, with a user having restricted permissions (for example with openshift cluster), go to Kubernetes Dashboard, the not permitted resources should be greyed, and a dash must replace the count.

In non experimental mode, nothing changed: not permitted resources are still showing 0 as count.

- [x] Tests are covering the bug fix or the new feature
