### PR TITLE
chore(dependabot): grouping typedoc deps update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,3 +60,10 @@ updates:
         patterns:
           - "@vitest/*"
           - "vitest"
+      typedoc:
+        applies-to: version-updates
+        patterns:
+          - "typedoc"
+          - "typedoc-plugin-markdown"
+          - "docusaurus-plugin-typedoc"
+


### PR DESCRIPTION
### What does this PR do?

Grouping typedoc deps to let dependabot upgrade them together. (See https://github.com/podman-desktop/podman-desktop/pull/11691)

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
