### PR TITLE
refactor(status-bar): move providers logic to dedicated component

### DIFF
--- a/packages/renderer/src/lib/statusbar/Providers.spec.ts
+++ b/packages/renderer/src/lib/statusbar/Providers.spec.ts
@@ -1,0 +1,103 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import '@testing-library/jest-dom/vitest';
+
+import { render } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import Providers from '/@/lib/statusbar/Providers.svelte';
+import ProviderWidget from '/@/lib/statusbar/ProviderWidget.svelte';
+import { providerInfos } from '/@/stores/providers';
+import type {
+  ProviderContainerConnectionInfo,
+  ProviderInfo,
+  ProviderKubernetesConnectionInfo,
+} from '/@api/provider-info';
+
+// mock provider widget
+vi.mock(import('./ProviderWidget.svelte'));
+
+const EMPTY_PROVIDER_MOCK: ProviderInfo = {
+  name: 'empty-provider',
+  containerConnections: [],
+  kubernetesConnections: [],
+} as unknown as ProviderInfo;
+
+const CONTAINER_CONNECTION_MOCK: ProviderContainerConnectionInfo = {
+  name: 'container-connection',
+} as unknown as ProviderContainerConnectionInfo;
+
+const KUBERNETES_CONNECTION_MOCK: ProviderKubernetesConnectionInfo = {
+  name: 'kubernetes-connection',
+} as unknown as ProviderKubernetesConnectionInfo;
+
+const CONTAINER_PROVIDER_MOCK: ProviderInfo = {
+  ...EMPTY_PROVIDER_MOCK,
+  containerConnections: [CONTAINER_CONNECTION_MOCK],
+};
+
+const KUBERNETES_PROVIDER_MOCK: ProviderInfo = {
+  ...EMPTY_PROVIDER_MOCK,
+  kubernetesConnections: [KUBERNETES_CONNECTION_MOCK],
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  // reset the store
+  providerInfos.set([]);
+});
+
+test('no provider should not render any provider widget', () => {
+  render(Providers);
+
+  expect(ProviderWidget).not.toHaveBeenCalled();
+});
+
+test('provider without any connections should not be displayed', () => {
+  providerInfos.set([EMPTY_PROVIDER_MOCK]);
+
+  render(Providers);
+
+  expect(ProviderWidget).not.toHaveBeenCalled();
+});
+
+test('provider with container connection should be displayed', () => {
+  // mock two provider: one empty, and one with container connection
+  providerInfos.set([CONTAINER_PROVIDER_MOCK, EMPTY_PROVIDER_MOCK]);
+
+  render(Providers);
+
+  // should only render one
+  expect(ProviderWidget).toHaveBeenCalledOnce();
+  expect(ProviderWidget).toHaveBeenCalledWith(expect.anything(), {
+    entry: CONTAINER_PROVIDER_MOCK,
+  });
+});
+
+test('provider with kubernetes connection should be displayed', () => {
+  // mock two provider: one empty, and one with kubernetes connection
+  providerInfos.set([KUBERNETES_PROVIDER_MOCK, EMPTY_PROVIDER_MOCK]);
+
+  render(Providers);
+
+  // should only render one
+  expect(ProviderWidget).toHaveBeenCalledOnce();
+  expect(ProviderWidget).toHaveBeenCalledWith(expect.anything(), {
+    entry: KUBERNETES_PROVIDER_MOCK,
+  });
+});

--- a/packages/renderer/src/lib/statusbar/Providers.svelte
+++ b/packages/renderer/src/lib/statusbar/Providers.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+import { providerInfos } from '/@/stores/providers';
+import type { ProviderInfo } from '/@api/provider-info';
+
+import ProviderWidget from './ProviderWidget.svelte';
+
+let providers: ProviderInfo[] = $derived(
+  $providerInfos.filter(
+    provider => provider.containerConnections.length > 0 || provider.kubernetesConnections.length > 0,
+  ),
+);
+</script>
+
+{#each providers as entry}
+  <ProviderWidget entry={entry}/>
+{/each}

--- a/packages/renderer/src/lib/statusbar/StatusBar.svelte
+++ b/packages/renderer/src/lib/statusbar/StatusBar.svelte
@@ -3,20 +3,15 @@ import { onDestroy, onMount } from 'svelte';
 
 import TaskIndicator from '/@/lib/statusbar/TaskIndicator.svelte';
 import { onDidChangeConfiguration } from '/@/stores/configurationProperties';
-import { providerInfos } from '/@/stores/providers';
 import { statusBarEntries } from '/@/stores/statusbar';
 import { ExperimentalTasksSettings } from '/@api/tasks-preferences';
 
 import type { StatusBarEntry } from '../../../../main/src/plugin/statusbar/statusbar-registry';
-import ProviderWidget from './ProviderWidget.svelte';
+import Providers from './Providers.svelte';
 import StatusBarItem from './StatusBarItem.svelte';
 
 let leftEntries: StatusBarEntry[] = $state([]);
 let rightEntries: StatusBarEntry[] = $state([]);
-
-let containerProviders = $derived($providerInfos.filter(provider => provider.containerConnections.length > 0));
-
-let kubernetesProviders = $derived($providerInfos.filter(provider => provider.kubernetesConnections.length > 0));
 
 let experimentalTaskStatusBar: boolean = $state(false);
 let experimentalProvidersStatusBar: boolean = $state(false);
@@ -95,12 +90,7 @@ onDestroy(() => {
       <StatusBarItem entry={entry} />
     {/each}
     {#if experimentalProvidersStatusBar}
-      {#each containerProviders as entry}
-        <ProviderWidget entry={entry}/>
-      {/each}
-      {#each kubernetesProviders as entry}
-        <ProviderWidget entry={entry}/>
-      {/each}
+      <Providers/>
     {/if}
   </div>
   <div class="flex flex-wrap flex-row-reverse gap-x-1.5 h-full place-self-end">


### PR DESCRIPTION
### What does this PR do?

Simplifying the `StatusBar.svelte` component, as the pinning logic will add extra code, let's have a dedicated `Providers.svelte` component, to avoid having too much logic concentrated.

### Notes

- Moving the logic of selecting the providers to display in the `Providers` component
- Simplifying the tests in the `StatusBar.spec` to check for Providers to be renderer 
- Creating tests in `Providers.spec.ts` to ensure providers are properly displayed 
- Simplifying how providers where selected (single derived instead of two)

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Required for
- https://github.com/podman-desktop/podman-desktop/issues/9950

Following 
- https://github.com/podman-desktop/podman-desktop/pull/11701
- https://github.com/podman-desktop/podman-desktop/pull/11422

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x Tests are covering the bug fix or the new feature
