### PR TITLE
feat: vm provider details / terminal

### DIFF
--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -79,8 +79,10 @@ export type ConfigurationScope =
   | 'DEFAULT'
   | 'ContainerConnection'
   | 'KubernetesConnection'
+  | 'VmConnection'
   | 'ContainerProviderConnectionFactory'
   | 'KubernetesProviderConnectionFactory'
+  | 'VmProviderConnectionFactory'
   | 'DockerCompatibility'
   | 'Onboarding';
 

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1275,7 +1275,7 @@ export class PluginSystem {
       async (
         _listener,
         internalProviderId: string,
-        connectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo,
+        connectionInfo: ProviderConnectionInfo,
         onDataId: number,
       ): Promise<number> => {
         // provide the data content to the remote side

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -1449,7 +1449,7 @@ export class ProviderRegistry {
 
   async shellInProviderConnection(
     internalProviderId: string,
-    providerConnectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo,
+    providerConnectionInfo: ProviderConnectionInfo,
     onData: (data: string) => void,
     onError: (error: string) => void,
     onEnd: () => void,
@@ -1463,7 +1463,7 @@ export class ProviderRegistry {
       let shellAccess: ProviderConnectionShellAccess | undefined;
       let connection: ProviderConnectionShellAccessSession | undefined;
       const disposables: Disposable[] = [];
-      if (this.isContainerConnection(containerConnection) && providerConnectionInfo.status === 'started') {
+      if (!this.isKubernetesConnection(containerConnection) && providerConnectionInfo.status === 'started') {
         shellAccess = containerConnection.shellAccess;
         connection = shellAccess?.open();
         connection?.onData(

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -636,7 +636,7 @@ export function initExposure(): void {
     'shellInProviderConnection',
     async (
       internalProviderId: string,
-      connectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo,
+      connectionInfo: ProviderConnectionInfo,
       onData: (data: string) => void,
       onError: (error: string) => void,
       onEnd: () => void,

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsTerminal.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsTerminal.svelte
@@ -10,7 +10,7 @@ import { onDestroy, onMount } from 'svelte';
 import { router } from 'tinro';
 
 import { getExistingTerminal, registerTerminal } from '/@/stores/provider-terminal-store';
-import type { ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provider-info';
+import type { ProviderContainerConnectionInfo, ProviderInfo, ProviderVmConnectionInfo } from '/@api/provider-info';
 
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
 import { getTerminalTheme } from '../../../../main/src/plugin/terminal-theme';
@@ -18,7 +18,7 @@ import NoLogIcon from '../ui/NoLogIcon.svelte';
 
 interface ProviderDetailsTerminalProps {
   provider: ProviderInfo;
-  connectionInfo: ProviderContainerConnectionInfo;
+  connectionInfo: ProviderContainerConnectionInfo | ProviderVmConnectionInfo;
   screenReaderMode?: boolean;
 }
 

--- a/packages/renderer/src/lib/preferences/PreferencesPage.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesPage.svelte
@@ -19,6 +19,7 @@ import PreferencesProxiesRendering from './PreferencesProxiesRendering.svelte';
 import PreferencesRegistriesEditing from './PreferencesRegistriesEditing.svelte';
 import PreferencesRendering from './PreferencesRendering.svelte';
 import PreferencesResourcesRendering from './PreferencesResourcesRendering.svelte';
+import PreferencesVmConnectionRendering from './PreferencesVmConnectionRendering.svelte';
 import { isDefaultScope } from './Util';
 
 let properties: IConfigurationPropertyRecordedSchema[];
@@ -119,5 +120,14 @@ onMount(async () => {
       providerInternalId={meta.params.provider}
       apiUrlBase64={meta.params.apiUrlBase64}
       properties={properties} />
+  </Route>
+  <Route
+    path="/vm-connection/:provider/:name/*"
+    breadcrumb="VM Engine"
+    let:meta
+    navigationHint="details">
+    <PreferencesVmConnectionRendering
+      providerInternalId={meta.params.provider}
+      connectionName={meta.params.name} />
   </Route>
 </div>

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -672,7 +672,17 @@ function handleError(errorMessage: string): void {
               connection={vmConnection}
               connectionStatus={containerConnectionStatus.get(getProviderConnectionName(provider, vmConnection))}
               updateConnectionStatus={updateContainerStatus}
-              addConnectionToRestartingQueue={addConnectionToRestartingQueue} />
+              addConnectionToRestartingQueue={addConnectionToRestartingQueue}>
+              <span slot="advanced-actions" class:hidden={providers.length === 0}>
+                <Tooltip bottom tip="More Options">
+                  <ActionsMenu dropdownMenu={true}>
+                    <DropdownMenu.Item title="Open Terminal" icon={faTerminal} onClick={(): void => router.goto(
+                      `/preferences/vm-connection/${provider.internalId}/${vmConnection.name}/terminal`,
+                    )}/>
+                  </ActionsMenu>
+                </Tooltip>
+              </span>
+            </PreferencesConnectionActions>
           </div>
         {/each}
         </div>

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -655,7 +655,7 @@ function handleError(errorMessage: string): void {
                   type="button"
                   on:click={(): void =>
                     router.goto(
-                      `/preferences/vm-connection/${provider.internalId}/${vmConnection.name}/summary`,
+                      `/preferences/vm-connection/${provider.internalId}/${vmConnection.name}/terminal`,
                     )}>
                   <Fa icon={faArrowUpRightFromSquare} />
                 </button>

--- a/packages/renderer/src/lib/preferences/PreferencesVmConnectionRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesVmConnectionRendering.spec.ts
@@ -1,0 +1,236 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { router } from 'tinro';
+import { expect, test, vi } from 'vitest';
+
+import type { ProviderInfo } from '/@api/provider-info';
+
+import { providerInfos } from '../../stores/providers';
+import * as preferencesConnectionActions from './PreferencesConnectionActions.svelte';
+import PreferencesVmConnectionRendering from './PreferencesVmConnectionRendering.svelte';
+import type { IConnectionRestart } from './Util';
+
+test('Expect that removing the connection is going back to the previous page', async () => {
+  const vm1 = 'vm 1';
+  const vm2 = 'vm 2';
+  const vm3 = 'vm 3';
+
+  const routerGotoSpy = vi.spyOn(router, 'goto');
+
+  const providerInfo: ProviderInfo = {
+    id: 'vmprovider',
+    name: 'vmp',
+    images: {
+      icon: 'img',
+    },
+    status: 'started',
+    warnings: [],
+    containerProviderConnectionCreation: true,
+    detectionChecks: [],
+    containerConnections: [],
+    installationSupport: false,
+    internalId: '0',
+    vmConnections: [
+      {
+        name: vm1,
+        status: 'started',
+      },
+      {
+        name: vm2,
+        status: 'stopped',
+        lifecycleMethods: ['delete'],
+      },
+      {
+        name: vm3,
+        status: 'started',
+      },
+    ],
+    vmProviderConnectionCreation: true,
+    kubernetesConnections: [],
+    kubernetesProviderConnectionCreation: false,
+    vmProviderConnectionInitialization: false,
+    links: [],
+    containerProviderConnectionInitialization: false,
+    containerProviderConnectionCreationDisplayName: 'Podman machine',
+    kubernetesProviderConnectionInitialization: false,
+    extensionId: '',
+    cleanupSupport: false,
+  };
+
+  providerInfos.set([providerInfo]);
+
+  // delete current vm 2 from the provider info
+  vi.mocked(window.deleteProviderConnectionLifecycle).mockImplementation(async () => {
+    providerInfos.update(providerInfos =>
+      providerInfos.map(provider => {
+        provider.vmConnections = provider.vmConnections.filter(vmConnection => vmConnection.name !== vm2);
+        return provider;
+      }),
+    );
+  });
+
+  render(PreferencesVmConnectionRendering, {
+    providerInternalId: '0',
+    connectionName: 'vm 2',
+  });
+
+  // expect to have the second machine being displayed
+  screen.getByRole('heading', { name: 'vm 2', level: 1 });
+
+  // ok now we delete the connection
+  const deleteButton = screen.getByRole('button', { name: 'Delete' });
+
+  // grab current route
+  const currentRoute = window.location;
+  expect(currentRoute.href).toBe('http://localhost:3000/');
+
+  // click on it
+  await userEvent.click(deleteButton);
+
+  // expect that we have called the router when page has been removed
+  // to jump to the resources page
+  expect(routerGotoSpy).toBeCalledWith('/preferences/resources');
+
+  // grab updated route
+  const afterRoute = window.location;
+  expect(afterRoute.href).toBe('http://localhost:3000/preferences/resources');
+});
+
+test('Expect to see error message if action fails', async () => {
+  const vm1 = 'vm 1';
+
+  const providerInfo: ProviderInfo = {
+    id: 'vmprovider',
+    name: 'vmp',
+    images: {
+      icon: 'img',
+    },
+    status: 'started',
+    warnings: [],
+    containerProviderConnectionCreation: true,
+    detectionChecks: [],
+    containerConnections: [],
+    installationSupport: false,
+    internalId: '0',
+    vmConnections: [
+      {
+        name: vm1,
+        status: 'stopped',
+        lifecycleMethods: ['delete'],
+      },
+    ],
+    vmProviderConnectionCreation: true,
+    kubernetesConnections: [],
+    kubernetesProviderConnectionCreation: false,
+    vmProviderConnectionInitialization: false,
+    links: [],
+    containerProviderConnectionInitialization: false,
+    containerProviderConnectionCreationDisplayName: 'Podman machine',
+    kubernetesProviderConnectionInitialization: false,
+    extensionId: '',
+    cleanupSupport: false,
+  };
+
+  providerInfos.set([providerInfo]);
+
+  // simulate that the delete action fails
+  vi.mocked(window.deleteProviderConnectionLifecycle).mockRejectedValue('failed to delete machine');
+
+  render(PreferencesVmConnectionRendering, {
+    connectionName: 'vm 1',
+    providerInternalId: '0',
+  });
+
+  // expect to have the machine title being displayed
+  screen.getByRole('heading', { name: 'vm 1', level: 1 });
+
+  let deleteFailedButton = screen.queryByRole('button', { name: 'delete failed' });
+
+  // expect that the delete failed button is not in the page
+  expect(deleteFailedButton).not.toBeInTheDocument();
+
+  // ok now we delete the connection
+  const deleteButton = screen.getByRole('button', { name: 'Delete' });
+
+  // click on it
+  await userEvent.click(deleteButton);
+
+  deleteFailedButton = screen.getByRole('button', { name: 'delete failed' });
+
+  // expect to see the delete failed button
+  expect(deleteFailedButton).toBeInTheDocument();
+});
+
+test('startProviderConnectionLifecycle is called when addConnectionToRestartingQueue is called by sub-component', async () => {
+  vi.spyOn(preferencesConnectionActions, 'default');
+  const providerInfo: ProviderInfo = {
+    id: 'vmprovider',
+    name: 'vmp',
+    images: {
+      icon: 'img',
+    },
+    status: 'started',
+    warnings: [],
+    containerProviderConnectionCreation: true,
+    detectionChecks: [],
+    containerConnections: [],
+    installationSupport: false,
+    internalId: '0',
+    vmConnections: [
+      {
+        name: 'vm 1',
+        status: 'stopped',
+        lifecycleMethods: ['delete'],
+      },
+    ],
+    vmProviderConnectionCreation: true,
+    kubernetesConnections: [],
+    kubernetesProviderConnectionCreation: false,
+    vmProviderConnectionInitialization: false,
+    links: [],
+    containerProviderConnectionInitialization: false,
+    containerProviderConnectionCreationDisplayName: 'Podman machine',
+    kubernetesProviderConnectionInitialization: false,
+    extensionId: '',
+    cleanupSupport: false,
+  };
+
+  providerInfos.set([providerInfo]);
+  render(PreferencesVmConnectionRendering, {
+    connectionName: 'vm 1',
+    providerInternalId: '0',
+  });
+
+  // simulate PreferencesConnectionActions is calling addConnectionToRestartingQueue
+  expect(preferencesConnectionActions.default).toHaveBeenCalledOnce();
+  const params = vi.mocked(preferencesConnectionActions.default).mock.calls[0][1];
+  const addConnectionToRestartingQueue = params['addConnectionToRestartingQueue'];
+
+  addConnectionToRestartingQueue({
+    loggerHandlerKey: (): void => {},
+  } as unknown as IConnectionRestart);
+
+  providerInfo.vmConnections[0].status = 'started';
+  providerInfos.set([providerInfo]);
+  expect(window.startProviderConnectionLifecycle).toHaveBeenCalledOnce();
+});

--- a/packages/renderer/src/lib/preferences/PreferencesVmConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesVmConnectionRendering.svelte
@@ -114,14 +114,16 @@ function addConnectionToRestartingQueue(connection: IConnectionRestart): void {
 
 {#if connectionInfo}
   <DetailsPage title={connectionInfo.name}>
-    <svelte:fragment slot="subtitle">
-      <div class="flex flex-row">
-        <ConnectionStatus status={connectionInfo.status} />
-        <ConnectionErrorInfoButton status={connectionStatus} />
-      </div>
-    </svelte:fragment>
-    <svelte:fragment slot="actions">
-      {#if providerInfo}
+    {#snippet subtitleSnippet()}
+      {#if connectionInfo}
+        <div class="flex flex-row">
+          <ConnectionStatus status={connectionInfo.status} />
+          <ConnectionErrorInfoButton status={connectionStatus} />
+        </div>
+      {/if}
+    {/snippet}
+    {#snippet actionsSnippet()}
+      {#if providerInfo && connectionInfo}
         <div class="flex justify-end">
           <PreferencesConnectionActions
             provider={providerInfo}
@@ -131,19 +133,19 @@ function addConnectionToRestartingQueue(connection: IConnectionRestart): void {
             addConnectionToRestartingQueue={addConnectionToRestartingQueue} />
         </div>
       {/if}
-    </svelte:fragment>
-    <svelte:fragment slot="icon">
+    {/snippet}
+    {#snippet iconSnippet()}
       <IconImage image={providerInfo?.images?.icon} alt={providerInfo?.name} class="max-h-10" />
-    </svelte:fragment>
-    <svelte:fragment slot="tabs">
+    {/snippet}
+    {#snippet tabsSnippet()}
       <Tab
         title="Terminal"
         selected={isTabSelected($router.path, 'terminal')}
         url={getTabUrl($router.path, 'terminal')} />
-    </svelte:fragment>
-    <svelte:fragment slot="content">
+    {/snippet}
+    {#snippet contentSnippet()}
       <div class="h-full">
-        {#if providerInfo}
+        {#if providerInfo && connectionInfo}
           <Route path="/terminal" breadcrumb="Terminal" navigationHint="tab">
             <PreferencesConnectionDetailsTerminal
               provider={providerInfo}
@@ -152,6 +154,6 @@ function addConnectionToRestartingQueue(connection: IConnectionRestart): void {
           </Route>
         {/if}
       </div>
-    </svelte:fragment>
+    {/snippet}
   </DetailsPage>
 {/if}

--- a/packages/renderer/src/lib/preferences/PreferencesVmConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesVmConnectionRendering.svelte
@@ -1,0 +1,157 @@
+<script lang="ts">
+import { Tab } from '@podman-desktop/ui-svelte';
+import { onDestroy, onMount } from 'svelte';
+import type { Unsubscriber } from 'svelte/store';
+import { router } from 'tinro';
+
+import { handleNavigation } from '/@/navigation';
+import Route from '/@/Route.svelte';
+import { NavigationPage } from '/@api/navigation-page';
+import type { ProviderContainerConnectionInfo, ProviderInfo, ProviderVmConnectionInfo } from '/@api/provider-info';
+
+import { providerInfos } from '../../stores/providers';
+import IconImage from '../appearance/IconImage.svelte';
+import ConnectionErrorInfoButton from '../ui/ConnectionErrorInfoButton.svelte';
+import ConnectionStatus from '../ui/ConnectionStatus.svelte';
+import DetailsPage from '../ui/DetailsPage.svelte';
+import { getTabUrl, isTabSelected } from '../ui/Util';
+import { eventCollect } from './preferences-connection-rendering-task';
+import PreferencesConnectionActions from './PreferencesConnectionActions.svelte';
+import PreferencesConnectionDetailsTerminal from './PreferencesConnectionDetailsTerminal.svelte';
+import type { IConnectionRestart, IConnectionStatus } from './Util';
+import { getProviderConnectionName } from './Util';
+
+export let providerInternalId: string | undefined = undefined;
+export let connectionName = '';
+
+let connectionStatus: IConnectionStatus;
+let connectionInfo: ProviderVmConnectionInfo | undefined;
+let providerInfo: ProviderInfo | undefined;
+let loggerHandlerKey: symbol | undefined;
+
+let providersUnsubscribe: Unsubscriber;
+onMount(async () => {
+  providersUnsubscribe = providerInfos.subscribe(providerInfosValue => {
+    const providers = providerInfosValue;
+    providerInfo = providers.find(provider => provider.internalId === providerInternalId);
+
+    connectionInfo = providerInfo?.vmConnections?.find(connection => connection.name === connectionName);
+    if (!connectionInfo) {
+      handleNavigation({
+        page: NavigationPage.RESOURCES,
+      });
+      return;
+    }
+    if (!providerInfo) {
+      return;
+    }
+    const vmConnectionName = getProviderConnectionName(providerInfo, connectionInfo);
+    if (vmConnectionName && (!connectionStatus || connectionStatus.status !== connectionInfo.status)) {
+      if (loggerHandlerKey !== undefined) {
+        connectionStatus = {
+          inProgress: true,
+          action: 'restart',
+          status: connectionInfo.status,
+        };
+        startConnectionProvider(providerInfo, connectionInfo, loggerHandlerKey).catch((err: unknown) =>
+          console.error(`Error starting provider ${connectionInfo?.name}`, err),
+        );
+        loggerHandlerKey = undefined;
+      } else {
+        connectionStatus = {
+          inProgress: false,
+          action: undefined,
+          status: connectionInfo.status,
+        };
+      }
+    }
+    connectionStatus = connectionStatus;
+  });
+});
+
+onDestroy(() => {
+  if (providersUnsubscribe) {
+    providersUnsubscribe();
+  }
+});
+
+async function startConnectionProvider(
+  provider: ProviderInfo,
+  connectionInfo: ProviderVmConnectionInfo,
+  loggerHandlerKey: symbol,
+): Promise<void> {
+  await window.startProviderConnectionLifecycle(provider.internalId, connectionInfo, loggerHandlerKey, eventCollect);
+}
+
+function updateConnectionStatus(
+  provider: ProviderInfo,
+  connectionInfo: ProviderVmConnectionInfo | ProviderContainerConnectionInfo,
+  action?: string,
+  error?: string,
+): void {
+  if (error) {
+    if (connectionStatus) {
+      connectionStatus = {
+        ...connectionStatus,
+        inProgress: false,
+        error,
+      };
+    }
+  } else if (action) {
+    connectionStatus = {
+      inProgress: true,
+      action: action,
+      status: connectionInfo.status,
+    };
+  }
+  connectionStatus = connectionStatus;
+}
+
+function addConnectionToRestartingQueue(connection: IConnectionRestart): void {
+  loggerHandlerKey = connection.loggerHandlerKey;
+}
+</script>
+
+{#if connectionInfo}
+  <DetailsPage title={connectionInfo.name}>
+    <svelte:fragment slot="subtitle">
+      <div class="flex flex-row">
+        <ConnectionStatus status={connectionInfo.status} />
+        <ConnectionErrorInfoButton status={connectionStatus} />
+      </div>
+    </svelte:fragment>
+    <svelte:fragment slot="actions">
+      {#if providerInfo}
+        <div class="flex justify-end">
+          <PreferencesConnectionActions
+            provider={providerInfo}
+            connection={connectionInfo}
+            connectionStatus={connectionStatus}
+            updateConnectionStatus={updateConnectionStatus}
+            addConnectionToRestartingQueue={addConnectionToRestartingQueue} />
+        </div>
+      {/if}
+    </svelte:fragment>
+    <svelte:fragment slot="icon">
+      <IconImage image={providerInfo?.images?.icon} alt={providerInfo?.name} class="max-h-10" />
+    </svelte:fragment>
+    <svelte:fragment slot="tabs">
+      <Tab
+        title="Terminal"
+        selected={isTabSelected($router.path, 'terminal')}
+        url={getTabUrl($router.path, 'terminal')} />
+    </svelte:fragment>
+    <svelte:fragment slot="content">
+      <div class="h-full">
+        {#if providerInfo}
+          <Route path="/terminal" breadcrumb="Terminal" navigationHint="tab">
+            <PreferencesConnectionDetailsTerminal
+              provider={providerInfo}
+              connectionInfo={connectionInfo}
+              screenReaderMode={true} />
+          </Route>
+        {/if}
+      </div>
+    </svelte:fragment>
+  </DetailsPage>
+{/if}


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Display details of VM connection, including terminal

## Prerequisites: 

- start Podman Desktop with this extension (and see prerequisites there): https://github.com/redhat-developer/podman-desktop-rhel-ext/pull/10
- create a RHEL VM with:
  - get a RHEL VM image (ask me) 
  - create a VM from Settings > Resources > Macadam > Create new...
  - start the VM

### Screenshot / video of UI

https://github.com/user-attachments/assets/93cecbe3-13b5-4698-a3f1-a2c586a3d368



### What issues does this PR fix or reference?

Fixes #11747 

### How to test this PR?

- Run prerequisites
- go to VM details
- use the terminal
- stop/start/delete connection from the details page

- [x] Tests are covering the bug fix or the new feature
