### PR TITLE
fix: remove Kubernetes provider from map when disposed

### DIFF
--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -106,7 +106,7 @@ export class ProviderRegistry {
   private lifecycleListeners: ProviderLifecycleListener[];
   private containerConnectionLifecycleListeners: ContainerConnectionProviderLifecycleListener[];
 
-  private kubernetesProviders: Map<string, KubernetesProviderConnection> = new Map();
+  protected kubernetesProviders: Map<string, KubernetesProviderConnection> = new Map();
 
   private readonly _onDidUpdateProvider = new Emitter<ProviderEvent>();
   readonly onDidUpdateProvider: Event<ProviderEvent> = this._onDidUpdateProvider.event;
@@ -1268,6 +1268,7 @@ export class ProviderRegistry {
     // listen to events
     return Disposable.create(() => {
       clearInterval(timer);
+      this.kubernetesProviders.delete(id);
       this.apiSender.send('provider-change', {});
     });
   }


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Remove Kubernetes provider from map when disposed

+1 for sourcery-ai: https://github.com/podman-desktop/podman-desktop/pull/11755#discussion_r2003926592

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Related to #11744 

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
