### PR TITLE
chore: expose VmProviderConnection and VmProviderConnectionFactory  in extension-api

### DIFF
--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -56,8 +56,10 @@ const updateWarningsMock = vi.fn();
 const provider: extensionApi.Provider = {
   setContainerProviderConnectionFactory: vi.fn(),
   setKubernetesProviderConnectionFactory: vi.fn(),
+  setVmProviderConnectionFactory: vi.fn(),
   registerContainerProviderConnection: vi.fn(),
   registerKubernetesProviderConnection: vi.fn(),
+  registerVmProviderConnection: vi.fn(),
   registerLifecycle: vi.fn(),
   registerInstallation: vi.fn(),
   registerUpdate: registerUpdateMock,

--- a/extensions/podman/packages/extension/src/utils/podman-install.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-install.spec.ts
@@ -40,8 +40,10 @@ const extensionContext = {
 const provider: extensionApi.Provider = {
   setContainerProviderConnectionFactory: vi.fn(),
   setKubernetesProviderConnectionFactory: vi.fn(),
+  setVmProviderConnectionFactory: vi.fn(),
   registerContainerProviderConnection: vi.fn(),
   registerKubernetesProviderConnection: vi.fn(),
+  registerVmProviderConnection: vi.fn(),
   registerLifecycle: vi.fn(),
   registerInstallation: vi.fn(),
   registerUpdate: vi.fn(),

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -674,9 +674,14 @@ declare module '@podman-desktop/api' {
       containerProviderConnectionFactory: KubernetesProviderConnectionFactory,
       connectionAuditor?: Auditor,
     ): Disposable;
+    setVmProviderConnectionFactory(
+      vmProviderConnectionFactory: VmProviderConnectionFactory,
+      connectionAuditor?: Auditor,
+    ): Disposable;
 
     registerContainerProviderConnection(connection: ContainerProviderConnection): Disposable;
     registerKubernetesProviderConnection(connection: KubernetesProviderConnection): Disposable;
+    registerVmProviderConnection(connection: VmProviderConnection): Disposable;
     registerLifecycle(lifecycle: ProviderLifecycle): Disposable;
 
     // register installation flow
@@ -1178,7 +1183,11 @@ declare module '@podman-desktop/api' {
   /**
    * The configuration scope
    */
-  export type ConfigurationScope = string | ContainerProviderConnection | KubernetesProviderConnection;
+  export type ConfigurationScope =
+    | string
+    | ContainerProviderConnection
+    | KubernetesProviderConnection
+    | VmProviderConnection;
 
   export interface Configuration {
     /**

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -525,6 +525,13 @@ declare module '@podman-desktop/api' {
     status(): ProviderConnectionStatus;
   }
 
+  export interface VmProviderConnection {
+    name: string;
+    shellAccess?: ProviderConnectionShellAccess;
+    lifecycle?: ProviderConnectionLifecycle;
+    status(): ProviderConnectionStatus;
+  }
+
   // common set of options for creating a provider
   export interface ProviderConnectionFactory {
     // Allow to initialize a provider
@@ -545,6 +552,12 @@ declare module '@podman-desktop/api' {
 
   // create a kubernetes provider
   export interface KubernetesProviderConnectionFactory extends ProviderConnectionFactory {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    create?(params: { [key: string]: any }, logger?: Logger, token?: CancellationToken): Promise<void>;
+  }
+
+  // create a Vm provider
+  export interface VmProviderConnectionFactory extends ProviderConnectionFactory {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     create?(params: { [key: string]: any }, logger?: Logger, token?: CancellationToken): Promise<void>;
   }

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -546,20 +546,17 @@ declare module '@podman-desktop/api' {
 
   // create programmatically a ContainerProviderConnection
   export interface ContainerProviderConnectionFactory extends ProviderConnectionFactory {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    create(params: { [key: string]: any }, logger?: Logger, token?: CancellationToken): Promise<void>;
+    create(params: { [key: string]: unknown }, logger?: Logger, token?: CancellationToken): Promise<void>;
   }
 
   // create a kubernetes provider
   export interface KubernetesProviderConnectionFactory extends ProviderConnectionFactory {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    create?(params: { [key: string]: any }, logger?: Logger, token?: CancellationToken): Promise<void>;
+    create?(params: { [key: string]: unknown }, logger?: Logger, token?: CancellationToken): Promise<void>;
   }
 
   // create a Vm provider
   export interface VmProviderConnectionFactory extends ProviderConnectionFactory {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    create?(params: { [key: string]: any }, logger?: Logger, token?: CancellationToken): Promise<void>;
+    create?(params: { [key: string]: unknown }, logger?: Logger, token?: CancellationToken): Promise<void>;
   }
 
   export interface AuditRecord {

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -801,13 +801,25 @@ declare module '@podman-desktop/api' {
     status: ProviderConnectionStatus;
   }
 
+  export interface UpdateVmConnectionEvent {
+    providerId: string;
+    connection: VmProviderConnection;
+    status: ProviderConnectionStatus;
+  }
+
   export interface UnregisterContainerConnectionEvent {
     providerId: string;
   }
   export interface UnregisterKubernetesConnectionEvent {
     providerId: string;
   }
+  export interface UnregisterVmConnectionEvent {
+    providerId: string;
+  }
   export interface RegisterKubernetesConnectionEvent {
+    providerId: string;
+  }
+  export interface RegisterVmConnectionEvent {
     providerId: string;
   }
   export interface RegisterContainerConnectionEvent {

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -546,12 +546,14 @@ declare module '@podman-desktop/api' {
 
   // create programmatically a ContainerProviderConnection
   export interface ContainerProviderConnectionFactory extends ProviderConnectionFactory {
-    create(params: { [key: string]: unknown }, logger?: Logger, token?: CancellationToken): Promise<void>;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    create(params: { [key: string]: any }, logger?: Logger, token?: CancellationToken): Promise<void>;
   }
 
   // create a kubernetes provider
   export interface KubernetesProviderConnectionFactory extends ProviderConnectionFactory {
-    create?(params: { [key: string]: unknown }, logger?: Logger, token?: CancellationToken): Promise<void>;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    create?(params: { [key: string]: any }, logger?: Logger, token?: CancellationToken): Promise<void>;
   }
 
   // create a Vm provider

--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -79,10 +79,8 @@ export type ConfigurationScope =
   | 'DEFAULT'
   | 'ContainerConnection'
   | 'KubernetesConnection'
-  | 'VmConnection'
   | 'ContainerProviderConnectionFactory'
   | 'KubernetesProviderConnectionFactory'
-  | 'VmProviderConnectionFactory'
   | 'DockerCompatibility'
   | 'Onboarding';
 

--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -79,8 +79,10 @@ export type ConfigurationScope =
   | 'DEFAULT'
   | 'ContainerConnection'
   | 'KubernetesConnection'
+  | 'VmConnection'
   | 'ContainerProviderConnectionFactory'
   | 'KubernetesProviderConnectionFactory'
+  | 'VmProviderConnectionFactory'
   | 'DockerCompatibility'
   | 'Onboarding';
 

--- a/packages/main/src/plugin/provider-impl.ts
+++ b/packages/main/src/plugin/provider-impl.ts
@@ -18,19 +18,14 @@
 
 import type {
   Auditor,
-  CancellationToken,
   ContainerProviderConnection,
   ContainerProviderConnectionFactory,
   Event,
   KubernetesProviderConnection,
   KubernetesProviderConnectionFactory,
-  Logger,
   Provider,
   ProviderAutostart,
   ProviderCleanup,
-  ProviderConnectionFactory,
-  ProviderConnectionLifecycle,
-  ProviderConnectionShellAccess,
   ProviderConnectionStatus,
   ProviderDetectionCheck,
   ProviderImages,
@@ -41,6 +36,8 @@ import type {
   ProviderOptions,
   ProviderStatus,
   ProviderUpdate,
+  VmProviderConnection,
+  VmProviderConnectionFactory,
 } from '@podman-desktop/api';
 
 import type { ContainerProviderRegistry } from './container-registry.js';
@@ -48,23 +45,6 @@ import { Emitter } from './events/emitter.js';
 import type { ProviderRegistry } from './provider-registry.js';
 import type { IDisposable } from './types/disposable.js';
 import { Disposable } from './types/disposable.js';
-
-/*
- * to be exposed in extension-api.d.ts
- */
-export interface VmProviderConnection {
-  name: string;
-  shellAccess?: ProviderConnectionShellAccess;
-  lifecycle?: ProviderConnectionLifecycle;
-  status(): ProviderConnectionStatus;
-}
-
-// create a Vm provider
-// to be exposed in extension-api.d.ts
-export interface VmProviderConnectionFactory extends ProviderConnectionFactory {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  create?(params: { [key: string]: any }, logger?: Logger, token?: CancellationToken): Promise<void>;
-}
 
 export class ProviderImpl implements Provider, IDisposable {
   private containerProviderConnections: Set<ContainerProviderConnection>;

--- a/packages/main/src/plugin/provider-registry.spec.ts
+++ b/packages/main/src/plugin/provider-registry.spec.ts
@@ -34,6 +34,7 @@ import type {
   ProviderInstallation,
   ProviderLifecycle,
   ProviderUpdate,
+  VmProviderConnection,
 } from '@podman-desktop/api';
 import { assert, beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -49,7 +50,7 @@ import type { ApiSenderType } from './api.js';
 import type { AutostartEngine } from './autostart-engine.js';
 import type { ContainerProviderRegistry } from './container-registry.js';
 import { LifecycleContextImpl } from './lifecycle-context.js';
-import type { ProviderImpl, VmProviderConnection } from './provider-impl.js';
+import type { ProviderImpl } from './provider-impl.js';
 import { ProviderRegistry, type UpdateVmConnectionEvent } from './provider-registry.js';
 import type { Telemetry } from './telemetry/telemetry.js';
 import { Disposable } from './types/disposable.js';

--- a/packages/main/src/plugin/provider-registry.spec.ts
+++ b/packages/main/src/plugin/provider-registry.spec.ts
@@ -34,6 +34,7 @@ import type {
   ProviderInstallation,
   ProviderLifecycle,
   ProviderUpdate,
+  UpdateVmConnectionEvent,
   VmProviderConnection,
 } from '@podman-desktop/api';
 import { assert, beforeEach, describe, expect, test, vi } from 'vitest';
@@ -51,7 +52,7 @@ import type { AutostartEngine } from './autostart-engine.js';
 import type { ContainerProviderRegistry } from './container-registry.js';
 import { LifecycleContextImpl } from './lifecycle-context.js';
 import type { ProviderImpl } from './provider-impl.js';
-import { ProviderRegistry, type UpdateVmConnectionEvent } from './provider-registry.js';
+import { ProviderRegistry } from './provider-registry.js';
 import type { Telemetry } from './telemetry/telemetry.js';
 import { Disposable } from './types/disposable.js';
 

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -43,10 +43,13 @@ import type {
   ProviderUpdate,
   RegisterContainerConnectionEvent,
   RegisterKubernetesConnectionEvent,
+  RegisterVmConnectionEvent,
   UnregisterContainerConnectionEvent,
   UnregisterKubernetesConnectionEvent,
+  UnregisterVmConnectionEvent,
   UpdateContainerConnectionEvent,
   UpdateKubernetesConnectionEvent,
+  UpdateVmConnectionEvent,
   VmProviderConnection,
 } from '@podman-desktop/api';
 
@@ -82,21 +85,6 @@ export type ContainerConnectionProviderLifecycleListener = (
   providerInfo: ProviderInfo,
   providerContainerConnectionInfo: ProviderContainerConnectionInfo,
 ) => void;
-
-/*
- * to be exposed in extension-api.d.ts
- */
-export interface RegisterVmConnectionEvent {
-  providerId: string;
-}
-export interface UnregisterVmConnectionEvent {
-  providerId: string;
-}
-export interface UpdateVmConnectionEvent {
-  providerId: string;
-  connection: VmProviderConnection;
-  status: ProviderConnectionStatus;
-}
 
 /**
  * Manage creation of providers and their lifecycle.

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -47,6 +47,7 @@ import type {
   UnregisterKubernetesConnectionEvent,
   UpdateContainerConnectionEvent,
   UpdateKubernetesConnectionEvent,
+  VmProviderConnection,
 } from '@podman-desktop/api';
 
 import type {
@@ -66,7 +67,7 @@ import type { ContainerProviderRegistry } from './container-registry.js';
 import type { Event } from './events/emitter.js';
 import { Emitter } from './events/emitter.js';
 import { LifecycleContextImpl, LoggerImpl } from './lifecycle-context.js';
-import { ProviderImpl, type VmProviderConnection } from './provider-impl.js';
+import { ProviderImpl } from './provider-impl.js';
 import type { Telemetry } from './telemetry/telemetry.js';
 import { Disposable } from './types/disposable.js';
 


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Exposes VmProviderConnection and VmProviderConnectionFactory  in extension-api and updates any references in Podman Desktop to use the new import

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/podman-desktop/issues/11748
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
