### PR TITLE
chore(website): modified community meeting link in the banner and docs

### DIFF
--- a/website/src/components/CommunityBanner.tsx
+++ b/website/src/components/CommunityBanner.tsx
@@ -8,13 +8,12 @@ function Banner(): JSX.Element {
         <img className="inline h-3 align-bottom mr-6" alt="Small box" src="img/banner/small_box.png" />
         Join us for the{' '}
         <a
-          href="https://github.com/podman-desktop/community/issues/3"
+          href="https://github.com/podman-desktop/community/blob/main/meetings/README.md#upcoming-community-meeting"
           target="_blank"
           rel="noreferrer"
           className="underline text-white ml-1">
-          first Podman Desktop Community Meeting
-        </a>{' '}
-        on March 27th
+          Next Podman Desktop Community Meeting
+        </a>
         <img className="inline h-10 align-middle ml-6" alt="Large box" src="img/banner/large_box.png" />
       </div>
     </div>

--- a/website/src/pages/community/index.tsx
+++ b/website/src/pages/community/index.tsx
@@ -102,8 +102,11 @@ export default function Home(): JSX.Element {
             <div>
               <h3 className="text-xl mb-2">3. Attend Community Events</h3>
               <p className="dark:text-gray-700">
-                Join us for upcoming <a href="https://github.com/podman-desktop/community/issues/3">meetups</a>,
-                webinars, and conferences.
+                Join us for upcoming{' '}
+                <a href="https://github.com/podman-desktop/community/blob/main/meetings/README.md#upcoming-community-meeting">
+                  meeting
+                </a>
+                , webinars, and conferences.
               </p>
             </div>
           </div>


### PR DESCRIPTION
### What does this PR do?
This is a temp fix to point to the upcoming meeting agenda link from the website banner and docs.
This will be modified when the community page will be refreshed in #11857 

### Screenshot / video of UI
![image](https://github.com/user-attachments/assets/9b402361-cda2-4135-8060-8b840ebf68fe)

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
