### PR TITLE
fix: wait for kubeconfig change while creating kind cluster

### DIFF
--- a/packages/main/src/plugin/kubernetes/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.ts
@@ -282,20 +282,20 @@ export class KubernetesClient {
 
     // needs to refresh
     this.kubeConfigWatcher.onDidChange(async () => {
-      this._onDidUpdateKubeconfig.fire({ type: 'UPDATE', location });
       await this.refresh();
+      this._onDidUpdateKubeconfig.fire({ type: 'UPDATE', location });
       this.apiSender.send('kubernetes-context-update');
     });
 
     this.kubeConfigWatcher.onDidCreate(async () => {
-      this._onDidUpdateKubeconfig.fire({ type: 'CREATE', location });
       await this.refresh();
+      this._onDidUpdateKubeconfig.fire({ type: 'CREATE', location });
       this.apiSender.send('kubernetes-context-update');
     });
 
     this.kubeConfigWatcher.onDidDelete(() => {
-      this._onDidUpdateKubeconfig.fire({ type: 'DELETE', location });
       this.kubeConfig = new KubeConfig();
+      this._onDidUpdateKubeconfig.fire({ type: 'DELETE', location });
       this.apiSender.send('kubernetes-context-update');
     });
   }


### PR DESCRIPTION
### What does this PR do?

The Kind extension was exec-ing the cli to create a cluster and then immediately creating the ingress by applying yaml. A recent fix to main/kubernetes-client to correctly use the cached version of kubeconfig (#11779) causes kind to fail because this doesn't give the file watcher enough time to be notified about the new cluster in kubeconfig.

This fix just waits for an update to kubeconfig between the two steps.

This still isn't 100% bulletproof because there could be some other process touching kubeconfig at exactly the same time, or there could be a timing issue because kubernetes-client notifies as it is re-reading kubeconfig instead of afterwards. However, this seems robust enough and with these changes my tests have gone from always failing to always passing.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #11813.

### How to test this PR?

Stop any running Kind clusters to avoid conflict.
Confirm creating a Kind cluster works normally.
Repeat a few times.

- [x] Tests are covering the bug fix or the new feature