### PR TITLE
refactor: migrate FormPage component to svelte 5

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesProviderRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProviderRendering.svelte
@@ -85,7 +85,7 @@ async function stopReceivingLogs(providerInternalId: string): Promise<void> {
 
 <Route path="/*" breadcrumb={providerInfo?.name} navigationHint="details">
   <FormPage title={title} inProgress={inProgress}>
-    <svelte:fragment slot="icon">
+    {#snippet icon()}
       {#if providerInfo?.images?.icon}
         {#if typeof providerInfo.images.icon === 'string'}
           <img src={providerInfo.images.icon} alt={providerInfo.name} class="max-h-10" />
@@ -94,9 +94,9 @@ async function stopReceivingLogs(providerInternalId: string): Promise<void> {
           <img src={providerInfo.images.icon.dark} alt={providerInfo.name} class="max-h-10" />
         {/if}
       {/if}
-    </svelte:fragment>
+    {/snippet}
 
-    <svelte:fragment slot="actions">
+    {#snippet actions()}
       <!-- Manage lifecycle-->
       {#if providerInfo?.lifecycleMethods}
         <div class="pl-1 py-2 px-6">
@@ -131,9 +131,10 @@ async function stopReceivingLogs(providerInternalId: string): Promise<void> {
           {/if}
         </div>
       {/if}
-    </svelte:fragment>
+    {/snippet}
 
-    <div slot="content" class="px-5 pb-5 min-w-full h-fit">
+    {#snippet content()}
+    <div class="px-5 pb-5 min-w-full h-fit">
       <div class="bg-[var(--pd-content-card-bg)] px-6 py-4">
         <!-- Create connection panel-->
         {#if providerInfo?.containerProviderConnectionCreation === true}
@@ -168,6 +169,7 @@ async function stopReceivingLogs(providerInternalId: string): Promise<void> {
         {/if}
       </div>
     </div>
+    {/snippet}
   </FormPage>
 </Route>
 {#if showModalProviderInfo}

--- a/packages/renderer/src/lib/ui/EngineFormPage.svelte
+++ b/packages/renderer/src/lib/ui/EngineFormPage.svelte
@@ -8,10 +8,14 @@ export let showEmptyScreen: boolean = false;
 </script>
 
 <FormPage title={title} inProgress={inProgress}>
-  <slot slot="icon" name="icon" />
-  <slot slot="actions" name="actions" />
-  <slot slot="tabs" name="tabs" />
-  <slot slot="content">
+  {#snippet icon()}
+  <slot name="icon" />
+  {/snippet}
+  {#snippet actions()}
+  <slot name="actions" />
+  {/snippet}
+  {#snippet content()}
+  <slot>
     <div class="p-5 min-w-full h-full">
       {#if showEmptyScreen}
         <NoContainerEngineEmptyScreen />
@@ -22,4 +26,5 @@ export let showEmptyScreen: boolean = false;
       {/if}
     </div>
   </slot>
+  {/snippet}
 </FormPage>

--- a/packages/renderer/src/lib/ui/FormPage.svelte
+++ b/packages/renderer/src/lib/ui/FormPage.svelte
@@ -1,11 +1,19 @@
 <script lang="ts">
 import { FormPage } from '@podman-desktop/ui-svelte';
+import type { Snippet } from 'svelte';
 import { router } from 'tinro';
 
 import { currentPage, lastPage } from '../../stores/breadcrumb';
 
-export let title: string;
-export let inProgress = false;
+interface Props {
+  title: string;
+  inProgress?: boolean;
+  icon?: Snippet;
+  actions?: Snippet;
+  content?: Snippet;
+}
+
+const { title, inProgress = false, icon: localIcon, actions: localActions, content: localContent }: Props = $props();
 
 export function goToPreviousPage(): void {
   router.goto($lastPage.path);
@@ -20,7 +28,7 @@ export function goToPreviousPage(): void {
   breadcrumbTitle="Go back to {$lastPage.name}"
   onclose={goToPreviousPage}
   onbreadcrumbClick={goToPreviousPage}>
-  <slot slot="icon" name="icon" />
-  <slot slot="actions" name="actions" />
-  <slot slot="content" name="content" />
+  {#snippet icon()}{@render localIcon?.()}{/snippet}
+  {#snippet actions()}{@render localActions?.()}{/snippet}
+  {#snippet content()}{@render localContent?.()}{/snippet}
 </FormPage>

--- a/packages/ui/src/lib/layouts/FormPage.svelte
+++ b/packages/ui/src/lib/layouts/FormPage.svelte
@@ -1,13 +1,33 @@
 <script lang="ts">
+import type { Snippet } from 'svelte';
+
 import Page from './Page.svelte';
 
-export let title: string;
-export let inProgress = false;
-export let breadcrumbLeftPart: string | undefined = undefined;
-export let breadcrumbRightPart: string | undefined = undefined;
-export let breadcrumbTitle: string | undefined = '';
-export let onclose: () => void = () => {};
-export let onbreadcrumbClick: () => void = () => {};
+interface Props {
+  title: string;
+  inProgress?: boolean;
+  breadcrumbLeftPart?: string;
+  breadcrumbRightPart?: string;
+  breadcrumbTitle?: string;
+  onclose?: () => void;
+  onbreadcrumbClick?: () => void;
+  icon?: Snippet;
+  actions?: Snippet;
+  content?: Snippet;
+}
+
+const {
+  title,
+  inProgress = false,
+  breadcrumbLeftPart = undefined,
+  breadcrumbRightPart = undefined,
+  breadcrumbTitle = '',
+  onclose = (): void => {},
+  onbreadcrumbClick = (): void => {},
+  icon,
+  actions,
+  content,
+}: Props = $props();
 </script>
 
 <Page
@@ -19,12 +39,12 @@ export let onbreadcrumbClick: () => void = () => {};
   onclose={onclose}
   onbreadcrumbClick={onbreadcrumbClick}>
   <svelte:fragment slot="icon">
-    <slot name="icon" />
+    {@render icon?.()}
   </svelte:fragment>
   <svelte:fragment slot="actions">
-    <slot name="actions" />
+    {@render actions?.()}
   </svelte:fragment>
   <div slot="content" class="flex w-full h-full overflow-auto">
-    <slot name="content" />
+    {@render content?.()}
   </div>
 </Page>

--- a/packages/ui/src/lib/layouts/FormPageSpec.svelte
+++ b/packages/ui/src/lib/layouts/FormPageSpec.svelte
@@ -3,11 +3,17 @@ import FormPage from './FormPage.svelte';
 </script>
 
 <FormPage title="Test component">
-  <i slot="icon" class="fas fa-lightbulb fa-2x" aria-label="icon"></i>
+  {#snippet icon()}
+  <i class="fas fa-lightbulb fa-2x" aria-label="icon"></i>
+  {/snippet}
 
-  <i slot="actions" class="fas fa-lightbulb fa-2x" aria-label="actions"></i>
+  {#snippet actions()}
+  <i class="fas fa-lightbulb fa-2x" aria-label="actions"></i>
+  {/snippet}
 
-  <div slot="content" class="flex flex-col">
+  {#snippet content()}
+  <div class="flex flex-col">
     <i class="fas fa-lightbulb fa-2x" aria-label="content"></i>
   </div>
+  {/snippet}
 </FormPage>


### PR DESCRIPTION
### What does this PR do?

Migrate FormPage component to svelte 5

EngineFormPage (using FormPage) will be migrated in a follow-up PR

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of #11579 

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
