### PR TITLE
refactor(podman): extract VirtualMachinePlatformCheck class from `podman-install.ts`

### DIFF
--- a/extensions/podman/packages/extension/src/checks/virtual-machine-platform-check.spec.ts
+++ b/extensions/podman/packages/extension/src/checks/virtual-machine-platform-check.spec.ts
@@ -1,0 +1,83 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { process } from '@podman-desktop/api';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { VirtualMachinePlatformCheck } from './virtual-machine-platform-check';
+
+vi.mock('@podman-desktop/api', () => ({
+  process: {
+    exec: vi.fn(),
+  },
+}));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('expect winVirtualMachine preflight check return successful result if the virtual machine platform feature is enabled', async () => {
+  vi.mocked(process.exec).mockImplementation(() =>
+    Promise.resolve({
+      stdout: 'VirtualMachinePlatform',
+      stderr: '',
+      command: 'command',
+    }),
+  );
+
+  const winVirtualMachinePlatformCheck = new VirtualMachinePlatformCheck();
+  const result = await winVirtualMachinePlatformCheck.execute();
+  expect(process.exec).toBeCalledWith(expect.anything(), expect.arrayContaining([expect.anything()]), {
+    encoding: 'utf16le',
+  });
+  expect(result.successful).toBeTruthy();
+});
+
+test('expect winVirtualMachine preflight check return successful result if the virtual machine platform feature is disabled', async () => {
+  vi.mocked(process.exec).mockImplementation(() =>
+    Promise.resolve({
+      stdout: 'some message',
+      stderr: '',
+      command: 'command',
+    }),
+  );
+
+  const winVirtualMachinePlatformCheck = new VirtualMachinePlatformCheck();
+  const result = await winVirtualMachinePlatformCheck.execute();
+  expect(result.description).equal('Virtual Machine Platform should be enabled to be able to run Podman.');
+  expect(result.docLinksDescription).equal('Learn about how to enable the Virtual Machine Platform feature:');
+  expect(result.docLinks?.[0].url).equal(
+    'https://learn.microsoft.com/en-us/windows/wsl/install-manual#step-3---enable-virtual-machine-feature',
+  );
+  expect(result.docLinks?.[0].title).equal('Enable Virtual Machine Platform');
+});
+
+test('expect winVirtualMachine preflight check return successful result if there is an error when checking if virtual machine platform feature is enabled', async () => {
+  vi.mocked(process.exec).mockImplementation(() => {
+    throw new Error();
+  });
+
+  const winVirtualMachinePlatformCheck = new VirtualMachinePlatformCheck();
+  const result = await winVirtualMachinePlatformCheck.execute();
+  expect(result.description).equal('Virtual Machine Platform should be enabled to be able to run Podman.');
+  expect(result.docLinksDescription).equal('Learn about how to enable the Virtual Machine Platform feature:');
+  expect(result.docLinks?.[0].url).equal(
+    'https://learn.microsoft.com/en-us/windows/wsl/install-manual#step-3---enable-virtual-machine-feature',
+  );
+  expect(result.docLinks?.[0].title).equal('Enable Virtual Machine Platform');
+});

--- a/extensions/podman/packages/extension/src/checks/virtual-machine-platform-check.ts
+++ b/extensions/podman/packages/extension/src/checks/virtual-machine-platform-check.ts
@@ -1,0 +1,50 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type extensionApi from '@podman-desktop/api';
+
+import { getPowerShellClient } from '../utils/powershell';
+import { BaseCheck } from './base-check';
+
+export class VirtualMachinePlatformCheck extends BaseCheck {
+  title = 'Virtual Machine Platform Enabled';
+
+  protected async isVirtualMachineAvailable(): Promise<boolean> {
+    const client = await getPowerShellClient();
+    return client.isVirtualMachineAvailable();
+  }
+
+  async execute(): Promise<extensionApi.CheckResult> {
+    try {
+      const result = await this.isVirtualMachineAvailable();
+      if (result) {
+        return this.createSuccessfulResult();
+      }
+    } catch (err) {
+      // ignore error, this means that VirtualMachinePlatform not enabled
+    }
+    return this.createFailureResult({
+      description: 'Virtual Machine Platform should be enabled to be able to run Podman.',
+      docLinksDescription: 'Learn about how to enable the Virtual Machine Platform feature:',
+      docLinks: {
+        url: 'https://learn.microsoft.com/en-us/windows/wsl/install-manual#step-3---enable-virtual-machine-feature',
+        title: 'Enable Virtual Machine Platform',
+      },
+    });
+  }
+}

