### PR TITLE
fix(renderer): status-bar min height

### DIFF
--- a/packages/renderer/src/lib/help/HelpMenu.svelte
+++ b/packages/renderer/src/lib/help/HelpMenu.svelte
@@ -5,7 +5,7 @@ let dropDownHeight: number;
 let dropDownWidth: number;
 let dropDownElement: HTMLElement;
 
-const STATUS_BAR_HEIGHT = 24;
+const STATUS_BAR_HEIGHT = 26;
 
 function updateMenuLocation(): void {
   dropDownElement.style.top = `${window.innerHeight - dropDownHeight - STATUS_BAR_HEIGHT}px`;
@@ -20,7 +20,7 @@ onMount(() => {
 onDestroy(() => window.removeEventListener('resize', updateMenuLocation));
 </script>
 
-<div 
+<div
   bind:offsetHeight={dropDownHeight}
   bind:offsetWidth={dropDownWidth}
   bind:this={dropDownElement}

--- a/packages/renderer/src/lib/statusbar/StatusBar.svelte
+++ b/packages/renderer/src/lib/statusbar/StatusBar.svelte
@@ -82,7 +82,7 @@ onDestroy(() => {
 </script>
 
 <div
-  class="flex justify-between px-1 bg-[var(--pd-statusbar-bg)] text-[var(--pd-statusbar-text)] text-sm space-x-2 z-40"
+  class="flex justify-between px-1 bg-[var(--pd-statusbar-bg)] min-h-[26px] text-[var(--pd-statusbar-text)] text-sm space-x-2 z-40"
   role="contentinfo"
   aria-label="Status Bar">
   <div class="flex flex-nowrap gap-x-1.5 h-full text-ellipsis whitespace-nowrap">


### PR DESCRIPTION
### What does this PR do?

While working on pin / unpin I noticed that the current status bar height is not defined anywhere, but a consequence of the font and icon of the entries.

The `ProviderWidget` has a height of 26 pixel, when we remove all of them we fallback on the previous 24, with a flickering. (See video bellow)

### Screenshot / video of UI

https://github.com/user-attachments/assets/e88fb85b-ba88-4e2d-a828-b7043bb3c054

### What issues does this PR fix or reference?

Required for
- https://github.com/podman-desktop/podman-desktop/issues/9950

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
