### PR TITLE
chore: migrate close button to svelte 5

### DIFF
--- a/packages/renderer/src/lib/dashboard/ReleaseNotesBox.svelte
+++ b/packages/renderer/src/lib/dashboard/ReleaseNotesBox.svelte
@@ -80,7 +80,7 @@ onDestroy(async () => {
           <p class="text-[var(--pd-content-card-header-text)] font-bold text-xl ml-2">
             {notesInfo?.title ?? ''}
           </p>
-          <CloseButton on:click={onClose} />
+          <CloseButton onclick={onClose} />
         </div>
         {#if notesInfo?.summary}
           <div
@@ -103,7 +103,7 @@ onDestroy(async () => {
             or try this <Link on:click={openReleaseNotes}>link</Link>
           {/if}
         </p>
-        <CloseButton on:click={onClose} />
+        <CloseButton onclick={onClose} />
       </div>
     </div>
   {/if}

--- a/packages/renderer/src/lib/dialogs/Dialog.svelte
+++ b/packages/renderer/src/lib/dialogs/Dialog.svelte
@@ -16,7 +16,7 @@ export let onclose: () => void = () => {
     <slot name="icon" />
     <h1 class="grow text-lg font-bold capitalize">{title}</h1>
 
-    <CloseButton on:click={onclose} />
+    <CloseButton onclick={onclose} />
   </div>
 
   <div class="relative max-h-80 overflow-auto text-[var(--pd-modal-text)] px-10 py-4">

--- a/packages/renderer/src/lib/feedback/SendFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/SendFeedback.svelte
@@ -59,7 +59,7 @@ function handleUpdate(e: boolean): void {
   <Modal name="Share your feedback" on:close={(): Promise<void> => hideModal()}>
     <div class="flex items-center justify-between pl-4 pr-3 py-3 space-x-2 text-[var(--pd-modal-header-text)]">
       <h1 class="grow text-lg font-bold capitalize">Share your feedback</h1>
-      <CloseButton on:click={(): Promise<void> => hideModal()} />
+      <CloseButton onclick={(): Promise<void> => hideModal()} />
     </div>
 
     <div class="relative text-[var(--pd-modal-text)] px-10 pt-4">

--- a/packages/renderer/src/lib/preferences/PreferencesProviderInstallationModal.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProviderInstallationModal.svelte
@@ -25,7 +25,7 @@ async function openLink(e: MouseEvent, url: string): Promise<void> {
       <div
         class="flex items-center justify-between px-5 py-4 mb-4 text-[var(--pd-modal-header-text)] bg-[var(--pd-modal-header-bg)]">
         <h1 class="text-md font-semibold">Create a new {providerToBeInstalled.displayName}</h1>
-        <CloseButton class="px-2 py-1" on:click={closeCallback} />
+        <CloseButton class="px-2 py-1" onclick={closeCallback} />
       </div>
       <div class="overflow-y-auto px-4 pb-4 text-[var(--pd-modal-text)]">
         <div class="flex flex-col rounded-lg">

--- a/packages/renderer/src/lib/recommendation/ExtensionBanner.svelte
+++ b/packages/renderer/src/lib/recommendation/ExtensionBanner.svelte
@@ -73,7 +73,7 @@ async function onClose(): Promise<void> {
   <!-- feature extension actions -->
   <div class="flex flex-col">
     <div class="flex flex-row justify-end">
-      <CloseButton on:click={onClose} />
+      <CloseButton onclick={onClose} />
     </div>
     <FeaturedExtension displayTitle={true} variant="secondary" featuredExtension={banner.featured} />
     <span class="text-base w-full text-end">{banner.featured.description}</span>

--- a/packages/renderer/src/lib/task-manager/TaskManager.svelte
+++ b/packages/renderer/src/lib/task-manager/TaskManager.svelte
@@ -48,7 +48,7 @@ const taskWordPlural = $derived(selectedItemsNumber > 1 ? 'tasks' : 'task');
     <NavPage title="Tasks" bind:searchTerm={searchTerm}>
       <svelte:fragment slot="additional-actions">
         <TaskManagerClearAllButton />
-        <CloseButton title="Hide (Escape)" on:click={hide} />
+        <CloseButton onclick={hide} />
       </svelte:fragment>
 
       <svelte:fragment slot="tabs">

--- a/packages/renderer/src/lib/toast/ToastCustomUi.svelte
+++ b/packages/renderer/src/lib/toast/ToastCustomUi.svelte
@@ -52,7 +52,7 @@ const executeAction = async (): Promise<void> => {
     {/if}
 
     <div class="flex grow flex-col items-end">
-      <CloseButton class="text-[var(--pd-modal-text)]" on:click={closeAction} />
+      <CloseButton class="text-[var(--pd-modal-text)]" onclick={closeAction} />
     </div>
   </div>
   <div class="flex flex-row items-center italic line-clamp-4">

--- a/packages/ui/src/lib/button/CloseButton.spec.ts
+++ b/packages/ui/src/lib/button/CloseButton.spec.ts
@@ -46,7 +46,7 @@ test('Check button styling', async () => {
 
 test('Check onclick action', async () => {
   const clickMock = vi.fn();
-  const comp = render(CloseButton, { onclick: clickMock });
+  render(CloseButton, { onclick: clickMock });
 
   const button = screen.getByRole('button');
   expect(button).toBeInTheDocument();

--- a/packages/ui/src/lib/button/CloseButton.spec.ts
+++ b/packages/ui/src/lib/button/CloseButton.spec.ts
@@ -44,12 +44,10 @@ test('Check button styling', async () => {
   expect(img).toHaveClass('svelte-fa');
 });
 
-test('Check on:click action', async () => {
+test('Check onclick action', async () => {
   const clickMock = vi.fn();
-  const comp = render(CloseButton);
-  comp.container.onclick = clickMock;
+  const comp = render(CloseButton, { onclick: clickMock });
 
-  // check on:click
   const button = screen.getByRole('button');
   expect(button).toBeInTheDocument();
   expect(clickMock).not.toHaveBeenCalled();

--- a/packages/ui/src/lib/button/CloseButton.svelte
+++ b/packages/ui/src/lib/button/CloseButton.svelte
@@ -4,24 +4,24 @@ import { createEventDispatcher } from 'svelte';
 import Fa from 'svelte-fa';
 
 interface Props {
-  onclick: () => void;
+  onclick?: () => void;
   class?: string;
 }
 
-let { onclick, class: className }: Props = $props();
+let {
+  onclick = (): void => {
+    dispatch('click');
+  },
+  class: className,
+}: Props = $props();
 
 const dispatch = createEventDispatcher<{ click: undefined }>();
-
-function click(): void {
-  onclick();
-  dispatch('click');
-}
 </script>
 
 <button
   type="button"
   class="hover:bg-[var(--pd-button-close-hover-bg)] hover:bg-opacity-10 transition-all rounded-[4px] p-1 no-underline cursor-pointer outline-transparent focus:outline-[var(--pd-button-primary-hover-bg)] {className}"
-  onclick={click}
+  onclick={onclick}
   title="Close"
   aria-label="Close">
   <Fa icon={faTimes} />

--- a/packages/ui/src/lib/button/CloseButton.svelte
+++ b/packages/ui/src/lib/button/CloseButton.svelte
@@ -1,20 +1,19 @@
 <script lang="ts">
 import { faTimes } from '@fortawesome/free-solid-svg-icons';
-import { createEventDispatcher } from 'svelte';
 import Fa from 'svelte-fa';
 
-const dispatch = createEventDispatcher<{ click: undefined }>();
-
-function click(): void {
-  dispatch('click');
+interface Props {
+  onclick: () => void;
+  class?: string;
 }
+
+let { onclick, class: className }: Props = $props();
 </script>
 
 <button
   type="button"
-  class="hover:bg-[var(--pd-button-close-hover-bg)] hover:bg-opacity-10 transition-all rounded-[4px] p-1 no-underline cursor-pointer outline-transparent focus:outline-[var(--pd-button-primary-hover-bg)] {$$props.class ??
-    ''}"
-  on:click={click}
+  class="hover:bg-[var(--pd-button-close-hover-bg)] hover:bg-opacity-10 transition-all rounded-[4px] p-1 no-underline cursor-pointer outline-transparent focus:outline-[var(--pd-button-primary-hover-bg)] {className}"
+  onclick={onclick}
   title="Close"
   aria-label="Close">
   <Fa icon={faTimes} />

--- a/packages/ui/src/lib/button/CloseButton.svelte
+++ b/packages/ui/src/lib/button/CloseButton.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { faTimes } from '@fortawesome/free-solid-svg-icons';
+import { createEventDispatcher } from 'svelte';
 import Fa from 'svelte-fa';
 
 interface Props {
@@ -8,12 +9,19 @@ interface Props {
 }
 
 let { onclick, class: className }: Props = $props();
+
+const dispatch = createEventDispatcher<{ click: undefined }>();
+
+function click(): void {
+  onclick();
+  dispatch('click');
+}
 </script>
 
 <button
   type="button"
   class="hover:bg-[var(--pd-button-close-hover-bg)] hover:bg-opacity-10 transition-all rounded-[4px] p-1 no-underline cursor-pointer outline-transparent focus:outline-[var(--pd-button-primary-hover-bg)] {className}"
-  onclick={onclick}
+  onclick={click}
   title="Close"
   aria-label="Close">
   <Fa icon={faTimes} />

--- a/packages/ui/src/lib/layouts/Page.svelte
+++ b/packages/ui/src/lib/layouts/Page.svelte
@@ -72,7 +72,7 @@ function handleKeydown(e: KeyboardEvent): void {
             <div class="grow font-extralight" aria-label="Page Name">{breadcrumbRightPart}</div>
           {/if}
           {#if hasClose}
-            <CloseButton class="justify-self-end text-lg" on:click={onclose} />
+            <CloseButton class="justify-self-end text-lg" onclick={onclose} />
           {/if}
         </div>
       {/if}
@@ -107,7 +107,7 @@ function handleKeydown(e: KeyboardEvent): void {
             </div>
           </div>
           {#if !showBreadcrumb}
-            <CloseButton class="justify-self-end" on:click={onclose} />
+            <CloseButton class="justify-self-end" onclick={onclose} />
           {/if}
         </div>
       </div>

--- a/storybook/src/stories/button/CloseButton.stories.svelte
+++ b/storybook/src/stories/button/CloseButton.stories.svelte
@@ -27,7 +27,7 @@ setTemplate(template);
 </script>
 
 {#snippet template({ _children }: Args<typeof Story>, _context: StoryContext<typeof Story>)}
-  <CloseButton on:click={doClick} />
+  <CloseButton onclick={doClick} />
 {/snippet}
 
 <Story name="Basic" />


### PR DESCRIPTION
### What does this PR do?

Migrates the CloseButton component to Svelte 5, primarily just migrating the on:click.

TaskManager was using a title property that didn't exist, I've removed it (vs adding a new property) because it doesn't seem necessary.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of #11573.

### How to test this PR?

Click some close buttons!

- [x] Tests are covering the bug fix or the new feature