### PR TITLE
chore: Continuation of the isUnixLike() crusade

### DIFF
--- a/extensions/compose/src/detect.spec.ts
+++ b/extensions/compose/src/detect.spec.ts
@@ -33,6 +33,7 @@ const osMock: OS = {
   isWindows: vi.fn(),
   isLinux: vi.fn(),
   isMac: vi.fn(),
+  isUnixLike: vi.fn(),
 };
 
 let detect: Detect;
@@ -49,7 +50,7 @@ vi.mock('@podman-desktop/api', async () => {
       exec: vi.fn(),
     },
     env: {
-      isLinux: false,
+      isUnixLike: false,
       isWindows: false,
       isMac: false,
     },
@@ -131,8 +132,8 @@ describe('Check getDockerComposePath uses proper tooling by platform', () => {
     );
   });
 
-  test('linux should use which', async () => {
-    (extensionApi.env.isLinux as boolean) = true;
+  test('unix-like OSes should use which', async () => {
+    (extensionApi.env.isUnixLike as boolean) = true;
     (extensionApi.env.isWindows as boolean) = false;
     (extensionApi.env.isMac as boolean) = false;
 
@@ -143,7 +144,7 @@ describe('Check getDockerComposePath uses proper tooling by platform', () => {
   test('mac should use which', async () => {
     (extensionApi.env.isMac as boolean) = true;
     (extensionApi.env.isWindows as boolean) = false;
-    (extensionApi.env.isLinux as boolean) = false;
+    (extensionApi.env.isUnixLike as boolean) = false;
 
     await detect.getDockerComposePath('docker-compose');
     expect(extensionApi.process.exec).toHaveBeenCalledWith('which', ['docker-compose']);
@@ -152,7 +153,7 @@ describe('Check getDockerComposePath uses proper tooling by platform', () => {
   test('windows should use which', async () => {
     (extensionApi.env.isWindows as boolean) = true;
     (extensionApi.env.isMac as boolean) = false;
-    (extensionApi.env.isLinux as boolean) = false;
+    (extensionApi.env.isUnixLike as boolean) = false;
 
     await detect.getDockerComposePath('docker-compose');
     expect(extensionApi.process.exec).toHaveBeenCalledWith('where.exe', ['docker-compose']);
@@ -189,7 +190,7 @@ describe('parseVersion', () => {
 
 describe('Check default socket path', async () => {
   test('linux', async () => {
-    (osMock.isLinux as Mock).mockReturnValue(true);
+    (osMock.isUnixLike as Mock).mockReturnValue(true);
     (osMock.isMac as Mock).mockReturnValue(false);
     (osMock.isWindows as Mock).mockReturnValue(false);
     const result = detect.getSocketPath();
@@ -197,7 +198,7 @@ describe('Check default socket path', async () => {
   });
 
   test('macOS', async () => {
-    (osMock.isLinux as Mock).mockReturnValue(false);
+    (osMock.isUnixLike as Mock).mockReturnValue(false);
     (osMock.isMac as Mock).mockReturnValue(true);
     (osMock.isWindows as Mock).mockReturnValue(false);
     const result = detect.getSocketPath();
@@ -205,7 +206,7 @@ describe('Check default socket path', async () => {
   });
 
   test('windows', async () => {
-    (osMock.isLinux as Mock).mockReturnValue(false);
+    (osMock.isUnixLike as Mock).mockReturnValue(false);
     (osMock.isMac as Mock).mockReturnValue(false);
     (osMock.isWindows as Mock).mockReturnValue(true);
     const result = detect.getSocketPath();

--- a/extensions/compose/src/detect.ts
+++ b/extensions/compose/src/detect.ts
@@ -92,8 +92,8 @@ export class Detect {
   }
 
   async getDockerComposePath(executable: string): Promise<string> {
-    // grab full path for Linux and mac
-    if (extensionApi.env.isLinux || extensionApi.env.isMac) {
+    // grab full path for Unix-like OSes and Mac
+    if (extensionApi.env.isUnixLike || extensionApi.env.isMac) {
       try {
         const { stdout: fullPath } = await extensionApi.process.exec('which', [executable]);
         return fullPath;

--- a/extensions/compose/src/os.spec.ts
+++ b/extensions/compose/src/os.spec.ts
@@ -35,9 +35,23 @@ test('linux', async () => {
   const isWindows = os.isWindows();
   const isLinux = os.isLinux();
   const isMac = os.isMac();
+  const isUnixLike = os.isUnixLike();
   expect(isWindows).toBeFalsy();
   expect(isLinux).toBeTruthy();
   expect(isMac).toBeFalsy();
+  expect(isUnixLike).toBeTruthy();
+});
+
+test('freebsd', async () => {
+  vitest.spyOn(process, 'platform', 'get').mockReturnValue('freebsd');
+  const isWindows = os.isWindows();
+  const isLinux = os.isLinux();
+  const isMac = os.isMac();
+  const isUnixLike = os.isUnixLike();
+  expect(isWindows).toBeFalsy();
+  expect(isLinux).toBeFalsy();
+  expect(isMac).toBeFalsy();
+  expect(isUnixLike).toBeTruthy();
 });
 
 test('mac', async () => {
@@ -45,9 +59,11 @@ test('mac', async () => {
   const isWindows = os.isWindows();
   const isLinux = os.isLinux();
   const isMac = os.isMac();
+  const isUnixLike = os.isUnixLike();
   expect(isWindows).toBeFalsy();
   expect(isLinux).toBeFalsy();
   expect(isMac).toBeTruthy();
+  expect(isUnixLike).toBeFalsy();
 });
 
 test('windows', async () => {
@@ -55,7 +71,9 @@ test('windows', async () => {
   const isWindows = os.isWindows();
   const isLinux = os.isLinux();
   const isMac = os.isMac();
+  const isUnixLike = os.isUnixLike();
   expect(isWindows).toBeTruthy();
   expect(isLinux).toBeFalsy();
   expect(isMac).toBeFalsy();
+  expect(isUnixLike).toBeFalsy();
 });

--- a/extensions/compose/src/os.ts
+++ b/extensions/compose/src/os.ts
@@ -28,4 +28,8 @@ export class OS {
   isLinux(): boolean {
     return process.platform === 'linux';
   }
+
+  isUnixLike(): boolean {
+    return this.isLinux() || process.platform === 'freebsd';
+  }
 }

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -254,6 +254,7 @@ vi.mock('@podman-desktop/api', async () => {
       isWindows: false,
       isMac: false,
       isLinux: false,
+      isUnixLike: false,
     },
     containerEngine: {
       info: vi.fn(),
@@ -350,6 +351,7 @@ beforeEach(() => {
 
   vi.mocked(extensionApi.env).isMac = false;
   vi.mocked(extensionApi.env).isLinux = false;
+  vi.mocked(extensionApi.env).isUnixLike = false;
   vi.mocked(extensionApi.env).isWindows = false;
 
   const mock = vi.spyOn(compatibilityModeLib, 'getSocketCompatibility');
@@ -1203,7 +1205,7 @@ test('test checkDefaultMachine, if the default connection is not in sync with th
 });
 
 test('ensure started machine reports default configuration', async () => {
-  vi.mocked(extensionApi.env).isLinux = true;
+  vi.mocked(extensionApi.env).isUnixLike = true;
   extension.initExtensionContext({ subscriptions: [] } as unknown as extensionApi.ExtensionContext);
   vi.spyOn(extensionApi.process, 'exec').mockImplementation(
     (_command, args) =>
@@ -1233,7 +1235,7 @@ test('ensure started machine reports default configuration', async () => {
 
 test('ensure stopped machine reports stopped provider', async () => {
   extension.initExtensionContext({ subscriptions: [] } as unknown as extensionApi.ExtensionContext);
-  vi.mocked(extensionApi.env).isLinux = false;
+  vi.mocked(extensionApi.env).isUnixLike = false;
   vi.mocked(extensionApi.env).isMac = true;
   vi.spyOn(extensionApi.process, 'exec').mockImplementation(
     (_command, args) =>
@@ -1263,7 +1265,7 @@ test('ensure stopped machine reports stopped provider', async () => {
 
 test('ensure running and starting machine reports starting provider', async () => {
   extension.initExtensionContext({ subscriptions: [] } as unknown as extensionApi.ExtensionContext);
-  vi.mocked(extensionApi.env).isLinux = false;
+  vi.mocked(extensionApi.env).isUnixLike = false;
   vi.mocked(extensionApi.env).isMac = true;
   vi.spyOn(extensionApi.process, 'exec').mockImplementation(
     (_command, args) =>
@@ -1294,7 +1296,7 @@ test('ensure running and starting machine reports starting provider', async () =
 
 test('ensure running and not starting machine reports ready provider', async () => {
   extension.initExtensionContext({ subscriptions: [] } as unknown as extensionApi.ExtensionContext);
-  vi.mocked(extensionApi.env).isLinux = false;
+  vi.mocked(extensionApi.env).isUnixLike = false;
   vi.mocked(extensionApi.env).isMac = true;
   vi.spyOn(extensionApi.process, 'exec').mockImplementation(
     (_command, args) =>
@@ -1362,7 +1364,7 @@ test('ensure started machine reports configuration', async () => {
 
 test('ensure stopped machine reports configuration', async () => {
   extension.initExtensionContext({ subscriptions: [] } as unknown as extensionApi.ExtensionContext);
-  vi.mocked(extensionApi.env).isLinux = true;
+  vi.mocked(extensionApi.env).isUnixLike = true;
   vi.spyOn(extensionApi.process, 'exec').mockImplementation(
     (_command, args) =>
       new Promise<extensionApi.RunResult>(resolve => {
@@ -1511,8 +1513,8 @@ test('provider is registered without edit capabilities on Windows', async () => 
   expect(registeredConnection?.lifecycle?.edit).toBeUndefined();
 });
 
-test('provider is registered without edit capabilities on Linux', async () => {
-  vi.mocked(extensionApi.env).isLinux = true;
+test('provider is registered without edit capabilities on Unix-like OS', async () => {
+  vi.mocked(extensionApi.env).isUnixLike = true;
   extension.initExtensionContext({ subscriptions: [] } as unknown as extensionApi.ExtensionContext);
   const spyExecPromise = vi.spyOn(extensionApi.process, 'exec');
   spyExecPromise.mockImplementation(() => {
@@ -1529,8 +1531,8 @@ test('provider is registered without edit capabilities on Linux', async () => {
   expect(registeredConnection?.lifecycle?.edit).toBeUndefined();
 });
 
-test('Even with getJSONMachineList erroring, do not show setup notification on Linux', async () => {
-  vi.mocked(extensionApi.env).isLinux = true;
+test('Even with getJSONMachineList erroring, do not show setup notification on Unix-like OSes', async () => {
+  vi.mocked(extensionApi.env).isUnixLike = true;
   vi.spyOn(extensionApi.process, 'exec').mockRejectedValue({
     name: 'name',
     message: 'description',
@@ -1540,8 +1542,8 @@ test('Even with getJSONMachineList erroring, do not show setup notification on L
   expect(extensionApi.window.showNotification).not.toBeCalled();
 });
 
-test('If machine list is empty, do not show setup notification on Linux', async () => {
-  vi.mocked(extensionApi.env).isLinux = true;
+test('If machine list is empty, do not show setup notification on Unix-like OSes', async () => {
+  vi.mocked(extensionApi.env).isUnixLike = true;
   const spyExecPromise = vi.spyOn(extensionApi.process, 'exec');
   spyExecPromise.mockResolvedValue({ stdout: '[]' } as extensionApi.RunResult);
   await extension.updateMachines(provider, podmanConfiguration);
@@ -1568,7 +1570,7 @@ test('Should notify clean machine if getJSONMachineList is erroring due to an in
 });
 
 test('No updates of machines in parallel', async () => {
-  vi.mocked(extensionApi.env).isLinux = false;
+  vi.mocked(extensionApi.env).isUnixLike = false;
   vi.mocked(extensionApi.env).isMac = true;
   const spyExecPromise = vi.spyOn(extensionApi.process, 'exec');
   spyExecPromise.mockResolvedValue({ stdout: '[]' } as extensionApi.RunResult);
@@ -2487,7 +2489,7 @@ describe('sendTelemetryRecords', () => {
       } as Record<string, unknown>,
       false,
     );
-    vi.mocked(extensionApi.env).isLinux = true;
+    vi.mocked(extensionApi.env).isUnixLike = true;
     (extensionApi.env.isMac as boolean) = false;
     vi.mocked(extensionApi.env).isWindows = false;
 
@@ -2515,7 +2517,7 @@ describe('sendTelemetryRecords', () => {
       } as Record<string, unknown>,
       false,
     );
-    (extensionApi.env.isLinux as boolean) = true;
+    (extensionApi.env.isUnixLike as boolean) = true;
     (extensionApi.env.isMac as boolean) = false;
     vi.mocked(extensionApi.env).isWindows = false;
 
@@ -2660,10 +2662,11 @@ async function testAudit(path: string, uri: string, condition: typeof expect | t
   expect(auditRecords.records).toEqual(condition.arrayContaining([expect.objectContaining({ type: 'error' })]));
 }
 
-test('activate on mac register commands for setting compatibility moide ', async () => {
+test('activate on mac register commands for setting compatibility mode ', async () => {
   vi.mocked(extensionApi.env).isMac = true;
   vi.mocked(extensionApi.env).isWindows = false;
   vi.mocked(extensionApi.env).isLinux = false;
+  vi.mocked(extensionApi.env).isUnixLike = false;
   vi.spyOn(PodmanInstall.prototype, 'checkForUpdate').mockResolvedValue({
     hasUpdate: false,
   } as unknown as UpdateCheck);
@@ -2741,13 +2744,14 @@ test('activate on mac register commands for setting compatibility moide ', async
   expect(enableMock).toBeCalled();
 });
 
-describe.each(['windows', 'mac', 'linux'])('podman machine properties audit on %s', os => {
+describe.each(['windows', 'mac', 'linux', 'freebsd'])('podman machine properties audit on %s', os => {
   beforeEach(() => {
     vi.mocked(extensionApi.env).isWindows = os === 'windows';
     vi.mocked(extensionApi.env).isMac = os === 'mac';
     vi.mocked(extensionApi.env).isLinux = os === 'windows';
+    vi.mocked(extensionApi.env).isUnixLike = os === 'windows';
   });
-  if (os === 'linux') {
+  if (os === 'linux' || os === 'freebsd') {
     test('is not used', async () => {
       vi.spyOn(fs, 'existsSync').mockImplementation((path: fs.PathLike) => {
         if (path.toString().endsWith('/podman/podman.sock')) {
@@ -3128,6 +3132,7 @@ test('activate and autostart should not duplicate machines ', async () => {
   vi.mocked(extensionApi.env).isMac = true;
   vi.mocked(extensionApi.env).isWindows = false;
   vi.mocked(extensionApi.env).isLinux = false;
+  vi.mocked(extensionApi.env).isUnixLike = false;
   vi.spyOn(PodmanInstall.prototype, 'checkForUpdate').mockResolvedValue({
     hasUpdate: false,
   } as unknown as UpdateCheck);

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -72,8 +72,8 @@ let autoMachineStarted = false;
 let autoMachineName: string | undefined;
 
 // System default notifier
-let defaultMachineNotify = !extensionApi.env.isLinux;
-let defaultConnectionNotify = !extensionApi.env.isLinux;
+let defaultMachineNotify = !extensionApi.env.isUnixLike;
+let defaultConnectionNotify = !extensionApi.env.isUnixLike;
 let defaultMachineMonitor = true;
 
 // current status of machines
@@ -281,7 +281,7 @@ async function doUpdateMachines(
 
     // Only on macOS and Windows should we show the setup notification
     // if for some reason doing getJSONMachineList fails..
-    if (shouldNotifySetup && !extensionApi.env.isLinux) {
+    if (shouldNotifySetup && !extensionApi.env.isUnixLike) {
       // push setup notification
       notifySetupPodman();
       shouldNotifySetup = false;
@@ -303,7 +303,7 @@ async function doUpdateMachines(
   }
 
   // invalid machines is not making the provider working properly so always notify
-  if (shouldCleanMachine && shouldNotifySetup && !extensionApi.env.isLinux) {
+  if (shouldCleanMachine && shouldNotifySetup && !extensionApi.env.isUnixLike) {
     // push setup notification
     notifySetupPodman();
     shouldNotifySetup = false;
@@ -312,17 +312,17 @@ async function doUpdateMachines(
   extensionApi.context.setValue(CLEANUP_REQUIRED_MACHINE_KEY, shouldCleanMachine);
 
   // Only show the notification on macOS and Windows
-  // as Podman is already installed on Linux and machine is OPTIONAL.
-  if (shouldNotifySetup && machines.length === 0 && !extensionApi.env.isLinux) {
+  // Expect Podman to be already installed on unix-like OSes and machine is OPTIONAL.
+  if (shouldNotifySetup && machines.length === 0 && !extensionApi.env.isUnixLike) {
     // push setup notification
     notifySetupPodman();
     shouldNotifySetup = false;
   }
 
-  // if there is at least one machine whihc does not need to be cleaned and the OS is not Linux
-  // podman is correctly setup so if there is an old notification asking the user to take action
+  // if there is at least one machine which does not need to be cleaned and the OS is not unix-like
+  // podman is correctly set up, so if there is an old notification asking the user to take action
   // we dispose it as not needed anymore
-  if (!shouldCleanMachine && machines.length > 0 && !extensionApi.env.isLinux) {
+  if (!shouldCleanMachine && machines.length > 0 && !extensionApi.env.isUnixLike) {
     notificationDisposable?.dispose();
     shouldNotifySetup = true;
   }
@@ -429,8 +429,8 @@ async function doUpdateMachines(
       if (!socketPath) {
         if (extensionApi.env.isMac) {
           socketPath = calcMacosSocketPath(machineName);
-        } else if (extensionApi.env.isLinux) {
-          socketPath = calcLinuxSocketPath(machineName);
+        } else if (extensionApi.env.isUnixLike) {
+          socketPath = calcUnixSocketPath(machineName);
         } else if (extensionApi.env.isWindows) {
           socketPath = calcWinPipeName(machineName);
         }
@@ -453,9 +453,9 @@ async function doUpdateMachines(
 
   // If the machine length is zero and we are on macOS or Windows,
   // we will update the provider as being 'installed', or ready / starting / configured if there is a machine
-  // if we are on Linux, ignore this as podman machine is OPTIONAL and the provider status in Linux is based upon
+  // if we are on Unix-like OS, ignore this as podman machine is OPTIONAL and the provider status is based upon
   // the native podman installation / not machine.
-  if (!extensionApi.env.isLinux) {
+  if (!extensionApi.env.isUnixLike) {
     if (machines.length === 0) {
       if (provider.status !== 'configuring') {
         provider.updateStatus('installed');
@@ -649,7 +649,7 @@ function calcMacosSocketPath(machineName: string): string {
   return socketPath;
 }
 
-function calcLinuxSocketPath(machineName: string): string {
+function calcUnixSocketPath(machineName: string): string {
   let socketPath = path.resolve(podmanMachineSocketsDirectory, machineName, 'podman.sock');
   if (isMovedPodmanSocket) {
     socketPath = path.resolve(podmanMachineSocketsDirectory, 'qemu', 'podman.sock');
@@ -821,7 +821,7 @@ async function monitorProvider(provider: extensionApi.Provider): Promise<void> {
 
         extensionApi.context.setValue('podmanIsNotInstalled', false, 'onboarding');
         // if podman has been installed, we reset the notification flag so if podman is uninstalled in future we can show the notification again
-        if (extensionApi.env.isLinux) {
+        if (extensionApi.env.isUnixLike) {
           shouldNotifySetup = true;
           // notification is no more required
           notificationDisposable?.dispose();
@@ -2013,7 +2013,7 @@ const PODMAN_MINIMUM_VERSION_FOR_NEW_SOCKET_LOCATION = '4.5.0';
 
 export function isPodmanSocketLocationMoved(podmanVersion: string): boolean {
   return (
-    extensionApi.env.isLinux && compareVersions(podmanVersion, PODMAN_MINIMUM_VERSION_FOR_NEW_SOCKET_LOCATION) >= 0
+    extensionApi.env.isUnixLike && compareVersions(podmanVersion, PODMAN_MINIMUM_VERSION_FOR_NEW_SOCKET_LOCATION) >= 0
   );
 }
 
@@ -2128,7 +2128,7 @@ export function sendTelemetryRecords(
         console.trace('unable to check wsl version', error);
         telemetryRecords.errorWslVersion = error;
       }
-    } else if (extensionApi.env.isLinux && telemetryRecords.provider === 'qemu') {
+    } else if (extensionApi.env.isUnixLike && telemetryRecords.provider === 'qemu') {
       try {
         telemetryRecords.qemuVersion = await qemuHelper.getQemuVersion();
       } catch (err: unknown) {

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -4305,6 +4305,15 @@ declare module '@podman-desktop/api' {
     export const isLinux: boolean;
 
     /**
+     * Flag indicating whether we are running on any Unix-like operating system,
+     * for instance Linux or FreeBSD.
+     *
+     * If the value of this flag is true, it means the current system is Unix-like.
+     * If the value is false, it means the current system is not Unix-like.
+     */
+    export const isUnixLike: boolean;
+
+    /**
      * Indicates whether the users has telemetry enabled.
      * Can be observed to determine if the extension should send telemetry.
      */

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -36,7 +36,7 @@ import { DEFAULT_TIMEOUT, ExtensionLoaderSettings } from '/@api/extension-loader
 import type { ImageInspectInfo } from '/@api/image-inspect-info.js';
 
 import { securityRestrictionCurrentHandler } from '../../security-restrictions-handler.js';
-import { getBase64Image, isLinux, isMac, isWindows } from '../../util.js';
+import { getBase64Image, isLinux, isMac, isUnixLike, isWindows } from '../../util.js';
 import type { ApiSenderType } from '../api.js';
 import type { PodInfo } from '../api/pod-info.js';
 import type { AuthenticationImpl } from '../authentication.js';
@@ -1291,6 +1291,9 @@ export class ExtensionLoader {
       },
       get isLinux() {
         return isLinux();
+      },
+      get isUnixLike() {
+        return isUnixLike();
       },
       openExternal: async (uri: containerDesktopAPI.Uri): Promise<boolean> => {
         const url = uri.toString();

--- a/packages/main/src/plugin/util/exec.spec.ts
+++ b/packages/main/src/plugin/util/exec.spec.ts
@@ -40,6 +40,7 @@ vi.mock('../../util', async () => {
     isWindows: vi.fn(),
     isMac: vi.fn(),
     isLinux: vi.fn(),
+    isUnixLike: vi.fn(),
   };
 });
 
@@ -376,11 +377,11 @@ describe('exec', () => {
     expect(stdout).toContain('Hello, World!');
   });
 
-  test('should run the command with privileges on Linux', async () => {
+  test('should run the command with privileges on Unix-like OS', async () => {
     const command = 'echo';
     const args = ['Hello, World!'];
 
-    (util.isLinux as Mock).mockReturnValue(true);
+    (util.isUnixLike as Mock).mockReturnValue(true);
 
     const on = vi.fn().mockImplementationOnce((event: string, cb: (arg0: string) => string) => {
       if (event === 'data') {
@@ -414,6 +415,7 @@ describe('exec', () => {
     const args = ['Hello, World!'];
 
     (util.isLinux as Mock).mockReturnValue(true);
+    (util.isUnixLike as Mock).mockReturnValue(true);
 
     const on = vi.fn().mockImplementationOnce((event: string, cb: (arg0: string) => string) => {
       if (event === 'data') {
@@ -524,6 +526,7 @@ describe('exec', () => {
     const args = ['Hello, World!'];
 
     (util.isLinux as Mock).mockReturnValue(true);
+    (util.isUnixLike as Mock).mockReturnValue(true);
 
     const on = vi.fn().mockImplementationOnce((event: string, cb: (arg0: string) => string) => {
       if (event === 'data') {

--- a/packages/main/src/plugin/util/exec.ts
+++ b/packages/main/src/plugin/util/exec.ts
@@ -22,7 +22,7 @@ import { spawn } from 'node:child_process';
 import type { RunError, RunOptions, RunResult } from '@podman-desktop/api';
 import * as sudo from 'sudo-prompt';
 
-import { isLinux, isMac, isWindows } from '../../util.js';
+import { isMac, isUnixLike, isWindows } from '../../util.js';
 import type { Proxy } from '../proxy.js';
 
 export const macosExtraPath = '/opt/podman/bin:/usr/local/bin:/opt/homebrew/bin:/opt/local/bin';
@@ -130,7 +130,7 @@ export class Exec {
           )}" with prompt "Podman Desktop requires admin privileges " with administrator privileges`,
         ];
         command = 'osascript';
-      } else if (isLinux()) {
+      } else if (isUnixLike()) {
         args = [command, ...(args ?? [])];
         command = 'pkexec';
       }


### PR DESCRIPTION
### What does this PR do?

This PR adds more `isUnixLike()` usage to make Podman Desktop work on FreeBSD.

- [X] Tests are covering the bug fix or the new feature
