### PR TITLE
chore: add setup podman-mac-helper to dashboard

### DIFF
--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -3298,3 +3298,72 @@ test('activate and autostart should not duplicate machines ', async () => {
   expect(podmanMachineListCalls).toBeLessThan(5);
   expect(promiseAutoStart).toBeDefined();
 });
+
+describe('podman-mac-helper tests', () => {
+  let contextMock: extensionApi.ExtensionContext;
+
+  beforeEach(() => {
+    // Make sure it's macOS only
+    vi.mocked(extensionApi.env).isMac = true;
+    vi.mocked(extensionApi.env).isWindows = false;
+    vi.mocked(extensionApi.env).isLinux = false;
+
+    // Mock the context
+    contextMock = {
+      subscriptions: [],
+      secrets: {
+        delete: vi.fn(),
+        get: vi.fn(),
+        onDidChange: vi.fn(),
+        store: vi.fn(),
+      },
+    } as unknown as extensionApi.ExtensionContext;
+
+    // Mock the get compatibility functionality.
+    // we just assume that it's false / not enabled by default to test the functionality.
+    vi.spyOn(compatibilityModeLib, 'getSocketCompatibility').mockReturnValue({
+      isEnabled: vi.fn(),
+      enable: vi.fn().mockReturnValue(false),
+      disable: vi.fn(),
+      details: '',
+      tooltipText: (): string => {
+        return '';
+      },
+    });
+  });
+
+  test('show setup podman mac helper notification if on mac and podman-mac-helper needs running', async () => {
+    // Activate
+    const api = await extension.activate(contextMock);
+    expect(api).toBeDefined();
+
+    // Make sure showNotification contains "body" as: "The Podman Mac Helper is not set up, some features might not function optimally.", ignore everything else.
+    expect(extensionApi.window.showNotification).toBeCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining(
+          'The Podman Mac Helper is not set up, some features might not function optimally.',
+        ),
+      }),
+    );
+  });
+
+  test('set do not show configuration setting to true, make sure notification is NOT shown', async () => {
+    // Set configuration to always be true
+    // mimicking the 'doNotShow' setting being true
+    const spyGetConfiguration = vi.spyOn(config, 'get');
+    spyGetConfiguration.mockReturnValue(true);
+
+    // Activate
+    const api = await extension.activate(contextMock);
+    expect(api).toBeDefined();
+
+    // Make sure showNotification is not shown at all.
+    expect(extensionApi.window.showNotification).not.toBeCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining(
+          'The Podman Mac Helper is not set up, some features might not function optimally.',
+        ),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
chore: add setup podman-mac-helper to dashboard

### What does this PR do?
* On mac, if we detect that socket forwarding has not been done, we will
  pose a notification to set it up
* When clicking enable, it will run the command to enable docker
  compatibility
* Notification will appear when podman machine is restarted or podman
  desktop is, etc. As long as "do not show" was not clicked.
* When clicking do not show again, it will save in configuration to
  never show the notification again.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->


https://github.com/user-attachments/assets/426cbb08-4812-4fab-9f6f-f4fabac60c99



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/podman-desktop/issues/11428

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

1. Disable docker compatibility
2. See that notification appears
3. Press enable
4. See it goes away after enabling
5. Disabling / enabling again will make the notification appear again as
   long as you do not press do not show again.
