### PR TITLE
feat(ProviderButton): adding left slot

### DIFF
--- a/packages/renderer/src/lib/statusbar/ProviderButton.spec.ts
+++ b/packages/renderer/src/lib/statusbar/ProviderButton.spec.ts
@@ -68,7 +68,7 @@ test('provider with an image should render it', async () => {
   );
 });
 
-test('left slot should be renderer if defined', async () => {
+test('left slot should be rendered if defined', async () => {
   const left = vi.fn();
   render(ProviderButton, {
     provider: PROVIDER_MOCK,

--- a/packages/renderer/src/lib/statusbar/ProviderButton.spec.ts
+++ b/packages/renderer/src/lib/statusbar/ProviderButton.spec.ts
@@ -67,3 +67,17 @@ test('provider with an image should render it', async () => {
     }),
   );
 });
+
+test('left slot should be renderer if defined', async () => {
+  const left = vi.fn();
+  render(ProviderButton, {
+    provider: PROVIDER_MOCK,
+    onclick: vi.fn(),
+    class: 'potatoes',
+    left,
+  });
+
+  await vi.waitFor(() => {
+    expect(left).toHaveBeenCalled();
+  });
+});

--- a/packages/renderer/src/lib/statusbar/ProviderButton.svelte
+++ b/packages/renderer/src/lib/statusbar/ProviderButton.svelte
@@ -19,9 +19,7 @@ let { provider, onclick, left, class: className }: Props = $props();
   on:click={onclick}
   class="px-1 py-px flex flex-row h-full items-center gap-1 min-w-fit hover:bg-[var(--pd-statusbar-hover-bg)] hover:cursor-pointer relative {className}"
   aria-label={provider.name}>
-  {#if left}
-    {@render left()}
-  {/if}
+  {@render left?.()}
   {#if provider.containerConnections.length > 0 || provider.kubernetesConnections.length > 0 || provider.status }
     <ProviderWidgetStatus entry={provider} />
   {/if}

--- a/packages/renderer/src/lib/statusbar/ProviderButton.svelte
+++ b/packages/renderer/src/lib/statusbar/ProviderButton.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+import type { Snippet } from 'svelte';
+
 import IconImage from '/@/lib/appearance/IconImage.svelte';
 import ProviderWidgetStatus from '/@/lib/statusbar/ProviderWidgetStatus.svelte';
 import type { ProviderInfo } from '/@api/provider-info';
@@ -7,15 +9,19 @@ interface Props {
   provider: ProviderInfo;
   onclick: () => void;
   class?: string;
+  left?: Snippet<[]>;
 }
 
-let { provider, onclick, class: className }: Props = $props();
+let { provider, onclick, left, class: className }: Props = $props();
 </script>
 
 <button
   on:click={onclick}
   class="px-1 py-px flex flex-row h-full items-center gap-1 min-w-fit hover:bg-[var(--pd-statusbar-hover-bg)] hover:cursor-pointer relative {className}"
   aria-label={provider.name}>
+  {#if left}
+    {@render left()}
+  {/if}
   {#if provider.containerConnections.length > 0 || provider.kubernetesConnections.length > 0 || provider.status }
     <ProviderWidgetStatus entry={provider} />
   {/if}


### PR DESCRIPTION
### What does this PR do?

Following https://github.com/podman-desktop/podman-desktop/pull/11804 I need to add a left slot to be able to add a :heavy_check_mark: icon as per design (see bellow)

![image](https://github.com/user-attachments/assets/8f674dbc-2433-4712-bda0-3498e433a17f)

We can see that left to the ProviderButton, I need to add a check icon, but I need it to be part of the button, so adding a left slot, so the parent component can just provide a snippet.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Required for
- https://github.com/podman-desktop/podman-desktop/issues/9950

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
