### PR TITLE
chore(package.json): build should include build:preload:types

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "main": "packages/main/dist/index.cjs",
   "scripts": {
-    "build": "pnpm run build:main && pnpm run build:preload && pnpm run build:preload-docker-extension && pnpm run build:preload-webview && pnpm run build:ui && pnpm run build:renderer && pnpm run build:extensions",
+    "build": "pnpm run build:main && pnpm run build:preload && pnpm run build:preload-docker-extension && pnpm run build:preload-webview && npm run build:preload:types && pnpm run build:ui && pnpm run build:renderer && pnpm run build:extensions",
     "build:main": "cd ./packages/main && vite build",
     "build:extensions": "pnpm run build:extensions:compose && pnpm run build:extensions:docker && pnpm run build:extensions:lima && pnpm run build:extensions:podman && pnpm run build:extensions:kubecontext && pnpm run build:extensions:kind && pnpm run build:extensions:registries && pnpm run build:extensions:kubectl-cli",
     "build:extensions:compose": "cd ./extensions/compose && pnpm run build",


### PR DESCRIPTION
### What does this PR do?

The `pnpm build` does not execute the `build:preload:types`. The `pnpm compile:current` works because vite does not check the types when building, it just transpile to JS.

We only require to build the preload:types for the tests, and typecheck. But it makes sense to include them into the `build` script, so we don't have to check what need to be build when we want to test things (like the renderer package.).

The goal is to simplify the `test:*` scripts in the `packages.json` to avoid having multiple step, and just do the testing, not the building.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Related to https://github.com/podman-desktop/podman-desktop/pull/12026

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- Pipeline should be :heavy_check_mark: 
