### PR TITLE
fix(storybook/expandable): enable rule no-useless-children-snippet and fix one violation

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -267,7 +267,6 @@ export default [
       'unicorn/prefer-node-protocol': 'off',
       'sonarjs/no-nested-assignment': 'off',
       'sonarjs/no-alphabetical-sort': 'off',
-      'svelte/no-useless-children-snippet': 'off',
       'svelte/require-each-key': 'off',
       'svelte/no-reactive-literals': 'error',
     },

--- a/storybook/src/stories/Expandable.stories.svelte
+++ b/storybook/src/stories/Expandable.stories.svelte
@@ -26,9 +26,6 @@ setTemplate(template);
     {#snippet title()}
       Title
     {/snippet}
-    <!-- eslint-disable-next-line sonarjs/no-unused-vars -->
-    {#snippet children()}
-      Children
-    {/snippet}
+    Children
   </Expandable>
 </Story>


### PR DESCRIPTION
### What does this PR do?

This PR enables eslint no-usless-childern-snippet rule and fixes one violation.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fix #11507.

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
