### PR TITLE
chore: update contributing guide to use lint-staged

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -232,18 +232,10 @@ When contributing the new code, you should consider not lowering overall code co
 
 We use `@biomejs/biome` (and `prettier` for markdown) as formatter and `eslint` for linting.
 
-Check that your code is properly formatted with the linter and formatter:
-
-Checking:
+Stage your changes in git and check that it is properly linted and formatted:
 
 ```sh
-pnpm lint:check && pnpm format:check
-```
-
-Fix:
-
-```sh
-pnpm lint:fix && pnpm format:fix
+pnpm lint-staged
 ```
 
 ### Step 8. Compile production binaries (optional)


### PR DESCRIPTION
### What does this PR do?

Updates the contributing guide to use lint-staged, because:
- it's simpler
- it's faster in many cases. e.g. for this PR on my machine it is one task and a consistent 17s vs two tasks and 3.5s format + anywhere from 4-42s for lint
- that's what our Husky task does

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #12141.

### How to test this PR?

`pnpm lint-staged` and confirm steps work.