### PR TITLE
feat: expose ListImagesOptions to main world

### DIFF
--- a/packages/api/src/image-info.ts
+++ b/packages/api/src/image-info.ts
@@ -190,7 +190,7 @@ export interface ListImagesOptions {
    *
    * @defaultValue undefined
    */
-  provider?: ContainerProviderConnection;
+  provider?: ContainerProviderConnection | ProviderContainerConnectionInfo;
 }
 
 export interface PodmanListImagesOptions {
@@ -217,5 +217,5 @@ export interface PodmanListImagesOptions {
    *
    * @defaultValue undefined
    */
-  provider?: ContainerProviderConnection;
+  provider?: ContainerProviderConnection | ProviderContainerConnectionInfo;
 }

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -88,7 +88,7 @@ import type { HistoryInfo } from '/@api/history-info.js';
 import type { IconInfo } from '/@api/icon-info.js';
 import type { ImageCheckerInfo } from '/@api/image-checker-info.js';
 import type { ImageFilesInfo } from '/@api/image-files-info.js';
-import type { ImageInfo } from '/@api/image-info.js';
+import type { ImageInfo, PodmanListImagesOptions } from '/@api/image-info.js';
 import type { ImageInspectInfo } from '/@api/image-inspect-info.js';
 import type { ImageSearchOptions, ImageSearchResult, ImageTagsListOptions } from '/@api/image-registry.js';
 import type { KubeContext } from '/@api/kubernetes-context.js';
@@ -772,9 +772,12 @@ export class PluginSystem {
     this.ipcHandle('container-provider-registry:listSimpleContainers', async (): Promise<SimpleContainerInfo[]> => {
       return containerProviderRegistry.listSimpleContainers();
     });
-    this.ipcHandle('container-provider-registry:listImages', async (): Promise<ImageInfo[]> => {
-      return containerProviderRegistry.podmanListImages();
-    });
+    this.ipcHandle(
+      'container-provider-registry:listImages',
+      async (_listener, options?: PodmanListImagesOptions): Promise<ImageInfo[]> => {
+        return containerProviderRegistry.podmanListImages(options);
+      },
+    );
     this.ipcHandle('container-provider-registry:listPods', async (): Promise<PodInfo[]> => {
       return containerProviderRegistry.listPods();
     });

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -66,7 +66,7 @@ import type { HistoryInfo } from '/@api/history-info';
 import type { IconInfo } from '/@api/icon-info';
 import type { ImageCheckerInfo } from '/@api/image-checker-info';
 import type { ImageFilesInfo } from '/@api/image-files-info';
-import type { ImageInfo } from '/@api/image-info';
+import type { ImageInfo, PodmanListImagesOptions } from '/@api/image-info';
 import type { ImageInspectInfo } from '/@api/image-inspect-info';
 import type { ImageSearchOptions, ImageSearchResult, ImageTagsListOptions } from '/@api/image-registry';
 import type { KubeContext } from '/@api/kubernetes-context';
@@ -261,8 +261,8 @@ export function initExposure(): void {
     },
   );
 
-  contextBridge.exposeInMainWorld('listImages', async (): Promise<ImageInfo[]> => {
-    return ipcInvoke('container-provider-registry:listImages');
+  contextBridge.exposeInMainWorld('listImages', async (options?: PodmanListImagesOptions): Promise<ImageInfo[]> => {
+    return ipcInvoke('container-provider-registry:listImages', options);
   });
 
   contextBridge.exposeInMainWorld('listVolumes', async (fetchUsage = true): Promise<VolumeListInfo[]> => {


### PR DESCRIPTION
### What does this PR do?

To be able to work on https://github.com/podman-desktop/podman-desktop/issues/10734 (current sprint) I need to replace the container engine Dropdown of the `CreateContainerFromExistingImage` component.

However, the existing dropdown does not work, so I need to fix https://github.com/podman-desktop/podman-desktop/issues/11697 before replacing the dropdown with the appropriate component.

#### Deep dive

The main problem is that the renderer list all images, regardless of the selected container engine, so it populate the `matchingLocalImages` with content from all connections (when it should not if you have multiple).

https://github.com/podman-desktop/podman-desktop/blob/5dc5f2c92387a7488cf0306acf4e8b5122f77379/packages/renderer/src/lib/container/CreateContainerFromExistingImage.svelte#L225

To let the frontend filter based on a given container connection, we should expose the optional argument `PodmanListImagesOptions`.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Related to 
- https://github.com/podman-desktop/podman-desktop/issues/11697
- https://github.com/podman-desktop/podman-desktop/issues/10734

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Typescript should be happy
