### PR TITLE
fix: update tooltip position for first provider in statusbar

### DIFF
--- a/packages/renderer/src/lib/statusbar/ProviderWidget.svelte
+++ b/packages/renderer/src/lib/statusbar/ProviderWidget.svelte
@@ -13,6 +13,7 @@ interface Props {
   command?: () => void;
   disableTooltip?: boolean;
   class?: string;
+  tooltipTopRight?: boolean;
 }
 
 let {
@@ -20,6 +21,7 @@ let {
   command = (): void => router.goto('/preferences/resources'),
   disableTooltip = false,
   class: className,
+  tooltipTopRight = false,
 }: Props = $props();
 
 let connections = $derived.by(() => {
@@ -33,7 +35,7 @@ let connections = $derived.by(() => {
 });
 </script>
 
-<Tooltip top class="mb-[20px]">
+<Tooltip top={!tooltipTopRight} topRight={tooltipTopRight} class="mb-[20px]">
   <div slot="tip" class="py-2 px-4" hidden={disableTooltip}>
     <div class="flex flex-col">
       {#each connections as connection}

--- a/packages/renderer/src/lib/statusbar/Providers.spec.ts
+++ b/packages/renderer/src/lib/statusbar/Providers.spec.ts
@@ -86,6 +86,7 @@ test('provider with container connection should be displayed', () => {
   expect(ProviderWidget).toHaveBeenCalledOnce();
   expect(ProviderWidget).toHaveBeenCalledWith(expect.anything(), {
     entry: CONTAINER_PROVIDER_MOCK,
+    tooltipTopRight: true,
   });
 });
 
@@ -99,5 +100,21 @@ test('provider with kubernetes connection should be displayed', () => {
   expect(ProviderWidget).toHaveBeenCalledOnce();
   expect(ProviderWidget).toHaveBeenCalledWith(expect.anything(), {
     entry: KUBERNETES_PROVIDER_MOCK,
+    tooltipTopRight: true,
+  });
+});
+
+test('Expect first provider to have a top right tooltip', () => {
+  providerInfos.set([CONTAINER_PROVIDER_MOCK, KUBERNETES_PROVIDER_MOCK]);
+
+  render(Providers);
+
+  expect(ProviderWidget).toHaveBeenNthCalledWith(1, expect.anything(), {
+    entry: CONTAINER_PROVIDER_MOCK,
+    tooltipTopRight: true,
+  });
+  expect(ProviderWidget).toHaveBeenNthCalledWith(2, expect.anything(), {
+    entry: KUBERNETES_PROVIDER_MOCK,
+    tooltipTopRight: false,
   });
 });

--- a/packages/renderer/src/lib/statusbar/Providers.svelte
+++ b/packages/renderer/src/lib/statusbar/Providers.svelte
@@ -11,6 +11,6 @@ let providers: ProviderInfo[] = $derived(
 );
 </script>
 
-{#each providers as entry}
-  <ProviderWidget entry={entry}/>
+{#each providers as entry, i}
+  <ProviderWidget entry={entry} tooltipTopRight={i === 0}/>
 {/each}


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR updates the tooltip of the first provider in the statusbar to have a top right position so that it won't be cut off by the window

### Screenshot / video of UI
<img width="244" alt="Screenshot 2025-03-21 at 6 06 58 PM" src="https://github.com/user-attachments/assets/9b15d2cb-5e9a-4d3b-beed-b5011942a849" />


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Fixes https://github.com/podman-desktop/podman-desktop/issues/11780

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
