### PR TITLE
chore: added overflow visible property to modal component

### DIFF
--- a/packages/ui/src/lib/modal/Modal.svelte
+++ b/packages/ui/src/lib/modal/Modal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { createEventDispatcher, onDestroy, type Snippet } from 'svelte';
+import { createEventDispatcher, onDestroy } from 'svelte';
 
 import { tabWithinParent } from '../utils/dialog-utils';
 
@@ -9,8 +9,8 @@ interface Props {
   name?: string;
   top?: boolean;
   ignoreFocusOut?: boolean;
+  overflowVisible?: boolean;
   onclose?: () => void;
-  children?: Snippet;
 }
 
 let modal: HTMLDivElement;
@@ -18,10 +18,10 @@ let {
   name = 'drop-down-dialog',
   top = false,
   ignoreFocusOut = false,
+  overflowVisible = false,
   onclose = (): void => {
     dispatch('close');
   },
-  children,
 }: Props = $props();
 
 const handle_keydown = (e: KeyboardEvent): void => {
@@ -66,11 +66,11 @@ function handleMousedown(e: MouseEvent): void {
   <div
     class:translate-y-[-5%]={!top}
     class:my-[32px]={top}
-    class="bg-[var(--pd-modal-bg)] z-50 rounded-xl overflow-auto w-[calc(200vw-4em)] h-fit max-w-[42em] max-h-[calc(100vh-4em)] border-[1px] border-[var(--pd-modal-border)]"
+    class="bg-[var(--pd-modal-bg)] z-50 rounded-xl {overflowVisible ? 'overflow-visible' : 'overflow-auto'} w-[calc(200vw-4em)] h-fit max-w-[42em] max-h-[calc(100vh-4em)] border-[1px] border-[var(--pd-modal-border)]"
     role="dialog"
     aria-label={name}
     aria-modal="true"
     bind:this={modal}>
-    {@render children?.()}
+    <slot />
   </div>
 </div>

--- a/packages/ui/src/lib/modal/Modal.svelte
+++ b/packages/ui/src/lib/modal/Modal.svelte
@@ -9,7 +9,6 @@ interface Props {
   name?: string;
   top?: boolean;
   ignoreFocusOut?: boolean;
-  overflow?: 'auto' | 'visible';
   onclose?: () => void;
   children?: Snippet;
 }
@@ -19,7 +18,6 @@ let {
   name = 'drop-down-dialog',
   top = false,
   ignoreFocusOut = false,
-  overflow = 'auto',
   onclose = (): void => {
     dispatch('close');
   },
@@ -68,7 +66,7 @@ function handleMousedown(e: MouseEvent): void {
   <div
     class:translate-y-[-5%]={!top}
     class:my-[32px]={top}
-    class="bg-[var(--pd-modal-bg)] z-50 rounded-xl {overflow === 'auto' ? 'overflow-auto' : 'overflow-visible'} w-[calc(200vw-4em)] h-fit max-w-[42em] max-h-[calc(100vh-4em)] border-[1px] border-[var(--pd-modal-border)]"
+    class="bg-[var(--pd-modal-bg)] z-50 rounded-xl overflow-visible w-[calc(200vw-4em)] h-fit max-w-[42em] max-h-[calc(100vh-4em)] border-[1px] border-[var(--pd-modal-border)]"
     role="dialog"
     aria-label={name}
     aria-modal="true"

--- a/packages/ui/src/lib/modal/Modal.svelte
+++ b/packages/ui/src/lib/modal/Modal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { createEventDispatcher, onDestroy } from 'svelte';
+import { createEventDispatcher, onDestroy, type Snippet } from 'svelte';
 
 import { tabWithinParent } from '../utils/dialog-utils';
 
@@ -9,8 +9,9 @@ interface Props {
   name?: string;
   top?: boolean;
   ignoreFocusOut?: boolean;
-  overflowVisible?: boolean;
+  overflow?: 'auto' | 'visible';
   onclose?: () => void;
+  children?: Snippet;
 }
 
 let modal: HTMLDivElement;
@@ -18,10 +19,11 @@ let {
   name = 'drop-down-dialog',
   top = false,
   ignoreFocusOut = false,
-  overflowVisible = false,
+  overflow = 'auto',
   onclose = (): void => {
     dispatch('close');
   },
+  children,
 }: Props = $props();
 
 const handle_keydown = (e: KeyboardEvent): void => {
@@ -66,11 +68,11 @@ function handleMousedown(e: MouseEvent): void {
   <div
     class:translate-y-[-5%]={!top}
     class:my-[32px]={top}
-    class="bg-[var(--pd-modal-bg)] z-50 rounded-xl {overflowVisible ? 'overflow-visible' : 'overflow-auto'} w-[calc(200vw-4em)] h-fit max-w-[42em] max-h-[calc(100vh-4em)] border-[1px] border-[var(--pd-modal-border)]"
+    class="bg-[var(--pd-modal-bg)] z-50 rounded-xl {overflow === 'auto' ? 'overflow-auto' : 'overflow-visible'} w-[calc(200vw-4em)] h-fit max-w-[42em] max-h-[calc(100vh-4em)] border-[1px] border-[var(--pd-modal-border)]"
     role="dialog"
     aria-label={name}
     aria-modal="true"
     bind:this={modal}>
-    <slot />
+    {@render children?.()}
   </div>
 </div>


### PR DESCRIPTION
### What does this PR do?
Adds overflow visible property to modal component

### Screenshot / video of UI

### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/podman-desktop/issues/10228

Whole feature can be tried out in https://github.com/podman-desktop/podman-desktop/pull/11598

### How to test this PR?


- [ ] Tests are covering the bug fix or the new feature
