### PR TITLE
chore(dockerode): bump to 3.3.37

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "@rollup/plugin-typescript": "^12.1.2",
     "@tsconfig/strictest": "^2.0.5",
     "@types/adm-zip": "^0.5.7",
-    "@types/dockerode": "^3.3.36",
+    "@types/dockerode": "^3.3.37",
     "@types/express": "^4.17.21",
     "@types/getos": "^3.0.4",
     "@types/js-yaml": "^4.0.9",

--- a/packages/api/src/image-info.ts
+++ b/packages/api/src/image-info.ts
@@ -85,7 +85,7 @@ export interface BuildImageOptions {
   /**
    * Attempt to pull the image even if an older image exists locally.
    */
-  pull?: string;
+  pull?: boolean;
 
   /**
    * Default: true

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -3510,7 +3510,7 @@ declare module '@podman-desktop/api' {
     /**
      * Attempt to pull the image even if an older image exists locally.
      */
-    pull?: boolean;
+    pull?: boolean | string;
 
     /**
      * Default: true

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -3510,7 +3510,7 @@ declare module '@podman-desktop/api' {
     /**
      * Attempt to pull the image even if an older image exists locally.
      */
-    pull?: string;
+    pull?: boolean;
 
     /**
      * Default: true

--- a/packages/main/src/plugin/extension/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension/extension-loader.spec.ts
@@ -1946,8 +1946,8 @@ describe('containerEngine', async () => {
     });
 
     test('non-(string | boolean) pull option should throw an error', async () => {
-      await expect(() => {
-        return api.containerEngine.buildImage('context', vi.fn(), {
+      await expect(async () => {
+        await api.containerEngine.buildImage('context', vi.fn(), {
           pull: { foo: 'bar' }, // non-sense
         } as unknown as containerDesktopAPI.BuildImageOptions);
       }).rejects.toThrowError('option pull should be of type string or boolean got object');

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -1102,7 +1102,31 @@ export class ExtensionLoader {
         eventCollect: (eventName: 'stream' | 'error' | 'finish', data: string) => void,
         options?: containerDesktopAPI.BuildImageOptions,
       ) {
-        return containerProviderRegistry.buildImage(context, eventCollect, options);
+        // to avoid breaking the extension-api the pull option may be `string | boolean`.
+        let pull: boolean | undefined;
+        if (options?.pull) {
+          switch (typeof options.pull) {
+            case 'boolean':
+              pull = options.pull;
+              break;
+            case 'string':
+              pull = options.pull.toLowerCase() === 'true';
+              break;
+            default:
+              throw new Error(`option pull should be of type string or boolean got ${typeof options.pull}`);
+          }
+        }
+
+        return containerProviderRegistry.buildImage(
+          context,
+          eventCollect,
+          options
+            ? {
+                ...options,
+                pull: pull,
+              }
+            : undefined,
+        );
       },
       listImages(options?: containerDesktopAPI.ListImagesOptions): Promise<containerDesktopAPI.ImageInfo[]> {
         return containerProviderRegistry.podmanListImages(options);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,8 +166,8 @@ importers:
         specifier: ^0.5.7
         version: 0.5.7
       '@types/dockerode':
-        specifier: ^3.3.36
-        version: 3.3.36
+        specifier: ^3.3.37
+        version: 3.3.37
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.21
@@ -4086,8 +4086,8 @@ packages:
   '@types/docker-modem@3.0.6':
     resolution: {integrity: sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==}
 
-  '@types/dockerode@3.3.36':
-    resolution: {integrity: sha512-K0wTBKjjVI1xS4zeLynssmmbpPl4AnWZ/MJ3JBTi9eGzEmu+xgMLVSKiWzsy/z+3GBPLD5+uE/i/6ZTeZPaX7A==}
+  '@types/dockerode@3.3.37':
+    resolution: {integrity: sha512-r+IoKpE5MLKaeD8CvoEh39ckWMLHR/+WBMoRQxrkL+apJqEWLMhBHh+93KIfyPWGd6gK7Q21jpoULKgNoRI0YA==}
 
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
@@ -4199,9 +4199,6 @@ packages:
 
   '@types/node@22.13.10':
     resolution: {integrity: sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==}
-
-  '@types/node@22.13.14':
-    resolution: {integrity: sha512-Zs/Ollc1SJ8nKUAgc7ivOEdIBM8JAKgrqqUYi2J997JuKO7/tpQC+WCetQ1sypiKCQWHdvdg9wBNpUPEWZae7w==}
 
   '@types/node@22.14.0':
     resolution: {integrity: sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==}
@@ -15929,10 +15926,10 @@ snapshots:
       '@types/node': 22.14.0
       '@types/ssh2': 1.15.5
 
-  '@types/dockerode@3.3.36':
+  '@types/dockerode@3.3.37':
     dependencies:
       '@types/docker-modem': 3.0.6
-      '@types/node': 22.13.14
+      '@types/node': 22.14.0
       '@types/ssh2': 1.15.5
 
   '@types/eslint-scope@3.7.7':
@@ -16054,10 +16051,6 @@ snapshots:
       undici-types: 6.19.8
 
   '@types/node@22.13.10':
-    dependencies:
-      undici-types: 6.20.0
-
-  '@types/node@22.13.14':
     dependencies:
       undici-types: 6.20.0
 
@@ -19903,7 +19896,7 @@ snapshots:
 
   history@4.10.1:
     dependencies:
-      '@babel/runtime': 7.26.10
+      '@babel/runtime': 7.27.0
       loose-envify: 1.4.0
       resolve-pathname: 3.0.0
       tiny-invariant: 1.3.3
@@ -23140,7 +23133,7 @@ snapshots:
 
   regenerator-transform@0.15.2:
     dependencies:
-      '@babel/runtime': 7.26.10
+      '@babel/runtime': 7.27.0
 
   regexp-ast-analysis@0.7.1:
     dependencies:


### PR DESCRIPTION
### What does this PR do?

Supersede https://github.com/podman-desktop/podman-desktop/pull/11969 and update the pull property of the `BuildImageOptions ` both in our internal api and extension api.

We don't seems to use this option anywhere, the `window.buildImage` do not provide it, and we just omit it when we call the dockerode from the renderer, only the extension-api may be using it.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/11977

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- typecheck and tests should be ✅ 
