### PR TITLE
chore: allow more permissive data in test

### DIFF
--- a/packages/main/src/plugin/kubernetes/kubeconfig-single-context.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubeconfig-single-context.spec.ts
@@ -71,7 +71,7 @@ test('KubeConfigSingleContext', () => {
     clusters: [clusters[0]],
     currentContext: 'context1',
   } as KubeConfig;
-  expect(single.getKubeConfig()).toEqual(expected);
+  expect(single.getKubeConfig()).toEqual(expect.objectContaining(expected));
 
   const kcExpected = new KubeConfig();
   kcExpected.loadFromOptions(expected);


### PR DESCRIPTION
### What does this PR do?
in newer version of the lib, a field custom_authenticators has been added use contains to be more permissive than equal

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/pull/12097

### How to test this PR?

tests should be 💚 

- [x] Tests are covering the bug fix or the new feature
