### PR TITLE
fix: removed compose /usr/local/bin in PATH check to align with kubectl

### DIFF
--- a/extensions/compose/src/cli-run.ts
+++ b/extensions/compose/src/cli-run.ts
@@ -89,7 +89,7 @@ export async function installBinaryToSystem(binaryPath: string, binaryName: stri
     // Use admin privileges / ask for password for copying to /usr/local/bin
     await extensionApi.process.exec(command, args, { isAdmin: true });
     console.log(`Successfully installed '${binaryName}' binary.`);
-    if (!process.env.PATH?.includes(destinationFolder)) {
+    if (!(system === 'darwin' || process.env.FLATPAK_ID) && !process.env.PATH?.includes(destinationFolder)) {
       await extensionApi.window.showWarningMessage(
         `The compose binary has been installed into ${destinationFolder} but it is not in the system path. You should add it manually if you want to use compose from cli.`,
         'OK',


### PR DESCRIPTION
### What does this PR do?

This PR removes the composed PATH check for mac and flatpack because neither inherits the global system PATH for an accurate check.

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/10840

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

pnpm build
then run the build on macos or flatpack