### PR TITLE
chore: clone kubeconfig instead of re-reading from disk

### DIFF
--- a/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
@@ -322,7 +322,8 @@ beforeAll(() => {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  KubeConfig.prototype.loadFromFile = vi.fn();
+  KubeConfig.prototype.loadFromString = vi.fn();
+  KubeConfig.prototype.exportConfig = vi.fn();
   KubeConfig.prototype.makeApiClient = makeApiClientMock;
   KubeConfig.prototype.getContextObject = getContextObjectMock;
   KubeConfig.prototype.currentContext = 'context';

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.ts
@@ -1189,12 +1189,12 @@ export class KubernetesClient {
     }
 
     try {
-      const ctx = new KubeConfig();
-      ctx.loadFromFile(this.kubeconfigPath);
-      ctx.currentContext = context;
+      const configCopy = new KubeConfig();
+      configCopy.loadFromString(this.kubeConfig.exportConfig());
+      configCopy.currentContext = context;
       const validSpecs = manifests.filter(s => isKubernetesObjectWithKindAndName(s));
 
-      const client = ctx.makeApiClient(KubernetesObjectApi);
+      const client = configCopy.makeApiClient(KubernetesObjectApi);
       const created: KubernetesObject[] = [];
       for (const spec of validSpecs) {
         // this is to convince TypeScript that metadata exists


### PR DESCRIPTION
### What does this PR do?

syncResources() (apply yaml) can apply to any context or namespace, so it needs a copy of the kubeconfig to avoid changing the user's current context. However, instead of re-reading the file from disk it can just clone the config, which should be marginally faster and safer. This code is copied directly from the same logic in the refresh() function.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Found during review for #11753.

### How to test this PR?

Just code review.

- [x] Tests are covering the bug fix or the new feature