### PR TITLE
chore: migrate status icon to svelte 5

### DIFF
--- a/packages/ui/src/lib/progress/Spinner.svelte
+++ b/packages/ui/src/lib/progress/Spinner.svelte
@@ -4,15 +4,15 @@ interface Props {
   class?: string;
   style?: string;
 }
-let { size = '2em', class: classProp, style: styleProp }: Props = $props();
+let { size = '2em', class: className, style }: Props = $props();
 </script>
 
 <i
   role="progressbar"
   aria-label="Loading"
   aria-busy="true"
-  class="flex justify-center items-center {classProp}"
-  style={styleProp}>
+  class="flex justify-center items-center {className}"
+  style={style}>
   <svg width={size} height={size} viewBox="0 0 100 100" role="img">
     <defs>
       <linearGradient id="grad1" x1="0%" y1="0%" x2="0%" y2="100%">

--- a/packages/ui/src/lib/progress/Spinner.svelte
+++ b/packages/ui/src/lib/progress/Spinner.svelte
@@ -1,13 +1,18 @@
 <script lang="ts">
-export let size = '2em';
+interface Props {
+  size?: string;
+  class?: string;
+  style?: string;
+}
+let { size = '2em', class: classProp, style: styleProp }: Props = $props();
 </script>
 
 <i
   role="progressbar"
   aria-label="Loading"
   aria-busy="true"
-  class="flex justify-center items-center {$$props.class}"
-  style={$$props.style}>
+  class="flex justify-center items-center {classProp}"
+  style={styleProp}>
   <svg width={size} height={size} viewBox="0 0 100 100" role="img">
     <defs>
       <linearGradient id="grad1" x1="0%" y1="0%" x2="0%" y2="100%">

--- a/packages/ui/src/lib/statusIcon/StatusIcon.svelte
+++ b/packages/ui/src/lib/statusIcon/StatusIcon.svelte
@@ -2,14 +2,17 @@
 import StarIcon from '../icons/StarIcon.svelte';
 import Spinner from '../progress/Spinner.svelte';
 
-// status: one of RUNNING, STARTING, USED, CREATED, DELETING, or DEGRADED
-// any other status will result in a standard outlined box
-export let status: 'RUNNING' | 'STARTING' | 'USED' | 'DEGRADED' | 'DELETING' | 'CREATED' | string = 'UNKNOWN';
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export let icon: any = undefined;
-export let size = 20;
+interface Props {
+  // status: one of RUNNING, STARTING, USED, CREATED, DELETING, or DEGRADED
+  // any other status will result in a standard outlined box
+  status?: 'RUNNING' | 'STARTING' | 'USED' | 'DEGRADED' | 'DELETING' | 'CREATED' | string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  icon?: any;
+  size?: number;
+}
+let { status = 'UNKNOWN', icon, size = 20 }: Props = $props();
 
-$: solid = status === 'RUNNING' || status === 'STARTING' || status === 'USED' || status === 'DEGRADED';
+let solid = $derived(status === 'RUNNING' || status === 'STARTING' || status === 'USED' || status === 'DEGRADED');
 </script>
 
 <div class="grid place-content-center" style="position:relative">
@@ -31,7 +34,8 @@ $: solid = status === 'RUNNING' || status === 'STARTING' || status === 'USED' ||
     {:else if typeof icon === 'string'}
       <span class={icon} aria-hidden="true"></span>
     {:else}
-      <svelte:component this={icon} size={size} solid={solid} />
+      {@const IconComponent = icon}
+      <IconComponent size={size} solid={solid} />
     {/if}
   </div>
   {#if status === 'CREATED'}


### PR DESCRIPTION
### What does this PR do?

Migrate the status icon component to Svelte 5.

svelte:component has been removed. In order to support it being string | Component (and needing capitalization in the second case), I've used the technique provided by the Svelte team here: https://github.com/sveltejs/svelte/issues/12668#issuecomment-2563451764

Typing of icon could be improved but deferring that as it is a bigger change and
not related to Svelte migration.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #11584.

### How to test this PR?

Check status icons in various screens.