### PR TITLE
chore: prepare compatibility with kubernetes-client v1.1.0

### DIFF
--- a/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
@@ -343,16 +343,24 @@ test('Create Kubernetes resources with v1 resource should return ok', async () =
     read: readMock,
     create: createMock,
   });
-  await client.createResources('dummy', [{ apiVersion: 'v1', kind: 'Namespace' }]);
+  await client.createResources('dummy', [{ apiVersion: 'v1', kind: 'Namespace', metadata: { name: 'n1' } }]);
   expect(createMock).toHaveBeenCalled();
   expect(telemetry.track).toHaveBeenCalledWith('kubernetesSyncResources', { action: 'create', manifestsSize: 1 });
 });
 
 describe.each([
-  { manifest: { apiVersion: 'apps/v1', kind: 'Deployment' }, namespace: undefined, expectedNamespace: 'default' },
-  { manifest: { apiVersion: 'apps/v1', kind: 'Deployment' }, namespace: 'defaultns', expectedNamespace: 'defaultns' },
   {
-    manifest: { apiVersion: 'apps/v1', kind: 'Deployment', metadata: { namespace: 'demons' } },
+    manifest: { apiVersion: 'apps/v1', kind: 'Deployment', metadata: { name: 'n1' } },
+    namespace: undefined,
+    expectedNamespace: 'default',
+  },
+  {
+    manifest: { apiVersion: 'apps/v1', kind: 'Deployment', metadata: { name: 'n1' } },
+    namespace: 'defaultns',
+    expectedNamespace: 'defaultns',
+  },
+  {
+    manifest: { apiVersion: 'apps/v1', kind: 'Deployment', metadata: { name: 'n1', namespace: 'demons' } },
     namespace: undefined,
     expectedNamespace: 'demons',
   },
@@ -384,17 +392,17 @@ describe.each([
 
 describe.each([
   {
-    manifest: { apiVersion: 'networking.k8s.io/v1', kind: 'Ingress' },
+    manifest: { apiVersion: 'networking.k8s.io/v1', kind: 'Ingress', metadata: { name: 'n1' } },
     namespace: undefined,
     expectedNamespace: 'default',
   },
   {
-    manifest: { apiVersion: 'networking.k8s.io/v1', kind: 'Ingress' },
+    manifest: { apiVersion: 'networking.k8s.io/v1', kind: 'Ingress', metadata: { name: 'n1' } },
     namespace: 'defaultns',
     expectedNamespace: 'defaultns',
   },
   {
-    manifest: { apiVersion: 'networking.k8s.io/v1', kind: 'Ingress', metadata: { namespace: 'demons' } },
+    manifest: { apiVersion: 'networking.k8s.io/v1', kind: 'Ingress', metadata: { name: 'n1', namespace: 'demons' } },
     namespace: undefined,
     expectedNamespace: 'demons',
   },
@@ -426,17 +434,17 @@ describe.each([
 
 describe.each([
   {
-    manifest: { apiVersion: 'group/v1', kind: 'Namespace' },
+    manifest: { apiVersion: 'group/v1', kind: 'Namespace', metadata: { name: 'n1' } },
     namespace: undefined,
     expectedNamespace: 'default',
   },
   {
-    manifest: { apiVersion: 'group/v1', kind: 'Namespace' },
+    manifest: { apiVersion: 'group/v1', kind: 'Namespace', metadata: { name: 'n1' } },
     namespace: 'defaultns',
     expectedNamespace: 'defaultns',
   },
   {
-    manifest: { apiVersion: 'group/v1', kind: 'Namespace', metadata: { namespace: 'demons' } },
+    manifest: { apiVersion: 'group/v1', kind: 'Namespace', metadata: { name: 'n1', namespace: 'demons' } },
     namespace: undefined,
     expectedNamespace: 'demons',
   },
@@ -903,7 +911,7 @@ test('Expect apply with empty yaml should throw error', async () => {
 
 test('Expect apply should create if object does not exist', async () => {
   const client = createTestClient('default');
-  const manifests = { kind: test, metadata: { annotations: test } } as unknown as KubernetesObject;
+  const manifests = { kind: test, metadata: { name: 'n1', annotations: test } } as unknown as KubernetesObject;
   const createdObj = { kind: 'created' };
   vi.spyOn(client, 'loadManifestsFromFile').mockResolvedValue([manifests]);
   makeApiClientMock.mockReturnValue({
@@ -918,7 +926,7 @@ test('Expect apply should create if object does not exist', async () => {
 
 test('Expect apply should patch if object exists', async () => {
   const client = createTestClient('default');
-  const manifests = { kind: test, metadata: { annotations: test } } as unknown as KubernetesObject;
+  const manifests = { kind: test, metadata: { name: 'n1', annotations: test } } as unknown as KubernetesObject;
   const patchedObj = { kind: 'patched' };
   vi.spyOn(client, 'loadManifestsFromFile').mockResolvedValue([manifests]);
   const patchMock = vi.fn();
@@ -936,7 +944,7 @@ test('Expect apply should patch if object exists', async () => {
 
 test('Expect apply should patch with specific field manager', async () => {
   const client = createTestClient('default');
-  const manifests = { kind: test, metadata: { annotations: test } } as unknown as KubernetesObject;
+  const manifests = { kind: test, metadata: { name: 'n1', annotations: test } } as unknown as KubernetesObject;
   const patchedObj = { kind: 'patched' };
   vi.spyOn(client, 'loadManifestsFromFile').mockResolvedValue([manifests]);
   const patchMock = vi.fn();
@@ -951,7 +959,7 @@ test('Expect apply should patch with specific field manager', async () => {
 
 test('Expect apply should work with multiple files', async () => {
   const client = createTestClient('default');
-  const manifests = { kind: test, metadata: { annotations: test } } as unknown as KubernetesObject;
+  const manifests = { kind: test, metadata: { name: 'n1', annotations: test } } as unknown as KubernetesObject;
   const createdObjs = [{ kind: 'created' }, { kind: 'created' }];
   let count = 0;
   vi.spyOn(client, 'loadManifestsFromFile').mockResolvedValue([manifests]);


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Prepare compatibility with kubernetes-client v1.1.0


In kubernetes-client v1.0:
```
read<T extends KubernetesObject | KubernetesObject>(
  spec: T, 
  [...]
```

In v1.1:
```
type KubernetesObjectHeader<T extends KubernetesObject | KubernetesObject> = Pick<
    T,
    'apiVersion' | 'kind'
> & {
    metadata: {
        name: string;
        namespace?: string;
    };
};

read<T extends KubernetesObject | KubernetesObject>(
  spec: KubernetesObjectHeader<T>,
  [...]
```

### Screenshot / video of UI


### What issues does this PR fix or reference?

Needed by #11667

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
