### PR TITLE
feat(main): creating GitHub client class

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,7 +177,8 @@
     "validator": "^13.15.0",
     "vite": "^6.2.5",
     "vitest": "^3.1.1",
-    "xvfb-maybe": "^0.2.1"
+    "xvfb-maybe": "^0.2.1",
+    "@octokit/rest": "^21.1.1"
   },
   "dependencies": {
     "@docker/extension-api-client-types": "0.3.4",

--- a/packages/main/src/plugin/github/github-client.spec.ts
+++ b/packages/main/src/plugin/github/github-client.spec.ts
@@ -1,0 +1,183 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { assert, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { GithubClient } from '/@/plugin/github/github-client.js';
+
+const FETCH_MOCK: typeof fetch = vi.fn();
+
+// let's mock a timestamp in ONE hour
+const RESET_TIMESTAMP = new Date().getTime() / 1000 + 60 * 60;
+
+const BODY_RATE_LIMIT_BELLOW: unknown = {
+  resources: {
+    // omitted
+  },
+  rate: {
+    limit: 60,
+    remaining: 57,
+    reset: RESET_TIMESTAMP,
+  },
+};
+
+const BODY_RATE_LIMIT_ABOVE: unknown = {
+  resources: {
+    // omitted
+  },
+  rate: {
+    limit: 60,
+    remaining: 0,
+    reset: RESET_TIMESTAMP,
+  },
+};
+
+const RESPONSE_RATE_LIMIT_BELLOW: Response = {
+  url: 'https://api.github.com/rate_limit',
+  status: 200,
+  headers: new Headers({
+    'content-type': 'application/json; charset=utf-8',
+    'x-ratelimit-remaining': '57',
+    'x-ratelimit-reset': `${RESET_TIMESTAMP}`,
+  }),
+  text: () => Promise.resolve(JSON.stringify(BODY_RATE_LIMIT_BELLOW)),
+} as unknown as Response;
+
+const RESPONSE_RATE_LIMIT_ABOVE: Response = {
+  url: 'https://api.github.com/rate_limit',
+  status: 200,
+  headers: new Headers({
+    'content-type': 'application/json; charset=utf-8',
+    'x-ratelimit-remaining': '0',
+    'x-ratelimit-reset': `${RESET_TIMESTAMP}`,
+  }),
+  text: () => Promise.resolve(JSON.stringify(BODY_RATE_LIMIT_ABOVE)),
+} as unknown as Response;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(FETCH_MOCK).mockResolvedValue(RESPONSE_RATE_LIMIT_BELLOW);
+});
+
+function getClient(): GithubClient {
+  return new GithubClient({
+    fetch: FETCH_MOCK,
+  });
+}
+
+test('client not initialized should not be ready', () => {
+  const client = getClient();
+  expect(client.ready).toBeFalsy();
+});
+
+test('trying to use octokit on non-ready will throw an error', () => {
+  const client = getClient();
+  expect(() => {
+    client.octokit.log.info('dummy');
+  }).toThrowError('cannot use GitHub client: rate limit reached');
+});
+
+test('rate limit bellow should enable client', async () => {
+  const client = getClient();
+  client.init();
+
+  await vi.waitFor(() => {
+    expect(client.ready).toBeFalsy();
+  });
+});
+
+test('init should check rate limits', async () => {
+  const client = getClient();
+  client.init();
+
+  await vi.waitFor(() => {
+    expect(FETCH_MOCK).toHaveBeenCalledWith('https://api.github.com/rate_limit', expect.anything());
+  });
+});
+
+describe('abort controller', () => {
+  test('octokit should provide fetch an abort signal', async () => {
+    const client = getClient();
+    client.init();
+
+    await vi.waitFor(() => {
+      expect(FETCH_MOCK).toHaveBeenCalledOnce();
+      const init = vi.mocked(FETCH_MOCK).mock.calls[0]?.[1];
+      expect(init?.signal).toBeDefined();
+    });
+  });
+
+  test('disposing the client should abort signal provided to fetch', async () => {
+    const client = getClient();
+    client.init();
+
+    const call: RequestInit = await vi.waitFor(() => {
+      expect(FETCH_MOCK).toHaveBeenCalledOnce();
+      const init = vi.mocked(FETCH_MOCK).mock.calls[0]?.[1];
+      assert(init, 'fetch should receive request init with an abort controller');
+      return init;
+    });
+
+    expect(call.signal).toBeDefined();
+    expect(call.signal?.aborted).toBeFalsy();
+
+    client.dispose();
+
+    expect(call.signal?.aborted).toBeTruthy();
+  });
+});
+
+test('rate limit reached should make client not ready', async () => {
+  vi.mocked(FETCH_MOCK).mockResolvedValue(RESPONSE_RATE_LIMIT_ABOVE);
+
+  const client = getClient();
+  client.init();
+
+  await vi.waitFor(() => {
+    expect(client.ready).toBeFalsy();
+  });
+});
+
+test('should should register octokit hook', async () => {
+  vi.mocked(FETCH_MOCK).mockResolvedValue(RESPONSE_RATE_LIMIT_BELLOW);
+
+  const client = getClient();
+  client.init();
+
+  await vi.waitFor(() => {
+    expect(client.ready).toBeTruthy();
+    expect(FETCH_MOCK).toHaveBeenCalledOnce();
+  });
+
+  // let's mock another call, with rate limit reached
+  vi.mocked(FETCH_MOCK).mockResolvedValue(RESPONSE_RATE_LIMIT_ABOVE);
+  // don't worry: we do not make external call, we provided a mocked fetch
+  await client.octokit.rest.repos.get({
+    owner: 'podman-desktop',
+    repo: 'podman-desktop',
+  });
+
+  await vi.waitFor(() => {
+    expect(client.ready).toBeFalsy();
+    expect(FETCH_MOCK).toHaveBeenCalledTimes(2);
+    expect(FETCH_MOCK).toHaveBeenCalledWith(
+      'https://api.github.com/repos/podman-desktop/podman-desktop',
+      expect.anything(),
+    );
+  });
+});

