### PR TITLE
feat(frontend): adding class props to provider widget

### DIFF
--- a/packages/renderer/src/lib/statusbar/ProviderWidget.spec.ts
+++ b/packages/renderer/src/lib/statusbar/ProviderWidget.spec.ts
@@ -108,3 +108,13 @@ test('Expect tooltip to include Kubernetes provider connections', () => {
   expect(screen.getByText(': connection 2')).toBeInTheDocument();
   expect(screen.getByText(': connection 3')).toBeInTheDocument();
 });
+
+test('class props should be propagated to button', async () => {
+  const { getByRole } = render(ProviderWidget, {
+    entry: providerMock,
+    class: 'potatoes',
+  });
+
+  const widget = getByRole('button', { name: 'provider1' });
+  expect(widget).toHaveClass('potatoes');
+});

--- a/packages/renderer/src/lib/statusbar/ProviderWidget.svelte
+++ b/packages/renderer/src/lib/statusbar/ProviderWidget.svelte
@@ -12,9 +12,15 @@ interface Props {
   entry: ProviderInfo;
   command?: () => void;
   disableTooltip?: boolean;
+  class?: string;
 }
 
-let { entry, command = (): void => router.goto('/preferences/resources'), disableTooltip = false }: Props = $props();
+let {
+  entry,
+  command = (): void => router.goto('/preferences/resources'),
+  disableTooltip = false,
+  class: className,
+}: Props = $props();
 
 let connections = $derived.by(() => {
   if (entry.containerConnections.length > 0) {
@@ -42,10 +48,10 @@ let connections = $derived.by(() => {
   </div>
   <Button
     on:click={command}
-    class="rounded-none gap-1 flex h-full min-w-fit items-center hover:bg-[var(--pd-statusbar-hover-bg)] hover:cursor-pointer relative text-base text-[var(--pd-button-text)] bg-transparent"
+    class="rounded-none gap-1 flex h-full min-w-fit items-center hover:bg-[var(--pd-statusbar-hover-bg)] hover:cursor-pointer relative text-base text-[var(--pd-button-text)] bg-transparent {className}"
     aria-label={entry.name}
     padding="px-2 py-1">
-    
+
     {#if entry.containerConnections.length > 0 || entry.kubernetesConnections.length > 0 || entry.status }
       <ProviderWidgetStatus entry={entry} />
     {/if}


### PR DESCRIPTION
### What does this PR do?

Adding a `class` prop to `ProviderWidget` component, to allow parent component to add styling to the button.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Required for https://github.com/podman-desktop/podman-desktop/pull/11036

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
