### PR TITLE
chore: support for changing namespace in experimental mode

### DIFF
--- a/packages/renderer/src/lib/kube/NamespaceDropdown.svelte
+++ b/packages/renderer/src/lib/kube/NamespaceDropdown.svelte
@@ -1,14 +1,36 @@
 <script lang="ts">
 import { Dropdown } from '@podman-desktop/ui-svelte';
+import { onMount } from 'svelte';
 
+import { kubernetesContextsHealths } from '/@/stores/kubernetes-context-health';
 import { kubernetesCurrentContextState } from '/@/stores/kubernetes-contexts-state';
 
+let isExperimental: boolean = $state(false);
+
+onMount(async () => {
+  try {
+    isExperimental = (await window.getConfigurationValue<boolean>('kubernetes.statesExperimental')) ?? false;
+  } catch {
+    // keep default value
+  }
+});
+
+let reachablePromise = $derived.by(async () => {
+  if (isExperimental) {
+    const contextName = await window.kubernetesGetCurrentContextName();
+    return $kubernetesContextsHealths.some(
+      contextHealth => contextHealth.contextName === contextName && contextHealth.reachable,
+    );
+  }
+  return $kubernetesCurrentContextState?.reachable;
+});
+
 let namespacesPromise = $derived.by(async () => {
-  return $kubernetesCurrentContextState?.reachable ? await window.kubernetesListNamespaces() : undefined;
+  return (await reachablePromise) ? await window.kubernetesListNamespaces() : undefined;
 });
 
 let currentNamespacePromise = $derived.by(async () => {
-  return $kubernetesCurrentContextState?.reachable ? await window.kubernetesGetCurrentNamespace() : '';
+  return (await reachablePromise) ? await window.kubernetesGetCurrentNamespace() : '';
 });
 
 async function handleNamespaceChange(value: unknown): Promise<void> {
@@ -21,6 +43,7 @@ async function handleNamespaceChange(value: unknown): Promise<void> {
 }
 </script>
 
+{#await reachablePromise then reachable}
 {#await currentNamespacePromise then currentNamespace}
 {#await namespacesPromise then namespaces}
 <Dropdown
@@ -28,7 +51,7 @@ async function handleNamespaceChange(value: unknown): Promise<void> {
   name="namespace"
   class="w-56 max-w-56"
   value={currentNamespace}
-  disabled={!$kubernetesCurrentContextState?.reachable}
+  disabled={!reachable}
   onChange={handleNamespaceChange}
   options={namespaces?.items?.map(namespace => ({
     label: namespace.metadata?.name ?? '',
@@ -38,5 +61,6 @@ async function handleNamespaceChange(value: unknown): Promise<void> {
   <div class="mr-1 text-[var(--pd-input-field-placeholder-text)]">Namespace:</div>
   {/snippet}
 </Dropdown>
+{/await}
 {/await}
 {/await}


### PR DESCRIPTION
### What does this PR do?

Add support for experimental mode reachable status to the namespace dropdown.

I'm still seeing some reactivity issues in experimental mode - e.g.:
- switching to a namespace with no resources doesn't clear the current resources, but namespace appears set since switching pages or after leaving and coming back everything looks correct.
- badge still says connection lost after reconnection (but namespace reappears and changing it triggers refresh).

AFAIK these are still somewhat expected in experimental mode; when testing you may need to play around to confirm this is working vs other issue.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Experimental part of #11274.

### How to test this PR?

Confirm no regressions / able to use namespace dropdown in regular Kubernetes mode.
Enable Kubernetes experimental mode and restart, confirm this now works as well.