### PR TITLE
chore: avoid error saying that we use a variable before its assignment

### DIFF
--- a/packages/renderer/src/lib/manifest/ManifestDetails.svelte
+++ b/packages/renderer/src/lib/manifest/ManifestDetails.svelte
@@ -22,7 +22,7 @@ export let imageID: string;
 export let engineId: string;
 export let base64RepoTag: string;
 
-let globalContext: ContextUI;
+let globalContext: ContextUI | undefined;
 let viewContributions: ViewInfoUI[] = [];
 let allImages: ImageInfo[];
 


### PR DESCRIPTION
### What does this PR do?
avoid:

```
packages/renderer/src/lib/manifest/ManifestDetails.svelte:45:87
Error: Variable 'globalContext' is used before being assigned. (ts)
  if (imageInfo) {
    tempImage = imageUtils.getImageInfoUI(imageInfo, base64RepoTag, $containersInfos, globalContext, viewContributions);
  }


====================================
svelte-check found 1 error and 0 warnings in 1 file
 ELIFECYCLE  Command failed with exit code 1.
```

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

https://github.com/podman-desktop/podman-desktop/pull/11615

### How to test this PR?

pr checks should be 💚 
- [ ] Tests are covering the bug fix or the new feature
