### PR TITLE
fix(ui): race condition in ImageDetailsCheck tests

### DIFF
--- a/packages/renderer/src/lib/image/ImageDetailsCheck.spec.ts
+++ b/packages/renderer/src/lib/image/ImageDetailsCheck.spec.ts
@@ -35,7 +35,7 @@ beforeAll(() => {
   Object.defineProperty(window, 'getCancellableTokenSource', { value: getCancellableTokenSourceMock });
   getCancellableTokenSourceMock.mockImplementation(() => tokenID);
   Object.defineProperty(window, 'imageCheck', { value: imageCheckMock });
-  Object.defineProperty(window, 'cancelToken', { value: cancelTokenSpy });
+  Object.defineProperty(window, 'cancelToken', { value: cancelTokenSpy.mockResolvedValue(undefined) });
   Object.defineProperty(window, 'telemetryTrack', { value: vi.fn().mockResolvedValue(undefined) });
 });
 

--- a/packages/renderer/src/lib/image/ImageDetailsCheck.svelte
+++ b/packages/renderer/src/lib/image/ImageDetailsCheck.svelte
@@ -117,15 +117,20 @@ async function callProviders(_providers: readonly ImageCheckerInfo[]): Promise<v
 async function handleAbort(): Promise<void> {
   if (cancellableTokenId !== 0 && remainingProviders > 0) {
     await window.cancelToken(cancellableTokenId);
+    // reset token
+    cancellableTokenId = 0;
+    aborted = true;
+
+    // update providers
     providers = providers.map(p => {
       if (p.state === 'running') {
         p.state = 'canceled';
       }
       return p;
     });
-    aborted = true;
+
+    // telemetry
     await window.telemetryTrack('imageCheck.aborted');
-    cancellableTokenId = 0;
   }
 }
 </script>


### PR DESCRIPTION
### What does this PR do?

While dependabot tried to update svelte, we got an error on `ImageDetailsCheck` tests. This is because of a race condition, where svelte better manage the unmount of components, and therefore make our test fails because it was depending on the _order_  svelte was destroying component

Required for https://github.com/podman-desktop/podman-desktop/pull/12071 to pass

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/12078

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
