### PR TITLE
fix(Table.svelte): children function usage

### DIFF
--- a/packages/ui/src/lib/table/Table.svelte
+++ b/packages/ui/src/lib/table/Table.svelte
@@ -233,21 +233,20 @@ function toggleChildren(name: string | undefined): void {
   <!-- Table body -->
   <div role="rowgroup">
     {#each data as object (object)}
+      {@const children = row.info.children?.(object) ?? []}
       <div class="min-h-[48px] h-fit bg-[var(--pd-content-card-bg)] rounded-lg mb-2">
         <div
           class="grid grid-table gap-x-0.5 min-h-[48px] hover:bg-[var(--pd-content-card-hover-bg)]"
           class:rounded-t-lg={object.name &&
             !collapsed.includes(object.name) &&
-            row.info.children &&
-            row.info.children(object).length > 0}
+            children.length > 0}
           class:rounded-lg={!object.name ||
             collapsed.includes(object.name) ||
-            !row.info.children ||
-            row.info.children(object).length === 0}
+            children.length === 0}
           role="row"
           aria-label={object.name}>
           <div class="whitespace-nowrap place-self-center" role="cell">
-            {#if row.info.children && row.info.children(object).length > 0}
+            {#if children.length > 0}
               <button on:click={toggleChildren.bind(undefined, object.name)}>
                 <Fa
                   size="0.8x"
@@ -286,11 +285,11 @@ function toggleChildren(name: string | undefined): void {
         </div>
 
         <!-- Child objects -->
-        {#if object.name && !collapsed.includes(object.name) && row.info.children}
-          {#each row.info.children(object) as child, i (child)}
+        {#if object.name && !collapsed.includes(object.name) && children.length > 0}
+          {#each children as child, i (child)}
             <div
               class="grid grid-table gap-x-0.5 hover:bg-[var(--pd-content-card-hover-bg)]"
-              class:rounded-b-lg={i === row.info.children(object).length - 1}
+              class:rounded-b-lg={i === children.length - 1}
               role="row"
               aria-label={child.name}>
               <div class="whitespace-nowrap justify-self-start" role="cell"></div>


### PR DESCRIPTION
### What does this PR do?

When we display the children of a row in the table component  (E.g. containers of a pods) the parent component provide a `children` function returning an array of item. This function is call a lot of time per render, for operation like `children().length` etc.

To avoid recalling multiple time we can use `@const` template syntax of svelte[^1] which allow us to define local constant after a Each block.

[^1]: https://svelte.dev/docs/svelte/@const

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/11836

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] tests added in https://github.com/podman-desktop/podman-desktop/pull/11886 ensure no regression
