### PR TITLE
feat: add control to change the kubernetes namespace

### DIFF
--- a/packages/renderer/src/lib/kube/KubernetesDashboard.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesDashboard.svelte
@@ -32,6 +32,7 @@ import deployAndTestKubernetesImage from './DeployAndTestKubernetes.png';
 import KubernetesDashboardGuideCard from './KubernetesDashboardGuideCard.svelte';
 import KubernetesDashboardResourceCard from './KubernetesDashboardResourceCard.svelte';
 import KubernetesEmptyPage from './KubernetesEmptyPage.svelte';
+import NamespaceDropdown from './NamespaceDropdown.svelte';
 import shareYourLocalProdmanImagesWithTheKubernetesImage from './ShareYourLocalPodmanImagesWithTheKubernetes.png';
 import workingWithKubernetesImage from './WorkingWithKubernetes.png';
 
@@ -208,7 +209,10 @@ async function openKubernetesDocumentation(): Promise<void> {
             <div class="flex flex-col gap-4 bg-[var(--pd-content-card-bg)] grow p-5">
               {#if currentContextName}
                 <!-- Metrics - non-collapsible -->
-                <div class="text-xl pt-2">Metrics</div>
+                <div class="flex flex-row">
+                  <div class="text-xl pt-2 grow">Metrics</div>
+                  <div class="justify-end"><NamespaceDropdown/></div>
+                </div>
                 <div class="grid grid-cols-4 gap-4">
                     <KubernetesDashboardResourceCard type='Nodes' activeCount={activeCounts.nodes} count={counts.nodes} permitted={isPermitted(notPermittedResources, 'nodes')} kind='Node'/>
                     <KubernetesDashboardResourceCard type='Deployments' activeCount={activeCounts.deployments} count={counts.deployments} permitted={isPermitted(notPermittedResources, 'deployments')} kind='Deployment'/>

--- a/packages/renderer/src/lib/kube/NamespaceDropdown.spec.ts
+++ b/packages/renderer/src/lib/kube/NamespaceDropdown.spec.ts
@@ -1,0 +1,113 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import type { V1NamespaceList } from '@kubernetes/client-node';
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { writable } from 'svelte/store';
+import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
+
+import * as kubernetesContextsStateStore from '/@/stores/kubernetes-contexts-state';
+import type { ContextGeneralState } from '/@api/kubernetes-contexts-states';
+
+import NamespaceDropdown from './NamespaceDropdown.svelte';
+
+const firstNS = 'ns1';
+const secondNS = 'ns2';
+
+vi.mock('/@/stores/kubernetes-contexts-state');
+
+beforeAll(() => {
+  vi.mocked(window.kubernetesListNamespaces).mockResolvedValue({
+    items: [
+      {
+        metadata: {
+          name: firstNS,
+        },
+      },
+      {
+        metadata: {
+          name: secondNS,
+        },
+      },
+    ],
+  } as V1NamespaceList);
+  vi.mocked(window.kubernetesGetCurrentNamespace).mockResolvedValue(firstNS);
+  vi.mocked(window.kubernetesSetCurrentNamespace).mockResolvedValue();
+  vi.mocked(kubernetesContextsStateStore).kubernetesCurrentContextState = writable<ContextGeneralState>({
+    reachable: true,
+    resources: { pods: 0, deployments: 0 },
+  });
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test('Expect basic styling', async () => {
+  render(NamespaceDropdown);
+
+  await waitFor(() => expect(screen.queryByText('Namespace:')).toBeInTheDocument());
+
+  const dropdown = screen.getByLabelText('Kubernetes Namespace');
+  expect(dropdown).toBeInTheDocument();
+  expect(dropdown).toHaveClass('w-56 max-w-56');
+});
+
+test('Expect namespaces are in the dropdown', async () => {
+  render(NamespaceDropdown);
+
+  await waitFor(() => expect(screen.queryByText(firstNS)).toBeInTheDocument());
+
+  const dropdown = screen.getByRole('button');
+  expect(dropdown).toBeInTheDocument();
+  expect(dropdown.textContent).toContain(firstNS);
+
+  // open the dropdown
+  await fireEvent.click(dropdown);
+
+  // first namespace is in the original button and in the dropdown
+  const item1 = screen.getAllByRole('button', { name: firstNS });
+  expect(item1.length).toEqual(2);
+
+  // second namespace is also clickable
+  const item2 = screen.getByRole('button', { name: secondNS });
+  expect(item2).toBeInTheDocument();
+});
+
+test('Expect clicking works', async () => {
+  render(NamespaceDropdown);
+
+  await waitFor(() => expect(screen.queryByText(firstNS)).toBeInTheDocument());
+
+  const dropdown = screen.getByRole('button');
+  expect(dropdown).toBeInTheDocument();
+  expect(dropdown.textContent).toContain(firstNS);
+
+  // open the dropdown
+  await fireEvent.click(dropdown);
+
+  const item = screen.getByRole('button', { name: secondNS });
+  expect(item).toBeInTheDocument();
+
+  // select the new namspace
+  await fireEvent.click(item);
+
+  await waitFor(() => expect(window.kubernetesSetCurrentNamespace).toHaveBeenCalledWith(secondNS));
+});

--- a/packages/renderer/src/lib/kube/NamespaceDropdown.spec.ts
+++ b/packages/renderer/src/lib/kube/NamespaceDropdown.spec.ts
@@ -110,4 +110,5 @@ test('Expect clicking works', async () => {
   await fireEvent.click(item);
 
   await waitFor(() => expect(window.kubernetesSetCurrentNamespace).toHaveBeenCalledWith(secondNS));
+  expect(window.telemetryTrack).toHaveBeenCalledWith('kubernetes.set.namespace');
 });

--- a/packages/renderer/src/lib/kube/NamespaceDropdown.svelte
+++ b/packages/renderer/src/lib/kube/NamespaceDropdown.svelte
@@ -4,11 +4,11 @@ import { Dropdown } from '@podman-desktop/ui-svelte';
 import { kubernetesCurrentContextState } from '/@/stores/kubernetes-contexts-state';
 
 let namespacesPromise = $derived.by(async () => {
-  return $kubernetesCurrentContextState.reachable ? await window.kubernetesListNamespaces() : undefined;
+  return $kubernetesCurrentContextState?.reachable ? await window.kubernetesListNamespaces() : undefined;
 });
 
 let currentNamespacePromise = $derived.by(async () => {
-  return $kubernetesCurrentContextState.reachable ? await window.kubernetesGetCurrentNamespace() : '';
+  return $kubernetesCurrentContextState?.reachable ? await window.kubernetesGetCurrentNamespace() : '';
 });
 
 async function handleNamespaceChange(value: unknown): Promise<void> {
@@ -24,7 +24,7 @@ async function handleNamespaceChange(value: unknown): Promise<void> {
   name="namespace"
   class="w-56 max-w-56"
   value={currentNamespace}
-  disabled={!$kubernetesCurrentContextState.reachable}
+  disabled={!$kubernetesCurrentContextState?.reachable}
   onChange={handleNamespaceChange}
   options={namespaces?.items?.map(namespace => ({
     label: namespace.metadata?.name ?? '',

--- a/packages/renderer/src/lib/kube/NamespaceDropdown.svelte
+++ b/packages/renderer/src/lib/kube/NamespaceDropdown.svelte
@@ -13,7 +13,11 @@ let currentNamespacePromise = $derived.by(async () => {
 
 async function handleNamespaceChange(value: unknown): Promise<void> {
   const namespace = String(value);
-  await window.kubernetesSetCurrentNamespace(namespace);
+  try {
+    await window.kubernetesSetCurrentNamespace(namespace);
+  } finally {
+    await window.telemetryTrack('kubernetes.set.namespace');
+  }
 }
 </script>
 

--- a/packages/renderer/src/lib/kube/NamespaceDropdown.svelte
+++ b/packages/renderer/src/lib/kube/NamespaceDropdown.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+import { Dropdown } from '@podman-desktop/ui-svelte';
+
+import { kubernetesCurrentContextState } from '/@/stores/kubernetes-contexts-state';
+
+let namespacesPromise = $derived.by(async () => {
+  return $kubernetesCurrentContextState.reachable ? await window.kubernetesListNamespaces() : undefined;
+});
+
+let currentNamespacePromise = $derived.by(async () => {
+  return $kubernetesCurrentContextState.reachable ? await window.kubernetesGetCurrentNamespace() : '';
+});
+
+async function handleNamespaceChange(value: unknown): Promise<void> {
+  const namespace = String(value);
+  await window.kubernetesSetCurrentNamespace(namespace);
+}
+</script>
+
+{#await currentNamespacePromise then currentNamespace}
+{#await namespacesPromise then namespaces}
+<Dropdown
+  ariaLabel="Kubernetes Namespace"
+  name="namespace"
+  class="w-56 max-w-56"
+  value={currentNamespace}
+  disabled={!$kubernetesCurrentContextState.reachable}
+  onChange={handleNamespaceChange}
+  options={namespaces?.items?.map(namespace => ({
+    label: namespace.metadata?.name ?? '',
+    value: namespace.metadata?.name ?? '',
+  }))}>
+  {#snippet left()}
+  <div class="mr-1 text-[var(--pd-input-field-placeholder-text)]">Namespace:</div>
+  {/snippet}
+</Dropdown>
+{/await}
+{/await}

--- a/packages/renderer/src/lib/objects/KubernetesObjectsList.svelte
+++ b/packages/renderer/src/lib/objects/KubernetesObjectsList.svelte
@@ -11,6 +11,7 @@ import type { IDisposable } from '/@api/disposable.js';
 
 import { withBulkConfirmation } from '../actions/BulkActions';
 import KubeActions from '../kube/KubeActions.svelte';
+import NamespaceDropdown from '../kube/NamespaceDropdown.svelte';
 import KubernetesCurrentContextConnectionBadge from '../ui/KubernetesCurrentContextConnectionBadge.svelte';
 import type { KubernetesObjectUI } from './KubernetesObjectUI';
 
@@ -129,6 +130,9 @@ let table: Table;
   </svelte:fragment>
 
   <svelte:fragment slot="bottom-additional-actions">
+    {#if kinds[0].resource !== 'nodes'}
+      <NamespaceDropdown/>
+    {/if}
     {#if selectedItemsNumber > 0}
       <Button
         on:click={(): void =>


### PR DESCRIPTION
### What does this PR do?

Creates a new namespace dropdown that shows the currently accessible namespaces
and allows you to change it. This dropdown is added to the Kubernetes Dashboard
and every Kubernetes list page (except Nodes).

### Screenshot / video of UI

https://github.com/user-attachments/assets/95f29481-c1ba-4b01-9dc9-d939bd273a15

### What issues does this PR fix or reference?

Fixes #11274.

### How to test this PR?

Go to the Kubernetes Dashboard and several resource pages, changing the namespace as you go.

- [x] Tests are covering the bug fix or the new feature