### PR TITLE
chore: bump lint memory

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,8 +80,8 @@
     "markdownlint:check": "markdownlint-cli2 \"website/**/*.md\" \"#website/node_modules\" \"#website/api\"",
     "markdownlint:fix": "markdownlint-cli2 --fix \"website/**/*.md\" \"#website/node_modules\"",
     "lint:clean": "rimraf .eslintcache",
-    "lint:fix": "node --max-old-space-size=6144 node_modules/eslint/bin/eslint.js --cache . --cache-strategy content --fix",
-    "lint:check": "node --max-old-space-size=6144 node_modules/eslint/bin/eslint.js --cache . --cache-strategy content",
+    "lint:fix": "node --max-old-space-size=8192 node_modules/eslint/bin/eslint.js --cache . --cache-strategy content --fix",
+    "lint:check": "node --max-old-space-size=8192 node_modules/eslint/bin/eslint.js --cache . --cache-strategy content",
     "svelte:check": "svelte-check --ignore \"packages/ui/dist,packages/renderer/src/lib/ui/DetailsPage.svelte,packages/renderer/src/lib/ui/EngineFormPage.svelte,packages/renderer/src/lib/ui/FormPage.svelte,storybook\"",
     "typecheck:extension-api": "tsc --noEmit -p packages/extension-api/tsconfig.json",
     "typecheck:main": "tsc --noEmit -p packages/main/tsconfig.json",
@@ -112,7 +112,7 @@
   },
   "lint-staged": {
     "*.{js,ts,tsx,svelte}": [
-      "node --max-old-space-size=6144 node_modules/eslint/bin/eslint.js --cache --fix",
+      "node --max-old-space-size=8192 node_modules/eslint/bin/eslint.js --cache --fix",
       "biome format --write"
     ],
     "*.md": "prettier --cache --write",


### PR DESCRIPTION
### What does this PR do?

Bump lint max-old-space-size to 8192 to avoid crashes when doing fresh lint or switching branches.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #12136.

### How to test this PR?

PR checks.