### PR TITLE
test(e2e): added number of expected objects in stress test's case names

### DIFF
--- a/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
+++ b/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
@@ -33,7 +33,7 @@ test.afterAll(async ({ runner }) => {
 });
 
 test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui-stress'] }, () => {
-  test(`Verification of ` + (numberOfObjects + 2) + ` images`, async ({ navigationBar }) => {
+  test(`Verification of ${numberOfObjects + 2} images`, async ({ navigationBar }) => {
     test.setTimeout(300_000);
 
     const images = await navigationBar.openImages();
@@ -47,7 +47,7 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
     }
   });
 
-  test(`Verification of ` + 3 * numberOfObjects + ` containers`, async ({ navigationBar }) => {
+  test(`Verification of  ${3 * numberOfObjects} containers`, async ({ navigationBar }) => {
     test.setTimeout(300_000);
 
     const containers = await navigationBar.openContainers();
@@ -63,7 +63,7 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
     }
   });
 
-  test(`Verification of ` + numberOfObjects + ` pods`, async ({ navigationBar }) => {
+  test(`Verification of ${numberOfObjects} pods`, async ({ navigationBar }) => {
     test.setTimeout(300_000);
 
     const pods = await navigationBar.openPods();

--- a/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
+++ b/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
@@ -33,7 +33,7 @@ test.afterAll(async ({ runner }) => {
 });
 
 test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui-stress'] }, () => {
-  test(`Verification of images`, async ({ navigationBar }) => {
+  test(`Verification of ` + numberOfObjects + 2 + ` images`, async ({ navigationBar }) => {
     test.setTimeout(300_000);
 
     const images = await navigationBar.openImages();
@@ -47,7 +47,7 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
     }
   });
 
-  test(`Verification of containers`, async ({ navigationBar }) => {
+  test(`Verification of ` + 3 * numberOfObjects + ` containers`, async ({ navigationBar }) => {
     test.setTimeout(300_000);
 
     const containers = await navigationBar.openContainers();
@@ -63,7 +63,7 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
     }
   });
 
-  test(`Verification of pods`, async ({ navigationBar }) => {
+  test(`Verification of ` + numberOfObjects + ` pods`, async ({ navigationBar }) => {
     test.setTimeout(300_000);
 
     const pods = await navigationBar.openPods();

--- a/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
+++ b/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
@@ -33,7 +33,7 @@ test.afterAll(async ({ runner }) => {
 });
 
 test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui-stress'] }, () => {
-  test(`Verification of ` + numberOfObjects + 2 + ` images`, async ({ navigationBar }) => {
+  test(`Verification of ` + (numberOfObjects + 2) + ` images`, async ({ navigationBar }) => {
     test.setTimeout(300_000);
 
     const images = await navigationBar.openImages();


### PR DESCRIPTION
### What does this PR do?
This PR adds the number of expected objects in each test case of the ui-stress-test spec file for improved clarity while checking the results / debugging.

### What issues does this PR fix or reference?
https://github.com/podman-desktop/e2e/issues/327
https://github.com/podman-desktop/podman-desktop/issues/4836
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
Run `pnpm test:e2e:ui-stress`
