### PR TITLE
refactor: add ProviderConnection union type

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -532,6 +532,8 @@ declare module '@podman-desktop/api' {
     status(): ProviderConnectionStatus;
   }
 
+  export type ProviderConnection = ContainerProviderConnection | KubernetesProviderConnection | VmProviderConnection;
+
   // common set of options for creating a provider
   export interface ProviderConnectionFactory {
     // Allow to initialize a provider
@@ -1194,11 +1196,7 @@ declare module '@podman-desktop/api' {
   /**
    * The configuration scope
    */
-  export type ConfigurationScope =
-    | string
-    | ContainerProviderConnection
-    | KubernetesProviderConnection
-    | VmProviderConnection;
+  export type ConfigurationScope = string | ProviderConnection;
 
   export interface Configuration {
     /**

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -28,6 +28,7 @@ import type {
   ProviderCleanup,
   ProviderCleanupAction,
   ProviderCleanupExecuteOptions,
+  ProviderConnection,
   ProviderConnectionShellAccess,
   ProviderConnectionShellAccessSession,
   ProviderConnectionShellDimensions,
@@ -104,10 +105,7 @@ export class ProviderRegistry {
   private providerCleanup: Map<string, ProviderCleanup> = new Map();
   private autostartEngine: AutostartEngine | undefined = undefined;
 
-  private connectionLifecycleContexts: Map<
-    ContainerProviderConnection | KubernetesProviderConnection | VmProviderConnection,
-    LifecycleContextImpl
-  > = new Map();
+  private connectionLifecycleContexts: Map<ProviderConnection, LifecycleContextImpl> = new Map();
   private listeners: ProviderEventListener[];
   private lifecycleListeners: ProviderLifecycleListener[];
   private containerConnectionLifecycleListeners: ContainerConnectionProviderLifecycleListener[];
@@ -593,7 +591,7 @@ export class ProviderRegistry {
     }
 
     const provider = this.getMatchingProvider(providerInternalId);
-    let connection: ContainerProviderConnection | KubernetesProviderConnection | VmProviderConnection | undefined;
+    let connection: ProviderConnection | undefined;
 
     if (provider.containerConnections && provider.containerConnections.length > 0) {
       connection = provider.containerConnections[0];
@@ -678,9 +676,7 @@ export class ProviderRegistry {
     return this.getProviderConnectionInfo(connection) as ProviderVmConnectionInfo;
   }
 
-  private getProviderConnectionInfo(
-    connection: ContainerProviderConnection | KubernetesProviderConnection | VmProviderConnection,
-  ): ProviderConnectionInfo {
+  private getProviderConnectionInfo(connection: ProviderConnection): ProviderConnectionInfo {
     let providerConnection: ProviderConnectionInfo;
     if (this.isContainerConnection(connection)) {
       providerConnection = {
@@ -1049,7 +1045,7 @@ export class ProviderRegistry {
   getMatchingConnectionFromProvider(
     internalProviderId: string,
     providerContainerConnectionInfo: ProviderConnectionInfo | ContainerProviderConnection,
-  ): ContainerProviderConnection | KubernetesProviderConnection | VmProviderConnection {
+  ): ProviderConnection {
     if (this.isProviderContainerConnection(providerContainerConnectionInfo)) {
       return this.getMatchingContainerConnectionFromProvider(internalProviderId, providerContainerConnectionInfo);
     } else if (this.isProviderKubernetesConnectionInfo(providerContainerConnectionInfo)) {
@@ -1074,15 +1070,11 @@ export class ProviderRegistry {
     );
   }
 
-  isContainerConnection(
-    connection: ContainerProviderConnection | KubernetesProviderConnection | VmProviderConnection,
-  ): connection is ContainerProviderConnection {
+  isContainerConnection(connection: ProviderConnection): connection is ContainerProviderConnection {
     return (connection as ContainerProviderConnection).endpoint?.socketPath !== undefined;
   }
 
-  isKubernetesConnection(
-    connection: ContainerProviderConnection | KubernetesProviderConnection | VmProviderConnection,
-  ): connection is KubernetesProviderConnection {
+  isKubernetesConnection(connection: ProviderConnection): connection is KubernetesProviderConnection {
     return (
       !this.isContainerConnection(connection) && (connection as ContainerProviderConnection).endpoint !== undefined
     );


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Adds a new type `ProviderConnection = ContainerProviderConnection | KubernetesProviderConnection | VmProviderConnection` to `extension-api.d.ts`, and updates existing `ContainerProviderConnection | KubernetesProviderConnection | VmProviderConnection` references to use it

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
related to https://github.com/podman-desktop/podman-desktop/pull/11982

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
