### PR TITLE
feat: register VM provider connection

### DIFF
--- a/packages/main/src/plugin/provider-registry.spec.ts
+++ b/packages/main/src/plugin/provider-registry.spec.ts
@@ -64,9 +64,13 @@ class TestProviderRegistry extends ProviderRegistry {
   getKubernetesProviders(): Map<string, KubernetesProviderConnection> {
     return this.kubernetesProviders;
   }
+  getVmProviders(): Map<string, VmProviderConnection> {
+    return this.vmProviders;
+  }
 }
 
 beforeEach(() => {
+  vi.useRealTimers();
   vi.clearAllMocks();
   vi.restoreAllMocks();
   telemetryTrackMock.mockImplementation(() => Promise.resolve());
@@ -392,23 +396,109 @@ describe('a Kubernetes provider is registered', async () => {
   });
 });
 
-test('should register vm provider', async () => {
-  const provider = providerRegistry.createProvider('id', 'name', {
-    id: 'internal',
-    name: 'internal',
-    status: 'installed',
+describe('registerVmProviderConnection is called on ProviderImpl', async () => {
+  let provider: ProviderImpl;
+  let connection: VmProviderConnection;
+  let disposable: Disposable;
+
+  beforeEach(() => {
+    provider = providerRegistry.createProvider('id', 'name', {
+      id: 'internal',
+      name: 'internal',
+      status: 'installed',
+    }) as ProviderImpl;
+
+    connection = {
+      name: 'connection',
+      lifecycle: undefined,
+      status: (): ProviderConnectionStatus => 'started',
+    };
+
+    vi.spyOn(providerRegistry, 'registerVmConnection');
+    vi.spyOn(providerRegistry, 'onDidRegisterVmConnectionCallback');
+    vi.spyOn(providerRegistry, 'onDidUnregisterVmConnectionCallback');
+    disposable = provider.registerVmProviderConnection(connection);
   });
-  const connection: VmProviderConnection = {
-    name: 'connection',
-    lifecycle: undefined,
-    status: () => 'started',
-  };
 
-  providerRegistry.registerVmConnection(provider, connection);
+  test('registerVmConnection is called on registry and provider added to set', async () => {
+    expect(providerRegistry.registerVmConnection).toHaveBeenCalled();
+    expect(providerRegistry.onDidRegisterVmConnectionCallback).toHaveBeenCalled();
+    expect(provider.vmConnections).toHaveLength(1);
+  });
 
-  expect(telemetryTrackMock).toHaveBeenLastCalledWith('registerVmProviderConnection', {
-    name: 'connection',
-    total: 1,
+  test('should be removed from set when disposed', async () => {
+    disposable.dispose();
+    expect(provider.vmConnections).toHaveLength(0);
+    expect(providerRegistry.onDidUnregisterVmConnectionCallback).toHaveBeenCalled();
+  });
+});
+
+describe('a vm provider is registered', async () => {
+  let provider: Provider;
+  let disposable: Disposable;
+  let connection: VmProviderConnection;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    provider = providerRegistry.createProvider('id', 'name', {
+      id: 'internal',
+      name: 'internal',
+      status: 'installed',
+    });
+    connection = {
+      name: 'connection',
+      lifecycle: undefined,
+      status: (): ProviderConnectionStatus => 'started',
+    };
+
+    disposable = providerRegistry.registerVmConnection(provider, connection);
+  });
+
+  test('should send telemetry and be added to registry', async () => {
+    expect(telemetryTrackMock).toHaveBeenLastCalledWith('registerVmProviderConnection', {
+      name: 'connection',
+      total: 1,
+    });
+
+    expect(providerRegistry.getVmProviders().keys()).toContain('internal.connection');
+  });
+
+  test('should be removed from registry when disposed', async () => {
+    disposable.dispose();
+    expect(providerRegistry.getVmProviders().keys()).not.toContain('internal.connection');
+  });
+
+  test('should send provider-change when status of vm changes', async () => {
+    // status unchanged, do not send event
+    vi.advanceTimersByTime(2005);
+    expect(apiSenderSendMock).not.toHaveBeenCalledWith('provider-change', expect.anything());
+
+    connection.status = (): ProviderConnectionStatus => 'stopped';
+
+    // status changed, send event
+    vi.advanceTimersByTime(2000);
+    expect(apiSenderSendMock).toHaveBeenCalledWith('provider-change', {});
+  });
+
+  test('should send provider-change when vm provider disposed', async () => {
+    expect(apiSenderSendMock).not.toHaveBeenCalledWith('provider-change', expect.anything());
+
+    disposable.dispose();
+    expect(apiSenderSendMock).toHaveBeenCalledWith('provider-change', {});
+  });
+
+  test('should not send provider-change when vm provider disposed and status changes', async () => {
+    expect(apiSenderSendMock).not.toHaveBeenCalledWith('provider-change', expect.anything());
+
+    disposable.dispose();
+    expect(apiSenderSendMock).toHaveBeenCalledWith('provider-change', {});
+
+    apiSenderSendMock.mockClear();
+    connection.status = (): ProviderConnectionStatus => 'stopped';
+
+    // status changed, do not send event
+    vi.advanceTimersByTime(20_000);
+    expect(apiSenderSendMock).not.toHaveBeenCalledWith('provider-change', {});
   });
 });
 

--- a/packages/main/src/plugin/provider-registry.spec.ts
+++ b/packages/main/src/plugin/provider-registry.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2024 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ import type { ApiSenderType } from './api.js';
 import type { AutostartEngine } from './autostart-engine.js';
 import type { ContainerProviderRegistry } from './container-registry.js';
 import { LifecycleContextImpl } from './lifecycle-context.js';
-import type { ProviderImpl } from './provider-impl.js';
+import type { ProviderImpl, VmProviderConnection } from './provider-impl.js';
 import { ProviderRegistry } from './provider-registry.js';
 import type { Telemetry } from './telemetry/telemetry.js';
 import { Disposable } from './types/disposable.js';
@@ -389,6 +389,26 @@ describe('a Kubernetes provider is registered', async () => {
     // status changed, do not send event
     vi.advanceTimersByTime(20_000);
     expect(apiSenderSendMock).not.toHaveBeenCalledWith('provider-change', {});
+  });
+});
+
+test('should register vm provider', async () => {
+  const provider = providerRegistry.createProvider('id', 'name', {
+    id: 'internal',
+    name: 'internal',
+    status: 'installed',
+  });
+  const connection: VmProviderConnection = {
+    name: 'connection',
+    lifecycle: undefined,
+    status: () => 'started',
+  };
+
+  providerRegistry.registerVmConnection(provider, connection);
+
+  expect(telemetryTrackMock).toHaveBeenLastCalledWith('registerVmProviderConnection', {
+    name: 'connection',
+    total: 1,
   });
 });
 

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022-2024 Red Hat, Inc.
+ * Copyright (C) 2022-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,7 +64,7 @@ import type { ContainerProviderRegistry } from './container-registry.js';
 import type { Event } from './events/emitter.js';
 import { Emitter } from './events/emitter.js';
 import { LifecycleContextImpl, LoggerImpl } from './lifecycle-context.js';
-import { ProviderImpl } from './provider-impl.js';
+import { ProviderImpl, type VmProviderConnection } from './provider-impl.js';
 import type { Telemetry } from './telemetry/telemetry.js';
 import { Disposable } from './types/disposable.js';
 
@@ -79,6 +79,16 @@ export type ContainerConnectionProviderLifecycleListener = (
   providerInfo: ProviderInfo,
   providerContainerConnectionInfo: ProviderContainerConnectionInfo,
 ) => void;
+
+/*
+ * to be exposed in extension-api.d.ts
+ */
+export interface RegisterVmConnectionEvent {
+  providerId: string;
+}
+export interface UnregisterVmConnectionEvent {
+  providerId: string;
+}
 
 /**
  * Manage creation of providers and their lifecycle.
@@ -99,7 +109,7 @@ export class ProviderRegistry {
   private autostartEngine: AutostartEngine | undefined = undefined;
 
   private connectionLifecycleContexts: Map<
-    ContainerProviderConnection | KubernetesProviderConnection,
+    ContainerProviderConnection | KubernetesProviderConnection | VmProviderConnection,
     LifecycleContextImpl
   > = new Map();
   private listeners: ProviderEventListener[];
@@ -107,6 +117,7 @@ export class ProviderRegistry {
   private containerConnectionLifecycleListeners: ContainerConnectionProviderLifecycleListener[];
 
   protected kubernetesProviders: Map<string, KubernetesProviderConnection> = new Map();
+  private vmProviders: Map<string, VmProviderConnection> = new Map();
 
   private readonly _onDidUpdateProvider = new Emitter<ProviderEvent>();
   readonly onDidUpdateProvider: Event<ProviderEvent> = this._onDidUpdateProvider.event;
@@ -133,9 +144,15 @@ export class ProviderRegistry {
   readonly onDidUnregisterKubernetesConnection: Event<UnregisterKubernetesConnectionEvent> =
     this._onDidUnregisterKubernetesConnection.event;
 
+  private readonly _onDidUnregisterVmConnection = new Emitter<UnregisterVmConnectionEvent>();
+  readonly onDidUnregisterVmConnection: Event<UnregisterVmConnectionEvent> = this._onDidUnregisterVmConnection.event;
+
   private readonly _onDidRegisterKubernetesConnection = new Emitter<RegisterKubernetesConnectionEvent>();
   readonly onDidRegisterKubernetesConnection: Event<RegisterKubernetesConnectionEvent> =
     this._onDidRegisterKubernetesConnection.event;
+
+  private readonly _onDidRegisterVmConnection = new Emitter<RegisterVmConnectionEvent>();
+  readonly onDidRegisterVmConnection: Event<RegisterVmConnectionEvent> = this._onDidRegisterVmConnection.event;
 
   private readonly _onDidRegisterContainerConnection = new Emitter<RegisterContainerConnectionEvent>();
   readonly onDidRegisterContainerConnection: Event<RegisterContainerConnectionEvent> =
@@ -1177,6 +1194,12 @@ export class ProviderRegistry {
     this._onDidRegisterKubernetesConnection.fire({ providerId: provider.id });
   }
 
+  onDidRegisterVmConnectionCallback(provider: ProviderImpl, vmProviderConnection: VmProviderConnection): void {
+    this.connectionLifecycleContexts.set(vmProviderConnection, new LifecycleContextImpl());
+    this.apiSender.send('provider-register-vm-connection', { name: vmProviderConnection.name });
+    this._onDidRegisterVmConnection.fire({ providerId: provider.id });
+  }
+
   onDidChangeContainerProviderConnectionStatus(
     provider: ProviderImpl,
     containerConnection: ContainerProviderConnection,
@@ -1212,6 +1235,11 @@ export class ProviderRegistry {
   ): void {
     this.apiSender.send('provider-unregister-kubernetes-connection', { name: kubernetesProviderConnection.name });
     this._onDidUnregisterKubernetesConnection.fire({ providerId: provider.id });
+  }
+
+  onDidUnregisterVmConnectionCallback(provider: ProviderImpl, vmProviderConnection: VmProviderConnection): void {
+    this.apiSender.send('provider-unregister-vm-connection', { name: vmProviderConnection.name });
+    this._onDidUnregisterVmConnection.fire({ providerId: provider.id });
   }
 
   onDidUpdateProviderStatus(providerId: string, callback: (providerInfo: ProviderInfo) => void): void {
@@ -1269,6 +1297,33 @@ export class ProviderRegistry {
     return Disposable.create(() => {
       clearInterval(timer);
       this.kubernetesProviders.delete(id);
+      this.apiSender.send('provider-change', {});
+    });
+  }
+
+  registerVmConnection(provider: Provider, vmProviderConnection: VmProviderConnection): Disposable {
+    const providerName = vmProviderConnection.name;
+    const id = `${provider.id}.${providerName}`;
+    this.vmProviders.set(id, vmProviderConnection);
+    this.telemetryService.track('registerVmProviderConnection', {
+      name: vmProviderConnection.name,
+      total: this.vmProviders.size,
+    });
+
+    let previousStatus = vmProviderConnection.status();
+
+    // track the status of the provider
+    const timer = setInterval(() => {
+      const newStatus = vmProviderConnection.status();
+      if (newStatus !== previousStatus) {
+        this.apiSender.send('provider-change', {});
+        previousStatus = newStatus;
+      }
+    }, 2000);
+
+    // listen to events
+    return Disposable.create(() => {
+      clearInterval(timer);
       this.apiSender.send('provider-change', {});
     });
   }

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -117,7 +117,7 @@ export class ProviderRegistry {
   private containerConnectionLifecycleListeners: ContainerConnectionProviderLifecycleListener[];
 
   protected kubernetesProviders: Map<string, KubernetesProviderConnection> = new Map();
-  private vmProviders: Map<string, VmProviderConnection> = new Map();
+  protected vmProviders: Map<string, VmProviderConnection> = new Map();
 
   private readonly _onDidUpdateProvider = new Emitter<ProviderEvent>();
   readonly onDidUpdateProvider: Event<ProviderEvent> = this._onDidUpdateProvider.event;
@@ -1321,9 +1321,9 @@ export class ProviderRegistry {
       }
     }, 2000);
 
-    // listen to events
     return Disposable.create(() => {
       clearInterval(timer);
+      this.vmProviders.delete(id);
       this.apiSender.send('provider-change', {});
     });
   }


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Add a method `registerVmProviderConnection` to `provider-impl` to register VM provider connection (to be exposed later in `extension-api.t.ts` in `Provider` interface)

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of #11744 

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
