### PR TITLE
fix: do not forget to refresh context list after switching docker context

### DIFF
--- a/extensions/docker/src/docker-compatibility-setup.ts
+++ b/extensions/docker/src/docker-compatibility-setup.ts
@@ -56,6 +56,7 @@ export class DockerCompatibilitySetup {
         if (contextName) {
           try {
             await this.#dockerContextHandler.switchContext(contextName);
+            await this.refreshContextList();
           } catch (error: unknown) {
             console.error('error while switching the context', error);
           }


### PR DESCRIPTION
### What does this PR do?
context list was not refreshed after changing the context

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/podman-desktop/podman-desktop/issues/11679

### How to test this PR?

follow steps from the issue + unit tests added

- [x] Tests are covering the bug fix or the new feature
