### PR TITLE
chore: api to change kubernetes namespace

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -2648,6 +2648,10 @@ export class PluginSystem {
       return kubernetesClient.getCurrentNamespace();
     });
 
+    this.ipcHandle('kubernetes-client:setCurrentNamespace', async (_listener, namespace: string): Promise<void> => {
+      return kubernetesClient.setCurrentNamespace(namespace);
+    });
+
     this.ipcHandle(
       'kubernetes-client:deleteContext',
       async (_listener, contextName: string): Promise<KubernetesContext[]> => {

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
@@ -117,7 +117,7 @@ class TestKubernetesClient extends KubernetesClient {
     return super.createWatchObject();
   }
 
-  public setCurrentNamespace(namespace: string): void {
+  public setInitialNamespace(namespace: string): void {
     this.currentNamespace = namespace;
   }
 
@@ -258,7 +258,7 @@ class TestKubernetesClient extends KubernetesClient {
 function createTestClient(namespace?: string): TestKubernetesClient {
   const client = new TestKubernetesClient(apiSender, configurationRegistry, fileSystemMonitoring, telemetry);
   if (namespace) {
-    client.setCurrentNamespace(namespace);
+    client.setInitialNamespace(namespace);
   }
   return client;
 }
@@ -520,6 +520,31 @@ test('test that blank kubeconfig path will be set to default one', async () => {
   const kubeconfigPath = Uri.file(resolve(homedir(), '.kube', 'config'));
   // Should be default kubeconfigpath
   expect(setKubeconfigSpy).toBeCalledWith(kubeconfigPath);
+});
+
+test('test that setting current namespace updates namespace but not kubeconfig', async () => {
+  const initialNS = 'fooNS';
+  const client = createTestClient(initialNS);
+
+  KubeConfig.prototype.contexts = [
+    {
+      name: 'foo',
+      cluster: 'cluster',
+      namespace: initialNS,
+      user: 'user',
+    },
+  ];
+  KubeConfig.prototype.loadFromOptions = vi.fn();
+
+  const newNS = 'new-ns';
+  await client.setCurrentNamespace(newNS);
+
+  // current namespace is changed and event is triggered
+  expect(client.getCurrentNamespace()).toEqual(newNS);
+  expect(apiSenderSendMock).toHaveBeenCalledWith('kubernetes-context-update');
+
+  // but context namespace is unchanged
+  expect(client.getContexts()[0]?.namespace).toEqual(initialNS);
 });
 
 test('should throw error if cannot call the cluster (readNamespacedDeployment reject)', async () => {

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1906,6 +1906,10 @@ export function initExposure(): void {
     return ipcInvoke('kubernetes-client:getCurrentNamespace');
   });
 
+  contextBridge.exposeInMainWorld('kubernetesSetCurrentNamespace', async (namespace: string): Promise<void> => {
+    return ipcInvoke('kubernetes-client:setCurrentNamespace', namespace);
+  });
+
   contextBridge.exposeInMainWorld(
     'kubernetesListNamespacedPod',
     async (namespace: string, fieldSelector?: string, labelSelector?: string): Promise<V1PodList> => {


### PR DESCRIPTION
### What does this PR do?

Adds new function to allow the user to change the Kubernetes namespace on the current context and updates state, but without modifying the kubeconfig. Logic is similar to what happens in the refresh() method, and exposed to renderer.

Existing function on the TestKubernetesClient renamed due to conflict and test confirms that the namespace is updated and event fired without modifying kubeconfig.

This will support a UI allowing the user to quickly switch namespaces from Kubernetes resource pages.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

First part of #11274.

### How to test this PR?

UI will be updated in future PR, just PR checks and code review for now.

- [x] Tests are covering the bug fix or the new feature