### PR TITLE
chore: Use isUnixLike() instead of isLinux() in some places

### DIFF
--- a/packages/main/src/plugin/close-behavior.spec.ts
+++ b/packages/main/src/plugin/close-behavior.spec.ts
@@ -26,7 +26,7 @@ import type { Directories } from './directories.js';
 
 vi.mock('./util', () => {
   return {
-    isLinux: vi.fn(),
+    isUnixLike: vi.fn(),
   };
 });
 
@@ -46,14 +46,14 @@ test('should register a configuration', async () => {
   expect(after).toBeDefined();
 });
 
-test('should set default value of configuraton registry on Linux to true', async () => {
-  vi.spyOn(util, 'isLinux').mockImplementation(() => true);
+test('should set default value of configuraton registry on Linux and FreeBSD to true', async () => {
+  vi.spyOn(util, 'isUnixLike').mockImplementation(() => true);
   await closeBehavior.init();
   expect(configurationRegistry.getConfigurationProperties()['preferences.ExitOnClose']?.default).toBeTruthy();
 });
 
-test('should set default value of configuraton registry if not Linux', async () => {
-  vi.spyOn(util, 'isLinux').mockImplementation(() => false);
+test('should set default value of configuraton registry if not Linux or FreeBSD', async () => {
+  vi.spyOn(util, 'isUnixLike').mockImplementation(() => false);
   await closeBehavior.init();
   expect(configurationRegistry.getConfigurationProperties()['preferences.ExitOnClose']?.default).toBeFalsy();
 });

--- a/packages/main/src/plugin/close-behavior.ts
+++ b/packages/main/src/plugin/close-behavior.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { isLinux } from '../util.js';
+import { isUnixLike } from '../util.js';
 import type { ConfigurationRegistry, IConfigurationNode } from './configuration-registry.js';
 
 export class CloseBehavior {
@@ -32,7 +32,7 @@ export class CloseBehavior {
         ['preferences.ExitOnClose']: {
           description: 'Quit the app when the close button is clicked instead of minimizing to the tray.',
           type: 'boolean',
-          default: isLinux(),
+          default: isUnixLike(),
         },
       },
     };

--- a/packages/main/src/plugin/contribution-manager.spec.ts
+++ b/packages/main/src/plugin/contribution-manager.spec.ts
@@ -319,7 +319,7 @@ describe('findComposeBinary', () => {
     return {
       isWindows: vi.fn(),
       isMac: vi.fn(),
-      isLinux: vi.fn(),
+      isUnixLike: vi.fn(),
       exec: vi.fn(),
     };
   });
@@ -376,7 +376,7 @@ describe('findComposeBinary', () => {
   test('Check findComposeBinary on Linux', async () => {
     vi.mock('node:fs');
 
-    vi.spyOn(util, 'isLinux').mockImplementation(() => true);
+    vi.spyOn(util, 'isUnixLike').mockImplementation(() => true);
     vi.spyOn(util, 'isMac').mockImplementation(() => false);
     vi.spyOn(util, 'isWindows').mockImplementation(() => false);
 

--- a/packages/main/src/plugin/contribution-manager.ts
+++ b/packages/main/src/plugin/contribution-manager.ts
@@ -24,7 +24,7 @@ import * as jsYaml from 'js-yaml';
 
 import type { ContributionInfo } from '/@api/contribution-info.js';
 
-import { isLinux, isMac, isWindows } from '../util.js';
+import { isMac, isUnixLike, isWindows } from '../util.js';
 import type { ApiSenderType } from './api.js';
 import type { ContainerProviderRegistry } from './container-registry.js';
 import type { Directories } from './directories.js';
@@ -181,7 +181,7 @@ export class ContributionManager {
     } else if (isMac()) {
       binaries.push('/usr/local/bin/docker-compose');
       binaries.push('/opt/homebrew/bin/docker-compose');
-    } else if (isLinux()) {
+    } else if (isUnixLike()) {
       binaries.push('/usr/bin/docker-compose');
       binaries.push('/usr/local/bin/docker-compose');
     }


### PR DESCRIPTION
### What does this PR do?

This PR changes some Linux-specific code paths to work on FreeBSD too by replacing `isLinux` check with `isUnixLike`.

- [X] Tests are covering the bug fix or the new feature
