### PR TITLE
feat: create VM provider frontend

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesProviderRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesProviderRendering.spec.ts
@@ -1,9 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
 import { render, screen } from '@testing-library/svelte';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
+import { providerInfos } from '/@/stores/providers';
 import type { ProviderInfo } from '/@api/provider-info';
 
-import { providerInfos } from '../../stores/providers';
 import * as PreferencesConnectionCreationRendering from './PreferencesConnectionCreationOrEditRendering.svelte';
 import PreferencesProviderRendering from './PreferencesProviderRendering.svelte';
 

--- a/packages/renderer/src/lib/preferences/PreferencesProviderRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesProviderRendering.spec.ts
@@ -1,0 +1,117 @@
+import { render, screen } from '@testing-library/svelte';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { ProviderInfo } from '/@api/provider-info';
+
+import { providerInfos } from '../../stores/providers';
+import * as PreferencesConnectionCreationRendering from './PreferencesConnectionCreationOrEditRendering.svelte';
+import PreferencesProviderRendering from './PreferencesProviderRendering.svelte';
+
+const defaultProviderInfo = {
+  id: 'test',
+  internalId: 'id',
+  name: 'provider default name',
+  containerConnections: [],
+  kubernetesConnections: undefined,
+  status: 'started',
+  containerProviderConnectionCreation: false,
+  containerProviderConnectionInitialization: false,
+  kubernetesProviderConnectionCreation: false,
+  kubernetesProviderConnectionInitialization: false,
+  links: undefined,
+  detectionChecks: undefined,
+  warnings: undefined,
+  images: undefined,
+  installationSupport: undefined,
+} as unknown as ProviderInfo;
+
+vi.mock('./PreferencesConnectionCreationOrEditRendering.svelte');
+
+describe.each<{
+  name: string;
+  setProviderInfo: (providerInfo: ProviderInfo) => void;
+  expectedTitle: string;
+  expectedPropertyScope: string;
+  expectedCallback: unknown;
+}>([
+  {
+    name: 'container provider without display name',
+    setProviderInfo: (providerInfo: ProviderInfo): void => {
+      providerInfo.containerProviderConnectionCreation = true;
+    },
+    expectedTitle: 'Create provider default name',
+    expectedPropertyScope: 'ContainerProviderConnectionFactory',
+    expectedCallback: window.createContainerProviderConnection,
+  },
+  {
+    name: 'container provider with display name',
+    setProviderInfo: (providerInfo: ProviderInfo): void => {
+      providerInfo.containerProviderConnectionCreation = true;
+      providerInfo.containerProviderConnectionCreationDisplayName = 'container Provider 1';
+    },
+    expectedTitle: 'Create container Provider 1',
+    expectedPropertyScope: 'ContainerProviderConnectionFactory',
+    expectedCallback: window.createContainerProviderConnection,
+  },
+  {
+    name: 'kubernetes provider without display name',
+    setProviderInfo: (providerInfo: ProviderInfo): void => {
+      providerInfo.kubernetesProviderConnectionCreation = true;
+    },
+    expectedTitle: 'Create provider default name',
+    expectedPropertyScope: 'KubernetesProviderConnectionFactory',
+    expectedCallback: window.createKubernetesProviderConnection,
+  },
+  {
+    name: 'kubernetes provider with display name',
+    setProviderInfo: (providerInfo: ProviderInfo): void => {
+      providerInfo.kubernetesProviderConnectionCreation = true;
+      providerInfo.kubernetesProviderConnectionCreationDisplayName = 'Kubernetes Provider 1';
+    },
+    expectedTitle: 'Create Kubernetes Provider 1',
+    expectedPropertyScope: 'KubernetesProviderConnectionFactory',
+    expectedCallback: window.createKubernetesProviderConnection,
+  },
+  {
+    name: 'VM provider without display name',
+    setProviderInfo: (providerInfo: ProviderInfo): void => {
+      providerInfo.vmProviderConnectionCreation = true;
+    },
+    expectedTitle: 'Create provider default name',
+    expectedPropertyScope: 'VmProviderConnectionFactory',
+    expectedCallback: window.createVmProviderConnection,
+  },
+  {
+    name: 'VM provider with display name',
+    setProviderInfo: (providerInfo: ProviderInfo): void => {
+      providerInfo.vmProviderConnectionCreation = true;
+      providerInfo.vmProviderConnectionCreationDisplayName = 'VM Provider 1';
+    },
+    expectedTitle: 'Create VM Provider 1',
+    expectedPropertyScope: 'VmProviderConnectionFactory',
+    expectedCallback: window.createVmProviderConnection,
+  },
+])('$name', ({ name: _name, setProviderInfo, expectedTitle, expectedPropertyScope, expectedCallback }) => {
+  beforeEach(() => {
+    const info = { ...defaultProviderInfo };
+    setProviderInfo(info);
+    providerInfos.set([info]);
+    render(PreferencesProviderRendering, {
+      providerInternalId: 'id',
+    });
+  });
+
+  test('title', () => {
+    screen.getByRole('heading', { name: expectedTitle });
+  });
+
+  test('PreferencesConnectionCreationRendering call', () => {
+    expect(PreferencesConnectionCreationRendering.default).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        propertyScope: expectedPropertyScope,
+        callback: expectedCallback,
+      }),
+    );
+  });
+});

