### PR TITLE
chore: make dropdown left control clickable

### DIFF
--- a/packages/ui/src/lib/dropdown/Dropdown.spec.ts
+++ b/packages/ui/src/lib/dropdown/Dropdown.spec.ts
@@ -183,4 +183,5 @@ test('Left snippet is renderered', async () => {
 
   const left = screen.getByText('Left:');
   expect(left).toBeInTheDocument();
+  expect(left.parentElement).toHaveClass('bg-[var(--pd-input-field-bg)]');
 });

--- a/packages/ui/src/lib/dropdown/Dropdown.svelte
+++ b/packages/ui/src/lib/dropdown/Dropdown.svelte
@@ -189,7 +189,6 @@ function onWindowClick(e: Event): void {
   aria-label={ariaLabel}
   aria-invalid={ariaInvalid}
   bind:this={comp}>
-  {@render left?.()}
   <button
     class="flex flex-row w-full outline-0 bg-[var(--pd-input-field-bg)] placeholder:text-[color:var(--pd-input-field-placeholder-text)] items-center text-start"
     class:text-[color:var(--pd-input-field-focused-text)]={!disabled}
@@ -202,6 +201,7 @@ function onWindowClick(e: Event): void {
     name={name}
     onclick={toggleOpen}
     onkeydown={onKeyDown}>
+    {@render left?.()}
     <span class="grow">{selectLabel}</span>
     <div
       class:text-[var(--pd-input-field-stroke)]={!disabled}

--- a/storybook/src/stories/Dropdown.stories.svelte
+++ b/storybook/src/stories/Dropdown.stories.svelte
@@ -57,3 +57,13 @@ setTemplate(template);
     value: 'Disabled dropdown',
     disabled: true,
   }} />
+
+<Story name="Left snippet">
+  <Dropdown>
+    <option value="a">One</option>
+    <option value="b">Two</option>
+    {#snippet left()}
+      Selected value:&nbsp;
+    {/snippet}
+  </Dropdown>
+</Story>


### PR DESCRIPTION
### What does this PR do?

Minor omission from #11810 - the left control should be clickable. This moves the control down one step into the button and adds a test for one of the button classes to confirm location.

### Screenshot / video of UI

N/A, just means you can click on the word 'Namespace:' in dropdowns like #11756.

### What issues does this PR fix or reference?

Related to #11274.

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature