### PR TITLE
fix(tests): fix the heading locator for extensions page

### DIFF
--- a/tests/playwright/src/model/pages/extensions-page.ts
+++ b/tests/playwright/src/model/pages/extensions-page.ts
@@ -36,7 +36,7 @@ export class ExtensionsPage {
     this.page = page;
     this.header = page.getByRole('region', { name: 'header' });
     this.content = page.getByRole('region', { name: 'content' });
-    this.heading = this.header.getByLabel('Title').getByText('extensions');
+    this.heading = this.header.getByRole('heading', { name: 'extensions' });
     this.additionalActions = this.header.getByRole('group', {
       name: 'additionalActions',
     });

--- a/tests/playwright/src/specs/extension-installation-smoke.spec.ts
+++ b/tests/playwright/src/specs/extension-installation-smoke.spec.ts
@@ -94,6 +94,7 @@ for (const { extensionName, extensionType } of extentionTypes) {
       test.setTimeout(200000);
 
       const extensionsPage = new ExtensionsPage(page);
+      await playExpect(extensionsPage.heading).toBeVisible();
 
       await extensionsPage.openCatalogTab();
       const extensionCatalog = new ExtensionCatalogCardPage(page, extensionType);


### PR DESCRIPTION
### What does this PR do?
It fixes the locator for the heading in the extensions POM page.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
