### PR TITLE
fix: use intermediate ca store as well on Windows

### DIFF
--- a/packages/main/src/plugin/certificate.spec.ts
+++ b/packages/main/src/plugin/certificate.spec.ts
@@ -94,7 +94,7 @@ describe('Windows', () => {
 
   test('expect retrieve certificates', async () => {
     const rootCertificate = `${BEGIN_CERTIFICATE}${CR}Root${CR}${END_CERTIFICATE}${CR}`;
-    const intermediateCertificate = `${BEGIN_CERTIFICATE}${CR}CAt${CR}${END_CERTIFICATE}${CR}`;
+    const intermediateCertificate = `${BEGIN_CERTIFICATE}${CR}CA${CR}${END_CERTIFICATE}${CR}`;
     vi.mocked(wincaAPI).mockImplementation((options: WincaAPIOptions) => {
       if (options.store === 'ca') {
         options.ondata(rootCertificate);

--- a/packages/main/src/plugin/certificate.spec.ts
+++ b/packages/main/src/plugin/certificate.spec.ts
@@ -96,11 +96,8 @@ describe('Windows', () => {
     const rootCertificate = `${BEGIN_CERTIFICATE}${CR}Root${CR}${END_CERTIFICATE}${CR}`;
     const intermediateCertificate = `${BEGIN_CERTIFICATE}${CR}CA${CR}${END_CERTIFICATE}${CR}`;
     vi.mocked(wincaAPI).mockImplementation((options: WincaAPIOptions) => {
-      if (options.store === 'ca') {
-        options.ondata(rootCertificate);
-      } else {
-        options.ondata(intermediateCertificate);
-      }
+      options.ondata(rootCertificate);
+      options.ondata(intermediateCertificate);
       if (options.onend) options.onend();
     });
     const certificates = await certificate.retrieveCertificates();

--- a/packages/main/src/plugin/certificate.spec.ts
+++ b/packages/main/src/plugin/certificate.spec.ts
@@ -16,8 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { beforeEach, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import wincaAPI from 'win-ca/api';
 
+import { isWindows } from '../util.js';
 import { Certificates } from './certificates.js';
 
 let certificate: Certificates;
@@ -30,6 +32,38 @@ const CR = '\n';
 vi.mock('node:child_process', () => {
   return {
     spawn: vi.fn(),
+  };
+});
+
+vi.mock('../util.js', () => {
+  return {
+    isWindows: vi.fn(),
+    isMac: vi.fn(),
+    isLinux: vi.fn(),
+  };
+});
+
+interface WincaProcedure {
+  exe: () => string;
+  inject: (cert: string) => void;
+  der2: {
+    pem: string;
+  };
+}
+
+interface WincaAPIOptions {
+  store?: string;
+  ondata: (ca: unknown) => void;
+  onend?: () => void;
+}
+
+vi.mock('win-ca/api', () => {
+  const wincaAPI = vi.fn();
+  (wincaAPI as unknown as WincaProcedure).exe = vi.fn();
+  (wincaAPI as unknown as WincaProcedure).inject = vi.fn();
+  (wincaAPI as unknown as WincaProcedure).der2 = { pem: 'pem' };
+  return {
+    default: wincaAPI,
   };
 });
 
@@ -51,4 +85,26 @@ test('expect parse correctly certificates', async () => {
       .replace(new RegExp(CR, 'g'), ''),
   );
   expect(stripped).toStrictEqual(['Foo', 'Bar', 'Baz', 'Qux']);
+});
+
+describe('Windows', () => {
+  beforeEach(() => {
+    vi.mocked(isWindows).mockReturnValue(true);
+  });
+
+  test('expect retrieve certificates', async () => {
+    const rootCertificate = `${BEGIN_CERTIFICATE}${CR}Root${CR}${END_CERTIFICATE}${CR}`;
+    const intermediateCertificate = `${BEGIN_CERTIFICATE}${CR}CAt${CR}${END_CERTIFICATE}${CR}`;
+    vi.mocked(wincaAPI).mockImplementation((options: WincaAPIOptions) => {
+      if (options.store === 'ca') {
+        options.ondata(rootCertificate);
+      } else {
+        options.ondata(intermediateCertificate);
+      }
+      if (options.onend) options.onend();
+    });
+    const certificates = await certificate.retrieveCertificates();
+    expect(certificates).toContain(rootCertificate);
+    expect(certificates).toContain(intermediateCertificate);
+  });
 });

--- a/packages/main/src/plugin/certificates.ts
+++ b/packages/main/src/plugin/certificates.ts
@@ -93,6 +93,14 @@ export class Certificates {
         ondata: (ca: string) => {
           CAs.push(ca);
         },
+      });
+      wincaAPI({
+        format: wincaAPI.der2.pem,
+        inject: false,
+        store: 'ca',
+        ondata: (ca: string) => {
+          CAs.push(ca);
+        },
         onend: () => {
           resolve(CAs);
         },

--- a/packages/main/src/plugin/certificates.ts
+++ b/packages/main/src/plugin/certificates.ts
@@ -90,14 +90,7 @@ export class Certificates {
       wincaAPI({
         format: wincaAPI.der2.pem,
         inject: false,
-        ondata: (ca: string) => {
-          CAs.push(ca);
-        },
-      });
-      wincaAPI({
-        format: wincaAPI.der2.pem,
-        inject: false,
-        store: 'ca',
+        store: ['root', 'ca'],
         ondata: (ca: string) => {
           CAs.push(ca);
         },


### PR DESCRIPTION
Fixes #9826

### What does this PR do?

Update the certificates loaded from the Windows store to include both root and intermediate CA certificates

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

#9826 

### How to test this PR?
1. Unzip the zip file in a directory
2. Run podman run -d --rm --name squid -v squid:/etc/squid -p 3128:3128 ubuntu/squid
3. Add rootCA.crt to the Windows Root Certificates store and CA.crt to the Intermediate Certificate store
4. Launch Podman Desktop and define https://localhost:3128 for Web proxy and secure Web proxy
5. Check that Internet access is enabled

[squid.zip](https://github.com/user-attachments/files/19635136/squid.zip)


- [x] Tests are covering the bug fix or the new feature
