### PR TITLE
fix(frontend): status bar order

### DIFF
--- a/packages/renderer/src/lib/statusbar/StatusBar.svelte
+++ b/packages/renderer/src/lib/statusbar/StatusBar.svelte
@@ -86,12 +86,12 @@ onDestroy(() => {
   role="contentinfo"
   aria-label="Status Bar">
   <div class="flex flex-nowrap gap-x-1.5 h-full text-ellipsis whitespace-nowrap">
-    {#each leftEntries as entry}
-      <StatusBarItem entry={entry} />
-    {/each}
     {#if experimentalProvidersStatusBar}
       <Providers/>
     {/if}
+    {#each leftEntries as entry}
+      <StatusBarItem entry={entry} />
+    {/each}
   </div>
   <div class="flex flex-wrap flex-row-reverse gap-x-1.5 h-full place-self-end">
     {#each rightEntries as entry}


### PR DESCRIPTION
### What does this PR do?

Making the providers first on the status bar as per requested in https://github.com/podman-desktop/podman-desktop/issues/10920

### Screenshot / video of UI

| Before  | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/451f1ee1-1dcf-48d5-ad19-e4735d4e93d7) | ![image](https://github.com/user-attachments/assets/a0054bd1-6aba-4553-a2fe-70028add2829) |

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/10920

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
