### PR TITLE
refactor(Dropdown): enforce string key

### DIFF
--- a/packages/renderer/src/lib/forms/ContainerConnectionDropdown.spec.ts
+++ b/packages/renderer/src/lib/forms/ContainerConnectionDropdown.spec.ts
@@ -90,7 +90,10 @@ test('expect dropdown onchange to be propagated', async () => {
   // ensure the component has provided on onChange method
   expect(onChange).toBeDefined();
   // simulate user selected the provider container connection
-  onChange?.(options?.[0].value);
+  const value = options?.[0].value;
+  if (!value) throw new Error('undefined value for option at index 0');
+
+  onChange?.(value);
 
   expect(onchange).toHaveBeenCalledWith(CONTAINER_CONNECTION_INFO);
 });
@@ -110,7 +113,10 @@ test('expect binding to properly work', async () => {
   let alert = queryByRole('alert');
   expect(alert).toBeNull();
 
-  onChange?.(options?.[0].value);
+  const value = options?.[0].value;
+  if (!value) throw new Error('undefined value for option at index 0');
+
+  onChange?.(value);
 
   alert = await vi.waitFor(() => {
     return getByRole('alert');

--- a/packages/ui/src/lib/dropdown/Dropdown.svelte
+++ b/packages/ui/src/lib/dropdown/Dropdown.svelte
@@ -4,7 +4,7 @@ import { onMount, type Snippet } from 'svelte';
 import Fa from 'svelte-fa';
 
 interface Option {
-  value: unknown;
+  value: string;
   label: string;
 }
 
@@ -23,9 +23,9 @@ let {
 }: {
   id?: string;
   name?: string;
-  value?: unknown;
+  value?: string;
   disabled?: boolean;
-  onChange?: (val: unknown) => void;
+  onChange?: (val: string) => void;
   options?: Option[];
   class?: string;
   ariaInvalid?: boolean | 'grammar' | 'spelling';
@@ -48,7 +48,7 @@ onMount(() => {
 });
 
 $effect(() => {
-  selectLabel = options.find(o => o.value === value)?.label ?? (typeof value === 'string' ? (value as string) : '');
+  selectLabel = options.find(o => o.value === value)?.label ?? value ?? '';
 });
 
 function onKeyDown(e: KeyboardEvent): void {
@@ -131,7 +131,7 @@ function onEnter(i: number): void {
   highlightIndex = i;
 }
 
-function onSelect(e: Event, newValue: unknown): void {
+function onSelect(e: Event, newValue: string): void {
   onChange(newValue);
   value = newValue;
   close();


### PR DESCRIPTION
### What does this PR do?

The dropdown were allowing `unknown` type for keys, but this has some major drawback, and should be replaced by a primitive (such as string).

The problem to use complex object as value is related to how svelte5 pass proxy object as props, and therefore cannot compare by ref since they would not be matching. (most libraries are using string primitives. )

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/10734

Discussion reference to enforce string available in https://github.com/podman-desktop/podman-desktop/issues/10734#issuecomment-2631068467

Requires
- https://github.com/podman-desktop/podman-desktop/pull/10950
- https://github.com/podman-desktop/podman-desktop/pull/11700
- https://github.com/podman-desktop/podman-desktop/pull/11771
- https://github.com/podman-desktop/podman-desktop/pull/11702
- https://github.com/podman-desktop/podman-desktop/pull/11860

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
