### PR TITLE
fix: name column alignment

### DIFF
--- a/packages/renderer/src/lib/container/ContainerColumnName.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerColumnName.spec.ts
@@ -86,6 +86,10 @@ test('Expect simple column styling - pod', async () => {
 
   const text = screen.getByText(`${pod.name} (pod)`);
   expect(text).toBeInTheDocument();
+  expect(text).toHaveClass('overflow-hidden');
+  expect(text).toHaveClass('text-ellipsis');
+
+  expect(text.parentElement).toHaveClass('text-left');
 });
 
 test('Expect simple column styling - compose', async () => {
@@ -93,6 +97,10 @@ test('Expect simple column styling - compose', async () => {
 
   const text = screen.getByText(`${compose.name} (compose)`);
   expect(text).toBeInTheDocument();
+  expect(text).toHaveClass('overflow-hidden');
+  expect(text).toHaveClass('text-ellipsis');
+
+  expect(text.parentElement).toHaveClass('text-left');
 });
 
 test('Expect clicking works - container', async () => {

--- a/packages/renderer/src/lib/container/ContainerColumnNameGroup.svelte
+++ b/packages/renderer/src/lib/container/ContainerColumnNameGroup.svelte
@@ -27,7 +27,7 @@ function openGroupDetails(containerGroup: ContainerGroupInfoUI): void {
 </script>
 
 <button
-  class="flex flex-col text-[var(--pd-table-body-text-highlight)] max-w-full"
+  class="flex flex-col text-[var(--pd-table-body-text-highlight)] max-w-full text-left"
   title={object.type}
   on:click={(): void => openGroupDetails(object)}>
   <div class="max-w-full overflow-hidden text-ellipsis">

--- a/packages/renderer/src/lib/pod/PodColumnName.spec.ts
+++ b/packages/renderer/src/lib/pod/PodColumnName.spec.ts
@@ -47,6 +47,9 @@ test('Expect simple column styling', async () => {
   const text = screen.getByText(pod.name);
   expect(text).toBeInTheDocument();
   expect(text).toHaveClass('text-[var(--pd-table-body-text-highlight)]');
+  expect(text).toHaveClass('overflow-hidden');
+  expect(text).toHaveClass('text-ellipsis');
+  expect(text.parentElement).toHaveClass('text-left');
 
   const id = screen.getByText(pod.shortId);
   expect(id).toBeInTheDocument();

--- a/packages/renderer/src/lib/pod/PodColumnName.svelte
+++ b/packages/renderer/src/lib/pod/PodColumnName.svelte
@@ -17,7 +17,7 @@ function openDetailsPod(pod: PodInfoUI): void {
 }
 </script>
 
-<button class="hover:cursor-pointer flex flex-col max-w-full" on:click={(): void => openDetailsPod(object)}>
+<button class="hover:cursor-pointer flex flex-col max-w-full text-left" on:click={(): void => openDetailsPod(object)}>
   <div class="text-[var(--pd-table-body-text-highlight)] max-w-full overflow-hidden text-ellipsis">
     {object.name}
   </div>


### PR DESCRIPTION
### What does this PR do?

Moving to Electron 35 changed the default alignment of text to center, which only causes UI change when the parent component is wider than the text. So far I've only found impact to two name columns. I can't find the 'breaking' change listed anywhere, but it is easy enough to fix with text-left for these two columns.

### Screenshot / video of UI

Before:

<img width="370" alt="Screenshot 2025-03-24 at 12 10 55 PM" src="https://github.com/user-attachments/assets/0852b160-e84f-4bd6-b2c0-f99648fd7143" />

<img width="201" alt="Screenshot 2025-03-24 at 12 15 13 PM" src="https://github.com/user-attachments/assets/bc07365f-ee10-4cb7-bb61-07e7840800c1" />

After:

<img width="370" alt="Screenshot 2025-03-24 at 12 14 04 PM" src="https://github.com/user-attachments/assets/b34d543d-daf0-470e-a9e9-282d02b552b7" />

<img width="201" alt="Screenshot 2025-03-24 at 12 15 23 PM" src="https://github.com/user-attachments/assets/a6a76cd7-bad8-42d6-bd82-ebfbb92f0759" />

### What issues does this PR fix or reference?

Fixes #11831.

### How to test this PR?

See examples, the issue will only show up when you have names shorter/longer than other text in the column.

- [x] Tests are covering the bug fix or the new feature