### PR TITLE
feat(main): use media protocol for font-family

### DIFF
--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 import dns from 'node:dns';
 
-import { app, ipcMain, Menu, Tray } from 'electron';
+import { app, ipcMain, Menu, net, protocol, Tray } from 'electron';
 
 import { createNewWindow, restoreWindow } from '/@/mainWindow.js';
 import type { ExtensionLoader } from '/@/plugin/extension/extension-loader.js';
@@ -38,7 +38,7 @@ import { isMac, isWindows, stoppedExtensions } from './util.js';
 let extensionLoader: ExtensionLoader | undefined;
 
 // Main startup
-const podmanDesktopMain = new Main(app);
+const podmanDesktopMain = new Main(app, net, protocol);
 podmanDesktopMain.main(process.argv);
 
 // TODO: remove when index.spec.ts tests are migrated in podmanDesktopMain-main.spec

--- a/packages/main/src/main.ts
+++ b/packages/main/src/main.ts
@@ -15,8 +15,9 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import type { App as ElectronApp, BrowserWindow } from 'electron';
+import type { App as ElectronApp, BrowserWindow, Net as ElectronNet, Protocol as ElectronProtocol } from 'electron';
 
+import { ProtocolMedia } from '/@/protocol-media.js';
 import { SecurityRestrictions } from '/@/security-restrictions.js';
 import { isMac, isWindows } from '/@/util.js';
 
