### PR TITLE
refactor(Button): migrate to svelte5

### DIFF
--- a/packages/ui/src/lib/button/Button.svelte
+++ b/packages/ui/src/lib/button/Button.svelte
@@ -18,7 +18,7 @@ interface Props {
   padding?: string;
   class?: string;
   hidden?: boolean;
-  'aria-label': string;
+  'aria-label'?: string;
   onclick?: () => void;
   children?: Snippet;
 }

--- a/packages/ui/src/lib/button/Button.svelte
+++ b/packages/ui/src/lib/button/Button.svelte
@@ -103,7 +103,8 @@ let classes = $derived.by(() => {
       {:else if isFontAwesomeIcon(icon)}
         <Fa icon={icon} />
       {:else if iconType === 'unknown'}
-        {@render icon()}
+        {@const Icon = icon}
+        <Icon/>
       {/if}
       {#if children}
         <span>{@render children()}</span>

--- a/packages/ui/src/lib/button/Button.svelte
+++ b/packages/ui/src/lib/button/Button.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { Snippet } from 'svelte';
+import { createEventDispatcher } from 'svelte';
 import Fa from 'svelte-fa';
 
 import Spinner from '../progress/Spinner.svelte';
@@ -18,9 +19,12 @@ interface Props {
   class?: string;
   hidden?: boolean;
   'aria-label': string;
-  onclick: () => void;
+  onclick?: () => void;
   children?: Snippet;
 }
+
+// support legacy usage (on:click)
+const dispatch = createEventDispatcher<{ click: undefined }>();
 
 let {
   title,
@@ -34,7 +38,7 @@ let {
   class: classNames,
   hidden,
   'aria-label': ariaLabel,
-  onclick,
+  onclick = dispatch.bind(undefined, 'click'),
   children,
 }: Props = $props();
 
@@ -76,10 +80,6 @@ let classes = $derived.by(() => {
 
   return result;
 });
-
-function onClickHandler(): void {
-  onclick?.();
-}
 </script>
 
 <button
@@ -92,7 +92,7 @@ function onClickHandler(): void {
   hidden={hidden}
   title={title}
   aria-label={ariaLabel}
-  onclick={onClickHandler}
+  onclick={onclick}
   disabled={disabled || inProgress}>
   {#if icon ?? inProgress}
     <div

--- a/packages/ui/src/lib/button/Button.svelte
+++ b/packages/ui/src/lib/button/Button.svelte
@@ -1,101 +1,115 @@
 <script lang="ts">
-import { onMount } from 'svelte';
+import type { Snippet } from 'svelte';
 import Fa from 'svelte-fa';
 
 import Spinner from '../progress/Spinner.svelte';
 import { isFontAwesomeIcon } from '../utils/icon-utils';
 import type { ButtonType } from './Button';
 
-export let title: string | undefined = undefined;
-export let inProgress = false;
-export let disabled = false;
-export let type: ButtonType = 'primary';
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export let icon: any = undefined;
-export let selected: boolean | undefined = undefined;
-
-$: if (selected !== undefined && type !== 'tab') {
-  console.error('property selected can be used with type=tab only');
+interface Props {
+  title?: string;
+  inProgress?: boolean;
+  disabled?: boolean;
+  type?: ButtonType;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  icon?: any;
+  selected?: boolean;
+  padding?: string;
+  class?: string;
+  hidden?: boolean;
+  'aria-label': string;
+  onclick: () => void;
+  children?: Snippet;
 }
-export let padding: string =
-  'px-4 ' + (type === 'tab' ? 'pb-1' : type === 'secondary' ? 'py-[4px]' : type === 'danger' ? 'py-[3px]' : 'py-[5px]');
 
-let iconType: string | undefined = undefined;
+let {
+  title,
+  inProgress = false,
+  disabled = false,
+  type = 'primary',
+  icon,
+  selected,
+  padding = 'px-4 ' +
+    (type === 'tab' ? 'pb-1' : type === 'secondary' ? 'py-[4px]' : type === 'danger' ? 'py-[3px]' : 'py-[5px]'),
+  class: classNames,
+  hidden,
+  'aria-label': ariaLabel,
+  onclick,
+  children,
+}: Props = $props();
 
-onMount(() => {
-  if (isFontAwesomeIcon(icon)) {
-    iconType = 'fa';
-  } else {
-    iconType = 'unknown';
-  }
-});
+let iconType: string = $derived(isFontAwesomeIcon(icon) ? 'fa' : 'unknown');
 
-let classes = '';
-$: {
+let classes = $derived.by(() => {
+  let result: string = '';
   if (disabled || inProgress) {
     if (type === 'primary') {
-      classes = 'bg-[var(--pd-button-disabled)]';
+      result = 'bg-[var(--pd-button-disabled)]';
     } else if (type === 'secondary') {
-      classes = 'border-[1px] border-[var(--pd-button-disabled)] bg-[var(--pd-button-disabled)]';
+      result = 'border-[1px] border-[var(--pd-button-disabled)] bg-[var(--pd-button-disabled)]';
     } else if (type === 'danger') {
-      classes =
+      result =
         'border-2 border-[var(--pd-button-danger-disabled-border)] text-[var(--pd-button-danger-disabled-text)] bg-[var(--pd-button-danger-disabled-bg)]';
     }
     if (type !== 'danger') {
-      classes += ' text-[var(--pd-button-disabled-text)]';
+      result += ' text-[var(--pd-button-disabled-text)]';
     }
   } else if (type === 'primary') {
-    classes =
+    result =
       'bg-[var(--pd-button-primary-bg)] text-[var(--pd-button-text)] border-none hover:bg-[var(--pd-button-primary-hover-bg)]';
   } else if (type === 'secondary') {
-    classes =
+    result =
       'border-[1px] border-[var(--pd-button-secondary)] text-[var(--pd-button-secondary)] hover:bg-[var(--pd-button-secondary-hover)] hover:border-[var(--pd-button-secondary-hover)] hover:text-[var(--pd-button-text)]';
   } else if (type === 'danger') {
-    classes =
+    result =
       'border-2 border-[var(--pd-button-danger-border)] bg-[var(--pd-button-danger-bg)] text-[var(--pd-button-danger-text)] hover:bg-[var(--pd-button-danger-hover-bg)] hover:text-[var(--pd-button-danger-hover-text)]';
   } else if (type === 'tab') {
-    classes = 'border-b-[3px] border-[var(--pd-button-tab-border)]';
+    result = 'border-b-[3px] border-[var(--pd-button-tab-border)]';
   } else {
     // link
-    classes = 'border-none text-[var(--pd-button-link-text)] hover:bg-[var(--pd-button-link-hover-bg)]';
+    result = 'border-none text-[var(--pd-button-link-text)] hover:bg-[var(--pd-button-link-hover-bg)]';
   }
 
   if (type !== 'tab') {
-    classes += ' rounded-[4px]';
+    result += ' rounded-[4px]';
   }
+
+  return result;
+});
+
+function onClickHandler(): void {
+  onclick?.();
 }
 </script>
 
 <button
   type="button"
-  class="relative {padding} box-border whitespace-nowrap select-none transition-all outline-transparent focus:outline-[var(--pd-button-primary-hover-bg)] {classes} {$$props.class ??
-    ''}"
+  class="relative {padding} box-border whitespace-nowrap select-none transition-all outline-transparent focus:outline-[var(--pd-button-primary-hover-bg)] {classes} {classNames}"
   class:border-[var(--pd-button-tab-border-selected)]={type === 'tab' && selected}
   class:hover:border-[var(--pd-button-tab-hover-border)]={type === 'tab' && !selected}
   class:text-[var(--pd-button-tab-text-selected)]={type === 'tab' && selected}
   class:text-[var(--pd-button-tab-text)]={type === 'tab' && !selected}
-  hidden={$$props.hidden}
+  hidden={hidden}
   title={title}
-  aria-label={$$props['aria-label']}
-  on:click
+  aria-label={ariaLabel}
+  onclick={onClickHandler}
   disabled={disabled || inProgress}>
   {#if icon ?? inProgress}
     <div
       class="flex flex-row p-0 m-0 bg-transparent justify-center items-center space-x-[4px]"
-      class:py-[3px]={!$$slots.default}>
+      class:py-[3px]={!children}>
       {#if inProgress}
         <Spinner size="1em" />
       {:else if isFontAwesomeIcon(icon)}
         <Fa icon={icon} />
       {:else if iconType === 'unknown'}
-        <svelte:component this={icon} />
+        {@render icon()}
       {/if}
-      {#if $$slots.default}
-        <span><slot /></span>
+      {#if children}
+        <span>{@render children()}</span>
       {/if}
     </div>
   {:else}
-    <slot />
+    {@render children?.()}
   {/if}
 </button>


### PR DESCRIPTION
### What does this PR do?

Migrate the Button.svelte component to svelte5.

Would be nice to have https://github.com/podman-desktop/podman-desktop/pull/12076 merged before, so we can have a test that ensure the button works in legacy mode.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/11573

Need rebase after the following has been merged
- https://github.com/podman-desktop/podman-desktop/pull/12086
- https://github.com/podman-desktop/podman-desktop/pull/12076

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
