### PR TITLE
fix(ui): make Carousel generic

### DIFF
--- a/packages/renderer/src/lib/learning-center/LearningCenter.svelte
+++ b/packages/renderer/src/lib/learning-center/LearningCenter.svelte
@@ -39,8 +39,8 @@ async function toggle(expanded: boolean): Promise<void> {
 }
 </script>
 
-{#snippet card(guide: unknown)}
-<GuideCard guide={guide as Guide} />
+{#snippet card(guide: Guide)}
+  <GuideCard guide={guide} />
 {/snippet}
 
 

--- a/packages/ui/src/lib/carousel/Carousel.svelte
+++ b/packages/ui/src/lib/carousel/Carousel.svelte
@@ -1,14 +1,14 @@
-<script lang="ts">
+<script lang="ts" generics="T">
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { onDestroy, onMount, type Snippet } from 'svelte';
 import Fa from 'svelte-fa';
 
-interface Props {
-  cards: unknown[];
+interface Props<T> {
+  cards: T[];
   cardWidth?: number;
-  card: Snippet<[unknown]>;
+  card: Snippet<[T]>;
 }
-let { cards, card, cardWidth = 340 }: Props = $props();
+let { cards, card, cardWidth = 340 }: Props<T> = $props();
 
 let resizeObserver: ResizeObserver;
 

--- a/packages/ui/src/lib/carousel/CarouselTest.svelte
+++ b/packages/ui/src/lib/carousel/CarouselTest.svelte
@@ -1,15 +1,19 @@
 <script lang="ts">
 import Carousel from './Carousel.svelte';
+
+interface Item {
+  content: string;
+}
 </script>
 
 
-{#snippet card(cardItem: unknown)}
-<p>{cardItem}</p>
+{#snippet card(item: Item)}
+  <p>{item.content}</p>
 {/snippet}
 
 <div>
   <p class="text-lg first-letter:uppercase font-bold pb-5">Learning center:</p>
   <div class="bg-[var(--pd-content-card-bg)] p-4 rounded-lg">
-    <Carousel cards={['card 1', 'card 2', 'card 3']} {card} cardWidth={340} />
+    <Carousel cards={['card 1', 'card 2', 'card 3'].map((value) => ({ content: value }))} {card} cardWidth={340} />
   </div>
 </div>

--- a/packages/ui/src/lib/carousel/CarouselTest.svelte
+++ b/packages/ui/src/lib/carousel/CarouselTest.svelte
@@ -1,19 +1,15 @@
 <script lang="ts">
 import Carousel from './Carousel.svelte';
-
-interface Item {
-  content: string;
-}
 </script>
 
 
-{#snippet card(item: Item)}
-  <p>{item.content}</p>
+{#snippet card(cardItem: string)}
+<p>{cardItem}</p>
 {/snippet}
 
 <div>
   <p class="text-lg first-letter:uppercase font-bold pb-5">Learning center:</p>
   <div class="bg-[var(--pd-content-card-bg)] p-4 rounded-lg">
-    <Carousel cards={['card 1', 'card 2', 'card 3'].map((value) => ({ content: value }))} {card} cardWidth={340} />
+    <Carousel cards={['card 1', 'card 2', 'card 3']} {card} cardWidth={340} />
   </div>
 </div>


### PR DESCRIPTION
### What does this PR do?

The carousel component has the following props

https://github.com/podman-desktop/podman-desktop/blob/1428178825e2ed2c5b50d13fece9e8d79fd09211/packages/ui/src/lib/carousel/Carousel.svelte#L6-L10

- The `card` is a snippet (render function) taking as argument `unknown`
- The `cards` is an array of unknown, it will be the items rendered throw the card snippet.

With the unknown definition, there is a small issue: we could provide any snippet and any object to the card, there is no type contraint on what can be passed to the Carousel component.

We don't have much option here except using generic components.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/11856

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
