### PR TITLE
chore: migrate provider button onclick

### DIFF
--- a/packages/renderer/src/lib/statusbar/ProviderButton.svelte
+++ b/packages/renderer/src/lib/statusbar/ProviderButton.svelte
@@ -16,7 +16,7 @@ let { provider, onclick, left, class: className }: Props = $props();
 </script>
 
 <button
-  on:click={onclick}
+  onclick={onclick}
   class="px-1 py-px flex flex-row h-full items-center gap-1 min-w-fit hover:bg-[var(--pd-statusbar-hover-bg)] hover:cursor-pointer relative {className}"
   aria-label={provider.name}>
   {@render left?.()}


### PR DESCRIPTION
### What does this PR do?

I don't know when ProviderButton was migrated to Svelte 5, but I get a warning on every pnpm svelte:check b/c the on:click wasn't changed, just removes the ':'.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #11933.

### How to test this PR?

Confirm pnpm svelte:check doesn't warn for this.