### PR TITLE
fix: no current context on Kubernetes dashboard

### DIFF
--- a/packages/renderer/src/App.spec.ts
+++ b/packages/renderer/src/App.spec.ts
@@ -22,9 +22,10 @@ import { get, writable } from 'svelte/store';
 import { router } from 'tinro';
 import { beforeEach, expect, test, vi } from 'vitest';
 
+import * as kubernetesNoCurrentContext from '/@/stores/kubernetes-no-current-context';
+
 import App from './App.svelte';
 import { lastPage, lastSubmenuPages } from './stores/breadcrumb';
-import * as noKubernetesContext from './stores/kubernetes-no-current-context';
 import { navigationRegistry, type NavigationRegistryEntry } from './stores/navigation/navigation-registry';
 
 const mocks = vi.hoisted(() => ({
@@ -92,7 +93,7 @@ beforeEach(() => {
   };
   Object.defineProperty(window, 'dispatchEvent', { value: dispatchEventMock });
   (window.getConfigurationValue as unknown) = vi.fn();
-  vi.mocked(noKubernetesContext).noKubernetesCurrentContext = writable(false);
+  vi.mocked(kubernetesNoCurrentContext).kubernetesNoCurrentContext = writable(false);
 });
 
 test('test /image/run/* route', async () => {
@@ -167,7 +168,7 @@ test('do not display kubernetes empty screen if current context', async () => {
 });
 
 test('displays kubernetes empty screen if no current context, without Kubernetes menu', async () => {
-  vi.mocked(noKubernetesContext).noKubernetesCurrentContext = writable(true);
+  vi.mocked(kubernetesNoCurrentContext).kubernetesNoCurrentContext = writable(true);
 
   render(App);
   router.goto('/kubernetes/deployments');
@@ -178,7 +179,7 @@ test('displays kubernetes empty screen if no current context, without Kubernetes
 });
 
 test('go to last kubernetes page when available', async () => {
-  vi.mocked(noKubernetesContext).noKubernetesCurrentContext = writable(false);
+  vi.mocked(kubernetesNoCurrentContext).kubernetesNoCurrentContext = writable(false);
   lastSubmenuPages.set({ Kubernetes: '/kubernetes/deployments' });
   render(App);
   router.goto('/kubernetes');

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -5,7 +5,6 @@ import '@fortawesome/fontawesome-free/css/all.min.css';
 import { router } from 'tinro';
 
 import { handleNavigation } from '/@/navigation';
-import { NO_CURRENT_CONTEXT_ERROR } from '/@api/kubernetes-contexts-states';
 import type { KubernetesNavigationRequest } from '/@api/kubernetes-navigation';
 import type { NavigationRequest } from '/@api/navigation-request';
 
@@ -82,7 +81,7 @@ import WelcomePage from './lib/welcome/WelcomePage.svelte';
 import PreferencesNavigation from './PreferencesNavigation.svelte';
 import Route from './Route.svelte';
 import { lastSubmenuPages } from './stores/breadcrumb';
-import { kubernetesCurrentContextState } from './stores/kubernetes-contexts-state';
+import { noKubernetesCurrentContext } from './stores/kubernetes-no-current-context';
 import { navigationRegistry } from './stores/navigation/navigation-registry';
 import SubmenuNavigation from './SubmenuNavigation.svelte';
 
@@ -252,7 +251,7 @@ window.events?.receive('kubernetes-navigation', (args: unknown) => {
         <Route path="/volumes/:name/:engineId/*" breadcrumb="Volume Details" let:meta navigationHint="details">
           <VolumeDetails volumeName={decodeURI(meta.params.name)} engineId={decodeURI(meta.params.engineId)} />
         </Route>
-        {#if $kubernetesCurrentContextState.error === NO_CURRENT_CONTEXT_ERROR}
+        {#if $noKubernetesCurrentContext}
           <Route path="/kubernetes/*" breadcrumb="Kubernetes" navigationHint="root">
             <KubernetesDashboard />
           </Route>

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -5,6 +5,7 @@ import '@fortawesome/fontawesome-free/css/all.min.css';
 import { router } from 'tinro';
 
 import { handleNavigation } from '/@/navigation';
+import { kubernetesNoCurrentContext } from '/@/stores/kubernetes-no-current-context';
 import type { KubernetesNavigationRequest } from '/@api/kubernetes-navigation';
 import type { NavigationRequest } from '/@api/navigation-request';
 
@@ -81,7 +82,6 @@ import WelcomePage from './lib/welcome/WelcomePage.svelte';
 import PreferencesNavigation from './PreferencesNavigation.svelte';
 import Route from './Route.svelte';
 import { lastSubmenuPages } from './stores/breadcrumb';
-import { noKubernetesCurrentContext } from './stores/kubernetes-no-current-context';
 import { navigationRegistry } from './stores/navigation/navigation-registry';
 import SubmenuNavigation from './SubmenuNavigation.svelte';
 
@@ -251,7 +251,7 @@ window.events?.receive('kubernetes-navigation', (args: unknown) => {
         <Route path="/volumes/:name/:engineId/*" breadcrumb="Volume Details" let:meta navigationHint="details">
           <VolumeDetails volumeName={decodeURI(meta.params.name)} engineId={decodeURI(meta.params.engineId)} />
         </Route>
-        {#if $noKubernetesCurrentContext}
+        {#if $kubernetesNoCurrentContext}
           <Route path="/kubernetes/*" breadcrumb="Kubernetes" navigationHint="root">
             <KubernetesDashboard />
           </Route>

--- a/packages/renderer/src/lib/kube/KubernetesDashboard.spec.ts
+++ b/packages/renderer/src/lib/kube/KubernetesDashboard.spec.ts
@@ -29,6 +29,7 @@ import * as kubernetesPermissions from '/@/stores/kubernetes-context-permission'
 import { kubernetesContexts } from '/@/stores/kubernetes-contexts';
 import * as kubeContextStore from '/@/stores/kubernetes-contexts-state';
 import * as kubernetesExperimental from '/@/stores/kubernetes-experimental';
+import * as noKubernetesContext from '/@/stores/kubernetes-no-current-context';
 import * as kubernetesReourcesCount from '/@/stores/kubernetes-resources-count';
 import type { KubeContext } from '/@api/kubernetes-context';
 import type { ContextPermission } from '/@api/kubernetes-contexts-permissions';
@@ -57,6 +58,7 @@ vi.mock('/@/stores/kubernetes-resources-count');
 vi.mock('/@/lib/kube/active-resources-count-listen');
 
 vi.mock('/@/stores/kubernetes-context-permission');
+vi.mock('/@/stores/kubernetes-no-current-context');
 
 const openExternalMock = vi.fn();
 
@@ -69,6 +71,7 @@ beforeAll(() => {
 
 beforeEach(() => {
   vi.resetAllMocks();
+  vi.mocked(noKubernetesContext).noKubernetesCurrentContext = writable(false);
 });
 
 test('Verify basic page', async () => {

--- a/packages/renderer/src/lib/kube/KubernetesDashboard.spec.ts
+++ b/packages/renderer/src/lib/kube/KubernetesDashboard.spec.ts
@@ -29,7 +29,7 @@ import * as kubernetesPermissions from '/@/stores/kubernetes-context-permission'
 import { kubernetesContexts } from '/@/stores/kubernetes-contexts';
 import * as kubeContextStore from '/@/stores/kubernetes-contexts-state';
 import * as kubernetesExperimental from '/@/stores/kubernetes-experimental';
-import * as noKubernetesContext from '/@/stores/kubernetes-no-current-context';
+import * as kubernetesNoCurrentContext from '/@/stores/kubernetes-no-current-context';
 import * as kubernetesReourcesCount from '/@/stores/kubernetes-resources-count';
 import type { KubeContext } from '/@api/kubernetes-context';
 import type { ContextPermission } from '/@api/kubernetes-contexts-permissions';
@@ -71,7 +71,7 @@ beforeAll(() => {
 
 beforeEach(() => {
   vi.resetAllMocks();
-  vi.mocked(noKubernetesContext).noKubernetesCurrentContext = writable(false);
+  vi.mocked(kubernetesNoCurrentContext).kubernetesNoCurrentContext = writable(false);
 });
 
 test('Verify basic page', async () => {

--- a/packages/renderer/src/lib/kube/KubernetesDashboard.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesDashboard.svelte
@@ -20,14 +20,13 @@ import {
   kubernetesCurrentContextRoutes,
   kubernetesCurrentContextSecrets,
   kubernetesCurrentContextServices,
-  kubernetesCurrentContextState,
 } from '/@/stores/kubernetes-contexts-state';
 import { isKubernetesExperimentalModeStore } from '/@/stores/kubernetes-experimental';
 import { kubernetesResourcesCount } from '/@/stores/kubernetes-resources-count';
 import type { IDisposable } from '/@api/disposable';
-import { NO_CURRENT_CONTEXT_ERROR } from '/@api/kubernetes-contexts-states';
 import type { ResourceCount } from '/@api/kubernetes-resource-count';
 
+import { noKubernetesCurrentContext } from '../../stores/kubernetes-no-current-context';
 import deployAndTestKubernetesImage from './DeployAndTestKubernetes.png';
 import KubernetesDashboardGuideCard from './KubernetesDashboardGuideCard.svelte';
 import KubernetesDashboardResourceCard from './KubernetesDashboardResourceCard.svelte';
@@ -41,7 +40,6 @@ interface ExtendedKubernetesObject extends KubernetesObject {
   };
 }
 
-let noContexts = $derived($kubernetesCurrentContextState.error === NO_CURRENT_CONTEXT_ERROR);
 let currentContextName = $derived($kubernetesContexts.find(context => context.currentContext)?.name);
 
 // Stores and states for non-experimental mode
@@ -180,7 +178,7 @@ async function openKubernetesDocumentation(): Promise<void> {
 
 <div class="flex flex-col w-full h-full">
   <div class="flex flex-col w-full h-full pt-4">
-    {#if noContexts}
+    {#if $noKubernetesCurrentContext}
       <KubernetesEmptyPage />
     {:else}
       <!-- Details - collapsible -->

--- a/packages/renderer/src/lib/kube/KubernetesDashboard.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesDashboard.svelte
@@ -22,11 +22,11 @@ import {
   kubernetesCurrentContextServices,
 } from '/@/stores/kubernetes-contexts-state';
 import { isKubernetesExperimentalModeStore } from '/@/stores/kubernetes-experimental';
+import { kubernetesNoCurrentContext } from '/@/stores/kubernetes-no-current-context';
 import { kubernetesResourcesCount } from '/@/stores/kubernetes-resources-count';
 import type { IDisposable } from '/@api/disposable';
 import type { ResourceCount } from '/@api/kubernetes-resource-count';
 
-import { noKubernetesCurrentContext } from '../../stores/kubernetes-no-current-context';
 import deployAndTestKubernetesImage from './DeployAndTestKubernetes.png';
 import KubernetesDashboardGuideCard from './KubernetesDashboardGuideCard.svelte';
 import KubernetesDashboardResourceCard from './KubernetesDashboardResourceCard.svelte';
@@ -178,7 +178,7 @@ async function openKubernetesDocumentation(): Promise<void> {
 
 <div class="flex flex-col w-full h-full">
   <div class="flex flex-col w-full h-full pt-4">
-    {#if $noKubernetesCurrentContext}
+    {#if $kubernetesNoCurrentContext}
       <KubernetesEmptyPage />
     {:else}
       <!-- Details - collapsible -->

--- a/packages/renderer/src/stores/kubernetes-no-current-context.spec.ts
+++ b/packages/renderer/src/stores/kubernetes-no-current-context.spec.ts
@@ -1,0 +1,64 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { get } from 'svelte/store';
+import { expect, test } from 'vitest';
+
+import { kubernetesContexts } from './kubernetes-contexts';
+import { noKubernetesCurrentContext } from './kubernetes-no-current-context';
+
+test('is true when there is no context', () => {
+  kubernetesContexts.set([]);
+  const currentValue = get(noKubernetesCurrentContext);
+  expect(currentValue).toBeTruthy();
+});
+
+test('is false when there is a current context', () => {
+  kubernetesContexts.set([
+    {
+      name: 'ctx1',
+      cluster: 'cluster1',
+      user: 'user1',
+    },
+    {
+      name: 'ctx2',
+      cluster: 'cluster2',
+      user: 'user2',
+      currentContext: true,
+    },
+  ]);
+  const currentValue = get(noKubernetesCurrentContext);
+  expect(currentValue).toBeFalsy();
+});
+
+test('is true when there is no current context', () => {
+  kubernetesContexts.set([
+    {
+      name: 'ctx1',
+      cluster: 'cluster1',
+      user: 'user1',
+    },
+    {
+      name: 'ctx2',
+      cluster: 'cluster2',
+      user: 'user2',
+    },
+  ]);
+  const currentValue = get(noKubernetesCurrentContext);
+  expect(currentValue).toBeTruthy();
+});

--- a/packages/renderer/src/stores/kubernetes-no-current-context.spec.ts
+++ b/packages/renderer/src/stores/kubernetes-no-current-context.spec.ts
@@ -20,11 +20,11 @@ import { get } from 'svelte/store';
 import { expect, test } from 'vitest';
 
 import { kubernetesContexts } from './kubernetes-contexts';
-import { noKubernetesCurrentContext } from './kubernetes-no-current-context';
+import { kubernetesNoCurrentContext } from './kubernetes-no-current-context';
 
 test('is true when there is no context', () => {
   kubernetesContexts.set([]);
-  const currentValue = get(noKubernetesCurrentContext);
+  const currentValue = get(kubernetesNoCurrentContext);
   expect(currentValue).toBeTruthy();
 });
 
@@ -42,7 +42,7 @@ test('is false when there is a current context', () => {
       currentContext: true,
     },
   ]);
-  const currentValue = get(noKubernetesCurrentContext);
+  const currentValue = get(kubernetesNoCurrentContext);
   expect(currentValue).toBeFalsy();
 });
 
@@ -59,6 +59,6 @@ test('is true when there is no current context', () => {
       user: 'user2',
     },
   ]);
-  const currentValue = get(noKubernetesCurrentContext);
+  const currentValue = get(kubernetesNoCurrentContext);
   expect(currentValue).toBeTruthy();
 });

--- a/packages/renderer/src/stores/kubernetes-no-current-context.ts
+++ b/packages/renderer/src/stores/kubernetes-no-current-context.ts
@@ -1,0 +1,29 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { derived } from 'svelte/store';
+
+import { kubernetesContexts } from './kubernetes-contexts';
+
+// noKubernetesCurrentContext is true when no kubernetes current context is found
+// (generally when there id no kubeconfig file, but also if the file is empty or with no contexts, or with no current context)
+// this store is usable for both Kubernetes experimental and non-experimental modes
+export const noKubernetesCurrentContext = derived(
+  [kubernetesContexts],
+  ([contexts]) => !contexts.find(c => c.currentContext),
+);

--- a/packages/renderer/src/stores/kubernetes-no-current-context.ts
+++ b/packages/renderer/src/stores/kubernetes-no-current-context.ts
@@ -20,10 +20,10 @@ import { derived } from 'svelte/store';
 
 import { kubernetesContexts } from './kubernetes-contexts';
 
-// noKubernetesCurrentContext is true when no kubernetes current context is found
+// kubernetesNoCurrentContext is true when no kubernetes current context is found
 // (generally when there id no kubeconfig file, but also if the file is empty or with no contexts, or with no current context)
 // this store is usable for both Kubernetes experimental and non-experimental modes
-export const noKubernetesCurrentContext = derived(
+export const kubernetesNoCurrentContext = derived(
   [kubernetesContexts],
   ([contexts]) => !contexts.find(c => c.currentContext),
 );

--- a/packages/renderer/src/stores/navigation/navigation-registry-kubernetes.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-kubernetes.svelte.spec.ts
@@ -17,11 +17,12 @@
  ***********************************************************************/
 
 import type { KubernetesObject } from '@kubernetes/client-node';
-import { readable } from 'svelte/store';
+import { readable, writable } from 'svelte/store';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import KubeIcon from '/@/lib/images/KubeIcon.svelte';
-import { type ContextGeneralState, NO_CURRENT_CONTEXT_ERROR } from '/@api/kubernetes-contexts-states';
+import * as noKubernetesContext from '/@/stores/kubernetes-no-current-context';
+import { type ContextGeneralState } from '/@api/kubernetes-contexts-states';
 import type { ForwardConfig } from '/@api/kubernetes-port-forward-model';
 
 import * as kubeContextStore from '../kubernetes-contexts-state';
@@ -30,9 +31,11 @@ import { createNavigationKubernetesGroup } from './navigation-registry-kubernete
 vi.mock('../kubernetes-contexts-state', async () => {
   return {};
 });
+vi.mock('/@/stores/kubernetes-no-current-context');
 
 beforeEach(() => {
   vi.resetAllMocks();
+  vi.mocked(noKubernetesContext).noKubernetesCurrentContext = writable(false);
 });
 
 test('createNavigationImageEntry with current context', async () => {
@@ -79,9 +82,7 @@ test('createNavigationImageEntry with current context', async () => {
 });
 
 test('createNavigationImageEntry without current context', async () => {
-  vi.mocked(kubeContextStore).kubernetesCurrentContextState = readable<ContextGeneralState>({
-    error: NO_CURRENT_CONTEXT_ERROR,
-  } as ContextGeneralState);
+  vi.mocked(noKubernetesContext).noKubernetesCurrentContext = writable(true);
   vi.mocked(kubeContextStore).kubernetesCurrentContextNodes = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextCronJobs = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextJobs = readable<KubernetesObject[]>([]);

--- a/packages/renderer/src/stores/navigation/navigation-registry-kubernetes.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-kubernetes.svelte.spec.ts
@@ -21,7 +21,7 @@ import { readable, writable } from 'svelte/store';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import KubeIcon from '/@/lib/images/KubeIcon.svelte';
-import * as noKubernetesContext from '/@/stores/kubernetes-no-current-context';
+import * as kubernetesNoCurrentContext from '/@/stores/kubernetes-no-current-context';
 import { type ContextGeneralState } from '/@api/kubernetes-contexts-states';
 import type { ForwardConfig } from '/@api/kubernetes-port-forward-model';
 
@@ -35,7 +35,7 @@ vi.mock('/@/stores/kubernetes-no-current-context');
 
 beforeEach(() => {
   vi.resetAllMocks();
-  vi.mocked(noKubernetesContext).noKubernetesCurrentContext = writable(false);
+  vi.mocked(kubernetesNoCurrentContext).kubernetesNoCurrentContext = writable(false);
 });
 
 test('createNavigationImageEntry with current context', async () => {
@@ -82,7 +82,7 @@ test('createNavigationImageEntry with current context', async () => {
 });
 
 test('createNavigationImageEntry without current context', async () => {
-  vi.mocked(noKubernetesContext).noKubernetesCurrentContext = writable(true);
+  vi.mocked(kubernetesNoCurrentContext).kubernetesNoCurrentContext = writable(true);
   vi.mocked(kubeContextStore).kubernetesCurrentContextNodes = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextCronJobs = readable<KubernetesObject[]>([]);
   vi.mocked(kubeContextStore).kubernetesCurrentContextJobs = readable<KubernetesObject[]>([]);

--- a/packages/renderer/src/stores/navigation/navigation-registry-kubernetes.svelte.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-kubernetes.svelte.ts
@@ -18,9 +18,8 @@
 
 import KubeIcon from '/@/lib/images/KubeIcon.svelte';
 import { createNavigationKubernetesPortForwardEntry } from '/@/stores/navigation/kubernetes/navigation-registry-k8s-port-forward.svelte';
-import { NO_CURRENT_CONTEXT_ERROR } from '/@api/kubernetes-contexts-states';
 
-import { kubernetesCurrentContextState } from '../kubernetes-contexts-state';
+import { noKubernetesCurrentContext } from '../kubernetes-no-current-context';
 import { createNavigationKubernetesConfigMapSecretsEntry } from './kubernetes/navigation-registry-k8s-configmap-secrets.svelte';
 import { createNavigationKubernetesCronJobsEntry } from './kubernetes/navigation-registry-k8s-cronjobs.svelte';
 import { createNavigationKubernetesDashboardEntry } from './kubernetes/navigation-registry-k8s-dashboard.svelte';
@@ -55,8 +54,8 @@ export function createNavigationKubernetesGroup(): NavigationRegistryEntry {
   newItems.push(createNavigationKubernetesPortForwardEntry());
   kubernetesNavigationGroupItems = newItems;
 
-  kubernetesCurrentContextState.subscribe(value => {
-    context = value.error !== NO_CURRENT_CONTEXT_ERROR;
+  noKubernetesCurrentContext.subscribe(value => {
+    context = !value;
   });
 
   const mainGroupEntry: NavigationRegistryEntry = {

--- a/packages/renderer/src/stores/navigation/navigation-registry-kubernetes.svelte.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-kubernetes.svelte.ts
@@ -17,9 +17,9 @@
  ***********************************************************************/
 
 import KubeIcon from '/@/lib/images/KubeIcon.svelte';
+import { kubernetesNoCurrentContext } from '/@/stores/kubernetes-no-current-context';
 import { createNavigationKubernetesPortForwardEntry } from '/@/stores/navigation/kubernetes/navigation-registry-k8s-port-forward.svelte';
 
-import { noKubernetesCurrentContext } from '../kubernetes-no-current-context';
 import { createNavigationKubernetesConfigMapSecretsEntry } from './kubernetes/navigation-registry-k8s-configmap-secrets.svelte';
 import { createNavigationKubernetesCronJobsEntry } from './kubernetes/navigation-registry-k8s-cronjobs.svelte';
 import { createNavigationKubernetesDashboardEntry } from './kubernetes/navigation-registry-k8s-dashboard.svelte';
@@ -54,7 +54,7 @@ export function createNavigationKubernetesGroup(): NavigationRegistryEntry {
   newItems.push(createNavigationKubernetesPortForwardEntry());
   kubernetesNavigationGroupItems = newItems;
 
-  noKubernetesCurrentContext.subscribe(value => {
+  kubernetesNoCurrentContext.subscribe(value => {
     context = !value;
   });
 


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Fix UI when there is no current Kubernetes context, in Experimental mode

### Screenshot / video of UI

### What issues does this PR fix or reference?

Fixes #11664 

### How to test this PR?

In experimental and non-experimental mode:

- Start with some kube contexts, and one current
- Go to Kubernetes dashboard, resources counts should be visible
- Go to Deplyment page, the list should be visible
- rename your kubeconfig file to another name (`mv ~/.kube/config ~/.kube/config-test-11664)
- Kubernetes dashboard should display the "No Kubernetes cluster" page and the Kubernetes submenu should not be displayed
- rename your kubeconfig file to config (`mv ~/.kube/config-test-11664 ~/.kube/config)
- Menu and Deployments list should be visible
- Go to Kubernetes dashboard
- Dashboard should be visible

- [x] Tests are covering the bug fix or the new feature
