### PR TITLE
chore: kind extension - use configuration name when deploying ingress

### DIFF
--- a/extensions/kind/src/create-cluster.spec.ts
+++ b/extensions/kind/src/create-cluster.spec.ts
@@ -29,6 +29,7 @@ import { getKindPath, getMemTotalInfo } from './util';
 vi.mock('node:fs', () => ({
   promises: {
     writeFile: vi.fn(),
+    readFile: vi.fn(),
     mkdtemp: vi.fn(),
     rm: vi.fn(),
   },
@@ -87,7 +88,7 @@ test('expect error is cli returns non zero exit code', async () => {
 
 test('expect cluster to be created', async () => {
   vi.mocked(getKindPath).mockReturnValue('/kind/path');
-  (extensionApi.process.exec as Mock).mockReturnValue({} as extensionApi.RunResult);
+  (extensionApi.process.exec as Mock).mockResolvedValue({} as extensionApi.RunResult);
   await createCluster({}, '', telemetryLoggerMock);
   expect(telemetryLogUsageMock).toHaveBeenNthCalledWith(
     1,
@@ -103,7 +104,7 @@ test('expect cluster to be created', async () => {
 });
 
 test('expect cluster to be created using config file', async () => {
-  (extensionApi.process.exec as Mock).mockReturnValue({} as extensionApi.RunResult);
+  vi.mocked(extensionApi.process.exec).mockResolvedValue({} as extensionApi.RunResult);
   const logger = {
     log: vi.fn(),
     error: vi.fn(),
@@ -120,7 +121,7 @@ test('expect cluster to be created using config file', async () => {
 });
 
 test('expect cluster to not call setupIngressController function when supplying config file and ingress is set to no', async () => {
-  (extensionApi.process.exec as Mock).mockReturnValue({} as extensionApi.RunResult);
+  vi.mocked(extensionApi.process.exec).mockResolvedValue({} as extensionApi.RunResult);
   const logger = {
     log: vi.fn(),
     error: vi.fn(),
@@ -143,7 +144,7 @@ test('expect cluster to not call setupIngressController function when supplying 
 });
 
 test('expect cluster to call ingress controller setup when ingress is set to yes AND a config is supplied', async () => {
-  (extensionApi.process.exec as Mock).mockReturnValue({} as extensionApi.RunResult);
+  vi.mocked(extensionApi.process.exec).mockResolvedValue({} as extensionApi.RunResult);
   const logger = {
     log: vi.fn(),
     error: vi.fn(),
@@ -175,7 +176,7 @@ test('expect cluster to call ingress controller setup when ingress is set to yes
 });
 
 test('expect cluster to use "name: foobar" within the yaml file when supplying a config file', async () => {
-  (extensionApi.process.exec as Mock).mockReturnValue({} as extensionApi.RunResult);
+  vi.mocked(extensionApi.process.exec).mockResolvedValue({} as extensionApi.RunResult);
   const logger = {
     log: vi.fn(),
     error: vi.fn(),
@@ -183,15 +184,16 @@ test('expect cluster to use "name: foobar" within the yaml file when supplying a
   };
 
   // Mock the fs readFileSync function to return a fake yaml file
-  vi.mocked(fs.readFileSync).mockReturnValue(`
+  vi.mocked(fs.promises.readFile).mockResolvedValue(
+    `
     apiVersion: kind.x-k8s.io/v1alpha4
     kind: Cluster
     name: foobar
     nodes:
     - role: control-plane
     - role: worker
-    - role: worker
-  `);
+    - role: worker`,
+  );
 
   // Supply the configuration file
   await createCluster(
@@ -218,7 +220,7 @@ test('expect cluster to use "name: foobar" within the yaml file when supplying a
 });
 
 test('expect cluster to be created with ingress', async () => {
-  (extensionApi.process.exec as Mock).mockReturnValue({} as extensionApi.RunResult);
+  vi.mocked(extensionApi.process.exec).mockResolvedValue({} as extensionApi.RunResult);
   const logger = {
     log: vi.fn(),
     error: vi.fn(),
@@ -234,7 +236,7 @@ test('expect cluster to be created with ingress', async () => {
 });
 
 test('expect cluster to be created with ports as strings', async () => {
-  (extensionApi.process.exec as Mock).mockReturnValue({} as extensionApi.RunResult);
+  vi.mocked(extensionApi.process.exec).mockResolvedValue({} as extensionApi.RunResult);
   const logger = {
     log: vi.fn(),
     error: vi.fn(),
@@ -271,7 +273,7 @@ test('expect cluster to be created with ports as strings', async () => {
 });
 
 test('expect cluster to be created with ports as numbers', async () => {
-  (extensionApi.process.exec as Mock).mockReturnValue({} as extensionApi.RunResult);
+  vi.mocked(extensionApi.process.exec).mockResolvedValue({} as extensionApi.RunResult);
   const logger = {
     log: vi.fn(),
     error: vi.fn(),
@@ -310,7 +312,7 @@ test('expect cluster to be created with ports as numbers', async () => {
 test('expect error if Kubernetes reports error', async () => {
   const error = new Error('Kubernetes error');
   try {
-    (extensionApi.process.exec as Mock).mockReturnValue({} as extensionApi.RunResult);
+    vi.mocked(extensionApi.process.exec).mockResolvedValue({} as extensionApi.RunResult);
     const logger = {
       log: vi.fn(),
       error: vi.fn(),

--- a/extensions/kind/src/create-cluster.spec.ts
+++ b/extensions/kind/src/create-cluster.spec.ts
@@ -88,7 +88,7 @@ test('expect error is cli returns non zero exit code', async () => {
 
 test('expect cluster to be created', async () => {
   vi.mocked(getKindPath).mockReturnValue('/kind/path');
-  (extensionApi.process.exec as Mock).mockResolvedValue({} as extensionApi.RunResult);
+  vi.mocked(extensionApi.process.exec).mockResolvedValue({} as extensionApi.RunResult);
   await createCluster({}, '', telemetryLoggerMock);
   expect(telemetryLogUsageMock).toHaveBeenNthCalledWith(
     1,

--- a/extensions/kind/src/create-cluster.spec.ts
+++ b/extensions/kind/src/create-cluster.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2024 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ vi.mock('node:fs', () => ({
     mkdtemp: vi.fn(),
     rm: vi.fn(),
   },
+  readFileSync: vi.fn(),
 }));
 
 vi.mock('@podman-desktop/api', async () => {
@@ -116,6 +117,104 @@ test('expect cluster to be created using config file', async () => {
   );
   expect(telemetryLogErrorMock).not.toBeCalled();
   expect(extensionApi.kubernetes.createResources).not.toBeCalled();
+});
+
+test('expect cluster to not call setupIngressController function when supplying config file and ingress is set to no', async () => {
+  (extensionApi.process.exec as Mock).mockReturnValue({} as extensionApi.RunResult);
+  const logger = {
+    log: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  };
+
+  // Supply the configuration file
+  await createCluster({ 'kind.cluster.creation.configFile': '/path' }, '', telemetryLoggerMock, logger);
+
+  // Expect us to call the exec function as normal
+  expect(telemetryLogUsageMock).toHaveBeenNthCalledWith(
+    1,
+    'createCluster',
+    expect.objectContaining({ provider: 'docker' }),
+  );
+  expect(telemetryLogErrorMock).not.toBeCalled();
+
+  // Expect create resources to NOT be called
+  expect(extensionApi.kubernetes.createResources).not.toBeCalled();
+});
+
+test('expect cluster to call ingress controller setup when ingress is set to yes AND a config is supplied', async () => {
+  (extensionApi.process.exec as Mock).mockReturnValue({} as extensionApi.RunResult);
+  const logger = {
+    log: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  };
+
+  // Supply the configuration file
+  await createCluster(
+    { 'kind.cluster.creation.configFile': '/path', 'kind.cluster.creation.ingress': 'on' },
+    '',
+    telemetryLoggerMock,
+    logger,
+  );
+
+  // Expect us to call the exec function as normal
+  expect(telemetryLogUsageMock).toHaveBeenNthCalledWith(
+    1,
+    'createCluster',
+    expect.objectContaining({ provider: 'docker' }),
+  );
+  expect(telemetryLogErrorMock).not.toBeCalled();
+
+  // Expect create resources to be called
+  expect(extensionApi.kubernetes.createResources).toBeCalled();
+
+  // Expect createResources to be called with `kind-kind` as the namespace since we are using a "fake"
+  // config file and there was no name supplied, so it should be using the default
+  expect(extensionApi.kubernetes.createResources).toBeCalledWith('kind-kind', expect.anything());
+});
+
+test('expect cluster to use "name: foobar" within the yaml file when supplying a config file', async () => {
+  (extensionApi.process.exec as Mock).mockReturnValue({} as extensionApi.RunResult);
+  const logger = {
+    log: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  };
+
+  // Mock the fs readFileSync function to return a fake yaml file
+  vi.mocked(fs.readFileSync).mockReturnValue(`
+    apiVersion: kind.x-k8s.io/v1alpha4
+    kind: Cluster
+    name: foobar
+    nodes:
+    - role: control-plane
+    - role: worker
+    - role: worker
+  `);
+
+  // Supply the configuration file
+  await createCluster(
+    { 'kind.cluster.creation.configFile': '/path', 'kind.cluster.creation.ingress': 'on' },
+    '',
+    telemetryLoggerMock,
+    logger,
+  );
+
+  // Expect us to call the exec function as normal
+  expect(telemetryLogUsageMock).toHaveBeenNthCalledWith(
+    1,
+    'createCluster',
+    expect.objectContaining({ provider: 'docker' }),
+  );
+
+  expect(telemetryLogErrorMock).not.toBeCalled();
+
+  // Expect create resources to be called
+  expect(extensionApi.kubernetes.createResources).toBeCalled();
+
+  // Expect `kind-foobar` to appear as the kind name in the createResources call
+  expect(extensionApi.kubernetes.createResources).toBeCalledWith('kind-foobar', expect.anything());
 });
 
 test('expect cluster to be created with ingress', async () => {

--- a/extensions/kind/src/create-cluster.ts
+++ b/extensions/kind/src/create-cluster.ts
@@ -213,7 +213,7 @@ export async function createCluster(
     // Create ingress controller resources depending on whether a configFile was provided or not
 
     if (ingressController && configFile) {
-      const configClusterName = getClusterNameFromConfigFile(configFile);
+      const configClusterName = await getClusterNameFromConfigFile(configFile);
       logger?.log('Creating ingress controller from config file namespace: ', configClusterName);
       await setupIngressController(configClusterName);
     } else if (ingressController) {
@@ -243,8 +243,8 @@ export async function createCluster(
 
 // Function reads a path name, opens the yaml file and returns "name" from the kind configuration file
 // if no name is provided, we just use 'kind' which is the default.
-function getClusterNameFromConfigFile(configFilePath: string): string {
-  const configFile = fs.readFileSync(configFilePath, 'utf8');
+async function getClusterNameFromConfigFile(configFilePath: string): Promise<string> {
+  const configFile = await fs.promises.readFile(configFilePath, 'utf8');
 
   // We use parseAllDocument as there may be "multiple" yaml documents in the file,
   // we simply get the first name we find.

--- a/extensions/kind/src/create-cluster.ts
+++ b/extensions/kind/src/create-cluster.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -86,7 +86,8 @@ export async function connectionAuditor(provider: string, items: AuditRequestIte
   if (configFile) {
     records.push({
       type: 'warning',
-      record: 'By specifying a config file, all other options will be ignored.',
+      record:
+        'By specifying a config file, all other options will be ignored except for ingress controller deployment.',
     });
   }
 
@@ -208,8 +209,15 @@ export async function createCluster(
         token,
       },
     );
-    if (ingressController) {
-      logger?.log('Creating ingress controller resources');
+
+    // Create ingress controller resources depending on whether a configFile was provided or not
+
+    if (ingressController && configFile) {
+      const configClusterName = getClusterNameFromConfigFile(configFile);
+      logger?.log('Creating ingress controller from config file namespace: ', configClusterName);
+      await setupIngressController(configClusterName);
+    } else if (ingressController) {
+      logger?.log('Creating ingress controller resources on namespace: ', clusterName);
       await setupIngressController(clusterName);
     }
   } catch (error) {
@@ -231,4 +239,23 @@ export async function createCluster(
     // delete temporary directory/file
     await fs.promises.rm(tmpDirectory, { recursive: true });
   }
+}
+
+// Function reads a path name, opens the yaml file and returns "name" from the kind configuration file
+// if no name is provided, we just use 'kind' which is the default.
+function getClusterNameFromConfigFile(configFilePath: string): string {
+  const configFile = fs.readFileSync(configFilePath, 'utf8');
+
+  // We use parseAllDocument as there may be "multiple" yaml documents in the file,
+  // we simply get the first name we find.
+  const documents = parseAllDocuments(configFile);
+  for (const doc of documents) {
+    const config = doc.toJSON();
+    if (config && typeof config === 'object' && 'name' in config && typeof config.name === 'string') {
+      return config.name;
+    }
+  }
+
+  // If no name is found, we return the default name
+  return 'kind';
 }


### PR DESCRIPTION
chore: kind extension - use configuration name when deploying ingress

### What does this PR do?

When providing a configuration file and deploying an ingress, we should
be using the name from the configuration file regardless of other
options added above.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/podman-desktop/issues/11469

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

1. Deploy with yaml:

```
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
name: app-1-cluster
```

2. See that your contour ingress is added to `kind-app-1-cluster`. You
   can check by doing `kubectl get pods -A` and see that contour has
   been deployed.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