@@ -38,10 +39,16 @@ export class Main {
   // TODO: should be renamed to #protocolLauncher
   public protocolLauncher: ProtocolLauncher;
 
-  constructor(app: ElectronApp) {
+  #net: ElectronNet;
+  #protocol: ElectronProtocol;
+
+  constructor(app: ElectronApp, net: ElectronNet, protocol: ElectronProtocol) {
     this.app = app;
     this.mainWindowDeferred = new Deferred<BrowserWindow>();
     this.protocolLauncher = new ProtocolLauncher(this.mainWindowDeferred);
+
+    this.#net = net;
+    this.#protocol = protocol;
   }
 
   main(args: string[]): void {
@@ -74,6 +81,12 @@ export class Main {
      */
     const security = new SecurityRestrictions(this.app);
     security.init();
+
+    /**
+     * Media protocol
+     */
+    const media = new ProtocolMedia(this.app, this.#net, this.#protocol);
+    media.init();
 
     /**
      * Disable Hardware Acceleration for more power-save

--- a/packages/main/src/plugin/icon-registry.ts
+++ b/packages/main/src/plugin/icon-registry.ts
@@ -102,7 +102,7 @@ export class IconRegistry {
       if (isWindows()) {
         cleanedIconFontLocation = cleanedIconFontLocation.replace(/\\/g, '/');
       }
-      const browserURL = `url('file://${cleanedIconFontLocation}')`;
+      const browserURL = `url('media://${cleanedIconFontLocation}')`;
 
       // font definition
       const fontDefinition: FontDefinition = {

--- a/packages/main/src/protocol-media.spec.ts
+++ b/packages/main/src/protocol-media.spec.ts
@@ -1,0 +1,101 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { App as ElectronApp, Net as ElectronNet, Protocol as ElectronProtocol } from 'electron';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { ProtocolMedia } from '/@/protocol-media.js';
+
+const ELECTRON_APP_MOCK: ElectronApp = {
+  whenReady: vi.fn(),
+} as unknown as ElectronApp;
+
+const ELECTRON_NET_MOCK: ElectronNet = {
+  fetch: vi.fn(),
+} as unknown as ElectronNet;
+
+const ELECTRON_PROTOCOL_MOCK: ElectronProtocol = {
+  handle: vi.fn(),
+} as unknown as ElectronProtocol;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  vi.mocked(ELECTRON_APP_MOCK.whenReady).mockReturnValue(Promise.resolve());
+});
+
+function getProtocolMedia(): ProtocolMedia {
+  return new ProtocolMedia(ELECTRON_APP_MOCK, ELECTRON_NET_MOCK, ELECTRON_PROTOCOL_MOCK);
+}
+
+type PROTOCOL_HANDLER = Parameters<ElectronProtocol['handle']>[1];
+
+async function getHandle(): Promise<PROTOCOL_HANDLER> {
+  const media = getProtocolMedia();
+  media.init();
+  return await vi.waitFor(() => {
+    expect(ELECTRON_PROTOCOL_MOCK.handle).toHaveBeenCalled();
+    const call = vi.mocked(ELECTRON_PROTOCOL_MOCK.handle).mock.calls[0];
+    if (!call) throw new Error('ElectronProtocol#handle has empty call history');
+    return call[1];
+  });
+}
+
+test('ensure init register callback to app#whenReady', async () => {
+  const media = getProtocolMedia();
+  expect(ELECTRON_APP_MOCK.whenReady).not.toHaveBeenCalled();
+  expect(ELECTRON_PROTOCOL_MOCK.handle).not.toHaveBeenCalled();
+
+  media.init();
+  expect(ELECTRON_APP_MOCK.whenReady).toHaveBeenCalled();
+
+  // ensure the handle has been registered
+  await vi.waitFor(() => {
+    expect(ELECTRON_PROTOCOL_MOCK.handle).toHaveBeenCalled();
+  });
+});
+
+describe('handler should handle provided request', () => {
+  test('unknown extension should throw an error', async () => {
+    const handler = await getHandle();
+    await expect(async () => {
+      return handler({
+        url: 'media:///hello/world.invalid',
+      } as unknown as Request);
+    }).rejects.toThrowError(
+      'invalid path: trying to read media media:///hello/world.invalid, extension allowed: .woff2',
+    );
+  });
+
+  test('invalid protocol should throw an error', async () => {
+    const handler = await getHandle();
+    await expect(async () => {
+      return handler({
+        url: 'random:///hello/world.invalid',
+      } as unknown as Request);
+    }).rejects.toThrowError('invalid protocol: expected media: got random:');
+  });
+
+  test('.woff2 extension should use ElectronNet#fetch', async () => {
+    const handler = await getHandle();
+    await handler({
+      url: 'media:///hello/world.woff2',
+    } as unknown as Request);
+
+    expect(ELECTRON_NET_MOCK.fetch).toHaveBeenCalledWith('file:///hello/world.woff2');
+  });
+});

--- a/packages/main/src/protocol-media.ts
+++ b/packages/main/src/protocol-media.ts
@@ -1,0 +1,70 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { extname } from 'node:path';
+
+import type { App as ElectronApp, Net as ElectronNet, Protocol as ElectronProtocol } from 'electron';
+
+const MEDIA_ALLOWED = new Set<string>(['.woff2']);
+
+export class ProtocolMedia {
+  #app: ElectronApp;
+  #net: ElectronNet;
+  #protocol: ElectronProtocol;
+
+  constructor(app: ElectronApp, net: ElectronNet, protocol: ElectronProtocol) {
+    this.#app = app;
+    this.#net = net;
+    this.#protocol = protocol;
+  }
+
+  public init(): void {
+    this.#app
+      .whenReady()
+      .then(() => {
+        this.#protocol.handle('media', this.handle.bind(this));
+      })
+      .catch(console.error);
+  }
+
+  /**
+   * Validate a path based on the allowed extensions
+   * @param path
+   * @private
+   */
+  private validate(path: string): boolean {
+    return MEDIA_ALLOWED.has(extname(path));
+  }
+
+  /**
+   * Callback for {@link ElectronProtocol#handle}
+   * @remarks do not use directly
+   * @param request
+   * @private
+   */
+  private handle(request: Request): Promise<GlobalResponse> {
+    const parsed: URL = new URL(request.url);
+    if (parsed.protocol !== 'media:') throw new Error(`invalid protocol: expected media: got ${parsed.protocol}`);
+
+    if (!this.validate(parsed.href))
+      throw new Error(
+        `invalid path: trying to read media ${parsed.href}, extension allowed: ${Array.from(MEDIA_ALLOWED.values()).join(',')}`,
+      );
+    return this.#net.fetch(`file://${parsed.pathname}`);
+  }
+}


### PR DESCRIPTION
### What does this PR do?

Following https://github.com/podman-desktop/podman-desktop/pull/11340 resources with url `file://` could not be loaded (security restrictions).

I did not notice the issue with the font-family (oupsi sorry). 

### Solution proposal (short)

Instead of reverting the problematic PR, I would suggest to keep the security restriction and add a custom `media` protocol. So instead of using `file://<path-to-font>` we would use `media://<path-to-font>`, and we manually handle the media protocol, to avoid having to disable the web security.  (ref https://github.com/electron/electron/issues/23393#issuecomment-2379103959)

Instead of blindly allowing all resources using the media protocol, we can restrict to a set of extensions (here only allow `.woff2`. 

### Screenshot / video of UI

![image](https://github.com/user-attachments/assets/b8a390d9-babd-45e5-adf5-0aa3889e07f0)

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/11671

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
