### PR TITLE
fix(PinRegistry): listeners and VM support

### DIFF
--- a/packages/main/src/plugin/statusbar/pin-registry.ts
+++ b/packages/main/src/plugin/statusbar/pin-registry.ts
@@ -68,7 +68,12 @@ export class PinRegistry implements IDisposable {
   public getOptions(): Array<PinOption> {
     return this.providers
       .getProviderInfos()
-      .filter(provider => provider.containerConnections.length > 0 || provider.kubernetesConnections.length > 0)
+      .filter(
+        provider =>
+          provider.containerConnections.length > 0 ||
+          provider.kubernetesConnections.length > 0 ||
+          provider.vmConnections.length > 0,
+      )
       .map(provider => ({
         value: provider.id,
         label: provider.name,
@@ -121,8 +126,15 @@ export class PinRegistry implements IDisposable {
       this.notify();
     }
 
-    // notify if container connection / kubernetes connection changed
-    this.#disposables.push(this.providers.onDidUpdateContainerConnection(this.notify.bind(this)));
-    this.#disposables.push(this.providers.onDidUpdateKubernetesConnection(this.notify.bind(this)));
+    // ==== notify if container connection / kubernetes / vm connection changed
+    // containers
+    this.#disposables.push(this.providers.onDidRegisterContainerConnection(this.notify.bind(this)));
+    this.#disposables.push(this.providers.onDidUnregisterContainerConnection(this.notify.bind(this)));
+    // kubernetes
+    this.#disposables.push(this.providers.onDidRegisterKubernetesConnection(this.notify.bind(this)));
+    this.#disposables.push(this.providers.onDidUnregisterKubernetesConnection(this.notify.bind(this)));
+    // vm connections
+    this.#disposables.push(this.providers.onDidRegisterVmConnection(this.notify.bind(this)));
+    this.#disposables.push(this.providers.onDidUnregisterVmConnection(this.notify.bind(this)));
   }
 }


### PR DESCRIPTION
### What does this PR do?

While testing https://github.com/podman-desktop/podman-desktop/pull/11973 I noticed that the pin registry was not updating when a new connection is registered, or one is unregistered.

- This PR fixes that, by registering to all register, unregister event.
- It also add support for VM providers (can be in a separate PR, but this a one liner, and I also add the register, unregister event related to VM so... make sense to update all)

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/11974

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
