### PR TITLE
chore(test): add ARIA labels to Check tab content on Image details page

### DIFF
--- a/packages/renderer/src/lib/image/ImageDetailsCheck.spec.ts
+++ b/packages/renderer/src/lib/image/ImageDetailsCheck.spec.ts
@@ -73,8 +73,8 @@ test('expect to display wait message before to receive results', async () => {
   });
 
   await vi.waitFor(() => {
-    const msg = screen.getByText(content => content.includes('Image analysis in progress'));
-    expect(msg).toBeInTheDocument();
+    const msg = screen.getByRole('status', { name: 'Analysis Status' });
+    expect(msg).toHaveTextContent('Image analysis in progress');
   });
 });
 
@@ -113,8 +113,8 @@ test('expect to cancel when clicking the Cancel button', async () => {
   });
 
   await vi.waitFor(() => {
-    const msg = screen.getByText(content => content.includes('Image analysis canceled'));
-    expect(msg).toBeInTheDocument();
+    const msg = screen.getByRole('status', { name: 'Analysis Status' });
+    expect(msg).toHaveTextContent('Image analysis canceled');
   });
 
   expect(cancelTokenSpy).toHaveBeenCalledWith(tokenID);
@@ -193,8 +193,8 @@ test('expect to not cancel again when destroying the component after manual canc
   });
 
   await vi.waitFor(() => {
-    const msg = screen.getByText(content => content.includes('Image analysis canceled'));
-    expect(msg).toBeInTheDocument();
+    const msg = screen.getByRole('status', { name: 'Analysis Status' });
+    expect(msg).toHaveTextContent('Image analysis canceled');
   });
 
   expect(cancelTokenSpy).toHaveBeenCalledWith(tokenID);
@@ -240,12 +240,12 @@ test('expect to display results from image checker provider', async () => {
   });
 
   await vi.waitFor(() => {
-    const msg = screen.getByText(content => content.includes('Image analysis complete'));
-    expect(msg).toBeInTheDocument();
+    const msg = screen.getByRole('status', { name: 'Analysis Status' });
+    expect(msg).toHaveTextContent('Image analysis complete');
   });
 
   await vi.waitFor(() => {
-    const cell = screen.getByText('check1');
+    const cell = screen.getByRole('row', { name: 'check1' });
     expect(cell).toBeInTheDocument();
   });
 });
@@ -286,7 +286,7 @@ test('expect to not cancel when destroying the component after displaying result
   });
 
   await vi.waitFor(() => {
-    const cell = screen.getByText('check1');
+    const cell = screen.getByRole('row', { name: 'check1' });
     expect(cell).toBeInTheDocument();
   });
 

