### PR TITLE
feat: add VM provider lifecycle to frontend

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesConnectionActions.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionActions.svelte
@@ -3,11 +3,7 @@ import { faEdit, faPlay, faRotateRight, faStop, faTrash } from '@fortawesome/fre
 import { Buffer } from 'buffer';
 import { router } from 'tinro';
 
-import type {
-  ProviderContainerConnectionInfo,
-  ProviderInfo,
-  ProviderKubernetesConnectionInfo,
-} from '/@api/provider-info';
+import type { ProviderConnectionInfo, ProviderInfo } from '/@api/provider-info';
 
 import LoadingIconButton from '../ui/LoadingIconButton.svelte';
 import {
@@ -19,10 +15,10 @@ import { type IConnectionRestart, type IConnectionStatus } from './Util';
 
 export let connectionStatus: IConnectionStatus | undefined;
 export let provider: ProviderInfo;
-export let connection: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo;
+export let connection: ProviderConnectionInfo;
 export let updateConnectionStatus: (
   provider: ProviderInfo,
-  providerConnectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo,
+  providerConnectionInfo: ProviderConnectionInfo,
   action?: string,
   error?: string,
   inProgress?: boolean,
@@ -31,7 +27,7 @@ export let addConnectionToRestartingQueue: (connection: IConnectionRestart) => v
 
 async function startConnectionProvider(
   provider: ProviderInfo,
-  providerConnectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo,
+  providerConnectionInfo: ProviderConnectionInfo,
   loggerHandlerKey?: symbol,
 ): Promise<void> {
   try {
@@ -54,7 +50,7 @@ async function startConnectionProvider(
 
 async function restartConnectionProvider(
   provider: ProviderInfo,
-  providerConnectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo,
+  providerConnectionInfo: ProviderConnectionInfo,
 ): Promise<void> {
   if (providerConnectionInfo.status === 'started') {
     updateConnectionStatus(provider, providerConnectionInfo, 'restart');
@@ -75,7 +71,7 @@ async function restartConnectionProvider(
 
 async function stopConnectionProvider(
   provider: ProviderInfo,
-  providerConnectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo,
+  providerConnectionInfo: ProviderConnectionInfo,
 ): Promise<void> {
   try {
     if (providerConnectionInfo.status === 'started') {
@@ -95,7 +91,7 @@ async function stopConnectionProvider(
 
 async function editConnectionProvider(
   provider: ProviderInfo,
-  providerConnectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo,
+  providerConnectionInfo: ProviderConnectionInfo,
 ): Promise<void> {
   router.goto(
     `/preferences/container-connection/edit/${provider.internalId}/${Buffer.from(providerConnectionInfo.name).toString(
@@ -106,7 +102,7 @@ async function editConnectionProvider(
 
 async function deleteConnectionProvider(
   provider: ProviderInfo,
-  providerConnectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo,
+  providerConnectionInfo: ProviderConnectionInfo,
 ): Promise<void> {
   try {
     if (providerConnectionInfo.status === 'stopped' || providerConnectionInfo.status === 'unknown') {
@@ -126,10 +122,7 @@ async function deleteConnectionProvider(
   }
 }
 
-function getLoggerHandler(
-  provider: ProviderInfo,
-  containerConnectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo,
-): ConnectionCallback {
+function getLoggerHandler(provider: ProviderInfo, containerConnectionInfo: ProviderConnectionInfo): ConnectionCallback {
   return {
     log: (): void => {},
     warn: (): void => {},

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
@@ -7,11 +7,7 @@ import { router } from 'tinro';
 
 import { handleNavigation } from '/@/navigation';
 import { NavigationPage } from '/@api/navigation-page';
-import type {
-  ProviderContainerConnectionInfo,
-  ProviderInfo,
-  ProviderKubernetesConnectionInfo,
-} from '/@api/provider-info';
+import type { ProviderConnectionInfo, ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provider-info';
 
 import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import Route from '../../Route.svelte';
@@ -108,7 +104,7 @@ async function startContainerProvider(
 }
 function updateConnectionStatus(
   provider: ProviderInfo,
-  containerConnectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo,
+  containerConnectionInfo: ProviderConnectionInfo,
   action?: string,
   error?: string,
 ): void {

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.svelte
@@ -7,11 +7,7 @@ import { router } from 'tinro';
 
 import { handleNavigation } from '/@/navigation';
 import { NavigationPage } from '/@api/navigation-page';
-import type {
-  ProviderContainerConnectionInfo,
-  ProviderInfo,
-  ProviderKubernetesConnectionInfo,
-} from '/@api/provider-info';
+import type { ProviderConnectionInfo, ProviderInfo, ProviderKubernetesConnectionInfo } from '/@api/provider-info';
 
 import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import Route from '../../Route.svelte';
@@ -104,7 +100,7 @@ async function startConnectionProvider(
 
 function updateConnectionStatus(
   provider: ProviderInfo,
-  connectionInfo: ProviderKubernetesConnectionInfo | ProviderContainerConnectionInfo,
+  connectionInfo: ProviderConnectionInfo,
   action?: string,
   error?: string,
 ): void {

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -13,12 +13,7 @@ import Donut from '/@/lib/donut/Donut.svelte';
 import ActionsMenu from '/@/lib/image/ActionsMenu.svelte';
 import { context } from '/@/stores/context';
 import { onboardingList } from '/@/stores/onboarding';
-import type {
-  CheckStatus,
-  ProviderContainerConnectionInfo,
-  ProviderInfo,
-  ProviderKubernetesConnectionInfo,
-} from '/@api/provider-info';
+import type { CheckStatus, ProviderConnectionInfo, ProviderInfo } from '/@api/provider-info';
 
 import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import { type Menu, MenuContext } from '../../../../main/src/plugin/menu-registry';
@@ -145,6 +140,34 @@ onMount(async () => {
           }
         }
       });
+      provider.vmConnections.forEach(connection => {
+        const vmConnectionName = getProviderConnectionName(provider, connection);
+        connectionNames.push(vmConnectionName);
+        // update the map only if the container state is different from last time
+        if (
+          !containerConnectionStatus.has(vmConnectionName) ||
+          containerConnectionStatus.get(vmConnectionName)?.status !== connection.status
+        ) {
+          isStatusUpdated = true;
+          const containerToRestart = getContainerRestarting(provider.internalId, connection.name);
+          if (containerToRestart) {
+            containerConnectionStatus.set(vmConnectionName, {
+              inProgress: true,
+              action: 'restart',
+              status: connection.status,
+            });
+            startConnectionProvider(provider, connection, containerToRestart.loggerHandlerKey).catch((err: unknown) =>
+              console.error(`Error starting connection provider ${connection.name}`, err),
+            );
+          } else {
+            containerConnectionStatus.set(vmConnectionName, {
+              inProgress: false,
+              action: undefined,
+              status: connection.status,
+            });
+          }
+        }
+      });
     });
     // if a machine has been deleted we need to clean its old stored status
     containerConnectionStatus.forEach((v, k) => {
@@ -245,7 +268,7 @@ $: providerContainerConfiguration = tmpProviderContainerConfiguration
 
 function updateContainerStatus(
   provider: ProviderInfo,
-  containerConnectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo,
+  containerConnectionInfo: ProviderConnectionInfo,
   action?: string,
   error?: string,
   inProgress?: boolean,
@@ -276,7 +299,7 @@ function addConnectionToRestartingQueue(connection: IConnectionRestart): void {
 
 async function startConnectionProvider(
   provider: ProviderInfo,
-  containerConnectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo,
+  containerConnectionInfo: ProviderConnectionInfo,
   loggerHandlerKey: symbol,
 ): Promise<void> {
   await window.startProviderConnectionLifecycle(
@@ -420,19 +443,23 @@ function handleError(errorMessage: string): void {
                 </Button>
               {:else}
                 <div class="flex flex-row justify-around">
-                  {#if provider.containerProviderConnectionCreation || provider.kubernetesProviderConnectionCreation}
+                  {#if provider.containerProviderConnectionCreation || provider.kubernetesProviderConnectionCreation || provider.vmProviderConnectionCreation}
                     {@const providerDisplayName =
                       (provider.containerProviderConnectionCreation
                         ? (provider.containerProviderConnectionCreationDisplayName ?? undefined)
                         : provider.kubernetesProviderConnectionCreation
                           ? provider.kubernetesProviderConnectionCreationDisplayName
-                          : undefined) ?? provider.name}
+                          : provider.vmProviderConnectionCreation 
+                            ? provider.vmProviderConnectionCreationDisplayName
+                            : undefined) ?? provider.name}
                     {@const buttonTitle =
                       (provider.containerProviderConnectionCreation
                         ? (provider.containerProviderConnectionCreationButtonTitle ?? undefined)
                         : provider.kubernetesProviderConnectionCreation
                           ? provider.kubernetesProviderConnectionCreationButtonTitle
-                          : undefined) ?? 'Create new'}
+                          : provider.vmProviderConnectionCreation
+                            ? provider.vmProviderConnectionCreationButtonTitle
+                            : undefined) ?? 'Create new'}
                     <!-- create new provider button -->
                     <Tooltip bottom tip="Create new {providerDisplayName}">
                       <Button
@@ -469,7 +496,7 @@ function handleError(errorMessage: string): void {
           aria-label="Provider Connections">
           <PreferencesConnectionsEmptyRendering
             message={provider.emptyConnectionMarkdownDescription}
-            hidden={provider.containerConnections.length > 0 || provider.kubernetesConnections.length > 0} />
+            hidden={provider.containerConnections.length > 0 || provider.kubernetesConnections.length > 0 || provider.vmConnections.length > 0} />
           {#each provider.containerConnections as container}
             {@const peerProperties = new PeerProperties()}
             <div class="px-5 py-2 w-[240px]" role="region" aria-label={container.name}>
@@ -601,7 +628,7 @@ function handleError(errorMessage: string): void {
               <div class="font-semibold">
                 {kubeConnection.name}
               </div>
-              <div class="flex mt-1">
+              <div class="flex mt-1" aria-label="Connection Status">
                 <ConnectionStatus status={kubeConnection.status} />
               </div>
               <div class="mt-2">
@@ -619,6 +646,35 @@ function handleError(errorMessage: string): void {
                 addConnectionToRestartingQueue={addConnectionToRestartingQueue} />
             </div>
           {/each}
+          {#each provider.vmConnections as vmConnection}
+          <div class="px-5 py-2 w-[240px]" role="region" aria-label={vmConnection.name}>
+            <div class="float-right">
+              <Tooltip bottom tip="{provider.name} details">
+                <button
+                  aria-label="{provider.name} details"
+                  type="button"
+                  on:click={(): void =>
+                    router.goto(
+                      `/preferences/vm-connection/${provider.internalId}/${vmConnection.name}/summary`,
+                    )}>
+                  <Fa icon={faArrowUpRightFromSquare} />
+                </button>
+              </Tooltip>
+            </div>
+            <div class="font-semibold">
+              {vmConnection.name}
+            </div>
+            <div class="flex mt-1" aria-label="Connection Status">
+              <ConnectionStatus status={vmConnection.status} />
+            </div>            
+            <PreferencesConnectionActions
+              provider={provider}
+              connection={vmConnection}
+              connectionStatus={containerConnectionStatus.get(getProviderConnectionName(provider, vmConnection))}
+              updateConnectionStatus={updateContainerStatus}
+              addConnectionToRestartingQueue={addConnectionToRestartingQueue} />
+          </div>
+        {/each}
         </div>
       </div>
     {/each}

--- a/packages/renderer/src/lib/preferences/Util.ts
+++ b/packages/renderer/src/lib/preferences/Util.ts
@@ -21,6 +21,7 @@ import type { Terminal } from '@xterm/xterm';
 
 import { CONFIGURATION_DEFAULT_SCOPE } from '/@api/configuration/constants.js';
 import type {
+  ProviderConnectionInfo,
   ProviderContainerConnectionInfo,
   ProviderInfo,
   ProviderKubernetesConnectionInfo,
@@ -84,7 +85,7 @@ function writeMultilineString(xterm: Terminal, data: string, colorPrefix: string
 
 export function getProviderConnectionName(
   provider: ProviderInfo,
-  providerConnectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo,
+  providerConnectionInfo: ProviderConnectionInfo,
 ): string {
   return `${provider.name}-${providerConnectionInfo.name}`;
 }


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Add VM provider lifecycle to frontend

#### Prerequisites: 

(instructions are for mac, should be adapted for Windows - not tested on Linux)

- start Podman Desktop with this extension (and see prerequisites there): https://github.com/redhat-developer/podman-desktop-rhel-ext/pull/10
- create a RHEL VM with:
  - get a RHEL VM image (ask me) 
  - run `CONTAINERS_HELPER_BINARY_DIR=~/.local/share/containers/podman-desktop/extensions-storage/redhat.macadam/bin ~/.local/share/containers/podman-desktop/extensions-storage/redhat.macadam/bin/macadam-darwin-arm64 init <rhel-image-file>` 
### Screenshot / video of UI


### What issues does this PR fix or reference?

Related to #11747 

### How to test this PR?

- run prerequisites
- in PD, Settings > Resources > Macadam, a machine should be visible
- Start button should start the machine -> `~/.local/share/containers/podman-desktop/extensions-storage/redhat.macadam/bin/macadam-darwin-arm64 list` should indicate `Running: true`
- Stop button should stop the machine  -> `~/.local/share/containers/podman-desktop/extensions-storage/redhat.macadam/bin/macadam-darwin-arm64 list` should indicate `Running: false`
- Delete button should delete the machine -> `~/.local/share/containers/podman-desktop/extensions-storage/redhat.macadam/bin/macadam-darwin-arm64 list` output should be empty
- The label (OFF initially) should be updated with STARTING/RUNNING

![macadam-vm-view](https://github.com/user-attachments/assets/faaa07d7-502d-4ecb-b6f2-3c086cc5f103)

- `Create new...` is not expected to work for the moment
- link to machine details is not expected to work for the moment

- [x] Tests are covering the bug fix or the new feature
