### PR TITLE
fix(Button): binding usage and event type

### DIFF
--- a/packages/renderer/src/lib/container/ContainerExport.svelte
+++ b/packages/renderer/src/lib/container/ContainerExport.svelte
@@ -90,7 +90,7 @@ async function exportContainer(): Promise<void> {
     {#snippet icon()}
       <i class="fas fa-download fa-2x" aria-hidden="true"></i>
     {/snippet}
-      
+
     {#snippet content()}
       {#if container}
         <div class="space-y-2">
@@ -115,7 +115,7 @@ async function exportContainer(): Promise<void> {
               class="w-full mt-5"
               icon={faDownload}
               inProgress={inProgress}
-              bind:disabled={invalidFields}
+              disabled={invalidFields}
               aria-label="Export container">
               Export Container
             </Button>

--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -399,7 +399,7 @@ $: containersAndGroups = containerGroups.map(group =>
             )}
           aria-label="Delete selected containers and pods"
           title="Delete {selectedItemsNumber} selected items"
-          bind:inProgress={bulkDeleteInProgress}
+          inProgress={bulkDeleteInProgress}
           icon={faTrash}>
         </Button>
 

--- a/packages/renderer/src/lib/container/CreateContainerFromExistingImage.svelte
+++ b/packages/renderer/src/lib/container/CreateContainerFromExistingImage.svelte
@@ -424,13 +424,13 @@ function onContainerConnectionChange(): void {
             <Button
               icon={faArrowCircleDown}
               class="w-full"
-              bind:disabled={imageNameIsInvalid}
+              disabled={imageNameIsInvalid}
               on:click={pullImageAndRun}
-              bind:inProgress={pullInProgress}>
+              inProgress={pullInProgress}>
               Pull Image and Run
             </Button>
           {:else}
-            <Button icon={faCircleCheck} class="w-full" bind:disabled={imageNameIsInvalid} on:click={buildContainerFromImage}>Run Image</Button>
+            <Button icon={faCircleCheck} class="w-full" disabled={imageNameIsInvalid} on:click={buildContainerFromImage}>Run Image</Button>
           {/if}
         </div>
         {#if pullError}

--- a/packages/renderer/src/lib/image/ImagesList.svelte
+++ b/packages/renderer/src/lib/image/ImagesList.svelte
@@ -355,7 +355,7 @@ const row = new TableRow<ImageInfoUI>({
             `delete ${selectedItemsNumber} image${selectedItemsNumber > 1 ? 's' : ''}`,
           )}
         title="Delete {selectedItemsNumber} selected items"
-        bind:inProgress={bulkDeleteInProgress}
+        inProgress={bulkDeleteInProgress}
         icon={faTrash} />
       <Button
         on:click={saveSelectedImages}

--- a/packages/renderer/src/lib/image/ImportContainersImages.svelte
+++ b/packages/renderer/src/lib/image/ImportContainersImages.svelte
@@ -148,7 +148,7 @@ async function importContainers(): Promise<void> {
         class="w-full"
         icon={faPlay}
         aria-label="Import containers"
-        bind:disabled={importDisabled}>
+        disabled={importDisabled}>
         Import Containers
       </Button>
       <div aria-label="importError">

--- a/packages/renderer/src/lib/image/LoadImages.svelte
+++ b/packages/renderer/src/lib/image/LoadImages.svelte
@@ -118,7 +118,7 @@ async function loadImages(): Promise<void> {
         class="w-full"
         icon={faPlay}
         aria-label="Load images"
-        bind:disabled={loadDisabled}>
+        disabled={loadDisabled}>
         Load Images
       </Button>
       <div aria-label="loadError">

--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -345,9 +345,9 @@ async function searchFunction(value: string): Promise<void> {
         {#if !pullFinished}
           <Button
             icon={faArrowCircleDown}
-            bind:disabled={imageNameIsInvalid}
+            disabled={imageNameIsInvalid}
             on:click={pullImage}
-            bind:inProgress={pullInProgress}>
+            inProgress={pullInProgress}>
             Pull image
           </Button>
         {:else}

--- a/packages/renderer/src/lib/image/PushImageModal.svelte
+++ b/packages/renderer/src/lib/image/PushImageModal.svelte
@@ -127,7 +127,7 @@ $: window
         on:click={async (): Promise<void> => {
           await pushImage(selectedImageTag);
         }}
-        bind:inProgress={pushInProgress}>
+        inProgress={pushInProgress}>
         Push image
       </Button>
     {:else}

--- a/packages/renderer/src/lib/image/PushManifestModal.svelte
+++ b/packages/renderer/src/lib/image/PushManifestModal.svelte
@@ -73,7 +73,7 @@ async function pushManifestFinished(): Promise<void> {
         class="w-auto"
         icon={faCircleArrowUp}
         on:click={pushManifest}
-        bind:inProgress={pushInProgress}>
+        inProgress={pushInProgress}>
         Push manifest
       </Button>
     {:else}

--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -1138,7 +1138,7 @@ const envDialogOptions: OpenDialogOptions = {
           class="w-full"
           icon={faPlay}
           aria-label="Start Container"
-          bind:disabled={invalidFields}>
+          disabled={invalidFields}>
           Start Container
         </Button>
         <div aria-label="createError">

--- a/packages/renderer/src/lib/image/SaveImages.svelte
+++ b/packages/renderer/src/lib/image/SaveImages.svelte
@@ -170,7 +170,7 @@ async function saveImages(): Promise<void> {
           class="w-full"
           icon={faPlay}
           aria-label="Save images"
-          bind:disabled={saveDisabled}>
+          disabled={saveDisabled}>
           Save Images
         </Button>
         <div aria-label="saveError">

--- a/packages/renderer/src/lib/kube/KubePlayYAML.svelte
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.svelte
@@ -338,7 +338,7 @@ function goBackToPodsPage(): void {
           on:click={playKubeFile}
           disabled={hasInvalidFields || runStarted}
           class="w-full"
-          bind:inProgress={runStarted}
+          inProgress={runStarted}
           icon={KubePlayIcon}>
           Play
         </Button>

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
@@ -302,9 +302,9 @@ function navigateToContainers(): void {
           <Button type="link" on:click={navigateToContainers}>Close</Button>
           <Button
             icon={SolidPodIcon}
-            bind:disabled={createInProgress}
+            disabled={createInProgress}
             on:click={createPodFromContainers}
-            bind:inProgress={createInProgress}
+            inProgress={createInProgress}
             aria-label="Create pod">
             Create Pod
           </Button>

--- a/packages/renderer/src/lib/preferences/item-formats/EditableItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/EditableItem.svelte
@@ -34,7 +34,7 @@ function onChangeInput(_: string, _value: number): void {
   }
 }
 
-function onSwitchToInProgress(e: MouseEvent): void {
+function onSwitchToInProgress(e: Event): void {
   e.preventDefault();
   // we set the originalValue to keep a record of the initial value
   // if the updating is cancelled, we can reset to it
@@ -42,7 +42,7 @@ function onSwitchToInProgress(e: MouseEvent): void {
   editingInProgress = true;
 }
 
-function onSaveClick(e: MouseEvent): void {
+function onSaveClick(e: Event): void {
   e.preventDefault();
   editingInProgress = false;
   if (record.id) {
@@ -50,7 +50,7 @@ function onSaveClick(e: MouseEvent): void {
   }
 }
 
-function onCancelClick(e: MouseEvent): void {
+function onCancelClick(e: Event): void {
   e.preventDefault();
   // we set the value to the initial one - the value that was set when the edit mode was enabled
   editedValue = originalValue;

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngineGrabContainers.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngineGrabContainers.svelte
@@ -31,7 +31,7 @@ async function grabContainers(): Promise<void> {
 
 <div class="flex flex-row items-center">
   <div class="w-36">
-    <Button bind:inProgress={listInProgress} class="my-1 w-full" on:click={grabContainers} icon={faSignal}>
+    <Button inProgress={listInProgress} class="my-1 w-full" on:click={grabContainers} icon={faSignal}>
       Check containers
     </Button>
   </div>

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEnginePing.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEnginePing.svelte
@@ -32,7 +32,7 @@ async function pingConnection(): Promise<void> {
 
 <div class="flex flex-row items-center">
   <div class="w-36">
-    <Button bind:inProgress={pingInProgress} class="my-1 w-full" on:click={pingConnection} icon={faSignal}>
+    <Button inProgress={pingInProgress} class="my-1 w-full" on:click={pingConnection} icon={faSignal}>
       Ping
     </Button>
   </div>

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngineReconnect.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngineReconnect.svelte
@@ -27,7 +27,7 @@ async function reconnectContainerProviders(): Promise<void> {
 <div class="flex flex-row items-center">
   <Button
     class="my-1"
-    bind:inProgress={reconnectInProgress}
+    inProgress={reconnectInProgress}
     title="Re-establish connection to the container engine sockets"
     on:click={reconnectContainerProviders}
     icon={faPlug}>

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStore.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStore.svelte
@@ -36,7 +36,7 @@ let openDetails = false;
   <div class="text-sm">({eventStoreInfo.size} items)</div>
   <div class="">
     <Button
-      bind:inProgress={fetchInProgress}
+      inProgress={fetchInProgress}
       class="my-1"
       aria-label="Refresh"
       on:click={fetch}

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStoreDetails.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStoreDetails.svelte
@@ -34,7 +34,7 @@ async function fetch(): Promise<void> {
         <div class="mx-2 flex flex-row items-center">
           Size: <div role="status" aria-label="size">{eventStoreInfo.size}</div>
           <div class="mx-2">
-            <Button class="my-1" bind:inProgress={fetchInProgress} on:click={fetch} icon={faRefresh}
+            <Button class="my-1" inProgress={fetchInProgress} on:click={fetch} icon={faRefresh}
               >Refresh</Button>
           </div>
         </div>
@@ -48,7 +48,7 @@ async function fetch(): Promise<void> {
             {#if eventStoreInfo.bufferEvents.length > 0}
               <Button
                 class="my-1"
-                bind:inProgress={fetchInProgress}
+                inProgress={fetchInProgress}
                 title="Clear events"
                 on:click={eventStoreInfo.clearEvents}
                 icon={faTrash}>Clear</Button>


### PR DESCRIPTION
### What does this PR do?

In svelte4 there is **no** typecheck for using `bind:<prop>` but in svelte5 we will get an error if we try to bind a non-bindable prop.

This PR remove all the unnecessary `bind:` for the Button component as they have so effect. But they make the typecheck fails in https://github.com/podman-desktop/podman-desktop/pull/12079 . It also update the event type used for on:click.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Required for https://github.com/podman-desktop/podman-desktop/issues/11573

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- Pipeline should be :heavy_check_mark: 
