### PR TITLE
fix(electorn/build): configure access to specific DBus services for flatpak

### DIFF
--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -151,7 +151,6 @@ const config = {
   flatpak: {
     license: 'LICENSE',
     finishArgs: [
-      // allow to execute commands remotely
       '--socket=wayland',
       '--socket=x11',
       '--share=ipc',

--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -152,7 +152,6 @@ const config = {
     license: 'LICENSE',
     finishArgs: [
       // allow to execute commands remotely
-      '--socket=session-bus',
       '--socket=wayland',
       '--socket=x11',
       '--share=ipc',
@@ -170,6 +169,11 @@ const config = {
       '--share=network',
       // System notifications with libnotify
       '--talk-name=org.freedesktop.Notifications',
+      // Allow safeStorage access to keyring to encrypt/decrypt file used to store sensitive information
+      // In Gnome Desktop Environment
+      '--talk-name=org.freedesktop.secrets',
+      // In KDE Desktop Environment
+      '--talk-name=org.kde.kwalletd6',
     ],
     useWaylandFlags: 'false',
     artifactName: 'podman-desktop-${version}.${ext}',


### PR DESCRIPTION
### What does this PR do?

Replaces the --socket=session-bus option which open access to any DBus service to with --talk-name options to open access to specific services used in electon's safeStorage implementation:
- --talk-name=org.freedesktop.secrets for linux with Gnome Desktop Environment
- --talk-name=org.kde.kwalletd6 for linux with Gnome DE

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fix #11937.

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
