### PR TITLE
chore: update ui package icons to svelte 5

### DIFF
--- a/packages/renderer/src/stores/event-store.ts
+++ b/packages/renderer/src/stores/event-store.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2024 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,7 @@
  ***********************************************************************/
 
 import humanizeDuration from 'humanize-duration';
-// eslint-disable-next-line import/no-duplicates
-import type { ComponentType } from 'svelte';
-// eslint-disable-next-line import/no-duplicates
+import type { Component } from 'svelte';
 import type { Writable } from 'svelte/store';
 
 import DesktopIcon from '../lib/images/DesktopIcon.svelte';
@@ -48,7 +46,7 @@ interface EventStoreInfoEvent {
 export interface EventStoreInfo {
   name: string;
 
-  iconComponent?: ComponentType;
+  iconComponent?: Component;
 
   // list last 100 events
   bufferEvents: EventStoreInfoEvent[];
@@ -99,7 +97,7 @@ export class EventStore<T> {
     private updater: (...args: unknown[]) => Promise<T>,
 
     // Optional icon component to display in the UI
-    private iconComponent?: ComponentType,
+    private iconComponent?: Component,
   ) {
     if (!iconComponent) {
       this.iconComponent = DesktopIcon;

--- a/packages/ui/src/lib/icons/ContainerIcon.svelte
+++ b/packages/ui/src/lib/icons/ContainerIcon.svelte
@@ -1,13 +1,22 @@
 <script lang="ts">
-export let size = '40';
-export let solid = false;
+let {
+  size = '40',
+  solid = false,
+  class: className,
+  style,
+}: {
+  size?: string;
+  solid?: boolean;
+  class?: string;
+  style?: string;
+} = $props();
 </script>
 
 <svg
   width={size}
   height={size}
-  class={$$props.class}
-  style={$$props.style}
+  class={className}
+  style={style}
   viewBox="0.926 0.926 4.498 4.498"
   version="1.1"
   xml:space="preserve"

--- a/packages/ui/src/lib/icons/ContainerIcon.svelte
+++ b/packages/ui/src/lib/icons/ContainerIcon.svelte
@@ -1,15 +1,11 @@
 <script lang="ts">
-let {
-  size = '40',
-  solid = false,
-  class: className,
-  style,
-}: {
+interface Props {
   size?: string;
   solid?: boolean;
   class?: string;
   style?: string;
-} = $props();
+}
+let { size = '40', solid = false, class: className, style }: Props = $props();
 </script>
 
 <svg

--- a/packages/ui/src/lib/icons/StarIcon.svelte
+++ b/packages/ui/src/lib/icons/StarIcon.svelte
@@ -1,12 +1,20 @@
 <script lang="ts">
-export let size = '40';
+let {
+  size = '40',
+  class: className,
+  style,
+}: {
+  size: string;
+  class?: string;
+  style?: string;
+} = $props();
 </script>
 
 <svg
   width={size}
   height={size}
-  class={$$props.class}
-  style={$$props.style}
+  class={className}
+  style={style}
   viewBox="4.336 0.105 1.745 1.66"
   version="1.1"
   xml:space="preserve"

--- a/packages/ui/src/lib/icons/StarIcon.svelte
+++ b/packages/ui/src/lib/icons/StarIcon.svelte
@@ -1,13 +1,10 @@
 <script lang="ts">
-let {
-  size = '40',
-  class: className,
-  style,
-}: {
+interface Props {
   size: string;
   class?: string;
   style?: string;
-} = $props();
+}
+let { size = '40', class: className, style }: Props = $props();
 </script>
 
 <svg

--- a/packages/ui/src/lib/icons/StarIcon.svelte
+++ b/packages/ui/src/lib/icons/StarIcon.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 interface Props {
-  size: string;
+  size?: string;
   class?: string;
   style?: string;
 }


### PR DESCRIPTION
### What does this PR do?

Updates StarIcon and ContainerIcon to Svelte 5 syntax.

The event store type in renderer has to be updated to avoid type errors. Note that ContainerIcon size and solid had to be made optional ('?') as well (the other option seemed to be using 'Component<any>'), could be cleaned up later but probably not worth tracking.

Removing import/no-duplicates as it doesn't seem to be required anymore.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #11577.

### How to test this PR?

Just code review / PR tests.

- [x] Tests are covering the bug fix or the new feature