### PR TITLE
docs: adding an instruction to enable ip_tables

### DIFF
--- a/website/docs/kind/installing-extension.md
+++ b/website/docs/kind/installing-extension.md
@@ -27,3 +27,9 @@ The Kind extension provides the capability of creating a local Kubernetes cluste
 The following video provides a complete guide on creating a single-node cluster:
 
 <ReactPlayer playing playsinline controls url='https://github.com/containers/podman-desktop-media/raw/refs/heads/kind/video/cluster-creation-kind.mp4' width='100%' height='100%' />
+
+:::note
+
+If you are running Podman Desktop in a Linux system host and enabling the Contour ingress controller, you need to ensure that the `ip_tables` module is loaded, otherwise the `envoy` pod will fail to insert an iptable rule that it needs in order to be deployed (`/usr/sbin/iptables -t nat -S CNI-HOSTPORT-SETMARK 1 --wait`). To accomplish that, run the command `sudo modprobe ip_tables` to enable the required module, and then the command `lsmod | grep ip_tables` to check if it is enabled.
+
+:::


### PR DESCRIPTION
In a Linux system host, if you're enabling the Contour ingress controller while creating the kind cluster, and the `ip_tables` module is not enabled in the host system, the envoy pod will fail to be deployed with the following error message:

```
Failed to create pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox "xyz": plugin type="portmap" failed (add): unable to create chain CNI-HOSTPORT-SETMARK: failed to check iptables chain existence: running [/usr/sbin/iptables -t nat -S CNI-HOSTPORT-SETMARK 1 --wait]: exit status 3: modprobe: ERROR: could not insert 'ip_tables': Operation not permitted...
```

### What does this PR do?

Add an instruction the current documentation to enable the `ip_tables` module in a Linux system host when installing a `kind` cluster with the Contour ingress controller enabled.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

![Screenshot From 2025-03-17 17-57-35](https://github.com/user-attachments/assets/dbcdf1b7-af00-41a3-8510-3e6349bcfb24)

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
