### PR TITLE
chore: introduced micromark button image with command argument 

### DIFF
--- a/packages/renderer/src/lib/markdown/Markdown.spec.ts
+++ b/packages/renderer/src/lib/markdown/Markdown.spec.ts
@@ -78,14 +78,22 @@ describe('Custom button', () => {
   });
 
   test('Expect button to be rendered as a icon with args', async () => {
+    vi.mocked(window.executeCommand).mockResolvedValue({});
+
     const icon = 'faIconIcon';
     await waitRender({ markdown: `:button[${icon}]{command=command args='["arg1"]'}` });
     const markdownContent = screen.getByRole('region', { name: 'markdown-content' });
     expect(markdownContent).toBeInTheDocument();
-    expect(markdownContent).toContainHTML(`<button class="fa-solid ${icon} before:px-1 fa-3x"`);
+    expect(markdownContent).toContainHTML(
+      `<button class="fa-solid ${icon} before:px-1 fa-3x hover:text-[var(--pd-action-button-primary-hover-text)]"`,
+    );
     expect(markdownContent).toContainHTML('data-command="command"');
     expect(markdownContent).toContainHTML(`data-args="arg1"`);
     expect(markdownContent).toContainHTML('</button>');
+
+    const iconButton = screen.getByRole('button', { name: icon });
+    expect(iconButton).toBeDefined();
+    await fireEvent.click(iconButton);
   });
 });
 

--- a/packages/renderer/src/lib/markdown/Markdown.spec.ts
+++ b/packages/renderer/src/lib/markdown/Markdown.spec.ts
@@ -76,6 +76,17 @@ describe('Custom button', () => {
     expect(markdownContent).toContainHTML('data-command="command"');
     expect(markdownContent).toContainHTML('Name of the button</button>');
   });
+
+  test('Expect button to be rendered as a icon with args', async () => {
+    const icon = 'faIconIcon';
+    await waitRender({ markdown: `:button[${icon}]{command=command args='["arg1"]'}` });
+    const markdownContent = screen.getByRole('region', { name: 'markdown-content' });
+    expect(markdownContent).toBeInTheDocument();
+    expect(markdownContent).toContainHTML(`<button class="fa-solid ${icon} before:px-1 fa-3x"`);
+    expect(markdownContent).toContainHTML('data-command="command"');
+    expect(markdownContent).toContainHTML(`data-args="arg1"`);
+    expect(markdownContent).toContainHTML('</button>');
+  });
 });
 
 describe('Custom link', () => {

--- a/packages/renderer/src/lib/markdown/Markdown.spec.ts
+++ b/packages/renderer/src/lib/markdown/Markdown.spec.ts
@@ -94,6 +94,7 @@ describe('Custom button', () => {
     const iconButton = screen.getByRole('button', { name: icon });
     expect(iconButton).toBeDefined();
     await fireEvent.click(iconButton);
+    expect(window.executeCommand).toBeCalledWith('command', 'arg1');
   });
 });
 

--- a/packages/renderer/src/lib/markdown/micromark-button-directive.ts
+++ b/packages/renderer/src/lib/markdown/micromark-button-directive.ts
@@ -45,7 +45,8 @@ export function button(d: Directive): void {
   if (d.attributes && 'command' in d.attributes && 'args' in d.attributes) {
     this.tag(`
       <button 
-        class="fa-solid ${this.encode(d.label)} before:px-1 fa-3x" 
+        class="fa-solid ${this.encode(d.label)} before:px-1 fa-3x hover:text-[var(--pd-action-button-primary-hover-text)]" 
+        aria-label="${this.encode(d.label)}"
         data-command="${this.encode(d.attributes.command)}" 
         data-args="${JSON.parse(d.attributes.args)}">
       </button>

--- a/packages/renderer/src/lib/markdown/micromark-button-directive.ts
+++ b/packages/renderer/src/lib/markdown/micromark-button-directive.ts
@@ -40,8 +40,19 @@ export function button(d: Directive): void {
     return false;
   }
 
-  // Make sure {command=example} has been passed in
-  if (d.attributes && 'command' in d.attributes) {
+  // If {command=example args='["arg1"]'} has been passed in
+  // Icon format of a button
+  if (d.attributes && 'command' in d.attributes && 'args' in d.attributes) {
+    this.tag(`
+      <button 
+        class="fa-solid ${this.encode(d.label)} before:px-1 fa-3x" 
+        data-command="${this.encode(d.attributes.command)}" 
+        data-args="${JSON.parse(d.attributes.args)}">
+      </button>
+    `);
+
+    // Make sure {command=example} has been passed in
+  } else if (d.attributes && 'command' in d.attributes) {
     // Make this a button if it's a command
     this.tag(
       '<button class="px-4 py-[6px] rounded-[4px] text-white text-[13px] whitespace-nowrap bg-purple-600 hover:bg-purple-500 no-underline" data-command="' +

--- a/packages/renderer/src/lib/markdown/micromark-listener-handler.ts
+++ b/packages/renderer/src/lib/markdown/micromark-listener-handler.ts
@@ -37,12 +37,19 @@ export function createListener(
 
     // Retrieve the command and expandable within the dataset
     let command: string | undefined;
+    let args: string | undefined;
     let expandable: string | undefined;
 
     if ('dataset' in eventTarget && eventTarget.dataset && typeof eventTarget.dataset === 'object') {
       const targetDataset = eventTarget.dataset;
       if ('command' in targetDataset && typeof targetDataset.command === 'string') {
         command = targetDataset.command;
+      }
+      // The targetDataset.args is a JS object but represented as a string
+      // typeof targetDataset.args === 'object' => false
+      // console.log(targetDataset.args) => [object Object]
+      if ('args' in targetDataset && targetDataset.args && typeof targetDataset.args === 'string') {
+        args = targetDataset.args;
       }
       if ('expandable' in targetDataset && typeof targetDataset.expandable === 'string') {
         expandable = targetDataset.expandable;
@@ -97,7 +104,7 @@ export function createListener(
           targetButton.firstChild.style.display = 'inline-block';
         }
         window
-          .executeCommand(command)
+          .executeCommand(command, args)
           .then(value => inProgressMarkdownCommandExecutionCallback(command, 'successful', value))
           .catch((reason: unknown) => inProgressMarkdownCommandExecutionCallback(command, 'failed', reason))
           .finally(() => {
@@ -109,7 +116,7 @@ export function createListener(
       } else if (eventTarget instanceof HTMLAnchorElement) {
         // Execute the command since it's a simple "link" to it
         // usually associated with a dialog / quickpick action.
-        window.executeCommand(command).catch((reason: unknown) => console.error(String(reason)));
+        window.executeCommand(command, args).catch((reason: unknown) => console.error(String(reason)));
       }
     }
   };


### PR DESCRIPTION
### What does this PR do?
Adds option to micromark button to show  an image and call command with a argument 

### Screenshot / video of UI


### What issues does this PR fix or reference?
Required for  https://github.com/podman-desktop/podman-desktop/issues/10228

Whole feature can be tried out in https://github.com/podman-desktop/podman-desktop/pull/11598

### How to test this PR?


- [x] Tests are covering the bug fix or the new feature
