### PR TITLE
refactor(packages): simplify vitest config

### DIFF
--- a/packages/api/vite.config.js
+++ b/packages/api/vite.config.js
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,8 @@
 import { chrome } from '../../.electron-vendors.cache.json';
 import { join } from 'path';
 import { builtinModules } from 'module';
-import { coverageConfig } from '../../vitest-shared-extensions.config';
 
 const PACKAGE_ROOT = __dirname;
-const PACKAGE_NAME = 'api';
 
 /**
  * @type {import('vite').UserConfig}
@@ -57,7 +55,9 @@ const config = {
     reportCompressedSize: false,
   },
   test: {
-    ...coverageConfig(PACKAGE_ROOT, PACKAGE_NAME),
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
+    passWithNoTests: true,
   },
 };
 

--- a/packages/extension-api/vite.config.js
+++ b/packages/extension-api/vite.config.js
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2024 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,5 +43,10 @@ export default defineConfig({
 
     emptyOutDir: true,
     reportCompressedSize: false,
+  },
+  test: {
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
+    passWithNoTests: true,
   },
 });

--- a/packages/main/vite.config.js
+++ b/packages/main/vite.config.js
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2024 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,8 @@
 import { node } from '../../.electron-vendors.cache.json';
 import { join } from 'path';
 import { builtinModules } from 'module';
-import { coverageConfig } from '../../vitest-shared-extensions.config';
 
 const PACKAGE_ROOT = __dirname;
-const PACKAGE_NAME = 'main';
 /**
  * @type {import('vite').UserConfig}
  * @see https://vitejs.dev/config/
@@ -67,7 +65,8 @@ const config = {
   },
   test: {
     retry: 3, // Retries failing tests up to 3 times
-    ...coverageConfig(PACKAGE_ROOT, PACKAGE_NAME),
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
   },
 };
 

--- a/packages/preload-docker-extension/vite.config.js
+++ b/packages/preload-docker-extension/vite.config.js
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@
 import { chrome } from '../../.electron-vendors.cache.json';
 import { join } from 'path';
 import { builtinModules } from 'module';
-import { coverageConfig } from '../../vitest-shared-extensions.config';
 
 const PACKAGE_ROOT = __dirname;
 const PACKAGE_NAME = 'preload-docker-extension';
@@ -66,7 +65,8 @@ const config = {
     reportCompressedSize: false,
   },
   test: {
-    ...coverageConfig(PACKAGE_ROOT, PACKAGE_NAME),
+    environment: 'jsdom',
+    include: ['src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
   },
 };
 

--- a/packages/preload-webview/vite.config.js
+++ b/packages/preload-webview/vite.config.js
@@ -19,10 +19,8 @@
 import { chrome } from '../../.electron-vendors.cache.json';
 import { join } from 'path';
 import { builtinModules } from 'module';
-import { coverageConfig } from '../../vitest-shared-extensions.config';
 
 const PACKAGE_ROOT = __dirname;
-const PACKAGE_NAME = 'preload-webview';
 
 /**
  * @type {import('vite').UserConfig}
@@ -59,7 +57,7 @@ const config = {
   },
   test: {
     environment: 'jsdom',
-    ...coverageConfig(PACKAGE_ROOT, PACKAGE_NAME),
+    include: ['src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
   },
 };
 

--- a/packages/preload/vite.config.js
+++ b/packages/preload/vite.config.js
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,8 @@
 import { chrome } from '../../.electron-vendors.cache.json';
 import { join } from 'path';
 import { builtinModules } from 'module';
-import { coverageConfig } from '../../vitest-shared-extensions.config';
 
 const PACKAGE_ROOT = __dirname;
-const PACKAGE_NAME = 'preload';
 
 /**
  * @type {import('vite').UserConfig}
@@ -66,7 +64,9 @@ const config = {
     reportCompressedSize: false,
   },
   test: {
-    ...coverageConfig(PACKAGE_ROOT, PACKAGE_NAME),
+    environment: 'jsdom',
+    include: ['src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
+    passWithNoTests: true,
   },
 };
 

--- a/packages/renderer/vite.config.js
+++ b/packages/renderer/vite.config.js
@@ -23,12 +23,10 @@ import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { svelteTesting } from '@testing-library/svelte/vite';
 import { defineConfig } from 'vite';
 import { fileURLToPath } from 'url';
-import { coverageConfig } from '../../vitest-shared-extensions.config';
 import tailwindcss from '@tailwindcss/vite';
 
 let filename = fileURLToPath(import.meta.url);
 const PACKAGE_ROOT = path.dirname(filename);
-const PACKAGE_NAME = 'renderer';
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -59,7 +57,6 @@ export default defineConfig({
     deps: {
       inline: ['moment'],
     },
-    ...coverageConfig(PACKAGE_ROOT, PACKAGE_NAME),
     setupFiles: ['./vite.tests.setup.js'],
   },
   base: '',

--- a/packages/ui/vite.config.js
+++ b/packages/ui/vite.config.js
@@ -23,12 +23,10 @@ import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { svelteTesting } from '@testing-library/svelte/vite';
 import { defineConfig } from 'vite';
 import { fileURLToPath } from 'url';
-import { coverageConfig } from '../../vitest-shared-extensions.config';
 import tailwindcss from '@tailwindcss/vite';
 
 let filename = fileURLToPath(import.meta.url);
 const PACKAGE_ROOT = path.dirname(filename);
-const PACKAGE_NAME = 'ui';
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -48,7 +46,6 @@ export default defineConfig({
     deps: {
       inline: ['moment'],
     },
-    ...coverageConfig(PACKAGE_ROOT, PACKAGE_NAME),
   },
   base: '',
   server: {

--- a/packages/webview-api/vite.config.js
+++ b/packages/webview-api/vite.config.js
@@ -44,4 +44,9 @@ export default defineConfig({
     emptyOutDir: true,
     reportCompressedSize: false,
   },
+  test: {
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
+    passWithNoTests: true,
+  },
 });


### PR DESCRIPTION
### What does this PR do?

Same as https://github.com/podman-desktop/podman-desktop/pull/12103

### Notes

Removing usage of `coverageConfig` as coverage is a global option, and cannot be used in vitest project, it need to be configured at root level (workspace).

> _The coverage may be broken until all related PR are merged_

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
