### PR TITLE
chore: add left snippet to dropdown

### DIFF
--- a/packages/ui/src/lib/dropdown/Dropdown.spec.ts
+++ b/packages/ui/src/lib/dropdown/Dropdown.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -176,4 +176,11 @@ test('value of hidden select component is updated based on Dropdown value', asyn
   hiddenInput = screen.getByLabelText('hidden input');
   expect(hiddenInput).toBeInTheDocument();
   expect(hiddenInput).toHaveValue('a');
+});
+
+test('Left snippet is renderered', async () => {
+  render(DropdownTest);
+
+  const left = screen.getByText('Left:');
+  expect(left).toBeInTheDocument();
 });

--- a/packages/ui/src/lib/dropdown/Dropdown.svelte
+++ b/packages/ui/src/lib/dropdown/Dropdown.svelte
@@ -18,6 +18,7 @@ let {
   class: className = '',
   ariaInvalid = false,
   ariaLabel = '',
+  left = undefined,
   children = undefined,
 }: {
   id?: string;
@@ -29,6 +30,7 @@ let {
   class?: string;
   ariaInvalid?: boolean | 'grammar' | 'spelling';
   ariaLabel?: string;
+  left?: Snippet;
   children?: Snippet;
 } = $props();
 
@@ -187,6 +189,7 @@ function onWindowClick(e: Event): void {
   aria-label={ariaLabel}
   aria-invalid={ariaInvalid}
   bind:this={comp}>
+  {@render left?.()}
   <button
     class="flex flex-row w-full outline-0 bg-[var(--pd-input-field-bg)] placeholder:text-[color:var(--pd-input-field-placeholder-text)] items-center text-start"
     class:text-[color:var(--pd-input-field-focused-text)]={!disabled}

--- a/packages/ui/src/lib/dropdown/DropdownTest.svelte
+++ b/packages/ui/src/lib/dropdown/DropdownTest.svelte
@@ -6,4 +6,7 @@ import Dropdown from './Dropdown.svelte';
   <option value="a">A</option>
   <option value="b">B</option>
   <option value="c">C</option>
+  {#snippet left()}
+  Left:
+  {/snippet}
 </Dropdown>


### PR DESCRIPTION
### What does this PR do?

See discussion in #11273 for details. Adds a left snippet to Dropdown, allowing downstream users to add an icon or text to the left identically to how we have a left snippet in Input for rendering the search icon or +/- number input.

The Kubernetes namespace dropdown would use this to add 'Namespace:' to the left. Bootc isn't using Dropdown yet, but the Build page has an icon to the left of it's dropdown and this would allow similar support.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of #11274.

### How to test this PR?

Just code review.

- [x] Tests are covering the bug fix or the new feature