### PR TITLE
fix(renderer): create container from existing with multiple connections

### DIFF
--- a/packages/renderer/src/lib/container/CreateContainerFromExistingImage.spec.ts
+++ b/packages/renderer/src/lib/container/CreateContainerFromExistingImage.spec.ts
@@ -22,8 +22,9 @@ import type { ImageInfo, ProviderStatus } from '@podman-desktop/api';
 import { render, screen, waitFor, within } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { tick } from 'svelte';
+import { get } from 'svelte/store';
 import { router } from 'tinro';
-import { beforeEach, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { providerInfos } from '/@/stores/providers';
 import type { ImageSearchResult } from '/@api/image-registry';
@@ -87,22 +88,6 @@ vi.mock('tinro', () => {
   };
 });
 
-beforeEach(() => {
-  vi.resetAllMocks();
-  vi.mocked(window.listImages).mockResolvedValue(localImageList);
-  vi.mocked(window.searchImageInRegistry).mockResolvedValue(registryImageList);
-  window.HTMLElement.prototype.scrollIntoView = vi.fn();
-  Object.defineProperty(window, 'matchMedia', {
-    value: () => {
-      return {
-        matches: false,
-        addListener: (): void => {},
-        removeListener: (): void => {},
-      };
-    },
-  });
-});
-
 const pStatus: ProviderStatus = 'started';
 const pInfo: ProviderContainerConnectionInfo = {
   name: 'test',
@@ -130,7 +115,24 @@ const providerInfo = {
   images: undefined,
   installationSupport: undefined,
 } as unknown as ProviderInfo;
-providerInfos.set([providerInfo]);
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(window.listImages).mockResolvedValue(localImageList);
+  vi.mocked(window.searchImageInRegistry).mockResolvedValue(registryImageList);
+  window.HTMLElement.prototype.scrollIntoView = vi.fn();
+  Object.defineProperty(window, 'matchMedia', {
+    value: () => {
+      return {
+        matches: false,
+        addListener: (): void => {},
+        removeListener: (): void => {},
+      };
+    },
+  });
+
+  providerInfos.set([providerInfo]);
+});
 
 test('Expect that textbox and two buttons show up when page opened', async () => {
   render(CreateContainerFromExistingImage);
@@ -232,4 +234,75 @@ test('Expect no user input to show only local images', async () => {
   const list = screen.getByRole('row');
   const items = within(list).getAllByRole('button');
   expect(items.length).toBe(6);
+});
+
+describe('container connections', () => {
+  // create a dummy multi connection provider
+  const MULTI_CONNECTIONS: ProviderInfo = {
+    ...providerInfo,
+    containerConnections: Array.from({ length: 5 }).map((_, index) => ({
+      ...pInfo,
+      name: `connection-${index}`,
+      displayName: `Connection ${index}`,
+      endpoint: {
+        socketPath: `socket-${index}`,
+      },
+    })),
+  };
+
+  test('single container connection should not display the container engine dropdown', async () => {
+    // ensure we only have one container connections in the store
+    const providers = get(providerInfos);
+    const containerConnections = providers.map(provider => provider.containerConnections).flat();
+
+    expect(containerConnections).toHaveLength(1);
+
+    const { queryByRole } = render(CreateContainerFromExistingImage);
+    const dropdown = queryByRole('button', { name: 'Container Engine' });
+    expect(dropdown).toBeNull();
+  });
+
+  test('multiple container connection should display a dropdown', async () => {
+    providerInfos.set([MULTI_CONNECTIONS]);
+
+    const { getByRole } = render(CreateContainerFromExistingImage);
+    const dropdown = getByRole('button', { name: 'Container Engine' });
+    expect(dropdown).toBeEnabled();
+  });
+
+  test('dropdown should be disabled while pulling', async () => {
+    // mock no local image
+    vi.mocked(window.searchImageInRegistry).mockResolvedValue([]);
+
+    providerInfos.set([MULTI_CONNECTIONS]);
+
+    const { getByRole, getByPlaceholderText } = render(CreateContainerFromExistingImage);
+
+    // Ensure the dropdown is enabled
+    const dropdown = getByRole('button', { name: 'Container Engine' });
+    expect(dropdown).toBeEnabled();
+
+    // Get the input of the Typeahead
+    const inputBox = await vi.waitFor(() => {
+      return getByPlaceholderText('Select or enter an image to run');
+    });
+    expect(inputBox).toBeInTheDocument();
+
+    // type fedora
+    await userEvent.type(inputBox, 'fedora');
+
+    // Get the run button and click on it
+    const runBtn = getByRole('button', { name: 'Pull Image and Run' });
+    expect(runBtn).toBeEnabled();
+
+    const { promise } = Promise.withResolvers<void>();
+    vi.mocked(window.pullImage).mockReturnValue(promise);
+
+    await userEvent.click(runBtn);
+
+    // the dropdown should be disabled while we are pulling the image
+    await vi.waitFor(() => {
+      expect(dropdown).toBeDisabled();
+    });
+  });
 });

--- a/packages/renderer/src/lib/container/CreateContainerFromExistingImage.spec.ts
+++ b/packages/renderer/src/lib/container/CreateContainerFromExistingImage.spec.ts
@@ -236,6 +236,18 @@ test('Expect no user input to show only local images', async () => {
   expect(items.length).toBe(6);
 });
 
+test('window#listImages should not be call without a selected container connection', async () => {
+  const { getByPlaceholderText } = render(CreateContainerFromExistingImage);
+
+  const inputBox = getByPlaceholderText('Select or enter an image to run');
+  expect(inputBox).toBeEnabled();
+
+  expect(window.listImages).toHaveBeenCalledOnce();
+  expect(window.listImages).toHaveBeenCalledWith({
+    provider: pInfo,
+  });
+});
+
 describe('container connections', () => {
   // create a dummy multi connection provider
   const MULTI_CONNECTIONS: ProviderInfo = {

--- a/packages/renderer/src/lib/container/CreateContainerFromExistingImage.svelte
+++ b/packages/renderer/src/lib/container/CreateContainerFromExistingImage.svelte
@@ -165,6 +165,7 @@ async function gotoManageRegistries(): Promise<void> {
 }
 
 onMount(() => {
+  // Select default connection
   if (!selectedProviderConnection) {
     selectedProviderConnection = providerConnections.length > 0 ? providerConnections[0] : undefined;
   }
@@ -303,6 +304,9 @@ async function buildContainerFromImage(): Promise<void> {
 }
 
 async function searchFunction(value: string): Promise<void> {
+  // do not search for images if no connection is selected
+  if (!selectedProviderConnection) return;
+
   value = value.trim();
   const localImagesValues = await searchLocalImages(value);
   const remoteImagesValues = await searchImages(value);

--- a/packages/renderer/src/lib/container/CreateContainerFromExistingImage.svelte
+++ b/packages/renderer/src/lib/container/CreateContainerFromExistingImage.svelte
@@ -371,9 +371,9 @@ function onContainerConnectionChange(): void {
           resultItems={values}
           compare={sortResults}
           onChange={async (s: string): Promise<void> => {
-          validateImageName(s);
-          await resolveShortname();
-          await searchLatestTag();
+            validateImageName(s);
+            await resolveShortname();
+            await searchLatestTag();
         }}
           onEnter={onEnterOperation}
           disabled={pullFinished || pullInProgress}

--- a/packages/renderer/src/lib/container/CreateContainerFromExistingImage.svelte
+++ b/packages/renderer/src/lib/container/CreateContainerFromExistingImage.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
 import { faArrowCircleDown, faCircleCheck, faCog, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
-import { Button, Checkbox, Dropdown, ErrorMessage, Tooltip } from '@podman-desktop/ui-svelte';
+import { Button, Checkbox, ErrorMessage, Tooltip } from '@podman-desktop/ui-svelte';
 import type { Terminal } from '@xterm/xterm';
 import { onMount, tick } from 'svelte';
 import Fa from 'svelte-fa';
 import { router } from 'tinro';
 
+import ContainerConnectionDropdown from '/@/lib/forms/ContainerConnectionDropdown.svelte';
 import { ImageUtils } from '/@/lib/image/image-utils';
 import RecommendedRegistry from '/@/lib/image/RecommendedRegistry.svelte';
 import ImageIcon from '/@/lib/images/ImageIcon.svelte';
@@ -17,6 +18,7 @@ import WarningMessage from '/@/lib/ui/WarningMessage.svelte';
 import { lastPage } from '/@/stores/breadcrumb';
 import { providerInfos } from '/@/stores/providers';
 import { runImageInfo } from '/@/stores/run-image-store';
+import type { ImageInfo } from '/@api/image-info';
 import type { ImageSearchOptions } from '/@api/image-registry';
 import type { ProviderContainerConnectionInfo } from '/@api/provider-info';
 import type { PullEvent } from '/@api/pull-event';
@@ -222,7 +224,9 @@ async function searchImages(value: string): Promise<string[]> {
 }
 
 async function searchLocalImages(value: string): Promise<string[]> {
-  const listImages = await window.listImages();
+  const listImages: ImageInfo[] = await window.listImages({
+    provider: $state.snapshot(selectedProviderConnection),
+  });
   const localImagesNames = listImages.map(image => {
     if (image.RepoTags) {
       return image.RepoTags;
@@ -277,7 +281,11 @@ async function buildContainerFromImage(): Promise<void> {
     let [registry, imageName] = imageToPull.split('/');
     dockerLibraryImage = `${registry}/library/${imageName}`;
   }
-  const localImages = (await window.listImages()).filter(
+  const localImages = (
+    await window.listImages({
+      provider: $state.snapshot(selectedProviderConnection),
+    })
+  ).filter(
     image =>
       (
         image.RepoTags?.filter(repoTag =>
@@ -332,6 +340,13 @@ async function onEnterOperation(): Promise<void> {
     await pullImageAndRun();
   }
 }
+
+function onContainerConnectionChange(): void {
+  // reset values
+  values = [];
+  matchingLocalImages = [];
+  imageToPull = '';
+}
 </script>
 
 <EngineFormPage title="Select an image">
@@ -343,23 +358,25 @@ async function onEnterOperation(): Promise<void> {
   </svelte:fragment>
   <div slot="content" class="space-y-2 flex flex-col">
     <div class="flex flex-col">
-      <Typeahead
-        id="imageName"
-        name="imageName"
-        placeholder="Select or enter an image to run"
-        onInputChange={searchFunction}
-        resultItems={values}
-        compare={sortResults}
-        onChange={async (s: string): Promise<void> => {
+      {#key selectedProviderConnection}
+        <Typeahead
+          id="imageName"
+          name="imageName"
+          placeholder="Select or enter an image to run"
+          onInputChange={searchFunction}
+          resultItems={values}
+          compare={sortResults}
+          onChange={async (s: string): Promise<void> => {
           validateImageName(s);
           await resolveShortname();
           await searchLatestTag();
         }}
-        onEnter={onEnterOperation}
-        disabled={pullFinished || pullInProgress}
-        error={!isValidName}
-        required
-        initialFocus />
+          onEnter={onEnterOperation}
+          disabled={pullFinished || pullInProgress}
+          error={!isValidName}
+          required
+          initialFocus />
+      {/key}
       {#if selectedProviderConnection?.type === 'podman' && podmanFQN && !matchingLocalImages.includes(podmanFQN)}
         <div class="absolute mt-2 ml-[-18px] self-start">
           <Tooltip tip="Shortname images will be pulled from Docker Hub" topRight>
@@ -383,21 +400,19 @@ async function onEnterOperation(): Promise<void> {
       <div class="pt-4">
         <label for="providerChoice" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]"
           >Container Engine</label>
-        <Dropdown
+        <ContainerConnectionDropdown
           id="providerChoice"
           name="providerChoice"
+          onchange={onContainerConnectionChange}
           bind:value={selectedProviderConnection}
-          options={providerConnections.map(providerConnection => ({
-            label: providerConnection.name,
-            value: providerConnection,
-          }))}>
-        </Dropdown>
+          connections={providerConnections}
+          disabled={pullFinished || pullInProgress}/>
       </div>
     {/if}
     {#if providerConnections.length === 1}
       <input type="hidden" name="providerChoice" readonly bind:value={selectedProviderConnection} />
     {/if}
-  
+
     <footer>
       <div class="w-full flex flex-col justify-end gap-3 my-3">
         <div class="flex flex-row">


### PR DESCRIPTION
### What does this PR do?

Following https://github.com/podman-desktop/podman-desktop/pull/11700, fixes the `CreateContainerFromExisting.svelte` page when having multiple connections

### Screenshot / video of UI

https://github.com/user-attachments/assets/6bd0ad56-d2dc-4d83-9192-dac7a4d68cdf

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/11697

Required for
- https://github.com/podman-desktop/podman-desktop/pull/11693 (current sprint)

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

**Manually**

1. assert - have at least 2 connections 
2. Go to _containers_ page 
3. Click on `Create`
4. Click on `Existing Image`
5. Select any image and run it
6. Repeat but change for another connections
7. assert the container is running on the appropriate machine
