### PR TITLE
fix: updated configmap secret capitilization

### DIFF
--- a/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretList.spec.ts
+++ b/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretList.spec.ts
@@ -48,6 +48,41 @@ test('Expect configmap empty screen', async () => {
   });
 });
 
+test('Displays correct title', async () => {
+  const configMap: V1ConfigMap = {
+    metadata: {
+      name: 'my-configmap',
+      namespace: 'my-namespace',
+    },
+    data: {
+      key1: 'value1',
+      key2: 'value2',
+    },
+  };
+
+  const secret: V1Secret = {
+    metadata: {
+      name: 'my-secret',
+      namespace: 'my-namespace',
+    },
+    data: {
+      secretkey1: 'value1',
+      secretkey2: 'value2',
+    },
+    type: 'Opaque',
+  };
+
+  vi.mocked(states).kubernetesCurrentContextConfigMapsFiltered = writable<KubernetesObject[]>([configMap]);
+  vi.mocked(states).kubernetesCurrentContextSecretsFiltered = writable<KubernetesObject[]>([secret]);
+
+  render(ConfigMapSecretList);
+
+  await vi.waitFor(() => {
+    const title = screen.getByRole('heading', { name: 'ConfigMaps and Secrets' });
+    expect(title).toBeInTheDocument();
+  });
+});
+
 test('Expect configmap and secrets list', async () => {
   const configMap: V1ConfigMap = {
     metadata: {

--- a/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretList.svelte
+++ b/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretList.svelte
@@ -90,8 +90,8 @@ const row = new TableRow<ConfigMapSecretUI>({ selectable: (_configmapSecret): bo
       legacyObjectStore: kubernetesCurrentContextSecretsFiltered,
     },
   ]}
-  singular="configmap and secret"
-  plural="configmaps and secrets"
+  singular="ConfigMap and Secret"
+  plural="ConfigMaps and Secrets"
   icon={ConfigMapSecretIcon}
   searchTerm={searchTerm}
   columns={columns}


### PR DESCRIPTION
### What does this PR do?

Updates the name of the configmap and secret title 

### Screenshot / video of UI
![configmap](https://github.com/user-attachments/assets/da429fb7-e411-4992-8735-5da99a09d876)

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes  https://github.com/podman-desktop/podman-desktop/issues/11449

### How to test this PR?
pnpm watch
go to kubernetes tab and go to configmap and secrets tab to see change
