### PR TITLE
test(e2e): add env vars to keep traces and videos on pass 

### DIFF
--- a/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
+++ b/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
@@ -23,6 +23,8 @@ console.log(`numberOfObjects => ${numberOfObjects}`);
 
 test.beforeAll(async ({ runner, welcomePage, page }) => {
   runner.setVideoAndTraceName('ui-stress-e2e');
+  process.env.KEEP_TRACES_ON_PASS = 'true';
+  process.env.KEEP_VIDEOS_ON_PASS = 'true';
   await welcomePage.handleWelcomePage(true);
   await waitForPodmanMachineStartup(page);
 });


### PR DESCRIPTION
(in ui stress test)

### What does this PR do?
Adds KEEP_TRACES_ON_PASS and KEEP_VIDEOS_ON_PASS to ui-stress-test test case
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/12058 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
Run `pnpm test:e2e:ui-stress`
<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
