### PR TITLE
chore(test): allow to run podman-compose-smoke e2e test on macos inside Openshift Pipelines

### DIFF
--- a/tests/playwright/src/specs/compose-onboarding-smoke.spec.ts
+++ b/tests/playwright/src/specs/compose-onboarding-smoke.spec.ts
@@ -28,7 +28,7 @@ import { ResourcesPage } from '../model/pages/resources-page';
 import { SettingsBar } from '../model/pages/settings-bar';
 import type { NavigationBar } from '../model/workbench/navigation';
 import { expect as playExpect, test } from '../utility/fixtures';
-import { isCI, isLinux } from '../utility/platform';
+import { isCI, isLinux, isMac } from '../utility/platform';
 
 const RESOURCE_NAME: string = 'Compose';
 
@@ -37,6 +37,8 @@ let composeVersion: string;
 const composePartialInstallation = process.env.COMPOSE_PARTIAL_INSTALL ?? false;
 
 test.skip(!!isCI && isLinux, 'Tests suite should not run on Linux platform');
+//issue: https://github.com/podman-desktop/e2e/issues/348
+test.skip(isMac, 'Currently there is an issue with running this test on macOS platform');
 
 test.beforeAll(async ({ runner, welcomePage }) => {
   runner.setVideoAndTraceName('compose-onboarding-e2e');

--- a/tests/playwright/src/specs/podman-compose-smoke.spec.ts
+++ b/tests/playwright/src/specs/podman-compose-smoke.spec.ts
@@ -37,6 +37,11 @@ const composeContainer = 'resources';
 const backendImageName = 'quay.io/podman-desktop-demo/podify-demo-backend';
 const frontendImageName = 'quay.io/podman-desktop-demo/podify-demo-frontend';
 
+const IS_OPENSHIFT_PIPELINE_RUNNER: boolean = process.env.CI_PLATFORM === 'OpenShift';
+
+test.skip(!!isCI && isLinux, 'This test should not run on Ubuntu platform in Github Actions');
+test.skip(isMac && !IS_OPENSHIFT_PIPELINE_RUNNER, 'Run test on macOS only inside OpenShift pipelines');
+
 test.beforeAll(async ({ runner, welcomePage, page }) => {
   runner.setVideoAndTraceName('podman-compose-e2e');
   await welcomePage.handleWelcomePage(true);
@@ -57,9 +62,6 @@ test.afterAll(async ({ page, runner }) => {
 
 test.describe.serial('Compose compose workflow verification', { tag: '@smoke' }, () => {
   test('Verify Compose was installed', async ({ page, navigationBar }) => {
-    test.skip(!!isCI && isLinux, 'This test should not run on Ubuntu platform in Github Actions');
-    test.skip(!!isMac, 'Currently there is an issue with running this test on macOS platform');
-
     await navigationBar.openSettings();
     const settingsBar = new SettingsBar(page);
     const resourcesPage = await settingsBar.openTabPage(ResourcesPage);


### PR DESCRIPTION
Signed-off-by: Anton Misskii <amisskii@redhat.com>

### What does this PR do?
This PR allows running the podman-compose-smoke E2E test on macOS inside OpenShift Pipelines.

### What issues does this PR fix or reference?

https://github.com/podman-desktop/e2e/issues/302

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
