### PR TITLE
chore(task-popup): added disapearing task popups

### DIFF
--- a/packages/renderer/src/lib/toast/ToastCustomUi.svelte
+++ b/packages/renderer/src/lib/toast/ToastCustomUi.svelte
@@ -14,12 +14,17 @@ interface Props {
 
 let { toastId, taskInfo, onpop = (): void => {} }: Props = $props();
 
-const closeAction = (): void => {
+function hideToast(): void {
   toast.pop(toastId);
+}
+
+const closeAction = (): void => {
+  hideToast();
   onpop();
 };
 
 const executeAction = async (): Promise<void> => {
+  hideToast();
   await window.executeTask(taskInfo.id);
 };
 </script>


### PR DESCRIPTION
### What does this PR do?
Adds disappearing of popups after 5s
Task should appear 60s when completed if the task tooked longer than 60s to finish

### Screenshot / video of UI


[Screencast_20250404_073041.webm](https://github.com/user-attachments/assets/a6baf69e-cda3-4202-ac81-ab789d5cb8b8)


### What issues does this PR fix or reference?
Closes #9870 

### How to test this PR?
Enable toast popups in settings
Do some action that creates a popup e.g. creating service using recipe in AI Lab (the task should show the toast when it is completed)
The popup should disappear after 5s 


- [x] Tests are covering the bug fix or the new feature
