### PR TITLE
refactor: use provider id instead of socket to index terminal info

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsTerminal.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsTerminal.svelte
@@ -119,7 +119,7 @@ async function refreshTerminal(): Promise<void> {
   );
 
   // get terminal if any
-  const existingTerminal = getExistingTerminal(connectionInfo.name, connectionInfo.endpoint.socketPath);
+  const existingTerminal = getExistingTerminal(provider.internalId, connectionInfo.name);
   shellTerminal = new Terminal({
     fontSize,
     lineHeight,
@@ -169,7 +169,6 @@ onDestroy(async () => {
   // register terminal for reusing it
   registerTerminal({
     providerInternalId: provider.internalId,
-    connectionSocket: connectionInfo.endpoint.socketPath,
     connectionName: connectionInfo.name,
     callbackId: sendCallbackId,
     terminal: terminalContent,

--- a/packages/renderer/src/stores/provider-terminal-store.spec.ts
+++ b/packages/renderer/src/stores/provider-terminal-store.spec.ts
@@ -32,18 +32,17 @@ test('get a terminal', async () => {
   // register a new terminal
   registerTerminal({
     providerInternalId: '1',
-    connectionSocket: 'connectionSocket1',
     connectionName: 'connectionName1',
     callbackId: 1,
     terminal: {} as any,
   });
 
   // try to grab the terminal
-  const terminal1 = getExistingTerminal('connectionName1', 'connectionSocket1');
+  const terminal1 = getExistingTerminal('1', 'connectionName1');
   expect(terminal1).toBeDefined();
 
   // try to grab an unexisting terminal
-  const terminal2 = getExistingTerminal('connectionName2', 'connectionSocket2');
+  const terminal2 = getExistingTerminal('1', 'connectionName2');
   expect(terminal2).toBeUndefined();
 });
 
@@ -51,7 +50,6 @@ test('terminals should be updated in case of a matching provider connection is r
   // set list of terminals
   registerTerminal({
     providerInternalId: '1',
-    connectionSocket: 'connectionSocket1',
     connectionName: 'connectionName1',
     callbackId: 1,
     terminal: {} as any,

--- a/packages/renderer/src/stores/provider-terminal-store.ts
+++ b/packages/renderer/src/stores/provider-terminal-store.ts
@@ -26,9 +26,6 @@ export interface TerminalOfProvider {
   // engine id of the provider
   providerInternalId: string;
 
-  // connection socket
-  connectionSocket: string;
-
   // connection name
   connectionName: string;
 
@@ -71,7 +68,8 @@ export function registerTerminal(terminal: TerminalOfProvider): void {
   providerTerminals.update(terminals => {
     // remove old instance(s) of terminal if exists
     terminals = terminals.filter(
-      term => !(terminal.connectionName === term.connectionName && term.connectionSocket === terminal.connectionSocket),
+      term =>
+        !(terminal.providerInternalId === term.providerInternalId && terminal.connectionName === term.connectionName),
     );
     terminals.push(terminal);
     return terminals;
@@ -79,11 +77,11 @@ export function registerTerminal(terminal: TerminalOfProvider): void {
 }
 
 export function getExistingTerminal(
+  providerInternalId: string,
   connectionName: string,
-  connectionSocketPath: string,
 ): TerminalOfProvider | undefined {
   const terminals = get(providerTerminals);
   return terminals.find(
-    terminal => terminal.connectionName === connectionName && terminal.connectionSocket === connectionSocketPath,
+    terminal => terminal.providerInternalId === providerInternalId && terminal.connectionName === connectionName,
   );
 }


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Use provider id instead of socket to index terminal info, so the store can be used for any other provider (including VM provider)

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of #11747 

### How to test this PR?

Podman terminals should be accessible as before
 
- [x] Tests are covering the bug fix or the new feature
