### PR TITLE
feat: startProvider works for VM connections

### DIFF
--- a/packages/main/src/plugin/provider-registry.spec.ts
+++ b/packages/main/src/plugin/provider-registry.spec.ts
@@ -1982,6 +1982,26 @@ describe('startProvider', () => {
     await providerRegistry.startProvider((provider as ProviderImpl).internalId);
     expect(startMock).toBeCalled();
   });
+
+  test('if the provider has one VM connection with the start lifecycle, execute the start action', async () => {
+    const provider = providerRegistry.createProvider('id', 'name', {
+      id: 'internal',
+      name: 'internal',
+      status: 'installed',
+    });
+    const startMock = vi.fn();
+    (provider as ProviderImpl).registerVmProviderConnection({
+      name: 'connection',
+      lifecycle: {
+        start: startMock,
+      },
+      status() {
+        return 'stopped';
+      },
+    });
+    await providerRegistry.startProvider((provider as ProviderImpl).internalId);
+    expect(startMock).toBeCalled();
+  });
 });
 
 describe('shellInProviderConnection', () => {

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -604,12 +604,14 @@ export class ProviderRegistry {
     }
 
     const provider = this.getMatchingProvider(providerInternalId);
-    let connection: ContainerProviderConnection | KubernetesProviderConnection | undefined;
+    let connection: ContainerProviderConnection | KubernetesProviderConnection | VmProviderConnection | undefined;
 
     if (provider.containerConnections && provider.containerConnections.length > 0) {
       connection = provider.containerConnections[0];
     } else if (provider.kubernetesConnections && provider.kubernetesConnections.length > 0) {
       connection = provider.kubernetesConnections[0];
+    } else if (provider.vmConnections && provider.vmConnections.length > 0) {
+      connection = provider.vmConnections[0];
     }
 
     if (!connection) {


### PR DESCRIPTION
### What does this PR do?

Make startProvier work for providers with VM connections

### Screenshot / video of UI

Backend only

### What issues does this PR fix or reference?

Part of #11744 

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
