### PR TITLE
feat(status-bar): pin-unpin providers

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -4,6 +4,7 @@ import '@fortawesome/fontawesome-free/css/all.min.css';
 
 import { router } from 'tinro';
 
+import PinActions from '/@/lib/statusbar/PinActions.svelte';
 import { handleNavigation } from '/@/navigation';
 import { kubernetesNoCurrentContext } from '/@/stores/kubernetes-no-current-context';
 import type { KubernetesNavigationRequest } from '/@api/kubernetes-navigation';
@@ -388,6 +389,7 @@ window.events?.receive('kubernetes-navigation', (args: unknown) => {
       </div>
     </div>
     <HelpActions/>
+    <PinActions/>
     <StatusBar />
   </main>
 </Route>

--- a/packages/renderer/src/lib/statusbar/PinActions.spec.ts
+++ b/packages/renderer/src/lib/statusbar/PinActions.spec.ts
@@ -1,0 +1,245 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, type RenderResult } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import type { Component, ComponentProps, Snippet } from 'svelte';
+import { get } from 'svelte/store';
+import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import PinActions from '/@/lib/statusbar/PinActions.svelte';
+import ProviderButton from '/@/lib/statusbar/ProviderButton.svelte';
+import { providerInfos } from '/@/stores/providers';
+import { statusBarPinned } from '/@/stores/statusbar-pinned';
+import type { ProviderInfo } from '/@api/provider-info';
+import { STATUS_BAR_PIN_CONSTANTS } from '/@api/status-bar/pin-constants';
+
+vi.mock('/@/lib/statusbar/ProviderButton.svelte');
+
+const CONTAINER_CONNECTION_PROVIDER = {
+  name: 'podman',
+  id: 'podman',
+  containerConnections: [{}],
+  kubernetesConnections: [],
+  status: 'ready',
+  images: {},
+} as unknown as ProviderInfo;
+
+const KUBERNETES_CONNECTION_PROVIDER = {
+  name: 'kind',
+  id: 'kind',
+  containerConnections: [],
+  kubernetesConnections: [{}],
+  status: 'ready',
+  images: {},
+} as unknown as ProviderInfo;
+
+const RESIZE_OBSERVER_MOCK: ResizeObserver = {
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+} as unknown as ResizeObserver;
+
+beforeAll(() => {
+  Object.defineProperty(window, 'events', { value: { receive: vi.fn() } });
+  Object.defineProperty(window, 'ResizeObserver', { value: vi.fn() });
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  // define two providers
+  providerInfos.set([CONTAINER_CONNECTION_PROVIDER, KUBERNETES_CONNECTION_PROVIDER]);
+
+  // pin podman
+  statusBarPinned.set([
+    {
+      label: CONTAINER_CONNECTION_PROVIDER.name,
+      value: CONTAINER_CONNECTION_PROVIDER.id,
+      pinned: true,
+    },
+  ]);
+
+  vi.mocked(window.ResizeObserver).mockReturnValue(RESIZE_OBSERVER_MOCK);
+
+  vi.mocked(window.unpinStatusBar).mockResolvedValue(undefined);
+  vi.mocked(window.pinStatusBar).mockResolvedValue(undefined);
+});
+
+function getListener(): () => void {
+  expect(window.events.receive).toHaveBeenCalledOnce();
+  const [channel, listener] = vi.mocked(window.events.receive).mock.calls[0];
+
+  expect(channel).toStrictEqual(STATUS_BAR_PIN_CONSTANTS.TOGGLE_MENU);
+  expect(listener).toBeInstanceOf(Function);
+
+  return listener;
+}
+
+test('should register windows#events#receive', async () => {
+  render(PinActions);
+
+  const listener = getListener();
+  expect(listener).toBeDefined();
+});
+
+/**
+ * utility function to directly get the render result with the menu opened (default is hidden/closed)
+ */
+async function getOpenedPinActions(): Promise<RenderResult<Component<ComponentProps<typeof PinActions>>>> {
+  const { getByTitle, ...result } = render(PinActions);
+
+  // call toggle listener (will open the menu)
+  const listener = getListener();
+  listener();
+
+  // wait for the menu to be open
+  await vi.waitFor(() => {
+    const element = getByTitle('Pin Menu');
+    expect(element).toBeInTheDocument();
+  });
+
+  return {
+    getByTitle,
+    ...result,
+  };
+}
+
+test('opened menu should render provider based on pin options', async () => {
+  // ensure we only have one item in the store
+  expect(get(statusBarPinned)).toHaveLength(1);
+
+  // render
+  await getOpenedPinActions();
+
+  // ensure we only rendered one item
+  expect(ProviderButton).toHaveBeenCalledOnce();
+  expect(ProviderButton).toHaveBeenCalledWith(expect.anything(), {
+    class: expect.any(String),
+    provider: CONTAINER_CONNECTION_PROVIDER,
+    onclick: expect.any(Function),
+    left: expect.any(Function),
+    $$slots: expect.anything(),
+  });
+});
+
+test('escape should hide the menu', async () => {
+  // render
+  const { queryByTitle } = await getOpenedPinActions();
+
+  await userEvent.keyboard('{Escape}');
+
+  await vi.waitFor(() => {
+    expect(queryByTitle('Pin Menu')).toBeNull();
+  });
+});
+
+describe('pin / unpin', () => {
+  /**
+   * Utility method to get the function provided as props#onclick to the {@link ProviderWidget}
+   * @param providerId
+   */
+  function getProviderButtonProps(providerId: string): {
+    onclick: () => void;
+    left: Snippet;
+  } {
+    const call: [unknown, ComponentProps<typeof ProviderButton>] | undefined = vi
+      .mocked(ProviderButton)
+      .mock.calls.find(([_, { provider }]) => provider.id === providerId);
+
+    // throw if we cannot found the specific call we are looking for
+    if (!call) throw new Error(`cannot find ProviderWidget call for providerId ${providerId}`);
+    // deconstruct the props
+    const [, { onclick, left }] = call;
+
+    // throw if props is undefined
+    if (!onclick || !left)
+      throw new Error(`missing mandatory props on ProviderWidget render for providerId ${providerId}`);
+    return {
+      onclick: onclick,
+      left: left,
+    };
+  }
+
+  beforeEach(() => {
+    // pin podman
+    statusBarPinned.set([
+      {
+        label: CONTAINER_CONNECTION_PROVIDER.name,
+        value: CONTAINER_CONNECTION_PROVIDER.id,
+        pinned: true, // podman pinned
+      },
+      {
+        label: KUBERNETES_CONNECTION_PROVIDER.name,
+        value: KUBERNETES_CONNECTION_PROVIDER.id,
+        pinned: false, // kubernetes not pinned
+      },
+    ]);
+  });
+
+  test('expect pinned provider to have pin icon', async () => {
+    // render
+    await getOpenedPinActions();
+
+    // get the command
+    const { left } = getProviderButtonProps(CONTAINER_CONNECTION_PROVIDER.id);
+
+    // the pin icon should be visible
+    const { getByRole } = render(left);
+    const svg = getByRole('img', { hidden: true });
+    expect(svg).toBeInTheDocument();
+  });
+
+  test('expect unpinned provider to NOT have pin icon', async () => {
+    // render
+    await getOpenedPinActions();
+
+    // get the command
+    const { left } = getProviderButtonProps(KUBERNETES_CONNECTION_PROVIDER.id);
+
+    // the pin icon should be visible
+    const { queryByRole } = render(left);
+    const svg = queryByRole('img', { hidden: true });
+    expect(svg).toBeNull();
+  });
+
+  test('expect pinned provider to have unpin command', async () => {
+    // render
+    await getOpenedPinActions();
+
+    // get the onclick
+    const { onclick } = getProviderButtonProps(CONTAINER_CONNECTION_PROVIDER.id);
+    // call the onclick
+    onclick();
+
+    expect(window.unpinStatusBar).toHaveBeenCalledWith(CONTAINER_CONNECTION_PROVIDER.id);
+  });
+
+  test('expect unpinned provider to have pin command', async () => {
+    // render
+    await getOpenedPinActions();
+
+    // get the onclick
+    const { onclick } = getProviderButtonProps(KUBERNETES_CONNECTION_PROVIDER.id);
+    // call the onclick
+    onclick();
+
+    expect(window.pinStatusBar).toHaveBeenCalledWith(KUBERNETES_CONNECTION_PROVIDER.id);
+  });
+});

--- a/packages/renderer/src/lib/statusbar/PinActions.svelte
+++ b/packages/renderer/src/lib/statusbar/PinActions.svelte
@@ -56,7 +56,7 @@ function pin(providerId: string): void {
 <div bind:this={outsideWindow}>
   {#if showMenu}
     <PinMenu>
-      {#each providers.entries() as [provider, pinned] }
+      {#each providers.entries() as [provider, pinned] (provider.id)}
         <ProviderButton
           class="w-full text-[var(--pd-dropdown-item-text)] hover:rounded-md hover:!bg-[var(--pd-dropdown-item-hover-bg)] hover:text-[var(--pd-dropdown-item-hover-text)]"
           provider={provider}

--- a/packages/renderer/src/lib/statusbar/PinActions.svelte
+++ b/packages/renderer/src/lib/statusbar/PinActions.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+import { faCheck } from '@fortawesome/free-solid-svg-icons';
+import Fa from 'svelte-fa';
+
+import ProviderButton from '/@/lib/statusbar/ProviderButton.svelte';
+import { providerInfos } from '/@/stores/providers';
+import { statusBarPinned } from '/@/stores/statusbar-pinned';
+import type { ProviderInfo } from '/@api/provider-info';
+import { STATUS_BAR_PIN_CONSTANTS } from '/@api/status-bar/pin-constants';
+
+import PinMenu from './PinMenu.svelte';
+
+let showMenu: boolean = $state(false);
+let outsideWindow: HTMLDivElement;
+window.events?.receive(STATUS_BAR_PIN_CONSTANTS.TOGGLE_MENU, toggleMenu);
+
+let pinned: Map<string, boolean> = $derived(new Map($statusBarPinned.map(pin => [pin.value, pin.pinned])));
+
+let providers: Map<ProviderInfo, boolean> = $derived(
+  new Map(
+    $providerInfos
+      .filter(provider => pinned.has(provider.id))
+      .map(provider => [provider, pinned.get(provider.id) ?? false]),
+  ),
+);
+
+function toggleMenu(): void {
+  showMenu = !showMenu;
+}
+
+function handleEscape({ key }: KeyboardEvent): void {
+  if (key === 'Escape') {
+    showMenu = false;
+  }
+}
+
+function onWindowClick(e: Event): void {
+  const target = e.target as HTMLElement;
+  // Listen to anything **but** the button that has "data-task-button" attribute with a value of "Help"
+  if (target && target.getAttribute('data-task-button') !== 'Pin') {
+    showMenu = outsideWindow.contains(target);
+  }
+}
+
+function unpin(providerId: string): void {
+  window.unpinStatusBar(providerId).catch(console.error);
+}
+
+function pin(providerId: string): void {
+  window.pinStatusBar(providerId).catch(console.error);
+}
+</script>
+
+<svelte:window on:keyup={handleEscape} on:click={onWindowClick}/>
+
+<div bind:this={outsideWindow}>
+  {#if showMenu}
+    <PinMenu>
+      {#each providers.entries() as [provider, pinned] }
+        <ProviderButton
+          class="w-full text-[var(--pd-dropdown-item-text)] hover:rounded-md hover:!bg-[var(--pd-dropdown-item-hover-bg)] hover:text-[var(--pd-dropdown-item-hover-text)]"
+          provider={provider}
+          onclick={pinned?unpin.bind(undefined, provider.id):pin.bind(undefined, provider.id)}
+        >
+          {#snippet left()}
+            <div class="w-4">
+              {#if pinned}
+                <Fa icon={faCheck} title="Pinned" />
+              {/if}
+            </div>
+          {/snippet}
+        </ProviderButton>
+      {/each}
+    </PinMenu>
+  {/if}
+</div>

--- a/packages/renderer/src/lib/statusbar/PinActions.svelte
+++ b/packages/renderer/src/lib/statusbar/PinActions.svelte
@@ -60,7 +60,7 @@ function pin(providerId: string): void {
         <ProviderButton
           class="w-full text-[var(--pd-dropdown-item-text)] hover:rounded-md hover:!bg-[var(--pd-dropdown-item-hover-bg)] hover:text-[var(--pd-dropdown-item-hover-text)]"
           provider={provider}
-          onclick={pinned?unpin.bind(undefined, provider.id):pin.bind(undefined, provider.id)}
+          onclick={pinned ? unpin.bind(undefined, provider.id) : pin.bind(undefined, provider.id)}
         >
           {#snippet left()}
             <div class="w-4">

--- a/packages/renderer/src/lib/statusbar/PinMenu.spec.ts
+++ b/packages/renderer/src/lib/statusbar/PinMenu.spec.ts
@@ -1,0 +1,46 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render } from '@testing-library/svelte';
+import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
+
+import PinMenu from '/@/lib/statusbar/PinMenu.svelte';
+
+const RESIZE_OBSERVER_MOCK: ResizeObserver = {
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+} as unknown as ResizeObserver;
+
+beforeAll(() => {
+  Object.defineProperty(window, 'ResizeObserver', { value: vi.fn() });
+  Object.defineProperty(window, 'addEventListener', { value: vi.fn() });
+  Object.defineProperty(window, 'removeEventListener', { value: vi.fn() });
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(window.ResizeObserver).mockReturnValue(RESIZE_OBSERVER_MOCK);
+});
+
+test('component on mount should resize listener', () => {
+  render(PinMenu);
+  expect(window.addEventListener).toHaveBeenCalledOnce();
+  expect(window.addEventListener).toHaveBeenCalledWith('resize', expect.any(Function));
+});

--- a/packages/renderer/src/lib/statusbar/PinMenu.svelte
+++ b/packages/renderer/src/lib/statusbar/PinMenu.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+import { onDestroy, onMount } from 'svelte';
+
+let dropDownHeight: number;
+let dropDownElement: HTMLElement;
+
+const STATUS_BAR_HEIGHT = 26;
+
+function updateMenuLocation(): void {
+  dropDownElement.style.top = `${window.innerHeight - dropDownHeight - STATUS_BAR_HEIGHT}px`;
+  dropDownElement.style.left = '1px';
+}
+
+onMount(() => {
+  updateMenuLocation();
+  window.addEventListener('resize', updateMenuLocation);
+});
+
+onDestroy(() => window.removeEventListener('resize', updateMenuLocation));
+</script>
+
+<div
+  bind:offsetHeight={dropDownHeight}
+  bind:this={dropDownElement}
+  class="absolute z-10"
+  data-testid="pin-menu">
+  <div
+    title="Pin Menu"
+    class="z-10 m-1 rounded-md shadow-lg bg-[var(--pd-dropdown-bg)] ring-2 ring-[var(--pd-dropdown-ring)] hover:ring-[var(--pd-dropdown-hover-ring)] divide-y divide-[var(--pd-dropdown-divider)] focus:outline-hidden">
+    <slot />
+  </div>
+</div>

--- a/packages/renderer/src/lib/statusbar/Providers.svelte
+++ b/packages/renderer/src/lib/statusbar/Providers.svelte
@@ -1,15 +1,31 @@
 <script lang="ts">
+import ProviderWidget from '/@/lib/statusbar/ProviderWidget.svelte';
 import { providerInfos } from '/@/stores/providers';
+import { statusBarPinned } from '/@/stores/statusbar-pinned';
 import type { ProviderInfo } from '/@api/provider-info';
+import { STATUS_BAR_PIN_CONSTANTS } from '/@api/status-bar/pin-constants';
 
-import ProviderWidget from './ProviderWidget.svelte';
-
-let providers: ProviderInfo[] = $derived(
-  $providerInfos.filter(
-    provider => provider.containerConnections.length > 0 || provider.kubernetesConnections.length > 0,
-  ),
+let pinned: Set<string> = $derived(
+  new Set($statusBarPinned.filter(option => option.pinned).map(option => option.value)),
 );
+
+let providers: ProviderInfo[] = $derived($providerInfos.filter(provider => pinned.has(provider.id)));
+
+function onclick(): void {
+  window.executeCommand(STATUS_BAR_PIN_CONSTANTS.TOGGLE_MENU_COMMAND).catch(console.error);
+}
 </script>
+
+{#if $statusBarPinned.length > 0}
+  <!-- We cannot use <Fa> object here, as we detect click on this button and outside to toggle the menu -->
+  <button
+    data-task-button="Pin"
+    onclick={onclick}
+    class="px-1 py-px flex h-full items-center relative hover:bg-[var(--pd-statusbar-hover-bg)] hover:cursor-pointer z-1 fa-solid fa-thumbtack"
+    title="Pin"
+    aria-label="Pin">
+  </button>
+{/if}
 
 {#each providers as entry, i (entry.id)}
   <ProviderWidget entry={entry} tooltipTopRight={i === 0}/>


### PR DESCRIPTION
### What does this PR do?

Adding the frontend logic for the status-bar and display the pinned providers, with by default only podman as per spec.

### Screenshot / video of UI

![image](https://github.com/user-attachments/assets/b75802c8-988f-45b5-a172-6acda3d22ca6)

https://github.com/user-attachments/assets/96068ae0-c184-4372-832d-54d822ad0044

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/9950

Known problem: https://github.com/podman-desktop/podman-desktop/issues/11974

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
