### PR TITLE
refactor(podman): move `isVirtualMachineAvailable` function to `VirtalMachinePlatformCheck` class

### DIFF
--- a/extensions/podman/packages/extension/src/utils/podman-install.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-install.ts
@@ -644,11 +644,6 @@ class WinMemoryCheck extends BaseCheck {
   }
 }
 
-async function isVirtualMachineAvailable(): Promise<boolean> {
-  const client = await getPowerShellClient();
-  return client.isVirtualMachineAvailable();
-}
-
 async function isUserAdmin(): Promise<boolean> {
   const client = await getPowerShellClient();
   return client.isUserAdmin();
@@ -672,9 +667,14 @@ async function isHyperVRunning(): Promise<boolean> {
 export class VirtualMachinePlatformCheck extends BaseCheck {
   title = 'Virtual Machine Platform Enabled';
 
+  protected async isVirtualMachineAvailable(): Promise<boolean> {
+    const client = await getPowerShellClient();
+    return client.isVirtualMachineAvailable();
+  }
+
   async execute(): Promise<extensionApi.CheckResult> {
     try {
-      const result = await isVirtualMachineAvailable();
+      const result = await this.isVirtualMachineAvailable();
       if (result) {
         return this.createSuccessfulResult();
       }


### PR DESCRIPTION
### What does this PR do?

Following the work started on https://github.com/podman-desktop/podman-desktop/issues/10327 (refactoring the podman extension code). 

Let's start breaking down the `extensions/podman/packages/extension/src/utils/podman-install.ts` file, which is almost 1k lines, with 12 classes defined in it.

First step of simplifying this class, is to reduce coupling, the `isVirtualMachineAvailable` is globally defined, but only used in a single class, therefore moving it to `VirtualMachinePlatformCheck`.

Next step will be to extract the `VirtualMachinePlatformCheck` class from the `podman-install.ts` file and move it to `extensions/podman/packages/extension/src/checks/virtual-machine-platform-check.ts` as the class extend `BaseCheck`. 

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Related to https://github.com/podman-desktop/podman-desktop/issues/10327

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Existing tests ensure no regression
