### PR TITLE
chore: image and manifest details navigation

### DIFF
--- a/packages/renderer/src/lib/image/ImageColumnName.spec.ts
+++ b/packages/renderer/src/lib/image/ImageColumnName.spec.ts
@@ -33,12 +33,12 @@ const image: ImageInfoUI = {
   name: 'my-image-name',
   engineId: 'podman',
   engineName: '',
-  tag: 'latest-tag',
+  tag: 'latest',
   createdAt: 0,
   age: '',
   size: 0,
   humanSize: '',
-  base64RepoTag: 'repoTag',
+  base64RepoTag: 'bXktaW1hZ2UtbmFtZTpsYXRlc3Q=',
   selected: false,
   status: 'UNUSED',
   icon: ImageIcon,
@@ -83,7 +83,7 @@ test('Expect clicking works', async () => {
 
   fireEvent.click(text);
 
-  expect(routerGotoSpy).toBeCalledWith('/images/my-image/podman/repoTag/summary');
+  expect(routerGotoSpy).toBeCalledWith('/images/my-image/podman/bXktaW1hZ2UtbmFtZTpsYXRlc3Q=/summary');
 });
 
 test('Expect badge with simple color', async () => {
@@ -173,7 +173,7 @@ test('Expect badge with light color', async () => {
   await vi.waitFor(async () => expect(badge).toHaveStyle('background-color: #00ff00'));
 });
 
-test('Expect if image is a manifest, the on:click IS there', async () => {
+test('Expect clicking works for manifests', async () => {
   const manifestImage: ImageInfoUI = {
     ...image,
     isManifest: true,
@@ -187,5 +187,5 @@ test('Expect if image is a manifest, the on:click IS there', async () => {
   // test click
   const routerGotoSpy = vi.spyOn(router, 'goto');
   fireEvent.click(text);
-  expect(routerGotoSpy).toBeCalled();
+  expect(routerGotoSpy).toBeCalledWith('/manifests/my-image/podman/bXktaW1hZ2UtbmFtZTpsYXRlc3Q=/summary');
 });

--- a/packages/renderer/src/lib/image/ImageColumnName.svelte
+++ b/packages/renderer/src/lib/image/ImageColumnName.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-import { router } from 'tinro';
+import { handleNavigation } from '/@/navigation';
+import { NavigationPage } from '/@api/navigation-page';
 
 import Badge from '../ui/Badge.svelte';
 import type { ImageInfoUI } from './ImageInfoUI';
@@ -8,9 +9,15 @@ export let object: ImageInfoUI;
 
 function openDetails(image: ImageInfoUI): void {
   if (image.isManifest) {
-    router.goto(`/manifests/${image.id}/${image.engineId}/${image.base64RepoTag}/summary`);
+    handleNavigation({
+      page: NavigationPage.MANIFEST,
+      parameters: { id: image.id, engineId: image.engineId, tag: image.name + ':' + image.tag },
+    });
   } else {
-    router.goto(`/images/${image.id}/${image.engineId}/${image.base64RepoTag}/summary`);
+    handleNavigation({
+      page: NavigationPage.IMAGE,
+      parameters: { id: image.id, engineId: image.engineId, tag: image.name + ':' + image.tag },
+    });
   }
 }
 </script>

--- a/packages/renderer/src/lib/image/ImageColumnName.svelte
+++ b/packages/renderer/src/lib/image/ImageColumnName.svelte
@@ -8,17 +8,10 @@ import type { ImageInfoUI } from './ImageInfoUI';
 export let object: ImageInfoUI;
 
 function openDetails(image: ImageInfoUI): void {
-  if (image.isManifest) {
-    handleNavigation({
-      page: NavigationPage.MANIFEST,
-      parameters: { id: image.id, engineId: image.engineId, tag: image.name + ':' + image.tag },
-    });
-  } else {
-    handleNavigation({
-      page: NavigationPage.IMAGE,
-      parameters: { id: image.id, engineId: image.engineId, tag: image.name + ':' + image.tag },
-    });
-  }
+  handleNavigation({
+    page: image.isManifest ? NavigationPage.MANIFEST : NavigationPage.IMAGE,
+    parameters: { id: image.id, engineId: image.engineId, tag: image.name + ':' + image.tag },
+  });
 }
 </script>
 


### PR DESCRIPTION
### What does this PR do?

Two prior PRs fixed navigation to image details and added navigation to manifests. This just switches the links from the Images list Name column to use the navigation instead of directly using the router - minor cleanup and confirms the nav API works.

Fixed tests to match, including repotag that was inconsistent with the name and tag, and checking where manifests links to.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Follow up from #12139, #12143.

### How to test this PR?

Go to the Images page and click on an image and a manifest (can use `podman manifest create` if you don't have one) to confirm they both still go to details.

- [x] Tests are covering the bug fix or the new feature