--- a/packages/renderer/src/lib/image/ImageDetailsCheck.svelte
+++ b/packages/renderer/src/lib/image/ImageDetailsCheck.svelte
@@ -145,7 +145,7 @@ async function handleAbort(): Promise<void> {
 <ProviderResultPage providers={providers} results={results}>
   <!-- eslint-disable-next-line sonarjs/no-unused-vars -->
   {#snippet headerInfo()}
-  <div class="flex flex-row">
+  <div class="flex flex-row" role="status" aria-label="Analysis Status">
     <div class="w-full flex mb-4 space-x-4">
       <Fa size="1.5x" icon={faStethoscope} />
       {#if aborted}

--- a/packages/renderer/src/lib/ui/ProviderResultPage.spec.ts
+++ b/packages/renderer/src/lib/ui/ProviderResultPage.spec.ts
@@ -25,14 +25,22 @@ import { describe, expect, test } from 'vitest';
 import type { CheckUI, ProviderUI } from './ProviderResultPage';
 import ProviderResultPage from './ProviderResultPage.svelte';
 
+function findTargetRow(text: string): HTMLElement | undefined {
+  const rows = screen.getAllByRole('row');
+  // use the textContent to find the row
+  const targetRow = rows.find(row => row.textContent?.replace(/\s+/g, ' ').trim() === text);
+  return targetRow;
+}
+
 function checkResultDisplayed(result: CheckUI): void {
-  const res = screen.getByRole('row', { name: result.check.name + ' Reported by ' + result.provider.label });
-  expect(res).toBeInTheDocument();
+  const targetRow = findTargetRow(result.check.name + ' Reported by ' + result.provider.label);
+  expect(targetRow).toBeDefined();
 }
 
 function checkResultNotDisplayed(result: CheckUI): void {
-  const res = screen.queryByRole('row', { name: result.check.name + ' Reported by ' + result.provider.label });
-  expect(res).not.toBeInTheDocument();
+  const targetRow = findTargetRow(result.check.name + ' Reported by ' + result.provider.label);
+
+  expect(targetRow).toBeUndefined();
 }
 
 describe('test ProviderResultPage', async () => {

--- a/packages/renderer/src/lib/ui/ProviderResultPage.svelte
+++ b/packages/renderer/src/lib/ui/ProviderResultPage.svelte
@@ -109,7 +109,7 @@ function onSeverityClicked(severity: 'critical' | 'high' | 'medium' | 'low' | 's
   </div>
   <div class="mb-2 flex flex-row pr-12 pb-2">
     <span class="grow">Checkers</span>
-    <div>
+    <div role="group" aria-label="Severity Filters">
       <ToggleButtonGroup>
         <ToggleButton
           selected={true}
@@ -147,9 +147,9 @@ function onSeverityClicked(severity: 'critical' | 'high' | 'medium' | 'low' | 's
     </div>
   </div>
   <div class="h-full flex flex-row space-x-8">
-    <div class="h-full overflow-y-auto w-1/3">
+    <div class="h-full overflow-y-auto w-1/3" aria-label="Providers">
       {#each providers as provider (provider.info.id)}
-        <div role="row" class="rounded-lg bg-[var(--pd-content-bg)] mb-4 p-4 flex flex-col">
+        <div role="row" class="rounded-lg bg-[var(--pd-content-bg)] mb-4 p-4 flex flex-col" aria-label="{provider.info.label}" >
           <div class="flex flex-row items-center">
             <span class="grow">{provider.info.label}</span>
             {#if provider.state === 'running'}
@@ -173,25 +173,25 @@ function onSeverityClicked(severity: 'critical' | 'high' | 'medium' | 'low' | 's
             {/if}
           </div>
           {#if provider.error}
-            <div class="text-[var(--pd-state-error)] text-sm">{provider.error}</div>
+            <div class="text-[var(--pd-state-error)] text-sm" aria-label="Provider Error">{provider.error}</div>
           {/if}
           {#if provider.state === 'canceled'}
-            <div class="text-[var(--pd-content-text)] text-sm">Canceled by user</div>
+            <div class="text-[var(--pd-content-text)] text-sm" aria-label="Provider Canceled">Canceled by user</div>
           {/if}
         </div>
       {/each}
     </div>
-    <div class="h-full w-full pr-4 overflow-y-scroll pb-16">
+    <div class="h-full w-full pr-4 overflow-y-scroll pb-16"  aria-label="Analysis Results">
       {#each filtered as result, index (index)}
         <div
-          role="row"
+          role="row" aria-label="{result.check.name}" 
           class="rounded-r-lg bg-[var(--pd-content-bg)] mb-4 mr-4 p-4 border-l-2"
           class:border-l-[var(--pd-state-error)]={result.check.severity === 'critical'}
           class:border-l-[var(--pd-state-warning)]={result.check.severity === 'high'}
           class:border-l-[var(--pd-severity-medium)]={result.check.severity === 'medium'}
           class:border-l-[var(--pd-severity-low)]={result.check.severity === 'low'}
           class:border-l-[var(--pd-state-success)]={result.check.status === 'success'}>
-          <div class="flex flex-row space-x-2">
+          <div role="status" aria-label="Check Status" class="flex flex-row space-x-2">
             <span
               class:text-[var(--pd-state-error)]={result.check.severity === 'critical'}
               class:text-[var(--pd-state-warning)]={result.check.severity === 'high'}
@@ -201,10 +201,10 @@ function onSeverityClicked(severity: 'critical' | 'high' | 'medium' | 'low' | 's
               ><Fa size="1.1x" class="mt-1" icon={getIcon(result.check)} />
             </span>
             <div class="font-bold">{result.check.name}</div>
-            <div class="text-[var(--pd-content-text)] text-sm grow text-right">Reported by {result.provider.label}</div>
+            <div class="text-[var(--pd-content-text)] text-sm grow text-right" aria-label="Reported by {result.provider.label}">Reported by {result.provider.label}</div>
           </div>
           {#if result.check.markdownDescription}
-            <div class="mt-4">{result.check.markdownDescription}</div>
+            <div class="mt-4" aria-label="Result Description">{result.check.markdownDescription}</div>
           {/if}
         </div>
       {/each}


### PR DESCRIPTION
### What does this PR do?
Adds ARIA labels to `Images > Image Details > Check` tab.

Screenshot / video of UI

N/A

What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/11805
How to test this PR?

N/A

Tests are covering the bug fix or the new feature