### PR TITLE
chore: use lcov reporter locally

### DIFF
--- a/vitest-shared-extensions.config.js
+++ b/vitest-shared-extensions.config.js
@@ -43,7 +43,7 @@ export function coverageConfig(packageRoot, packageName) {
       ],
       provider: 'v8',
       reportsDirectory: path.join(packageRoot, '../../', `test-resources/coverage/${packageName}`),
-      reporter: ['json', 'text'],
+      reporter: process.env.CI ? ['json', 'text'] : ['lcov', 'text'],
     },
   };
   return obj;


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Since https://github.com/podman-desktop/podman-desktop/pull/11902, vscode-coverage-gutters (and probably other tools) does not work, as it expects coverage files in lcov format.

This PR reverts the original reporters for non-CI runs, by using the CI env var.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
