### PR TITLE
fix: add delete confirmation dialog for Kubernetes Ingress/Routes resources

### DIFF
--- a/packages/renderer/src/lib/ingresses-routes/IngressDetails.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressDetails.spec.ts
@@ -19,7 +19,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { KubernetesObject, V1Ingress } from '@kubernetes/client-node';
-import { fireEvent, render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { router } from 'tinro';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -81,6 +81,7 @@ describe.each<{
   });
 
   test('Expect redirect to previous page if ingress is deleted', async () => {
+    vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
     const routerGotoSpy = vi.spyOn(router, 'goto');
 
     // mock object store
@@ -108,6 +109,11 @@ describe.each<{
     // click on delete button
     const deleteButton = screen.getByRole('button', { name: 'Delete Ingress' });
     await fireEvent.click(deleteButton);
+
+    expect(window.showMessageBox).toHaveBeenCalledOnce();
+
+    // Wait for confirmation modal to disappear after clicking on delete
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
 
     // check that delete method has been called
     expect(window.kubernetesDeleteIngress).toHaveBeenCalled();

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteActions.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteActions.svelte
@@ -2,6 +2,7 @@
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
 import { createEventDispatcher } from 'svelte';
 
+import { withConfirmation } from '../dialogs/messagebox-utils';
 import ListItemButtonIcon from '../ui/ListItemButtonIcon.svelte';
 import { IngressRouteUtils } from './ingress-route-utils';
 import type { IngressUI } from './IngressUI';
@@ -30,6 +31,10 @@ async function deleteIngressRoute(): Promise<void> {
 
 <ListItemButtonIcon
   title={`Delete ${ingressRouteUtils.isIngress(ingressRoute) ? 'Ingress' : 'Route'}`}
-  onClick={deleteIngressRoute}
+  onClick={(): void =>
+    withConfirmation(
+      deleteIngressRoute,
+      `delete ${ingressRouteUtils.isIngress(ingressRoute) ? 'ingress' : 'route'} ${ingressRoute.name}`,
+    )}
   detailed={detailed}
   icon={faTrash} />

--- a/packages/renderer/src/lib/ingresses-routes/RouteDetails.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/RouteDetails.spec.ts
@@ -19,7 +19,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { KubernetesObject } from '@kubernetes/client-node';
-import { fireEvent, render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { router } from 'tinro';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -96,6 +96,7 @@ describe.each<{
   });
 
   test('Expect redirect to previous page if route is deleted', async () => {
+    vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
     const routerGotoSpy = vi.spyOn(router, 'goto');
 
     // mock object store
@@ -123,6 +124,11 @@ describe.each<{
     // click on delete button
     const deleteButton = screen.getByRole('button', { name: 'Delete Route' });
     await fireEvent.click(deleteButton);
+
+    expect(window.showMessageBox).toHaveBeenCalledOnce();
+
+    // Wait for confirmation modal to disappear after clicking on delete
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
 
     // check that delete method has been called
     expect(window.kubernetesDeleteRoute).toHaveBeenCalled();


### PR DESCRIPTION

Signed-off-by: Anton Misskii <amisskii@redhat.com>

### What does this PR do?
Adds delete confirmation dialog for Kubernetes Ingress/Routes resources. Modifies unit tests.

### Screenshot / video of UI

[Screencast from 2025-03-24 11-54-52.webm](https://github.com/user-attachments/assets/40193deb-9889-4f12-a94a-f8331ee8ae20)
[Screencast from 2025-03-24 11-55-06.webm](https://github.com/user-attachments/assets/2665bfe5-4cf4-46d9-a6d9-2018d66963f2)


### What issues does this PR fix or reference?

https://github.com/podman-desktop/podman-desktop/issues/11751
https://github.com/podman-desktop/podman-desktop/issues/10695

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
