### PR TITLE
fix: image details navigation

### DIFF
--- a/packages/renderer/src/navigation.spec.ts
+++ b/packages/renderer/src/navigation.spec.ts
@@ -114,7 +114,7 @@ test(`Test navigationHandle for ${NavigationPage.IMAGE}`, () => {
     parameters: { id: '123', engineId: 'dummyEngineId', tag: 'dummyTag' },
   });
 
-  expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/images/123/dummyEngineId/ZHVtbXlUYWc=');
+  expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/images/123/dummyEngineId/ZHVtbXlUYWc=/summary');
 });
 
 test(`Test navigationHandle for ${NavigationPage.ONBOARDING}`, () => {

--- a/packages/renderer/src/navigation.ts
+++ b/packages/renderer/src/navigation.ts
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+// eslint-disable-next-line unicorn/prefer-node-protocol
+import { Buffer } from 'buffer';
 import { router } from 'tinro';
 
 import { NavigationPage } from '/@api/navigation-page';
@@ -78,7 +80,7 @@ export const handleNavigation = (request: InferredNavigationRequest<NavigationPa
       break;
     case NavigationPage.IMAGE:
       router.goto(
-        `/images/${request.parameters.id}/${request.parameters.engineId}/${Buffer.from(request.parameters.tag).toString('base64')}`,
+        `/images/${request.parameters.id}/${request.parameters.engineId}/${Buffer.from(request.parameters.tag).toString('base64')}/summary`,
       );
       break;
     case NavigationPage.ONBOARDING:


### PR DESCRIPTION
### What does this PR do?

Navigating to an image (image details) was failing because Buffer was not imported. Tests worked because they run on Node where buffer exists by default.

Secondary failure because the default tab is the /summary and we weren't adding it to the URL (and don't auto-forward). Test was checking for wrong URL, fixed.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #12120.

### How to test this PR?

I'll do a follow-up PR to use this API from the Images page, but for now just code review.

- [x] Tests are covering the bug fix or the new feature