### PR TITLE
refactor: rename docker compatibility setting info name

### DIFF
--- a/packages/api/src/docker-compatibility-info.ts
+++ b/packages/api/src/docker-compatibility-info.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-export enum ExperimentalSettings {
+export enum DockerCompatibilitySettings {
   SectionName = 'dockerCompatibility',
   Enabled = 'enabled',
 }

--- a/packages/main/src/plugin/docker/docker-compatibility.ts
+++ b/packages/main/src/plugin/docker/docker-compatibility.ts
@@ -22,7 +22,7 @@ import Dockerode from 'dockerode';
 
 import { isMac, isWindows } from '/@/util.js';
 import type { DockerSocketMappingStatusInfo, DockerSocketServerInfoType } from '/@api/docker-compatibility-info.js';
-import { ExperimentalSettings } from '/@api/docker-compatibility-info.js';
+import { DockerCompatibilitySettings } from '/@api/docker-compatibility-info.js';
 
 import type { ConfigurationRegistry, IConfigurationNode } from '../configuration-registry.js';
 import type { LibPod } from '../dockerode/libpod-dockerode.js';
@@ -32,7 +32,8 @@ export class DockerCompatibility {
   static readonly WINDOWS_NPIPE = '//./pipe/docker_engine';
   static readonly UNIX_SOCKET_PATH = '/var/run/docker.sock';
 
-  static readonly ENABLED_FULL_KEY = `${ExperimentalSettings.SectionName}.${ExperimentalSettings.Enabled}`;
+  static readonly ENABLED_FULL_KEY =
+    `${DockerCompatibilitySettings.SectionName}.${DockerCompatibilitySettings.Enabled}`;
 
   #configurationRegistry: ConfigurationRegistry;
 

--- a/packages/renderer/src/PreferencesNavigation.svelte
+++ b/packages/renderer/src/PreferencesNavigation.svelte
@@ -5,7 +5,7 @@ import { onMount } from 'svelte';
 import type { TinroRouteMeta } from 'tinro';
 
 import { CONFIGURATION_DEFAULT_SCOPE } from '/@api/configuration/constants.js';
-import { ExperimentalSettings } from '/@api/docker-compatibility-info';
+import { DockerCompatibilitySettings } from '/@api/docker-compatibility-info';
 
 import { configurationProperties } from './stores/configurationProperties';
 
@@ -28,7 +28,7 @@ let experimentalSection: boolean = $state(false);
 
 function updateDockerCompatibility(): void {
   window
-    .getConfigurationValue<boolean>(`${ExperimentalSettings.SectionName}.${ExperimentalSettings.Enabled}`)
+    .getConfigurationValue<boolean>(`${DockerCompatibilitySettings.SectionName}.${DockerCompatibilitySettings.Enabled}`)
     .then(result => {
       if (result !== undefined) {
         dockerCompatibilityEnabled = result;
@@ -36,7 +36,7 @@ function updateDockerCompatibility(): void {
     })
     .catch((err: unknown) =>
       console.error(
-        `Error getting configuration value ${ExperimentalSettings.SectionName}.${ExperimentalSettings.Enabled}`,
+        `Error getting configuration value ${DockerCompatibilitySettings.SectionName}.${DockerCompatibilitySettings.Enabled}`,
         err,
       ),
     );


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Renames the docker compatibility setting info name to not include experimental

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/11216

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
