### PR TITLE
chore: add missing dispose method in TerminalWindow

### DIFF
--- a/packages/renderer/src/lib/ui/TerminalWindows.spec.ts
+++ b/packages/renderer/src/lib/ui/TerminalWindows.spec.ts
@@ -42,9 +42,16 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+function createTerminalMock(): Terminal {
+  return {
+    ...writable(),
+    dispose: vi.fn(),
+  } as unknown as Terminal;
+}
+
 test('expect terminal constructor to have been called on mount', async () => {
   render(TerminalWindow, {
-    terminal: writable() as unknown as Terminal,
+    terminal: createTerminalMock(),
   });
 
   await vi.waitFor(() => {
@@ -54,7 +61,7 @@ test('expect terminal constructor to have been called on mount', async () => {
 
 test('expect terminal constructor to reflect props', async () => {
   render(TerminalWindow, {
-    terminal: writable() as unknown as Terminal,
+    terminal: createTerminalMock(),
     disableStdIn: true,
     convertEol: true,
     screenReaderMode: true,
@@ -73,7 +80,7 @@ test('expect terminal constructor to reflect props', async () => {
 
 test('showCursor false or undefined should write specific instruction to terminal', async () => {
   render(TerminalWindow, {
-    terminal: writable() as unknown as Terminal,
+    terminal: createTerminalMock(),
     showCursor: false,
   });
 
@@ -87,7 +94,7 @@ test('terminal constructor should contains fontSize and lineHeight from configur
   vi.mocked(window.getConfigurationValue).mockResolvedValue(10);
 
   render(TerminalWindow, {
-    terminal: writable() as unknown as Terminal,
+    terminal: createTerminalMock(),
   });
 
   await vi.waitFor(() => {
@@ -115,7 +122,7 @@ test('addon fit should be loaded on mount', async () => {
   vi.mocked(FitAddon).mockReturnValue(fitAddonMock);
 
   render(TerminalWindow, {
-    terminal: writable() as unknown as Terminal,
+    terminal: createTerminalMock(),
   });
 
   await vi.waitFor(() => {
@@ -131,7 +138,7 @@ test('matchMedia resize listener should trigger fit addon', async () => {
   vi.spyOn(window, 'addEventListener');
 
   render(TerminalWindow, {
-    terminal: writable() as unknown as Terminal,
+    terminal: createTerminalMock(),
   });
 
   const listener: () => void = await vi.waitFor(() => {
@@ -154,7 +161,7 @@ test('matchMedia resize listener should trigger fit addon', async () => {
 
 test('search props should add terminal search controls', async () => {
   const { getByRole } = render(TerminalWindow, {
-    terminal: writable() as unknown as Terminal,
+    terminal: createTerminalMock(),
     search: true,
   });
 


### PR DESCRIPTION
### What does this PR do?
onDestroy method call a dispose method on the terminal object

https://github.com/podman-desktop/podman-desktop/blob/31a0a679a9bcf8b87e707c49a51c399ec6875ea7/packages/renderer/src/lib/ui/TerminalWindow.svelte#L84

but dispose method is not present in the mock so there is a failure

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

bug is there since day 1 but it's only triggered since a svelte update

### How to test this PR?

unit tests should be 💚 

- [x] Tests are covering the bug fix or the new feature
