### PR TITLE
fix(extensions/kind): use correct types in download.ts

### DIFF
--- a/extensions/kind/scripts/download.ts
+++ b/extensions/kind/scripts/download.ts
@@ -19,8 +19,13 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { Octokit } from '@octokit/rest';
-import type { OctokitOptions, ReposGetContentResponseData, OctokitResponse } from '@octokit/core/dist-types/types';
+import { Octokit, RestEndpointMethodTypes } from '@octokit/rest';
+import type { OctokitResponse } from '@octokit/types';
+import type { OctokitOptions } from '@octokit/core/dist-types/types';
+type ReposGetContentResponseData = RestEndpointMethodTypes['repos']['getContent']['response']['data'] & {
+  encoding?: string;
+  content?: string;
+}; // these are not mentioned in the openapi-schema but in its example
 
 const CONTOUR_ORG = 'projectcontour';
 const CONTOUR_REPO = 'contour';


### PR DESCRIPTION
The typehints in the download-script for projectcontour introduced with 35d7c77bd484e9ebdba74395455bb66ea83dba7e are not working (anymore?). This PR fixes them.