### PR TITLE
fix: tests on namespace dropdown

### DIFF
--- a/packages/renderer/src/lib/kube/NamespaceDropdown.spec.ts
+++ b/packages/renderer/src/lib/kube/NamespaceDropdown.spec.ts
@@ -83,7 +83,8 @@ test('Expect namespaces are in the dropdown', async () => {
   await fireEvent.click(dropdown);
 
   // first namespace is in the original button and in the dropdown
-  const item1 = screen.getAllByRole('button', { name: firstNS });
+  const item1 = screen.getAllByRole('button', { name: new RegExp(`${firstNS}$`) });
+
   expect(item1.length).toEqual(2);
 
   // second namespace is also clickable


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Fix test by using a regexp on the button name, as the first button contains `Namespace: ns1`

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
