### PR TITLE
chore: add error indication to statusbar provider

### DIFF
--- a/packages/renderer/src/lib/statusbar/ProviderButtonStatus.svelte
+++ b/packages/renderer/src/lib/statusbar/ProviderButtonStatus.svelte
@@ -15,6 +15,8 @@ let { status, class: className = '' }: Props = $props();
   <div aria-label="Connection Status Icon" class="h-3 w-3 rounded-full animate-spin border border-solid border-[var(--pd-action-button-spinner)] border-t-transparent {className}"></div>
 {:else if status === 'ready' || status === 'started'}
   <div aria-label="Connection Status Icon" class="h-[7px] w-[7px] absolute top-[0px] right-[-2px] rounded-full bg-[var(--pd-status-contrast)] border-1 border-[var(--pd-statusbar-bg)] {className}"></div>
+{:else if status === 'error'}
+  <div aria-label="Connection Status Icon" class="h-[7px] w-[7px] absolute top-[0px] right-[-2px] rounded-full bg-[var(--pd-state-error)] border-1 border-[var(--pd-statusbar-bg)] {className}"></div>
 {:else if status === 'Update available'}
   <IconImage image={arrowUp} aria-label="Connection Status Icon" class="h-[12px] w-auto absolute top-0 right-[-30%] {className}" />
 {/if}


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Adds an error indicator for the statusbar provider

### Screenshot / video of UI
![Screenshot from 2025-04-14 10-47-30](https://github.com/user-attachments/assets/ecced863-e254-49b7-b001-f0411c01bd62)


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->
Related to https://github.com/podman-desktop/podman-desktop/pull/12112

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
