### PR TITLE
feat: update start/stop/editProviderConnectionLifecycle for VM

### DIFF
--- a/packages/api/src/provider-info.ts
+++ b/packages/api/src/provider-info.ts
@@ -56,6 +56,11 @@ export interface ProviderVmConnectionInfo {
   lifecycleMethods?: LifecycleMethod[];
 }
 
+export type ProviderConnectionInfo =
+  | ProviderContainerConnectionInfo
+  | ProviderKubernetesConnectionInfo
+  | ProviderVmConnectionInfo;
+
 export interface ProviderInfo {
   internalId: string;
   id: string;

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -108,6 +108,7 @@ import type { V1Route } from '/@api/openshift-types.js';
 import type {
   PreflightCheckEvent,
   PreflightChecksCallback,
+  ProviderConnectionInfo,
   ProviderContainerConnectionInfo,
   ProviderInfo,
   ProviderKubernetesConnectionInfo,
@@ -2172,7 +2173,7 @@ export class PluginSystem {
       async (
         _listener: Electron.IpcMainInvokeEvent,
         providerId: string,
-        providerConnectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo,
+        providerConnectionInfo: ProviderConnectionInfo,
         loggerId: string,
       ): Promise<void> => {
         const task = taskManager.createTask({
@@ -2208,7 +2209,7 @@ export class PluginSystem {
       async (
         _listener: Electron.IpcMainInvokeEvent,
         providerId: string,
-        providerConnectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo,
+        providerConnectionInfo: ProviderConnectionInfo,
         loggerId: string,
       ): Promise<void> => {
         const task = taskManager.createTask({
@@ -2244,7 +2245,7 @@ export class PluginSystem {
       async (
         _listener: Electron.IpcMainInvokeEvent,
         providerId: string,
-        providerConnectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo,
+        providerConnectionInfo: ProviderConnectionInfo,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         params: { [key: string]: any },
         loggerId: string,
@@ -2290,7 +2291,7 @@ export class PluginSystem {
       async (
         _listener: Electron.IpcMainInvokeEvent,
         providerId: string,
-        providerConnectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo,
+        providerConnectionInfo: ProviderConnectionInfo,
         loggerId: string,
       ): Promise<void> => {
         const task = taskManager.createTask({

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -53,6 +53,7 @@ import type {
   LifecycleMethod,
   PreflightChecksCallback,
   ProviderCleanupActionInfo,
+  ProviderConnectionInfo,
   ProviderContainerConnectionInfo,
   ProviderInfo,
   ProviderKubernetesConnectionInfo,
@@ -688,11 +689,8 @@ export class ProviderRegistry {
 
   private getProviderConnectionInfo(
     connection: ContainerProviderConnection | KubernetesProviderConnection | VmProviderConnection,
-  ): ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo | ProviderVmConnectionInfo {
-    let providerConnection:
-      | ProviderContainerConnectionInfo
-      | ProviderKubernetesConnectionInfo
-      | ProviderVmConnectionInfo;
+  ): ProviderConnectionInfo {
+    let providerConnection: ProviderConnectionInfo;
     if (this.isContainerConnection(connection)) {
       providerConnection = {
         name: connection.name,
@@ -897,11 +895,7 @@ export class ProviderRegistry {
 
   getMatchingConnectionLifecycleContext(
     internalId: string,
-    providerContainerConnectionInfo:
-      | ProviderContainerConnectionInfo
-      | ProviderKubernetesConnectionInfo
-      | ProviderVmConnectionInfo
-      | ContainerProviderConnection,
+    providerContainerConnectionInfo: ProviderConnectionInfo | ContainerProviderConnection,
   ): LifecycleContextImpl {
     const connection = this.getMatchingConnectionFromProvider(internalId, providerContainerConnectionInfo);
 
@@ -1063,11 +1057,7 @@ export class ProviderRegistry {
 
   getMatchingConnectionFromProvider(
     internalProviderId: string,
-    providerContainerConnectionInfo:
-      | ProviderContainerConnectionInfo
-      | ProviderKubernetesConnectionInfo
-      | ProviderVmConnectionInfo
-      | ContainerProviderConnection,
+    providerContainerConnectionInfo: ProviderConnectionInfo | ContainerProviderConnection,
   ): ContainerProviderConnection | KubernetesProviderConnection | VmProviderConnection {
     if (this.isProviderContainerConnection(providerContainerConnectionInfo)) {
       return this.getMatchingContainerConnectionFromProvider(internalProviderId, providerContainerConnectionInfo);
@@ -1079,21 +1069,13 @@ export class ProviderRegistry {
   }
 
   isProviderContainerConnection(
-    connection:
-      | ProviderContainerConnectionInfo
-      | ProviderKubernetesConnectionInfo
-      | ProviderVmConnectionInfo
-      | ContainerProviderConnection,
+    connection: ProviderConnectionInfo | ContainerProviderConnection,
   ): connection is ProviderContainerConnectionInfo | ContainerProviderConnection {
     return (connection as ProviderContainerConnectionInfo).endpoint?.socketPath !== undefined;
   }
 
   isProviderKubernetesConnectionInfo(
-    connection:
-      | ProviderContainerConnectionInfo
-      | ProviderKubernetesConnectionInfo
-      | ProviderVmConnectionInfo
-      | ContainerProviderConnection,
+    connection: ProviderConnectionInfo | ContainerProviderConnection,
   ): connection is ProviderKubernetesConnectionInfo {
     return (
       !this.isProviderContainerConnection(connection) &&
@@ -1117,10 +1099,7 @@ export class ProviderRegistry {
 
   async startProviderConnection(
     internalProviderId: string,
-    providerConnectionInfo:
-      | ProviderContainerConnectionInfo
-      | ProviderKubernetesConnectionInfo
-      | ProviderVmConnectionInfo,
+    providerConnectionInfo: ProviderConnectionInfo,
     logHandler?: Logger,
   ): Promise<void> {
     // grab the correct provider
@@ -1189,7 +1168,7 @@ export class ProviderRegistry {
 
   async editProviderConnection(
     internalProviderId: string,
-    providerConnectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo,
+    providerConnectionInfo: ProviderConnectionInfo,
     params: { [key: string]: unknown },
     logHandler?: Logger,
     token?: CancellationToken,
@@ -1222,10 +1201,7 @@ export class ProviderRegistry {
 
   async stopProviderConnection(
     internalProviderId: string,
-    providerConnectionInfo:
-      | ProviderContainerConnectionInfo
-      | ProviderKubernetesConnectionInfo
-      | ProviderVmConnectionInfo,
+    providerConnectionInfo: ProviderConnectionInfo,
     logHandler?: Logger,
   ): Promise<void> {
     // grab the correct provider
@@ -1296,7 +1272,7 @@ export class ProviderRegistry {
 
   async deleteProviderConnection(
     internalProviderId: string,
-    providerConnectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo,
+    providerConnectionInfo: ProviderConnectionInfo,
     logHandler?: Logger,
   ): Promise<void> {
     // grab the correct provider

--- a/packages/preload/src/index.spec.ts
+++ b/packages/preload/src/index.spec.ts
@@ -263,4 +263,60 @@ describe('collect calls to exposeInMainWorld and ipcRenderer.on and calls initEx
     taskConnectionOnDataExposure({} as IpcRendererEvent, id, 'log', data);
     expect(logger).toHaveBeenCalledWith('key1', 'log', data);
   });
+
+  test('logger passed to startProviderConnectionLifecycle is called during provider-registry:taskConnection-onData', async () => {
+    vi.mocked(ipcRenderer.invoke).mockResolvedValue({ result: undefined });
+    const startProviderConnectionLifecycleExposure = getInMainWorld('startProviderConnectionLifecycle');
+    const logger: (key: symbol, eventName: 'log' | 'warn' | 'error' | 'finish', args: string[]) => void = vi.fn();
+    await startProviderConnectionLifecycleExposure('internal', {}, 'key1', logger);
+    expect(ipcRenderer.invoke).toHaveBeenCalledOnce();
+
+    const id = vi.mocked(ipcRenderer.invoke).mock.calls[0][3];
+    const taskConnectionOnDataExposure = getRendererOn('provider-registry:taskConnection-onData');
+    const data = { data: 'data' };
+    taskConnectionOnDataExposure({} as IpcRendererEvent, id, 'log', data);
+    expect(logger).toHaveBeenCalledWith('key1', 'log', data);
+  });
+
+  test('logger passed to stopProviderConnectionLifecycle is called during provider-registry:taskConnection-onData', async () => {
+    vi.mocked(ipcRenderer.invoke).mockResolvedValue({ result: undefined });
+    const stopProviderConnectionLifecycleExposure = getInMainWorld('stopProviderConnectionLifecycle');
+    const logger: (key: symbol, eventName: 'log' | 'warn' | 'error' | 'finish', args: string[]) => void = vi.fn();
+    await stopProviderConnectionLifecycleExposure('internal', {}, 'key1', logger);
+    expect(ipcRenderer.invoke).toHaveBeenCalledOnce();
+
+    const id = vi.mocked(ipcRenderer.invoke).mock.calls[0][3];
+    const taskConnectionOnDataExposure = getRendererOn('provider-registry:taskConnection-onData');
+    const data = { data: 'data' };
+    taskConnectionOnDataExposure({} as IpcRendererEvent, id, 'log', data);
+    expect(logger).toHaveBeenCalledWith('key1', 'log', data);
+  });
+
+  test('logger passed to editProviderConnectionLifecycle is called during provider-registry:taskConnection-onData', async () => {
+    vi.mocked(ipcRenderer.invoke).mockResolvedValue({ result: undefined });
+    const editProviderConnectionLifecycleExposure = getInMainWorld('editProviderConnectionLifecycle');
+    const logger: (key: symbol, eventName: 'log' | 'warn' | 'error' | 'finish', args: string[]) => void = vi.fn();
+    await editProviderConnectionLifecycleExposure('internal', {}, {}, 'key1', logger, 'token1', 'task1');
+    expect(ipcRenderer.invoke).toHaveBeenCalledOnce();
+
+    const id = vi.mocked(ipcRenderer.invoke).mock.calls[0][4];
+    const taskConnectionOnDataExposure = getRendererOn('provider-registry:taskConnection-onData');
+    const data = { data: 'data' };
+    taskConnectionOnDataExposure({} as IpcRendererEvent, id, 'log', data);
+    expect(logger).toHaveBeenCalledWith('key1', 'log', data);
+  });
+
+  test('logger passed to deleteProviderConnectionLifecycle is called during provider-registry:taskConnection-onData', async () => {
+    vi.mocked(ipcRenderer.invoke).mockResolvedValue({ result: undefined });
+    const deleteProviderConnectionLifecycleExposure = getInMainWorld('deleteProviderConnectionLifecycle');
+    const logger: (key: symbol, eventName: 'log' | 'warn' | 'error' | 'finish', args: string[]) => void = vi.fn();
+    await deleteProviderConnectionLifecycleExposure('internal', {}, 'key1', logger);
+    expect(ipcRenderer.invoke).toHaveBeenCalledOnce();
+
+    const id = vi.mocked(ipcRenderer.invoke).mock.calls[0][3];
+    const taskConnectionOnDataExposure = getRendererOn('provider-registry:taskConnection-onData');
+    const data = { data: 'data' };
+    taskConnectionOnDataExposure({} as IpcRendererEvent, id, 'log', data);
+    expect(logger).toHaveBeenCalledWith('key1', 'log', data);
+  });
 });

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -85,6 +85,7 @@ import type { V1Route } from '/@api/openshift-types';
 import type {
   PreflightCheckEvent,
   PreflightChecksCallback,
+  ProviderConnectionInfo,
   ProviderContainerConnectionInfo,
   ProviderInfo,
   ProviderKubernetesConnectionInfo,
@@ -1140,7 +1141,7 @@ export function initExposure(): void {
     'startProviderConnectionLifecycle',
     async (
       providerId: string,
-      providerConnectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo,
+      providerConnectionInfo: ProviderConnectionInfo,
       key: symbol,
       keyLogger: (key: symbol, eventName: 'log' | 'warn' | 'error' | 'finish', args: string[]) => void,
     ): Promise<void> => {
@@ -1160,7 +1161,7 @@ export function initExposure(): void {
     'stopProviderConnectionLifecycle',
     async (
       providerId: string,
-      providerConnectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo,
+      providerConnectionInfo: ProviderConnectionInfo,
       key: symbol,
       keyLogger: (key: symbol, eventName: 'log' | 'warn' | 'error' | 'finish', args: string[]) => void,
     ): Promise<void> => {
@@ -1180,7 +1181,7 @@ export function initExposure(): void {
     'editProviderConnectionLifecycle',
     async (
       providerId: string,
-      providerConnectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo,
+      providerConnectionInfo: ProviderConnectionInfo,
       params: { [key: string]: unknown },
       key: symbol,
       keyLogger: (key: symbol, eventName: 'log' | 'warn' | 'error' | 'finish', args: string[]) => void,
@@ -1206,7 +1207,7 @@ export function initExposure(): void {
     'deleteProviderConnectionLifecycle',
     async (
       providerId: string,
-      providerConnectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo,
+      providerConnectionInfo: ProviderConnectionInfo,
       key: symbol,
       keyLogger: (key: symbol, eventName: 'log' | 'warn' | 'error' | 'finish', args: string[]) => void,
     ): Promise<void> => {


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Adds the `ProviderVmConnectionInfo` type to accepted types for `ProviderConnectionLifecycle` related calls, and define a union type `ProviderConnectionInfo` on all providerconnectionInfos

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Related to #11744 

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