--- a/packages/renderer/src/lib/preferences/PreferencesProviderRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProviderRendering.svelte
@@ -6,11 +6,11 @@ import { onMount } from 'svelte';
 import { router } from 'tinro';
 
 import { operationConnectionsInfo } from '/@/stores/operation-connections';
+import { providerInfos } from '/@/stores/providers';
 import type { ProviderConnectionInfo, ProviderInfo } from '/@api/provider-info';
 
 import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import Route from '../../Route.svelte';
-import { providerInfos } from '../../stores/providers';
 import FormPage from '../ui/FormPage.svelte';
 import TerminalWindow from '../ui/TerminalWindow.svelte';
 import PreferencesConnectionCreationRendering from './PreferencesConnectionCreationOrEditRendering.svelte';

--- a/packages/renderer/src/lib/preferences/PreferencesProviderRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProviderRendering.svelte
@@ -6,11 +6,7 @@ import { onMount } from 'svelte';
 import { router } from 'tinro';
 
 import { operationConnectionsInfo } from '/@/stores/operation-connections';
-import type {
-  ProviderContainerConnectionInfo,
-  ProviderInfo,
-  ProviderKubernetesConnectionInfo,
-} from '/@api/provider-info';
+import type { ProviderConnectionInfo, ProviderInfo } from '/@api/provider-info';
 
 import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import Route from '../../Route.svelte';
@@ -32,7 +28,7 @@ router.subscribe(() => {
   providerLifecycleError = '';
 });
 
-let connectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo | undefined = undefined;
+let connectionInfo: ProviderConnectionInfo | undefined = undefined;
 
 let providers: ProviderInfo[] = [];
 onMount(() => {
@@ -56,7 +52,9 @@ $: providerDisplayName =
     ? (providerInfo?.containerProviderConnectionCreationDisplayName ?? undefined)
     : providerInfo?.kubernetesProviderConnectionCreation
       ? providerInfo?.kubernetesProviderConnectionCreationDisplayName
-      : undefined) ?? providerInfo?.name;
+      : providerInfo?.vmProviderConnectionCreation
+        ? providerInfo?.vmProviderConnectionCreationDisplayName
+        : undefined) ?? providerInfo?.name;
 
 let title: string;
 $: title = connectionInfo ? `Update ${providerDisplayName} ${connectionInfo.name}` : `Create ${providerDisplayName}`;
@@ -155,6 +153,16 @@ async function stopReceivingLogs(providerInternalId: string): Promise<void> {
             properties={properties}
             propertyScope="KubernetesProviderConnectionFactory"
             callback={window.createKubernetesProviderConnection}
+            taskId={taskId}
+            bind:inProgress={inProgress} />
+        {/if}
+
+        {#if providerInfo?.vmProviderConnectionCreation === true}
+          <PreferencesConnectionCreationRendering
+            providerInfo={providerInfo}
+            properties={properties}
+            propertyScope="VmProviderConnectionFactory"
+            callback={window.createVmProviderConnection}
             taskId={taskId}
             bind:inProgress={inProgress} />
         {/if}


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Frontend to create VM Provider


#### Prerequisites: 

(instructions are for mac, should be adapted for Windows - not tested on Linux)

- start Podman Desktop with this extension (and see prerequisites there): https://github.com/redhat-developer/podman-desktop-rhel-ext/pull/10
- get a RHEL VM image (ask me) 
 
### Screenshot / video of UI

![create-vm-provider](https://github.com/user-attachments/assets/e53eeb27-77ac-406a-8ef6-5461e9af3905)


### What issues does this PR fix or reference?

Part of #11747 

### How to test this PR?

Go to Settings > Resources > Macadam > Create new...

- [x] Tests are covering the bug fix or the new feature
