### PR TITLE
feat(extensions/kind): update projectcontour to v1.30.2

### DIFF
--- a/extensions/kind/scripts/download.ts
+++ b/extensions/kind/scripts/download.ts
@@ -26,7 +26,7 @@ const CONTOUR_ORG = 'projectcontour';
 const CONTOUR_REPO = 'contour';
 const CONTOUR_DEPLOY_FILE = 'contour.yaml';
 const CONTOUR_DEPLOY_PATH = 'examples/render';
-const CONTOUR_VERSION = 'v1.30.1';
+const CONTOUR_VERSION = 'v1.30.2';
 
 const octokitOptions: OctokitOptions = {};
 if (process.env.GITHUB_TOKEN) {

--- a/extensions/kind/src/resources/contour.yaml
+++ b/extensions/kind/src/resources/contour.yaml
@@ -8923,7 +8923,7 @@ rules:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: contour-certgen-v1-30-1
+  name: contour-certgen-v1-30-2
   namespace: projectcontour
 spec:
   template:
@@ -8933,7 +8933,7 @@ spec:
     spec:
       containers:
       - name: contour
-        image: ghcr.io/projectcontour/contour:v1.30.1
+        image: ghcr.io/projectcontour/contour:v1.30.2
         imagePullPolicy: IfNotPresent
         command:
         - contour
@@ -9192,7 +9192,7 @@ spec:
         - --contour-key-file=/certs/tls.key
         - --config-path=/config/contour.yaml
         command: ["contour"]
-        image: ghcr.io/projectcontour/contour:v1.30.1
+        image: ghcr.io/projectcontour/contour:v1.30.2
         imagePullPolicy: IfNotPresent
         name: contour
         ports:
@@ -9276,7 +9276,7 @@ spec:
         args:
           - envoy
           - shutdown-manager
-        image: ghcr.io/projectcontour/contour:v1.30.1
+        image: ghcr.io/projectcontour/contour:v1.30.2
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -9297,7 +9297,7 @@ spec:
         - --log-level info
         command:
         - envoy
-        image: docker.io/envoyproxy/envoy:v1.31.3
+        image: docker.io/envoyproxy/envoy:v1.31.5
         imagePullPolicy: IfNotPresent
         name: envoy
         env:
@@ -9358,7 +9358,7 @@ spec:
         - --envoy-key-file=/certs/tls.key
         command:
         - contour
-        image: ghcr.io/projectcontour/contour:v1.30.1
+        image: ghcr.io/projectcontour/contour:v1.30.2
         imagePullPolicy: IfNotPresent
         name: envoy-initconfig
         volumeMounts:


### PR DESCRIPTION
`pnpm -C extensions/kind install:contour` (requires  #11733)

Update the manifestfile for installing projectcontour in the kind-extension to its current version which is [v1.30.2](https://github.com/projectcontour/contour/releases)