### PR TITLE
feat(pin-registry): expose pin / unpin / list to main world

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -181,6 +181,7 @@ import { Proxy } from './proxy.js';
 import { RecommendationsRegistry } from './recommendations/recommendations-registry.js';
 import { ReleaseNotesBannerInit } from './release-notes-banner-init.js';
 import { SafeStorageRegistry } from './safe-storage/safe-storage-registry.js';
+import { PinRegistry } from './statusbar/pin-registry.js';
 import { StatusbarProvidersInit } from './statusbar/statusbar-providers-init.js';
 import type { StatusBarEntryDescriptor } from './statusbar/statusbar-registry.js';
 import { StatusBarRegistry } from './statusbar/statusbar-registry.js';
@@ -681,6 +682,9 @@ export class PluginSystem {
       apiSender,
     );
     extensionDevelopmentFolders.init();
+
+    const pinRegistry = new PinRegistry(commandRegistry, apiSender, configurationRegistry, providerRegistry);
+    pinRegistry.init();
 
     this.extensionLoader = new ExtensionLoader(
       commandRegistry,
@@ -3017,6 +3021,18 @@ export class PluginSystem {
         return kubernetesClient.getTroubleshootingInformation();
       },
     );
+
+    this.ipcHandle('statusbar:pin:get-options', async (): Promise<Array<PinOption>> => {
+      return pinRegistry.getOptions();
+    });
+
+    this.ipcHandle('statusbar:pin', async (_listener, optionId: string): Promise<void> => {
+      return pinRegistry.pin(optionId);
+    });
+
+    this.ipcHandle('statusbar:unpin', async (_listener, optionId: string): Promise<void> => {
+      return pinRegistry.unpin(optionId);
+    });
 
     const dockerDesktopInstallation = new DockerDesktopInstallation(
       apiSender,

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -115,6 +115,7 @@ import type {
 import type { ProxyState } from '/@api/proxy.js';
 import type { PullEvent } from '/@api/pull-event.js';
 import type { ReleaseNotesInfo } from '/@api/release-notes-info.js';
+import type { PinOption } from '/@api/status-bar/pin-option.js';
 import type { ViewInfoUI } from '/@api/view-info.js';
 import type { VolumeInspectInfo, VolumeListInfo } from '/@api/volume-info.js';
 import type { WebviewInfo } from '/@api/webview-info.js';

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -92,6 +92,7 @@ import type {
 import type { ProxyState } from '/@api/proxy';
 import type { PullEvent } from '/@api/pull-event';
 import type { ReleaseNotesInfo } from '/@api/release-notes-info';
+import type { PinOption } from '/@api/status-bar/pin-option';
 import type { ViewInfoUI } from '/@api/view-info';
 import type { VolumeInspectInfo, VolumeListInfo } from '/@api/volume-info';
 import type { WebviewInfo } from '/@api/webview-info';
@@ -2435,6 +2436,18 @@ export function initExposure(): void {
       return ipcInvoke('kubernetes:getTroubleshootingInformation');
     },
   );
+
+  contextBridge.exposeInMainWorld('getStatusBarPinOptions', async (): Promise<Array<PinOption>> => {
+    return ipcInvoke('statusbar:pin:get-options');
+  });
+
+  contextBridge.exposeInMainWorld('pinStatusBar', async (optionId: string): Promise<void> => {
+    return ipcInvoke('statusbar:pin', optionId);
+  });
+
+  contextBridge.exposeInMainWorld('unpinStatusBar', async (optionId: string): Promise<void> => {
+    return ipcInvoke('statusbar:unpin', optionId);
+  });
 }
 
 // expose methods

--- a/packages/renderer/src/stores/statusbar-pinned.ts
+++ b/packages/renderer/src/stores/statusbar-pinned.ts
@@ -1,0 +1,48 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { type Writable, writable } from 'svelte/store';
+
+import { STATUS_BAR_PIN_CONSTANTS } from '/@api/status-bar/pin-constants';
+import type { PinOption } from '/@api/status-bar/pin-option';
+
+import { EventStore } from './event-store';
+
+const windowEvents = [STATUS_BAR_PIN_CONSTANTS.PIN_OPTIONS_UPDATE];
+const windowListeners = ['system-ready'];
+
+export async function checkForUpdate(): Promise<boolean> {
+  return true;
+}
+
+export const statusBarPinned: Writable<Array<PinOption>> = writable([]);
+
+// use helper here as window methods are initialized after the store in tests
+const getStatusBarPinOptions = (): Promise<Array<PinOption>> => {
+  return window.getStatusBarPinOptions();
+};
+
+const eventStore = new EventStore<Array<PinOption>>(
+  'status bar pinned',
+  statusBarPinned,
+  checkForUpdate,
+  windowEvents,
+  windowListeners,
+  getStatusBarPinOptions,
+);
+eventStore.setup();


### PR DESCRIPTION
### What does this PR do?

Following https://github.com/podman-desktop/podman-desktop/pull/11422, this is the next step for https://github.com/podman-desktop/podman-desktop/issues/9950, exposing `list`, `pin`, `unpin` IPC, to interact from the renderer to the PinRegistry in the core.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Required for https://github.com/podman-desktop/podman-desktop/issues/9950

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Typecheck should be happy
