### PR TITLE
refactor(ProviderWidget): split component in two

### DIFF
--- a/packages/renderer/src/lib/statusbar/ProviderButton.spec.ts
+++ b/packages/renderer/src/lib/statusbar/ProviderButton.spec.ts
@@ -1,0 +1,69 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import '@testing-library/jest-dom/vitest';
+
+import type { ProviderStatus } from '@podman-desktop/api';
+import { render } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import IconImage from '/@/lib/appearance/IconImage.svelte';
+import ProviderButton from '/@/lib/statusbar/ProviderButton.svelte';
+import type { ProviderInfo } from '/@api/provider-info';
+
+vi.mock(import('/@/lib/statusbar/ProviderWidgetStatus.svelte'));
+vi.mock(import('/@/lib/appearance/IconImage.svelte'));
+
+const PROVIDER_MOCK = {
+  name: 'provider1',
+  containerConnections: [],
+  kubernetesConnections: [],
+  status: 'ready' as ProviderStatus,
+  images: {
+    icon: 'my-nice-icon',
+  },
+} as unknown as ProviderInfo;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('class props should be propagated to button', async () => {
+  const { getByRole } = render(ProviderButton, {
+    provider: PROVIDER_MOCK,
+    onclick: vi.fn(),
+    class: 'potatoes',
+  });
+
+  const widget = getByRole('button', { name: 'provider1' });
+  expect(widget).toHaveClass('potatoes');
+});
+
+test('provider with an image should render it', async () => {
+  render(ProviderButton, {
+    provider: PROVIDER_MOCK,
+    onclick: vi.fn(),
+    class: 'potatoes',
+  });
+
+  expect(IconImage).toHaveBeenCalledWith(
+    expect.anything(),
+    expect.objectContaining({
+      image: PROVIDER_MOCK.images.icon,
+    }),
+  );
+});

--- a/packages/renderer/src/lib/statusbar/ProviderButton.svelte
+++ b/packages/renderer/src/lib/statusbar/ProviderButton.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-import { Button } from '@podman-desktop/ui-svelte';
-
 import IconImage from '/@/lib/appearance/IconImage.svelte';
 import ProviderWidgetStatus from '/@/lib/statusbar/ProviderWidgetStatus.svelte';
 import type { ProviderInfo } from '/@api/provider-info';
@@ -14,11 +12,10 @@ interface Props {
 let { provider, onclick, class: className }: Props = $props();
 </script>
 
-<Button
+<button
   on:click={onclick}
-  class="rounded-none gap-1 flex h-full min-w-fit items-center hover:bg-[var(--pd-statusbar-hover-bg)] hover:cursor-pointer relative text-base text-[var(--pd-button-text)] bg-transparent {className}"
-  aria-label={provider.name}
-  padding="px-2 py-1">
+  class="px-1 py-px flex flex-row h-full items-center gap-1 min-w-fit hover:bg-[var(--pd-statusbar-hover-bg)] hover:cursor-pointer relative {className}"
+  aria-label={provider.name}>
   {#if provider.containerConnections.length > 0 || provider.kubernetesConnections.length > 0 || provider.status }
     <ProviderWidgetStatus entry={provider} />
   {/if}
@@ -28,4 +25,4 @@ let { provider, onclick, class: className }: Props = $props();
   {#if provider.name}
     <span class="whitespace-nowrap h-fit">{provider.name}</span>
   {/if}
-</Button>
+</button>

--- a/packages/renderer/src/lib/statusbar/ProviderButton.svelte
+++ b/packages/renderer/src/lib/statusbar/ProviderButton.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+import { Button } from '@podman-desktop/ui-svelte';
+
+import IconImage from '/@/lib/appearance/IconImage.svelte';
+import ProviderWidgetStatus from '/@/lib/statusbar/ProviderWidgetStatus.svelte';
+import type { ProviderInfo } from '/@api/provider-info';
+
+interface Props {
+  provider: ProviderInfo;
+  onclick: () => void;
+  class?: string;
+}
+
+let { provider, onclick, class: className }: Props = $props();
+</script>
+
+<Button
+  on:click={onclick}
+  class="rounded-none gap-1 flex h-full min-w-fit items-center hover:bg-[var(--pd-statusbar-hover-bg)] hover:cursor-pointer relative text-base text-[var(--pd-button-text)] bg-transparent {className}"
+  aria-label={provider.name}
+  padding="px-2 py-1">
+  {#if provider.containerConnections.length > 0 || provider.kubernetesConnections.length > 0 || provider.status }
+    <ProviderWidgetStatus entry={provider} />
+  {/if}
+  {#if provider.images.icon}
+    <IconImage image={provider.images.icon} class="max-h-3 grayscale" alt={provider.name}></IconImage>
+  {/if}
+  {#if provider.name}
+    <span class="whitespace-nowrap h-fit">{provider.name}</span>
+  {/if}
+</Button>

--- a/packages/renderer/src/lib/statusbar/ProviderWidget.svelte
+++ b/packages/renderer/src/lib/statusbar/ProviderWidget.svelte
@@ -2,9 +2,9 @@
 import { Tooltip } from '@podman-desktop/ui-svelte';
 import { router } from 'tinro';
 
+import ProviderButton from '/@/lib/statusbar/ProviderButton.svelte';
 import type { ProviderInfo } from '/@api/provider-info';
 
-import IconImage from '../appearance/IconImage.svelte';
 import ProviderWidgetStatus from './ProviderWidgetStatus.svelte';
 import ProviderWidgetStatusStyle from './ProviderWidgetStatusStyle.svelte';
 
@@ -45,18 +45,9 @@ let connections = $derived.by(() => {
       {/each}
     </div>
   </div>
-  <button
+  <ProviderButton
+    class={className}
+    provider={entry}
     onclick={command}
-    class="px-1 py-px flex flex-row h-full items-center gap-1 min-w-fit hover:bg-[var(--pd-statusbar-hover-bg)] hover:cursor-pointer relative {className}"
-    aria-label={entry.name}>
-    {#if entry.containerConnections.length > 0 || entry.kubernetesConnections.length > 0 || entry.status }
-      <ProviderWidgetStatus entry={entry} />
-    {/if}
-    {#if entry.images.icon}
-      <IconImage image={entry.images.icon} class="max-h-3 grayscale" alt={entry.name}></IconImage>
-    {/if}
-    {#if entry.name}
-      <span class="whitespace-nowrap h-fit">{entry.name}</span>
-    {/if}
-  </button>
+  />
 </Tooltip>


### PR DESCRIPTION
### What does this PR do?

The `ProviderWidget.svelte` component has two main element, the tooltip and the button. In https://github.com/podman-desktop/podman-desktop/issues/9950 I need to have a menu with the provider button **and** a check icon.

![image](https://github.com/user-attachments/assets/8f674dbc-2433-4712-bda0-3498e433a17f)

To be able to do that, I don't need the full `ProviderWidget` comonent, but only the button logic.

In a follow-up PR I will add a slot to be able to add the `check` icon (needed for the pin / unpin indication)

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Required for
- https://github.com/podman-desktop/podman-desktop/issues/9950

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

cc @SoniaSandler since you worked a lot of this component
