### PR TITLE
fix: remove unnecessary assignment

### DIFF
--- a/packages/renderer/src/lib/configmaps-secrets/ConfigMapDetails.svelte
+++ b/packages/renderer/src/lib/configmaps-secrets/ConfigMapDetails.svelte
@@ -79,7 +79,7 @@ async function loadDetails(): Promise<void> {
       {#if configMap}<StatusIcon icon={ConfigMapIcon} size={24} status={configMap.status} />{/if}
     {/snippet}
     {#snippet actionsSnippet()}
-      {#if configMap}<ConfigMapSecretActions configMapSecret={configMap} detailed={true} on:update={(): ConfigMapSecretUI | undefined => (configMap = configMap)} />{/if}
+      {#if configMap}<ConfigMapSecretActions configMapSecret={configMap} detailed={true} />{/if}
     {/snippet}
     {#snippet detailSnippet()}
       {#if configMap}

--- a/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretActions.spec.ts
+++ b/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretActions.spec.ts
@@ -24,7 +24,6 @@ import { afterEach, beforeAll, expect, test, vi } from 'vitest';
 import ConfigMapSecretActions from './ConfigMapSecretActions.svelte';
 import type { ConfigMapSecretUI } from './ConfigMapSecretUI';
 
-const updateMock = vi.fn();
 const deleteMock = vi.fn();
 const showMessageBoxMock = vi.fn();
 
@@ -59,7 +58,7 @@ afterEach(() => {
 
 test('Expect no error when deleting configmap', async () => {
   showMessageBoxMock.mockResolvedValue({ response: 0 });
-  render(ConfigMapSecretActions, { configMapSecret: fakeConfigMap, onUpdate: updateMock });
+  render(ConfigMapSecretActions, { configMapSecret: fakeConfigMap });
 
   // click on delete button
   const deleteButton = screen.getByRole('button', { name: 'Delete ConfigMap' });
@@ -71,7 +70,7 @@ test('Expect no error when deleting configmap', async () => {
 
 test('Expect no error when deleting secret', async () => {
   showMessageBoxMock.mockResolvedValue({ response: 0 });
-  render(ConfigMapSecretActions, { configMapSecret: fakeSecret, onUpdate: updateMock });
+  render(ConfigMapSecretActions, { configMapSecret: fakeSecret });
 
   // click on delete button
   const deleteButton = screen.getByRole('button', { name: 'Delete Secret' });

--- a/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretActions.svelte
+++ b/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretActions.svelte
@@ -15,11 +15,13 @@ const configmapSecretUtils = new ConfigMapSecretUtils();
 async function deleteConfigMapSecret(): Promise<void> {
   configMapSecret.status = 'DELETING';
 
-  if (configmapSecretUtils.isSecret(configMapSecret)) {
-    await window.kubernetesDeleteSecret(configMapSecret.name);
-  } else {
-    await window.kubernetesDeleteConfigMap((configMapSecret as ConfigMapSecretUI).name);
-  }
+  setTimeout(() => {
+    if (configmapSecretUtils.isSecret(configMapSecret)) {
+      window.kubernetesDeleteSecret(configMapSecret.name);
+    } else {
+      window.kubernetesDeleteConfigMap((configMapSecret as ConfigMapSecretUI).name);
+    }
+  }, 5_000);
 }
 </script>
 

--- a/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretActions.svelte
+++ b/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretActions.svelte
@@ -15,13 +15,11 @@ const configmapSecretUtils = new ConfigMapSecretUtils();
 async function deleteConfigMapSecret(): Promise<void> {
   configMapSecret.status = 'DELETING';
 
-  setTimeout(() => {
-    if (configmapSecretUtils.isSecret(configMapSecret)) {
-      window.kubernetesDeleteSecret(configMapSecret.name);
-    } else {
-      window.kubernetesDeleteConfigMap((configMapSecret as ConfigMapSecretUI).name);
-    }
-  }, 5_000);
+  if (configmapSecretUtils.isSecret(configMapSecret)) {
+    await window.kubernetesDeleteSecret(configMapSecret.name);
+  } else {
+    await window.kubernetesDeleteConfigMap((configMapSecret as ConfigMapSecretUI).name);
+  }
 }
 </script>
 

--- a/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretActions.svelte
+++ b/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretActions.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
-import { createEventDispatcher } from 'svelte';
 
 import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
 
@@ -11,16 +10,10 @@ import type { ConfigMapSecretUI } from './ConfigMapSecretUI';
 export let configMapSecret: ConfigMapSecretUI;
 export let detailed = false;
 
-const dispatch = createEventDispatcher<{ update: ConfigMapSecretUI }>();
-export let onUpdate: (update: ConfigMapSecretUI) => void = update => {
-  dispatch('update', update);
-};
-
 const configmapSecretUtils = new ConfigMapSecretUtils();
 
 async function deleteConfigMapSecret(): Promise<void> {
   configMapSecret.status = 'DELETING';
-  onUpdate(configMapSecret);
 
   if (configmapSecretUtils.isSecret(configMapSecret)) {
     await window.kubernetesDeleteSecret(configMapSecret.name);

--- a/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretColumnActions.svelte
+++ b/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretColumnActions.svelte
@@ -8,4 +8,4 @@ interface Props {
 let { object }: Props = $props();
 </script>
 
-<ConfigmapSecretActions configMapSecret={object} on:update />
+<ConfigmapSecretActions configMapSecret={object} />

--- a/packages/renderer/src/lib/configmaps-secrets/SecretDetails.svelte
+++ b/packages/renderer/src/lib/configmaps-secrets/SecretDetails.svelte
@@ -79,7 +79,7 @@ async function loadDetails(): Promise<void> {
       {#if secret}<StatusIcon icon={SecretIcon} size={24} status={secret.status} />{/if}
     {/snippet}
     {#snippet actionsSnippet()}
-      {#if secret}<ConfigMapSecretActions configMapSecret={secret} detailed={true} on:update={(): ConfigMapSecretUI | undefined => (secret = secret)} />{/if}
+      {#if secret}<ConfigMapSecretActions configMapSecret={secret} detailed={true} />{/if}
     {/snippet}
     {#snippet detailSnippet()}
       {#if secret}

--- a/packages/renderer/src/lib/deployments/DeploymentActions.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentActions.spec.ts
@@ -24,7 +24,6 @@ import { afterEach, beforeAll, expect, test, vi } from 'vitest';
 import DeploymentActions from './DeploymentActions.svelte';
 import type { DeploymentUI } from './DeploymentUI';
 
-const updateMock = vi.fn();
 const deleteMock = vi.fn();
 
 class DeploymentfUIImpl {
@@ -73,7 +72,7 @@ afterEach(() => {
 test('Expect no error and status deleting deployment', async () => {
   showMessageBoxMock.mockResolvedValue({ response: 0 });
 
-  render(DeploymentActions, { deployment, onUpdate: updateMock });
+  render(DeploymentActions, { deployment });
 
   // click on delete buttons
   const deleteButton = screen.getByRole('button', { name: 'Delete Deployment' });
@@ -84,6 +83,5 @@ test('Expect no error and status deleting deployment', async () => {
   await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
 
   expect(deployment.status).toEqual('DELETING');
-  expect(updateMock).toHaveBeenCalled();
   expect(deleteMock).toHaveBeenCalled();
 });

--- a/packages/renderer/src/lib/deployments/DeploymentActions.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentActions.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
-import { createEventDispatcher } from 'svelte';
 
 import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
 
@@ -10,13 +9,8 @@ import type { DeploymentUI } from './DeploymentUI';
 export let deployment: DeploymentUI;
 export let detailed = false;
 
-const dispatch = createEventDispatcher<{ update: DeploymentUI }>();
-export let onUpdate: (update: DeploymentUI) => void = update => {
-  dispatch('update', update);
-};
 async function deleteDeployment(): Promise<void> {
   deployment.status = 'DELETING';
-  onUpdate(deployment);
 
   await window.kubernetesDeleteDeployment(deployment.name);
 }

--- a/packages/renderer/src/lib/deployments/DeploymentColumnActions.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentColumnActions.svelte
@@ -8,4 +8,4 @@ interface Props {
 let { object }: Props = $props();
 </script>
 
-<DeploymentActions deployment={object} on:update />
+<DeploymentActions deployment={object} />

--- a/packages/renderer/src/lib/deployments/DeploymentDetails.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentDetails.svelte
@@ -87,7 +87,7 @@ async function loadDetails(): Promise<void> {
       {#if deployment}<StatusIcon icon={DeploymentIcon} size={24} status={deployment.status} />{/if}
     {/snippet}
     {#snippet actionsSnippet()}
-      {#if deployment}<DeploymentActions deployment={deployment} detailed={true} on:update={(): DeploymentUI | undefined => (deployment = deployment)} />{/if}
+      {#if deployment}<DeploymentActions deployment={deployment} detailed={true} />{/if}
     {/snippet}
     {#snippet tabsSnippet()}
       <Tab title="Summary" selected={isTabSelected($router.path, 'summary')} url={getTabUrl($router.path, 'summary')} />

--- a/packages/renderer/src/lib/ingresses-routes/IngressDetails.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressDetails.svelte
@@ -80,7 +80,7 @@ async function loadIngressDetails(): Promise<void> {
       {#if ingressUI}<StatusIcon icon={IngressRouteIcon} size={24} status={ingressUI.status} />{/if}
     {/snippet}
     {#snippet actionsSnippet()}
-      {#if ingressUI}<IngressRouteActions ingressRoute={ingressUI} detailed={true} on:update={(): IngressUI | undefined => (ingressUI = ingressUI)} />{/if}
+      {#if ingressUI}<IngressRouteActions ingressRoute={ingressUI} detailed={true} />{/if}
     {/snippet}
     {#snippet detailSnippet()}
       {#if ingressUI}

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteActions.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteActions.spec.ts
@@ -25,7 +25,6 @@ import IngressRouteActions from './IngressRouteActions.svelte';
 import type { IngressUI } from './IngressUI';
 import type { RouteUI } from './RouteUI';
 
-const updateMock = vi.fn();
 const deleteIngressMock = vi.fn();
 const deleteRoutesMock = vi.fn();
 const showMessageBoxMock = vi.fn();
@@ -62,7 +61,7 @@ test('Expect no error and status deleting ingress', async () => {
   ingressUI.namespace = 'test-namespace';
   ingressUI.selected = false;
 
-  render(IngressRouteActions, { ingressRoute: ingressUI, onUpdate: updateMock });
+  render(IngressRouteActions, { ingressRoute: ingressUI });
 
   // click on delete button
   const deleteButton = screen.getByRole('button', { name: 'Delete Ingress' });
@@ -73,7 +72,6 @@ test('Expect no error and status deleting ingress', async () => {
   await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
 
   expect(ingressUI.status).toEqual('DELETING');
-  expect(updateMock).toHaveBeenCalled();
   expect(deleteIngressMock).toHaveBeenCalled();
 });
 
@@ -93,7 +91,7 @@ test('Expect no error and status deleting route', async () => {
   routeUI.selected = false;
   routeUI.tlsEnabled = false;
 
-  render(IngressRouteActions, { ingressRoute: routeUI, onUpdate: updateMock });
+  render(IngressRouteActions, { ingressRoute: routeUI });
 
   // click on delete button
   const deleteButton = screen.getByRole('button', { name: 'Delete Route' });
@@ -104,6 +102,5 @@ test('Expect no error and status deleting route', async () => {
   await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
 
   expect(routeUI.status).toEqual('DELETING');
-  expect(updateMock).toHaveBeenCalled();
   expect(deleteRoutesMock).toHaveBeenCalled();
 });

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteActions.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteActions.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
-import { createEventDispatcher } from 'svelte';
 
 import { withConfirmation } from '../dialogs/messagebox-utils';
 import ListItemButtonIcon from '../ui/ListItemButtonIcon.svelte';
@@ -11,15 +10,10 @@ import type { RouteUI } from './RouteUI';
 export let ingressRoute: IngressUI | RouteUI;
 export let detailed = false;
 
-const dispatch = createEventDispatcher<{ update: IngressUI | RouteUI }>();
-export let onUpdate: (update: IngressUI | RouteUI) => void = update => {
-  dispatch('update', update);
-};
 const ingressRouteUtils = new IngressRouteUtils();
 
 async function deleteIngressRoute(): Promise<void> {
   ingressRoute.status = 'DELETING';
-  onUpdate(ingressRoute);
 
   if (ingressRouteUtils.isIngress(ingressRoute)) {
     await window.kubernetesDeleteIngress(ingressRoute.name);

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnActions.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteColumnActions.svelte
@@ -9,4 +9,4 @@ interface Props {
 let { object }: Props = $props();
 </script>
 
-<IngressRouteActions ingressRoute={object} on:update />
+<IngressRouteActions ingressRoute={object} />

--- a/packages/renderer/src/lib/ingresses-routes/RouteDetails.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/RouteDetails.svelte
@@ -80,7 +80,7 @@ onDestroy(() => {
       {#if routeUI}<StatusIcon icon={IngressRouteIcon} size={24} status={routeUI.status} />{/if}
     {/snippet}
     {#snippet actionsSnippet()}
-      {#if routeUI}<IngressRouteActions ingressRoute={routeUI} detailed={true} on:update={(): RouteUI | undefined => (routeUI = routeUI)} />{/if}
+      {#if routeUI}<IngressRouteActions ingressRoute={routeUI} detailed={true} />{/if}
     {/snippet}
     {#snippet detailSnippet()}
       {#if routeUI}

--- a/packages/renderer/src/lib/kube/pods/PodActions.spec.ts
+++ b/packages/renderer/src/lib/kube/pods/PodActions.spec.ts
@@ -27,7 +27,6 @@ import type { PodInfoContainerUI } from '../../pod/PodInfoUI';
 import PodActions from './PodActions.svelte';
 import type { PodUI } from './PodUI';
 
-const updateMock = vi.fn();
 const restartMock = vi.fn();
 const deleteMock = vi.fn();
 const showMessageBoxMock = vi.fn();
@@ -78,7 +77,7 @@ beforeEach(() => {
 test('Check deleting pod', async () => {
   showMessageBoxMock.mockResolvedValue({ response: 0 });
 
-  render(PodActions, { pod, onUpdate: updateMock });
+  render(PodActions, { pod });
 
   // click on delete button
   const deleteButton = screen.getByRole('button', { name: 'Delete Pod' });
@@ -89,21 +88,19 @@ test('Check deleting pod', async () => {
   await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
 
   expect(pod.status).toEqual('DELETING');
-  expect(updateMock).toHaveBeenCalled();
   expect(deleteMock).toHaveBeenCalled();
 });
 
 test('Check restarting pod', async () => {
   showMessageBoxMock.mockResolvedValue({ response: 0 });
 
-  render(PodActions, { pod, onUpdate: updateMock });
+  render(PodActions, { pod });
 
   // click on restart button
   const restartButton = screen.getByRole('button', { name: 'Restart Pod' });
   await fireEvent.click(restartButton);
 
   expect(pod.status).toEqual('RESTARTING');
-  expect(updateMock).toHaveBeenCalled();
   expect(restartMock).toHaveBeenCalled();
 });
 

--- a/packages/renderer/src/lib/kube/pods/PodActions.svelte
+++ b/packages/renderer/src/lib/kube/pods/PodActions.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { faArrowsRotate, faExternalLinkSquareAlt, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { DropdownMenu } from '@podman-desktop/ui-svelte';
-import { createEventDispatcher, onMount } from 'svelte';
+import { onMount } from 'svelte';
 
 import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
 
@@ -12,11 +12,6 @@ import type { PodUI } from './PodUI';
 export let pod: PodUI;
 export let dropdownMenu = false;
 export let detailed = false;
-
-const dispatch = createEventDispatcher<{ update: PodUI }>();
-export let onUpdate: (update: PodUI) => void = update => {
-  dispatch('update', update);
-};
 
 let openingKubernetesUrls = new Map();
 
@@ -40,14 +35,12 @@ onMount(async () => {
 
 async function restartPod(): Promise<void> {
   pod.status = 'RESTARTING';
-  onUpdate(pod);
 
   await window.restartKubernetesPod(pod.name);
 }
 
 async function deletePod(): Promise<void> {
   pod.status = 'DELETING';
-  onUpdate(pod);
 
   await window.kubernetesDeletePod(pod.name);
 }

--- a/packages/renderer/src/lib/kube/pods/PodColumnActions.svelte
+++ b/packages/renderer/src/lib/kube/pods/PodColumnActions.svelte
@@ -8,4 +8,4 @@ interface Props {
 let { object }: Props = $props();
 </script>
 
-<PodActions pod={object} dropdownMenu={true} on:update />
+<PodActions pod={object} dropdownMenu={true} />

--- a/packages/renderer/src/lib/pod/PodDetails.svelte
+++ b/packages/renderer/src/lib/pod/PodDetails.svelte
@@ -67,7 +67,10 @@ onMount(() => {
           <div>&nbsp;</div>
         {/if}
       </div>
-      <PodActions pod={pod} detailed={true} on:update={(): PodInfoUI => (pod = pod)} />
+      <PodActions pod={pod} detailed={true} on:update={(): PodInfoUI => {
+        pod = pod; // Keep this assignment for svelte 4 - can be safely removed when migrating to svelte 5
+        return pod;
+      }} />
     {/snippet}
     {#snippet detailSnippet()}
       <div class="flex py-2 w-full justify-end text-sm text-[var(--pd-content-text)]">

--- a/packages/renderer/src/lib/pvc/PVCActions.spec.ts
+++ b/packages/renderer/src/lib/pvc/PVCActions.spec.ts
@@ -24,7 +24,6 @@ import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import PVCActions from './PVCActions.svelte';
 import type { PVCUI } from './PVCUI';
 
-const updateMock = vi.fn();
 const deleteMock = vi.fn();
 const showMessageBoxMock = vi.fn();
 
@@ -67,7 +66,7 @@ afterEach(() => {
 
 test('Expect no error and status deleting PVC', async () => {
   showMessageBoxMock.mockResolvedValue({ response: 0 });
-  render(PVCActions, { pvc: fakePVC, onUpdate: updateMock });
+  render(PVCActions, { pvc: fakePVC });
 
   // click on delete buttons
   const deleteButton = screen.getByRole('button', { name: 'Delete PersistentVolumeClaim' });
@@ -75,6 +74,5 @@ test('Expect no error and status deleting PVC', async () => {
 
   await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
   expect(fakePVC.status).toEqual('DELETING');
-  expect(updateMock).toHaveBeenCalled();
   expect(deleteMock).toHaveBeenCalled();
 });

--- a/packages/renderer/src/lib/pvc/PVCActions.svelte
+++ b/packages/renderer/src/lib/pvc/PVCActions.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
-import { createEventDispatcher } from 'svelte';
 
 import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
 
@@ -10,13 +9,8 @@ import type { PVCUI } from './PVCUI';
 export let pvc: PVCUI;
 export let detailed = false;
 
-const dispatch = createEventDispatcher<{ update: PVCUI }>();
-export let onUpdate: (update: PVCUI) => void = update => {
-  dispatch('update', update);
-};
 async function deletePVC(): Promise<void> {
   pvc.status = 'DELETING';
-  onUpdate(pvc);
 
   await window.kubernetesDeletePersistentVolumeClaim(pvc.name);
 }

--- a/packages/renderer/src/lib/pvc/PVCColumnActions.svelte
+++ b/packages/renderer/src/lib/pvc/PVCColumnActions.svelte
@@ -8,4 +8,4 @@ interface Props {
 let { object }: Props = $props();
 </script>
 
-<PVCActions pvc={object} on:update />
+<PVCActions pvc={object} />

--- a/packages/renderer/src/lib/pvc/PVCDetails.svelte
+++ b/packages/renderer/src/lib/pvc/PVCDetails.svelte
@@ -79,7 +79,7 @@ async function loadDetails(): Promise<void> {
       {#if pvc}<StatusIcon icon={PVCIcon} size={24} status={pvc.status} />{/if}
     {/snippet}
     {#snippet actionsSnippet()}
-      {#if pvc}<PVCActions pvc={pvc} detailed={true} on:update={(): PVCUI | undefined => (pvc = pvc)} />{/if}
+      {#if pvc}<PVCActions pvc={pvc} detailed={true} />{/if}
     {/snippet}
     {#snippet detailSnippet()}
       {#if pvc}

--- a/packages/renderer/src/lib/service/ServiceActions.spec.ts
+++ b/packages/renderer/src/lib/service/ServiceActions.spec.ts
@@ -24,7 +24,6 @@ import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import ServiceActions from './ServiceActions.svelte';
 import type { ServiceUI } from './ServiceUI';
 
-const updateMock = vi.fn();
 const deleteMock = vi.fn();
 const showMessageBoxMock = vi.fn();
 
@@ -67,7 +66,7 @@ afterEach(() => {
 test('Expect no error and status deleting service', async () => {
   // Mock the showMessageBox to return 0 (yes)
   showMessageBoxMock.mockResolvedValue({ response: 0 });
-  render(ServiceActions, { service, onUpdate: updateMock });
+  render(ServiceActions, { service });
 
   // click on delete button
   const deleteButton = screen.getByRole('button', { name: 'Delete Service' });
@@ -75,6 +74,5 @@ test('Expect no error and status deleting service', async () => {
 
   expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   expect(service.status).toEqual('DELETING');
-  expect(updateMock).toHaveBeenCalled();
   expect(deleteMock).toHaveBeenCalled();
 });

--- a/packages/renderer/src/lib/service/ServiceActions.svelte
+++ b/packages/renderer/src/lib/service/ServiceActions.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
-import { createEventDispatcher } from 'svelte';
 
 import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
 
@@ -10,15 +9,8 @@ import type { ServiceUI } from './ServiceUI';
 export let service: ServiceUI;
 export let detailed = false;
 
-const dispatch = createEventDispatcher<{ update: ServiceUI }>();
-
-export let onUpdate: (service: ServiceUI) => void = service => {
-  dispatch('update', service);
-};
-
 async function deleteService(): Promise<void> {
   service.status = 'DELETING';
-  onUpdate(service);
 
   await window.kubernetesDeleteService(service.name);
 }

--- a/packages/renderer/src/lib/service/ServiceColumnActions.svelte
+++ b/packages/renderer/src/lib/service/ServiceColumnActions.svelte
@@ -8,4 +8,4 @@ interface Props {
 let { object }: Props = $props();
 </script>
 
-<ServiceActions service={object} on:update />
+<ServiceActions service={object} />

--- a/packages/renderer/src/lib/service/ServiceDetails.svelte
+++ b/packages/renderer/src/lib/service/ServiceDetails.svelte
@@ -85,7 +85,7 @@ async function loadDetails(): Promise<void> {
       {#if service}<StatusIcon icon={ServiceIcon} size={24} status={service.status} />{/if}
     {/snippet}
     {#snippet actionsSnippet()}
-      {#if service}<ServiceActions service={service} detailed={true} on:update={(): ServiceUI | undefined => (service = service)} />{/if}
+      {#if service}<ServiceActions service={service} detailed={true} />{/if}
     {/snippet}
     {#snippet detailSnippet()}
       <div class="flex py-2 w-full justify-end text-sm text-[var(--pd-content-text)]">


### PR DESCRIPTION
### What does this PR do?

Remove unnecessary assignment.

I suppose that this assignment has been added originally to force svelte to react on the change of the value on the parent component (ConfigMapDetails) when the value is modified in the child (ConfigMapSecretsActions): the child modifies the status of the configmap to DELETING, so the icon is changed to a spinner during the deletion. (@cdrage @deboer-tim I think you worked on the early versions of this page, do you confirm?)

With the current version of svelte, this assignment is not necessary to obtain the reaction. I've added a timeout to check that, without the assignment, the icon status is correctly changed to a spinner.

The second commit (setting timeout) will be removed if we agree on the fix, and I'll make the changes to all the other Kubernetes pages.



This change may seem completely off topic, but is helpful for fixing https://github.com/podman-desktop/podman-desktop/issues/12034 (with #12037) , related to #11579 

I have seen that is assignment has not been added for `CronJob` and `Job`, which makes me think they are not necessary anymore.

I added a comment for the podman pods, where this assignement is still necessary, because the `PodDetails` component is still in svelte 4. I tested to port it to svelte 5, and this removes the need of the assignment (I didn't include this change in this PR)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