--- a/packages/main/src/plugin/github/github-client.spec.ts
+++ b/packages/main/src/plugin/github/github-client.spec.ts
@@ -25,7 +25,7 @@ const FETCH_MOCK: typeof fetch = vi.fn();
 // let's mock a timestamp in ONE hour
 const RESET_TIMESTAMP = new Date().getTime() / 1000 + 60 * 60;
 
-const BODY_RATE_LIMIT_BELLOW: unknown = {
+const BODY_RATE_LIMIT_BELOW: unknown = {
   resources: {
     // omitted
   },
@@ -47,7 +47,7 @@ const BODY_RATE_LIMIT_ABOVE: unknown = {
   },
 };
 
-const RESPONSE_RATE_LIMIT_BELLOW: Response = {
+const RESPONSE_RATE_LIMIT_BELOW: Response = {
   url: 'https://api.github.com/rate_limit',
   status: 200,
   headers: new Headers({
@@ -55,7 +55,7 @@ const RESPONSE_RATE_LIMIT_BELLOW: Response = {
     'x-ratelimit-remaining': '57',
     'x-ratelimit-reset': `${RESET_TIMESTAMP}`,
   }),
-  text: () => Promise.resolve(JSON.stringify(BODY_RATE_LIMIT_BELLOW)),
+  text: () => Promise.resolve(JSON.stringify(BODY_RATE_LIMIT_BELOW)),
 } as unknown as Response;
 
 const RESPONSE_RATE_LIMIT_ABOVE: Response = {
@@ -71,7 +71,7 @@ const RESPONSE_RATE_LIMIT_ABOVE: Response = {
 
 beforeEach(() => {
   vi.resetAllMocks();
-  vi.mocked(FETCH_MOCK).mockResolvedValue(RESPONSE_RATE_LIMIT_BELLOW);
+  vi.mocked(FETCH_MOCK).mockResolvedValue(RESPONSE_RATE_LIMIT_BELOW);
 });
 
 function getClient(): GithubClient {
@@ -154,7 +154,7 @@ test('rate limit reached should make client not ready', async () => {
 });
 
 test('should should register octokit hook', async () => {
-  vi.mocked(FETCH_MOCK).mockResolvedValue(RESPONSE_RATE_LIMIT_BELLOW);
+  vi.mocked(FETCH_MOCK).mockResolvedValue(RESPONSE_RATE_LIMIT_BELOW);
 
   const client = getClient();
   client.init();

--- a/packages/main/src/plugin/github/github-client.ts
+++ b/packages/main/src/plugin/github/github-client.ts
@@ -1,0 +1,118 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { RestEndpointMethodTypes } from '@octokit/rest';
+import { Octokit } from '@octokit/rest';
+import type { Disposable } from '@podman-desktop/api';
+
+export type RateLimit = RestEndpointMethodTypes['rateLimit']['get']['response'];
+
+interface GithubClientOptions {
+  fetch?: typeof fetch;
+}
+
+export class GithubClient implements Disposable {
+  readonly #controller: AbortController;
+  readonly #octokit: Octokit;
+
+  #reset: number | undefined;
+  #remaining: number | undefined;
+
+  constructor(options?: GithubClientOptions) {
+    this.#controller = new AbortController();
+
+    this.#octokit = new Octokit({
+      request: {
+        fetch: options?.fetch,
+        signal: this.#controller.signal,
+      },
+    });
+  }
+
+  /**
+   * Get the Octokit instance managed by the GitHub client class
+   */
+  get octokit(): Octokit {
+    if (!this.ready) throw new Error('cannot use GitHub client: rate limit reached');
+    return this.#octokit;
+  }
+
+  /**
+   * Based on the remaining and reset rate limit provided by GitHub define
+   * if the client can be used or not
+   */
+  get ready(): boolean {
+    // if we don't have any value of remaining & reset: consider bad
+    // using ! operator would be misleading, as !0 would be true
+    if (this.#remaining === undefined || this.#reset === undefined) return false;
+
+    // if we have more than 5 remaining: consider ready
+    if (this.#remaining > 5) return true;
+
+    // if the reset timestamp is before us: consider ready
+    return this.#reset - new Date().getTime() < 0;
+  }
+
+  init(): void {
+    // check async
+    this.checkConnection().catch(console.error);
+
+    /**
+     * In every request GitHub will provide the rate limits in the API response headers
+     * ref https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28
+     */
+    this.#octokit.hook.wrap('request', async (request, options) => {
+      const response = await request(options);
+
+      // capture the remaining (The number of requests remaining in the current rate limit window)
+      if (response.headers['x-ratelimit-remaining']) {
+        this.#remaining = parseInt(response.headers['x-ratelimit-remaining'], 10);
+      }
+
+      // capture the reset (The time at which the current rate limit window resets, in UTC epoch seconds)
+      if (response.headers['x-ratelimit-reset']) {
+        this.#reset = parseInt(response.headers['x-ratelimit-reset'], 10) * 1000;
+      }
+
+      return response;
+    });
+  }
+
+  protected async checkConnection(): Promise<void> {
+    try {
+      // Let's get the rate limit
+      const { data } = await this.getRateLimit();
+      this.#remaining = data.rate.remaining;
+      this.#reset = data.rate.reset * 1000;
+    } catch (err: unknown) {
+      console.error('Something went wrong while trying to get rate limit', err);
+      // set reset to one hour and remaining to zero
+      this.#reset = new Date().getTime() + 60 * 60 * 1000;
+      this.#remaining = 0;
+    }
+  }
+
+  protected getRateLimit(): Promise<RateLimit> {
+    return this.#octokit.rateLimit.get();
+  }
+
+  dispose(): void {
+    this.#controller.abort('disposing github client');
+    this.#reset = undefined;
+    this.#remaining = undefined;
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,9 @@ importers:
       '@eslint/js':
         specifier: ^9.24.0
         version: 9.24.0
+      '@octokit/rest':
+        specifier: ^21.1.1
+        version: 21.1.1
       '@playwright/test':
         specifier: 1.51.1
         version: 1.51.1
@@ -221,7 +224,7 @@ importers:
         version: 9.24.0(jiti@2.4.2)
       eslint-import-resolver-custom-alias:
         specifier: ^1.3.2
-        version: 1.3.2(eslint-plugin-import@2.31.0)
+        version: 1.3.2(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.29.0(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@4.3.1)(eslint@9.24.0(jiti@2.4.2)))
       eslint-import-resolver-typescript:
         specifier: ^4.3.1
         version: 4.3.1(eslint-plugin-import@2.31.0)(eslint@9.24.0(jiti@2.4.2))
@@ -14648,11 +14651,11 @@ snapshots:
 
   '@isaacs/cliui@8.0.2':
     dependencies:
-      string-width: 5.1.2
+      string-width: 4.2.3
       string-width-cjs: string-width@4.2.3
       strip-ansi: 7.1.0
       strip-ansi-cjs: strip-ansi@6.0.1
-      wrap-ansi: 8.1.0
+      wrap-ansi: 7.0.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
   '@isaacs/fs-minipass@4.0.1':
@@ -16789,7 +16792,7 @@ snapshots:
 
   app-builder-bin@5.0.0-alpha.10: {}
 
-  app-builder-lib@25.1.8(dmg-builder@25.1.8)(electron-builder-squirrel-windows@25.1.8(dmg-builder@25.1.8)):
+  app-builder-lib@25.1.8(dmg-builder@25.1.8(electron-builder-squirrel-windows@25.1.8(dmg-builder@25.1.8)))(electron-builder-squirrel-windows@25.1.8(dmg-builder@25.1.8)):
     dependencies:
       '@develar/schema-utils': 2.6.5
       '@electron/notarize': 2.5.0
@@ -18306,7 +18309,7 @@ snapshots:
 
   dmg-builder@25.1.8(electron-builder-squirrel-windows@25.1.8(dmg-builder@25.1.8)):
     dependencies:
-      app-builder-lib: 25.1.8(dmg-builder@25.1.8)(electron-builder-squirrel-windows@25.1.8(dmg-builder@25.1.8))
+      app-builder-lib: 25.1.8(dmg-builder@25.1.8(electron-builder-squirrel-windows@25.1.8(dmg-builder@25.1.8)))(electron-builder-squirrel-windows@25.1.8(dmg-builder@25.1.8))
       builder-util: 25.1.7
       builder-util-runtime: 9.2.10
       fs-extra: 10.1.0
@@ -18485,7 +18488,7 @@ snapshots:
 
   electron-builder-squirrel-windows@25.1.8(dmg-builder@25.1.8):
     dependencies:
-      app-builder-lib: 25.1.8(dmg-builder@25.1.8)(electron-builder-squirrel-windows@25.1.8(dmg-builder@25.1.8))
+      app-builder-lib: 25.1.8(dmg-builder@25.1.8(electron-builder-squirrel-windows@25.1.8(dmg-builder@25.1.8)))(electron-builder-squirrel-windows@25.1.8(dmg-builder@25.1.8))
       archiver: 5.3.2
       builder-util: 25.1.7
       fs-extra: 10.1.0
@@ -18496,7 +18499,7 @@ snapshots:
 
   electron-builder@25.1.8(electron-builder-squirrel-windows@25.1.8(dmg-builder@25.1.8)):
     dependencies:
-      app-builder-lib: 25.1.8(dmg-builder@25.1.8)(electron-builder-squirrel-windows@25.1.8(dmg-builder@25.1.8))
+      app-builder-lib: 25.1.8(dmg-builder@25.1.8(electron-builder-squirrel-windows@25.1.8(dmg-builder@25.1.8)))(electron-builder-squirrel-windows@25.1.8(dmg-builder@25.1.8))
       builder-util: 25.1.7
       builder-util-runtime: 9.2.10
       chalk: 4.1.2
@@ -18820,7 +18823,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-custom-alias@1.3.2(eslint-plugin-import@2.31.0):
+  eslint-import-resolver-custom-alias@1.3.2(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.29.0(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@4.3.1)(eslint@9.24.0(jiti@2.4.2))):
     dependencies:
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.29.0(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@4.3.1)(eslint@9.24.0(jiti@2.4.2))
       glob-parent: 6.0.2
@@ -18848,7 +18851,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.29.0(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.3.1)(eslint@9.24.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.29.0(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.3.1(eslint-plugin-import@2.31.0)(eslint@9.24.0(jiti@2.4.2)))(eslint@9.24.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -18889,7 +18892,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.24.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.29.0(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.3.1)(eslint@9.24.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.29.0(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.3.1(eslint-plugin-import@2.31.0)(eslint@9.24.0(jiti@2.4.2)))(eslint@9.24.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
### What does this PR do?

To split https://github.com/podman-desktop/podman-desktop/pull/11989 and ease review, let's see each logic individually.

The issue https://github.com/podman-desktop/podman-desktop/issues/10227 wants a logic, to display the reactions for the discussions linked to each experimental feature.

We need
- GitHub client (handling the interaction with GitHub for us)
- Reaction Registry: holding the reactions (avoid calling GitHub every time, some caching)
- Some frontend logic

This PR adds the GitHub client, it need to handle some stuff: the rate limits, to avoid calling every X seconds, we can add a _middleware_ logic wrapping each request. In each api call, GitHub return some headers with the rate limit remaining[^1]. 

Using the Octokit[^2] library (that we already use in several places) we can implement the logic above, and pass its instance to anything that would need it: here in a follow-up PR, the _Reaction Registry_

[^1]: https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api
[^2]: https://www.npmjs.com/package/@octokit/rest

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/10227

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
