### PR TITLE
chore: website - update download links

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -439,6 +439,10 @@ const config = {
           },
           { to: '/blog', label: 'Blog', position: 'left' },
           {
+            type: 'custom-downloadButton',
+            position: 'right',
+          },
+          {
             href: 'https://github.com/podman-desktop/podman-desktop',
             className: 'header-github-link',
             position: 'right',

--- a/website/src/components/DownloadButton.tsx
+++ b/website/src/components/DownloadButton.tsx
@@ -1,0 +1,138 @@
+import Link from '@docusaurus/Link';
+import type { IconProp } from '@fortawesome/fontawesome-svg-core';
+import { faApple, faLinux, faWindows } from '@fortawesome/free-brands-svg-icons';
+import { faDownload, faEllipsis } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+import { TelemetryLink } from '../components/TelemetryLink';
+
+// Utility to detect platform
+function getClientPlatform(): {
+  os: string;
+  url: string;
+  icon: IconProp;
+} | null {
+  const ua = navigator.userAgent;
+
+  if (ua.includes('Windows')) {
+    return { os: 'Windows', url: 'windows', icon: faWindows };
+  }
+  if (ua.includes('Mac')) {
+    return { os: 'macOS', url: 'macos', icon: faApple };
+  }
+  if (ua.includes('Linux')) {
+    return { os: 'Linux', url: 'linux', icon: faLinux };
+  }
+  return null;
+}
+
+export function MainDownloadButton(): JSX.Element {
+  const platform = getClientPlatform();
+
+  if (!platform) {
+    return (
+      <div>
+        <Link
+          className="no-underline hover:no-underline inline-flex text-white hover:text-white bg-purple-500 border-0 py-2 px-4 mt-6 mb-1 focus:outline-hidden hover:bg-purple-600 rounded-sm text-lg"
+          to="/downloads">
+          Download Page
+        </Link>
+      </div>
+    );
+  }
+
+  const { os, url } = platform;
+
+  return (
+    <div>
+      <TelemetryLink
+        className="inline-flex font-semibold no-underline hover:no-underline items-center text-white hover:text-white bg-gradient-to-b from-violet-500 to-violet-600 border-0 py-3 px-6 focus:outline-hidden hover:from-violet-600 hover:to-violet-700 rounded-lg text-base mt-4 mb-0 ml-4"
+        eventPath="landing"
+        eventTitle="hero-download"
+        to={`/downloads/${url}`}>
+        <FontAwesomeIcon size="1x" icon={faDownload} className="px-2 py-1" /> Download Now
+      </TelemetryLink>
+      <caption className="block mt-2 dark:text-gray-400">
+        For <strong>{os}</strong> <em>(browser detected)</em>
+      </caption>
+    </div>
+  );
+}
+
+// Same as MainDownloadButton but instead it's "Download" and has no fontawesome icon
+export function HeaderDownloadButton(): JSX.Element {
+  const platform = getClientPlatform();
+
+  // If we cannot get the platform, make the link just go to downloads.
+  if (!platform) {
+    return (
+      <div>
+        <Link
+          className="hidden lg:flex font-semibold no-underline hover:no-underline items-center text-white hover:text-white bg-gradient-to-b from-violet-500 to-violet-600 border-0 py-3 px-6 focus:outline-hidden hover:from-violet-600 hover:to-violet-700 rounded-lg text-base mt-0 mb-0 ml-4"
+          to="/downloads">
+          Download
+        </Link>
+      </div>
+    );
+  }
+
+  const { url } = platform;
+
+  return (
+    <div>
+      <TelemetryLink
+        className="hidden lg:flex font-semibold no-underline hover:no-underline items-center text-white hover:text-white bg-gradient-to-b from-violet-500 to-violet-600 border-0 py-3 px-6 focus:outline-hidden hover:from-violet-600 hover:to-violet-700 rounded-lg text-base mt-0 mb-0 ml-4"
+        eventPath="landing"
+        eventTitle="hero-download"
+        to={`/downloads/${url}`}>
+        Download
+      </TelemetryLink>
+    </div>
+  );
+}
+
+export function OtherDownloadLink(): JSX.Element {
+  const platforms = [
+    { name: 'macOS', icon: faApple, url: '/downloads/macos' },
+    { name: 'Linux', icon: faLinux, url: '/downloads/linux' },
+    { name: 'Windows', icon: faWindows, url: '/downloads/windows' },
+    { name: 'Other', icon: faEllipsis, url: '/downloads' },
+  ];
+
+  return (
+    <div className="flex justify-center gap-6 my-4 pt-4">
+      {platforms.map(({ name, icon, url }) => (
+        <Link
+          key={name}
+          to={url}
+          className="text-black dark:text-white hover:text-purple-600 text-3xl p-1"
+          title={`Download for ${name}`}>
+          <FontAwesomeIcon size="2x" icon={icon} />
+        </Link>
+      ))}
+    </div>
+  );
+}
+
+export function DownloadClientLinks(): JSX.Element {
+  const platform = getClientPlatform();
+
+  return (
+    <div className="flex justify-center flex-col">
+      <MainDownloadButton />
+      {platform && <OtherDownloadLink />}
+    </div>
+  );
+}
+
+export function DownloadGenericLinks(): JSX.Element {
+  return (
+    <div className="flex justify-center">
+      <Link
+        className="no-underline hover:no-underline inline-flex text-white hover:text-white bg-purple-500 border-0 py-2 px-6 mt-6 mb-1 focus:outline-hidden hover:bg-purple-600 rounded-sm text-lg"
+        to="/downloads">
+        Download Page
+      </Link>
+    </div>
+  );
+}

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -1,7 +1,6 @@
 import BrowserOnly from '@docusaurus/BrowserOnly';
 import Link from '@docusaurus/Link';
 import useBaseUrl from '@docusaurus/useBaseUrl';
-import type { IconProp } from '@fortawesome/fontawesome-svg-core';
 import { faApple, faLinux, faWindows } from '@fortawesome/free-brands-svg-icons';
 import {
   faCertificate,
@@ -19,87 +18,8 @@ import ThemedImage from '@theme/ThemedImage';
 import React from 'react';
 
 import CommunityBanner from '../components/CommunityBanner';
+import { DownloadClientLinks, DownloadGenericLinks } from '../components/DownloadButton';
 import TailWindThemeSelector from '../components/TailWindThemeSelector';
-import { TelemetryLink } from '../components/TelemetryLink';
-
-function DownloadClientLinks(): JSX.Element {
-  let operatingSystem = '';
-  let varIcon = undefined;
-  let url = 'macos'; // Just use macos by default as the url before checking the user agent in case of an odd issue (unable to get userAgent / it's blank / etc.)
-  const userAgent = navigator.userAgent;
-
-  if (userAgent.indexOf('Windows') !== -1) {
-    operatingSystem = 'Windows';
-    url = 'windows';
-    varIcon = 'faWindows';
-  } else if (userAgent.indexOf('Mac') !== -1) {
-    operatingSystem = 'macOS';
-    // do not need to set url to macos as it is already set
-    varIcon = 'faApple';
-  } else if (userAgent.indexOf('Linux') !== -1) {
-    operatingSystem = 'Linux';
-    url = 'linux';
-    varIcon = 'faLinux';
-  }
-
-  let mainButton;
-  let otherButton;
-
-  if (operatingSystem !== '') {
-    mainButton = (
-      <div>
-        <TelemetryLink
-          className="no-underline hover:no-underline inline-flex text-white hover:text-white bg-violet-600 border-0 py-4 px-8 mt-6 mb-1 focus:outline-hidden hover:bg-violet-700 rounded-sm text-lg"
-          eventPath="landing"
-          eventTitle="hero-download"
-          to={'/downloads/' + url}>
-          <FontAwesomeIcon size="2x" icon={varIcon as IconProp} className="px-2" /> Download Now
-        </TelemetryLink>
-        <caption className="block mt-0 dark:text-gray-400">
-          For <strong>{operatingSystem}</strong> <em>(browser-detected)</em>
-        </caption>
-      </div>
-    );
-    otherButton = (
-      <div>
-        <Link
-          className="underline font-semibold hover:underline ml-4 inline-flex py-2 px-6 my-4  focus:outline-hidden text-lg"
-          to="/downloads">
-          Other downloads
-        </Link>
-      </div>
-    );
-  } else {
-    mainButton = (
-      <div>
-        <Link
-          className="no-underline hover:no-underline inline-flex text-white hover:text-white bg-purple-500 border-0 py-2 px-6 mt-6 mb-1 focus:outline-hidden hover:bg-purple-600 rounded-sm text-lg"
-          to="/downloads">
-          Download Page
-        </Link>
-      </div>
-    );
-  }
-
-  return (
-    <div className="flex justify-center flex-col">
-      {mainButton}
-      {otherButton}
-    </div>
-  );
-}
-
-function DownloadGenericLinks(): JSX.Element {
-  return (
-    <div className="flex justify-center">
-      <Link
-        className="no-underline hover:no-underline inline-flex text-white hover:text-white bg-purple-500 border-0 py-2 px-6 mt-6 mb-1 focus:outline-hidden hover:bg-purple-600 rounded-sm text-lg"
-        to="/downloads">
-        Download Page
-      </Link>
-    </div>
-  );
-}
 
 function Hero(): JSX.Element {
   return (

--- a/website/src/theme/NavbarItem/ComponentTypes.js
+++ b/website/src/theme/NavbarItem/ComponentTypes.js
@@ -1,6 +1,8 @@
 import ComponentTypes from '@theme-original/NavbarItem/ComponentTypes';
+import { HeaderDownloadButton } from '@site/src/components/DownloadButton';
 import { TelemetryLink } from '@site/src/components/TelemetryLink';
 
+// "Custom" navbar items to be added
 export default {
   ...ComponentTypes,
   'custom-telemetryLink': props => (
@@ -8,4 +10,5 @@ export default {
       Downloads
     </TelemetryLink>
   ),
+  'custom-downloadButton': () => <HeaderDownloadButton className="navbar__item navbar__link" />,
 };


### PR DESCRIPTION
chore: website - update download links

### What does this PR do?

* Refactors download buttons to separate file
* Changes Download Now button to match UI mockup
* Adds "Download" button to header

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

LEFT is mockup, RIGHT is PR changes.

![Screenshot 2025-04-09 at 2 02 43 PM](https://github.com/user-attachments/assets/b18263ee-bf67-4c96-a316-6c7ad8c7210e)



![Screenshot 2025-04-09 at 2 05 54 PM](https://github.com/user-attachments/assets/1f2845a3-f2fa-49f0-8c84-728cef190698)

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Part of https://github.com/podman-desktop/podman-desktop/issues/11816

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

Preview website on netlify :)

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