--- a/extensions/podman/packages/extension/src/utils/podman-install.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-install.spec.ts
@@ -30,7 +30,6 @@ import {
   getBundledPodmanVersion,
   HyperVCheck,
   PodmanInstall,
-  VirtualMachinePlatformCheck,
   WinInstaller,
   WSL2Check,
   WSLVersionCheck,
@@ -317,57 +316,6 @@ test('expect winMemory preflight check return failure result if the machine has 
   expect(result.docLinksDescription).toBeUndefined();
   expect(result.docLinks).toBeUndefined();
   expect(result.fixCommand).toBeUndefined();
-});
-
-test('expect winVirtualMachine preflight check return successful result if the virtual machine platform feature is enabled', async () => {
-  vi.spyOn(extensionApi.process, 'exec').mockImplementation(() =>
-    Promise.resolve({
-      stdout: 'VirtualMachinePlatform',
-      stderr: '',
-      command: 'command',
-    }),
-  );
-
-  const winVirtualMachinePlatformCheck = new VirtualMachinePlatformCheck();
-  const result = await winVirtualMachinePlatformCheck.execute();
-  expect(extensionApi.process.exec).toBeCalledWith(expect.anything(), expect.arrayContaining([expect.anything()]), {
-    encoding: 'utf16le',
-  });
-  expect(result.successful).toBeTruthy();
-});
-
-test('expect winVirtualMachine preflight check return successful result if the virtual machine platform feature is disabled', async () => {
-  vi.spyOn(extensionApi.process, 'exec').mockImplementation(() =>
-    Promise.resolve({
-      stdout: 'some message',
-      stderr: '',
-      command: 'command',
-    }),
-  );
-
-  const winVirtualMachinePlatformCheck = new VirtualMachinePlatformCheck();
-  const result = await winVirtualMachinePlatformCheck.execute();
-  expect(result.description).equal('Virtual Machine Platform should be enabled to be able to run Podman.');
-  expect(result.docLinksDescription).equal('Learn about how to enable the Virtual Machine Platform feature:');
-  expect(result.docLinks?.[0].url).equal(
-    'https://learn.microsoft.com/en-us/windows/wsl/install-manual#step-3---enable-virtual-machine-feature',
-  );
-  expect(result.docLinks?.[0].title).equal('Enable Virtual Machine Platform');
-});
-
-test('expect winVirtualMachine preflight check return successful result if there is an error when checking if virtual machine platform feature is enabled', async () => {
-  vi.spyOn(extensionApi.process, 'exec').mockImplementation(() => {
-    throw new Error();
-  });
-
-  const winVirtualMachinePlatformCheck = new VirtualMachinePlatformCheck();
-  const result = await winVirtualMachinePlatformCheck.execute();
-  expect(result.description).equal('Virtual Machine Platform should be enabled to be able to run Podman.');
-  expect(result.docLinksDescription).equal('Learn about how to enable the Virtual Machine Platform feature:');
-  expect(result.docLinks?.[0].url).equal(
-    'https://learn.microsoft.com/en-us/windows/wsl/install-manual#step-3---enable-virtual-machine-feature',
-  );
-  expect(result.docLinks?.[0].title).equal('Enable Virtual Machine Platform');
 });
 
 test('expect WSLVersion preflight check return fail result if wsl --version command fails its execution', async () => {

--- a/extensions/podman/packages/extension/src/utils/podman-install.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-install.ts
@@ -26,6 +26,7 @@ import { compare, compareVersions } from 'compare-versions';
 import { BaseCheck, OrCheck, SequenceCheck } from '../checks/base-check';
 import { getDetectionChecks } from '../checks/detection-checks';
 import { MacCPUCheck, MacMemoryCheck, MacPodmanInstallCheck, MacVersionCheck } from '../checks/macos-checks';
+import { VirtualMachinePlatformCheck } from '../checks/virtual-machine-platform-check';
 import { PodmanCleanupMacOS } from '../cleanup/podman-cleanup-macos';
 import { PodmanCleanupWindows } from '../cleanup/podman-cleanup-windows';
 import type { MachineJSON } from '../extension';
@@ -662,34 +663,6 @@ async function isHyperVInstalled(): Promise<boolean> {
 async function isHyperVRunning(): Promise<boolean> {
   const client = await getPowerShellClient();
   return client.isHyperVRunning();
-}
-
-export class VirtualMachinePlatformCheck extends BaseCheck {
-  title = 'Virtual Machine Platform Enabled';
-
-  protected async isVirtualMachineAvailable(): Promise<boolean> {
-    const client = await getPowerShellClient();
-    return client.isVirtualMachineAvailable();
-  }
-
-  async execute(): Promise<extensionApi.CheckResult> {
-    try {
-      const result = await this.isVirtualMachineAvailable();
-      if (result) {
-        return this.createSuccessfulResult();
-      }
-    } catch (err) {
-      // ignore error, this means that VirtualMachinePlatform not enabled
-    }
-    return this.createFailureResult({
-      description: 'Virtual Machine Platform should be enabled to be able to run Podman.',
-      docLinksDescription: 'Learn about how to enable the Virtual Machine Platform feature:',
-      docLinks: {
-        url: 'https://learn.microsoft.com/en-us/windows/wsl/install-manual#step-3---enable-virtual-machine-feature',
-        title: 'Enable Virtual Machine Platform',
-      },
-    });
-  }
 }
 
 export class WSL2Check extends BaseCheck {


### PR DESCRIPTION
### What does this PR do?

Following https://github.com/podman-desktop/podman-desktop/pull/11727, moving the `VirtualMachinePlatformCheck` class definition to its own file.

This class was extending the `BaseCheck` abstract class, so placing the new file to the `extensions/podman/packages/extension/src/checks` folder.

### Notes

- Moving the class to  `virtual-machine-platform-check.ts`
- Moving the related tests from `podman-install.spec` to  `virtual-machine-platform-check.spec.ts`

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
