### PR TITLE
chore: enable svelte/require-store-reactive-access rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -269,7 +269,6 @@ export default [
       'sonarjs/no-alphabetical-sort': 'off',
       'svelte/no-useless-children-snippet': 'off',
       'svelte/require-each-key': 'off',
-      'svelte/require-store-reactive-access': 'off',
       'svelte/no-reactive-literals': 'error',
     },
   },

--- a/packages/renderer/src/lib/ui/NavItem.svelte
+++ b/packages/renderer/src/lib/ui/NavItem.svelte
@@ -26,7 +26,7 @@ const navItems: Writable<number> = getContext('nav-items');
 $: tooltipText = counter ? `${tooltip} (${counter})` : tooltip;
 
 onMount(() => {
-  inSection = navItems !== undefined;
+  inSection = $navItems !== undefined;
   navItems?.update(i => i + 1);
 });
 onDestroy(() => {


### PR DESCRIPTION
chore: enable svelte/require-store-reactive-access rule

### What does this PR do?

Enables the rule by removing the `off` line in eslint.config.mjs 

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/podman-desktop/issues/11513

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

N/A

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
