### PR TITLE
chore: add aria roles and labels into troubleshooting pages

### DIFF
--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngine.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngine.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngine.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngine.spec.ts
@@ -47,6 +47,10 @@ test('Check containers button is available and click on it', async () => {
   } as unknown as ProviderContainerConnectionInfo;
   render(TroubleshootingContainerEngine, { containerEngineRunning });
 
+  // expect to be in a region with label
+  const region = screen.getByRole('region', { name: name });
+  expect(region).toBeInTheDocument();
+
   // expect to have the name label
   const nameHeading = screen.getByRole('heading', { name: 'name' });
   expect(nameHeading).toBeInTheDocument();

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngine.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngine.svelte
@@ -7,7 +7,8 @@ import TroubleshootingContainerEnginePing from './TroubleshootingContainerEngine
 export let containerEngineRunning: ProviderContainerConnectionInfo;
 </script>
 
-<div class="flex flex-col bg-[var(--pd-invert-content-card-bg)] m-4 p-4 text-sm">
+
+<div class="flex flex-col bg-[var(--pd-invert-content-card-bg)] m-4 p-4 text-sm" role="region" aria-label={containerEngineRunning.name}>
   <h6 aria-label="name">Name: {containerEngineRunning.name}</h6>
   <div class="mx-4">
     <h6 aria-label="status">Status: {containerEngineRunning.status}</h6>

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngine.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngine.svelte
@@ -7,7 +7,6 @@ import TroubleshootingContainerEnginePing from './TroubleshootingContainerEngine
 export let containerEngineRunning: ProviderContainerConnectionInfo;
 </script>
 
-
 <div class="flex flex-col bg-[var(--pd-invert-content-card-bg)] m-4 p-4 text-sm" role="region" aria-label={containerEngineRunning.name}>
   <h6 aria-label="name">Name: {containerEngineRunning.name}</h6>
   <div class="mx-4">

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngineReconnect.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngineReconnect.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngineReconnect.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngineReconnect.spec.ts
@@ -43,7 +43,7 @@ test('Check reconnect button is available and click on it', async () => {
   await fireEvent.click(reconnectButton);
 
   // check that we have the ping result
-  const reconnectResult = screen.getByRole('status', { name: '' });
+  const reconnectResult = screen.getByRole('status', { name: 'Reconnect Providers' });
   expect(reconnectResult).toBeInTheDocument();
   expect(reconnectResult).toHaveTextContent('Done');
 
@@ -66,7 +66,7 @@ test('Check reconnect button is available and get error', async () => {
   await fireEvent.click(reconnectButton);
 
   // check that we have the reconnect result
-  const reconnectResult = screen.getByRole('status', { name: '' });
+  const reconnectResult = screen.getByRole('status', { name: 'Reconnect Providers' });
   expect(reconnectResult).toBeInTheDocument();
   expect(reconnectResult).toHaveTextContent('Done');
 

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngineReconnect.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngineReconnect.svelte
@@ -33,7 +33,7 @@ async function reconnectContainerProviders(): Promise<void> {
     icon={faPlug}>
     Reconnect providers
   </Button>
-  <div role="status" class="mx-2">{reconnectResult}</div>
+  <div role="status" class="mx-2" aria-label="Reconnect Providers">{reconnectResult}</div>
   {#if reconnectError}
     <ErrorMessage class="mx-2" error={reconnectError} />
   {/if}

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngines.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngines.spec.ts
@@ -1,0 +1,83 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import type {
+  ProviderConnectionInfo,
+  ProviderContainerConnectionInfo,
+  ProviderInfo,
+  ProviderKubernetesConnectionInfo,
+} from '/@api/provider-info';
+
+import TroubleshootingContainerEngines from './TroubleshootingContainerEngines.svelte';
+
+const containerConnectionLabel = 'Container Connections';
+// mock ProviderContainerInfo
+const socketPath = '/foo/socket.path';
+const name = 'fooEngine';
+const status = 'started';
+const containerEngineRunning = {
+  name,
+  status,
+  endpoint: {
+    socketPath,
+  },
+} as unknown as ProviderContainerConnectionInfo;
+// mock ProviderInfo
+const internalId = 'some256';
+const id = 'someid256';
+const extensionId = 'my-extension';
+const providerName = 'my-provider-name';
+const containerConnections: ProviderConnectionInfo[] = [containerEngineRunning];
+const kubernetesConnections: ProviderKubernetesConnectionInfo[] = [];
+const vmConnections: ProviderConnectionInfo[] = [];
+const providerStatus = 'started';
+const providerInfo = {
+  internalId,
+  id,
+  extensionId,
+  providerName,
+  containerConnections,
+  kubernetesConnections,
+  vmConnections,
+  providerStatus,
+} as unknown as ProviderInfo;
+const providers = [providerInfo];
+
+test('Check containers connections widget is there', async () => {
+  render(TroubleshootingContainerEngines, {});
+
+  // expect to be in a region with label Container Connections
+  const region = screen.getByRole('region', { name: containerConnectionLabel });
+  expect(region).toBeInTheDocument();
+});
+
+test('Check containers connections status show correct information', async () => {
+  render(TroubleshootingContainerEngines, { providers });
+
+  // expect to have the name label
+  const statusElement = screen.getByRole('status', { name: containerConnectionLabel });
+  expect(statusElement).toBeInTheDocument();
+  expect(statusElement).toHaveTextContent('1 (1 running)');
+});

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngines.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngines.svelte
@@ -11,10 +11,10 @@ $: containerEngines = providers.map(provider => provider.containerConnections).f
 $: containerEnginesRunning = containerEngines.filter(containerEngine => containerEngine.status === 'started');
 </script>
 
-<div class="flex flex-col w-full bg-[var(--pd-content-card-bg)] p-4 rounded-lg" role="region" aria-label="Container connections">
+<div class="flex flex-col w-full bg-[var(--pd-content-card-bg)] p-4 rounded-lg" role="region" aria-label="Container Connections">
   <div class="flex flex-row align-middle items-center">
     <ContainerIcon size="40" solid={true} class="pr-3" />
-    <div role="status" aria-label="container connections" class="text-xl">
+    <div role="status" aria-label="Container Connections" class="text-xl">
       Container connections: {containerEngines.length} ({containerEnginesRunning.length} running)
     </div>
   </div>

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngines.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngines.svelte
@@ -11,7 +11,7 @@ $: containerEngines = providers.map(provider => provider.containerConnections).f
 $: containerEnginesRunning = containerEngines.filter(containerEngine => containerEngine.status === 'started');
 </script>
 
-<div class="flex flex-col w-full bg-[var(--pd-content-card-bg)] p-4 rounded-lg">
+<div class="flex flex-col w-full bg-[var(--pd-content-card-bg)] p-4 rounded-lg" role="region" aria-label="Container connections">
   <div class="flex flex-row align-middle items-center">
     <ContainerIcon size="40" solid={true} class="pr-3" />
     <div role="status" aria-label="container connections" class="text-xl">

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPage.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPage.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ test('Check Troubleshooting Page', async () => {
   await fireEvent.click(repairConnectionsLink);
 
   // check we have the container connections role
-  const containerConnections = screen.getByRole('status', { name: 'container connections' });
+  const containerConnections = screen.getByRole('status', { name: 'Container Connections' });
   expect(containerConnections).toBeInTheDocument();
 
   // click on the stores tab

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPageProviders.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPageProviders.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,6 @@ test('Check TroubleshootingPageProviders page', async () => {
   render(TroubleshootingPageProviders, {});
 
   // check we have the container connections role
-  const containerConnections = screen.getByRole('status', { name: 'container connections' });
+  const containerConnections = screen.getByRole('status', { name: 'Container Connections' });
   expect(containerConnections).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStore.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStore.spec.ts
@@ -27,6 +27,8 @@ import type { EventStoreInfo } from '/@/stores/event-store';
 
 import TroubleshootingPageStore from './TroubleshootingPageStore.svelte';
 
+const storeName = 'my-test-store';
+
 beforeAll(() => {});
 
 test('Check store info is displayed and clicking on buttons works', async () => {
@@ -34,7 +36,7 @@ test('Check store info is displayed and clicking on buttons works', async () => 
   const fetchMock = vi.fn();
 
   const eventStoreInfo: EventStoreInfo = {
-    name: 'my-test-store',
+    name: storeName,
     size: 3,
     bufferEvents: [],
     clearEvents: clearEventsMock,
@@ -42,6 +44,10 @@ test('Check store info is displayed and clicking on buttons works', async () => 
   };
 
   render(TroubleshootingPageStore, { eventStoreInfo });
+
+  // expect to have a list item with label of the store name
+  const store = screen.getByRole('listitem', { name: storeName });
+  expect(store).toBeInTheDocument();
 
   // expect to have the Refresh button
   const refreshButton = screen.getByRole('button', { name: 'Refresh' });

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStore.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStore.svelte
@@ -21,7 +21,7 @@ async function fetch(): Promise<void> {
 let openDetails = false;
 </script>
 
-<div class="flex flex-col bg-[var(--pd-invert-content-card-bg)] p-2 items-center rounded-sm w-full">
+<div class="flex flex-col bg-[var(--pd-invert-content-card-bg)] p-2 items-center rounded-sm w-full" role="listitem" aria-label={eventStoreInfo.name}>
   <div><svelte:component this={eventStoreInfo.iconComponent} size="20" /></div>
   <div class="text-xl">
     <button

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStores.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStores.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStores.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStores.spec.ts
@@ -33,4 +33,8 @@ test('Check stores widget is there', async () => {
   // get the title
   const title = screen.getByRole('status', { name: 'stores' });
   expect(title).toBeInTheDocument();
+
+  // expect to have store list
+  const stores = screen.getByRole('list', { name: 'stores' });
+  expect(stores).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStores.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStores.svelte
@@ -32,7 +32,7 @@ onDestroy(() => {
     <div role="status" aria-label="stores" class="text-xl">Stores</div>
   </div>
 
-  <div class="grid grid-cols-2 lg:grid-cols-4 gap-x-4 gap-y-4">
+  <div class="grid grid-cols-2 lg:grid-cols-4 gap-x-4 gap-y-4" role="list" aria-label="stores">
     {#each allEventstores as eventStore (eventStore.name)}
       <TroubleshootingPageStore eventStoreInfo={eventStore} />
     {/each}

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingRepair.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingRepair.spec.ts
@@ -34,3 +34,11 @@ test('Check widget is there', async () => {
   const repairDiv = screen.getByText('Repair', { exact: true });
   expect(repairDiv).toBeInTheDocument();
 });
+
+test('Check widget has proper role and label', async () => {
+  render(TroubleshootingRepair, {});
+
+  // check the repair title is there
+  const repairDiv = screen.getByRole('region', { name: 'Repair' });
+  expect(repairDiv).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingRepair.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingRepair.svelte
@@ -9,7 +9,7 @@ import TroubleshootingRepairCleanup from './TroubleshootingRepairCleanup.svelte'
 export let providers: ProviderInfo[] = [];
 </script>
 
-<div class="flex flex-col w-full bg-[var(--pd-content-card-bg)] p-4 rounded-lg">
+<div class="flex flex-col w-full bg-[var(--pd-content-card-bg)] p-4 rounded-lg" role="region" aria-label="Repair">
   <div class="flex flex-row w-full pb-2 items-center">
     <Fa size="1.5x" class="pr-2" icon={faWrench} />
     <div class="text-xl" aria-label="Repair">Repair</div>


### PR DESCRIPTION
### What does this PR do?
Adds aria roles and labels into Troubleshooting page. 

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#11887 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
