### PR TITLE
fix: grant access to the containers directory for the flatpak build

### DIFF
--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -162,6 +162,8 @@ const config = {
       '--filesystem=home',
       // Read podman socket
       '--filesystem=xdg-run/podman:create',
+      // Read/write containers directory access (ability to save the application preferences)
+      '--filesystem=xdg-run/containers:create',
       // Read docker socket
       '--filesystem=/run/docker.sock',
       // Allow communication with network


### PR DESCRIPTION
### What does this PR do?

The following changes request fixes the problem, when user using flatpak build can not save the application preferences (proxy settings).

The main problem was occurred due to sandbox policy in flatpak ecosystem. Application wasn't able to see the directory `/run/user/1000/containers` and couldn't update the `/run/user/1000/containers/containers.conf` file. `xdg-run` is an alias for `/run/user/1000`, so adding an additional finishArg solved the problem. The new arg was added to flatpak configuration:

```
'--filesystem=xdg-run/containers:create',
```

### Screenshot / video of UI

No screenshots.

### What issues does this PR fix or reference?

#10842 

### How to test this PR?

Open Podman Desktop from flatpak build and try to change the proxy settings. Make sure, that `/run/user/1000/containers/containers.conf` file successfully updated as well.

- [ ] Tests are covering the bug fix or the new feature
