### PR TITLE
fix: alignment in kubernetes name column

### DIFF
--- a/packages/renderer/src/lib/kube/column/Name.spec.ts
+++ b/packages/renderer/src/lib/kube/column/Name.spec.ts
@@ -44,6 +44,10 @@ test('Expect simple column styling', async () => {
   const name = screen.getByText(node.name);
   expect(name).toBeInTheDocument();
   expect(name).toHaveClass('text-[var(--pd-table-body-text-highlight)]');
+  expect(name).toHaveClass('overflow-hidden');
+  expect(name).toHaveClass('text-ellipsis');
+
+  expect(name.parentElement).toHaveClass('text-left');
 });
 
 test('Expect namespaced column styling', async () => {
@@ -52,9 +56,16 @@ test('Expect namespaced column styling', async () => {
   const name = screen.getByText(deployment.name);
   expect(name).toBeInTheDocument();
   expect(name).toHaveClass('text-[var(--pd-table-body-text-highlight)]');
+  expect(name).toHaveClass('overflow-hidden');
+  expect(name).toHaveClass('text-ellipsis');
+
+  expect(name.parentElement).toHaveClass('text-left');
 
   const namespace = screen.getByText(deployment.namespace);
   expect(namespace).toBeInTheDocument();
+  expect(namespace).toHaveClass('text-[var(--pd-table-body-text)]');
+  expect(namespace).toHaveClass('overflow-hidden');
+  expect(namespace).toHaveClass('text-ellipsis');
 });
 
 test('Expect clicking works', async () => {

--- a/packages/renderer/src/lib/kube/column/Name.svelte
+++ b/packages/renderer/src/lib/kube/column/Name.svelte
@@ -17,13 +17,13 @@ async function openDetails(): Promise<void> {
 }
 </script>
 
-<button class="hover:cursor-pointer flex flex-col max-w-full" onclick={openDetails}>
-  <div class="text-[var(--pd-table-body-text-highlight)] max-w-full overflow-hidden text-ellipsis">
+<button class="hover:cursor-pointer flex flex-col max-w-full text-left" onclick={openDetails}>
+  <div class="text-[var(--pd-table-body-text-highlight)] overflow-hidden text-ellipsis">
     {object.name}
   </div>
-  <div class="flex flex-row text-sm gap-1">
-    {#if isNamespaced(object)}
-      <div class="font-extra-light text-[var(--pd-table-body-text)]">{object.namespace}</div>
-    {/if}
-  </div>
+  {#if isNamespaced(object)}
+    <div class="text-[var(--pd-table-body-text)] font-extra-light text-sm overflow-hidden text-ellipsis">
+      {object.namespace}
+    </div>
+  {/if}
 </button>


### PR DESCRIPTION
### What does this PR do?

Adds text-left to parent, overflow+ellipsis to namespace, and simplified the structure of the Kubernetes name column, to avoid odd alignment or namespace getting cut off.

### Screenshot / video of UI

Before:

<img width="257" alt="Screenshot 2025-03-18 at 2 58 03 PM" src="https://github.com/user-attachments/assets/faf53dbf-cbce-45ed-8e38-08e6682d8c0d" />

After:

<img width="257" alt="Screenshot 2025-03-18 at 2 58 14 PM" src="https://github.com/user-attachments/assets/ca8fa3ad-6bb8-4f35-94af-af337f3b53a2" />

### What issues does this PR fix or reference?

Fixes #11731.

### How to test this PR?

Try namespaces that are shorter or longer and resize window to make sure it behaves better now.

- [x] Tests are covering the bug fix or the new feature