### PR TITLE
chore: added dialog for showing manual installation steps on windows

### DIFF
--- a/extensions/podman/packages/extension/src/utils/podman-install.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-install.spec.ts
@@ -863,6 +863,38 @@ describe('performUpdate', () => {
     expect(extensionApi.Uri.parse).toHaveBeenCalledWith(releaseNotes.href);
     expect(extensionApi.env.openExternal).toHaveBeenCalled();
   });
+
+  test('should not start instalation when updating from Podman 5.3.1 to 5.4.X', async () => {
+    vi.mocked(extensionApi.window.showInformationMessage).mockResolvedValue('Yes');
+    const podmanInstall: TestPodmanInstall = new TestPodmanInstall(extensionContext);
+    (extensionApi.env.isWindows as boolean) = true;
+    // all podman machine are stopped
+    vi.spyOn(podmanInstall, 'stopPodmanMachinesIfAnyBeforeUpdating').mockResolvedValue(true);
+    // return true if data have been cleaned or if user skip it
+    vi.spyOn(podmanInstall, 'wipeAllDataBeforeUpdatingToV5').mockResolvedValue(true);
+
+    // mock initialized
+    podmanInstall['podmanInfo'] = {} as unknown as PodmanInfo;
+    // mock checkForUpdate
+    vi.spyOn(podmanInstall, 'checkForUpdate').mockResolvedValue({
+      hasUpdate: true,
+      installedVersion: '5.3.1',
+      bundledVersion: '5.4.1',
+    });
+
+    await podmanInstall.performUpdate(providerMock, undefined);
+
+    expect(extensionApi.window.showInformationMessage).toHaveBeenCalledWith(
+      'Updating the podman from 5.3.1 to 5.4.1 requires manual installation.\nDo you want to show instructions for this?',
+      'Yes',
+      'No',
+    );
+
+    expect(extensionApi.Uri.parse).toHaveBeenCalledWith(
+      'https://github.com/containers/podman/blob/main/docs/tutorials/podman-for-windows.md',
+    );
+    expect(extensionApi.env.openExternal).toHaveBeenCalled();
+  });
 });
 
 describe('MacOSInstaller', () => {

--- a/extensions/podman/packages/extension/src/utils/podman-install.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-install.ts
@@ -340,8 +340,10 @@ export class PodmanInstall {
         return;
       }
 
-      // https://github.com/podman-desktop/podman-desktop/issues/11720
+      // Podman github link with information that 5.3.1 cant update to 5.4.X
       // https://github.com/containers/podman/pull/25135
+      // Podman Desktop link with proposed solution
+      // https://github.com/podman-desktop/podman-desktop/issues/11720
       if (!updateInfo.bundledVersion) return;
       if (
         extensionApi.env.isWindows &&


### PR DESCRIPTION
### What does this PR do?
Adds a dialog that opens URL on Podman github for manual installation of podman when updating from 5.3.1 to 5.4.X
When updating from 5.3.1 to 5.4.X on Windows it should NOT try to update, just show dialog with manual steps

### Screenshot / video of UI


### What issues does this PR fix or reference?
Closes #11720 

### How to test this PR?
Steps in the issue

- [x] Tests are covering the bug fix or the new feature
