### PR TITLE
chore: migrate empty screen to svelte 5

### DIFF
--- a/packages/renderer/src/lib/container/ContainerEmptyScreen.svelte
+++ b/packages/renderer/src/lib/container/ContainerEmptyScreen.svelte
@@ -85,8 +85,9 @@ async function runContainer(commandLine: string): Promise<void> {
   title={title}
   message={messageCommandLine}
   commandline={commandLine}
-  on:click={(): Promise<void> => window.clipboardWriteText(commandLine)}>
-  <div slot="upperContent" hidden={stoppedOnly}>
+  onClick={(): Promise<void> => window.clipboardWriteText(commandLine)}>
+  {#snippet upperContent()}
+  <div hidden={stoppedOnly}>
     <span class="text-[var(--pd-details-empty-sub-header)] max-w-[800px] text-pretty mx-2">{messageButton}</span>
     <div class="flex gap-2 justify-center p-3">
       <Button
@@ -97,4 +98,5 @@ async function runContainer(commandLine: string): Promise<void> {
     </div>
     <h1 class="text-xl text-[var(--pd-details-empty-header)]">OR</h1>
   </div>
+  {/snippet}
 </EmptyScreen>

--- a/packages/renderer/src/lib/container/ContainerEmptyScreen.svelte
+++ b/packages/renderer/src/lib/container/ContainerEmptyScreen.svelte
@@ -85,7 +85,7 @@ async function runContainer(commandLine: string): Promise<void> {
   title={title}
   message={messageCommandLine}
   commandline={commandLine}
-  onClick={(): Promise<void> => window.clipboardWriteText(commandLine)}>
+  onclick={(): Promise<void> => window.clipboardWriteText(commandLine)}>
   {#snippet upperContent()}
   <div hidden={stoppedOnly}>
     <span class="text-[var(--pd-details-empty-sub-header)] max-w-[800px] text-pretty mx-2">{messageButton}</span>

--- a/packages/renderer/src/lib/image/ImageEmptyScreen.svelte
+++ b/packages/renderer/src/lib/image/ImageEmptyScreen.svelte
@@ -42,8 +42,8 @@ async function pullFirstImage(): Promise<void> {
   title="No images"
   message="Pull a first image using the following command line:"
   commandline={commandLine}
-  on:click={(): Promise<void> => window.clipboardWriteText(commandLine)}>
-  <div slot="upperContent">
+  onClick={(): Promise<void> => window.clipboardWriteText(commandLine)}>
+  {#snippet upperContent()}
     <span class="text-[var(--pd-details-empty-sub-header)] max-w-[800px] text-pretty mx-2"
       >Pull a first image by clicking on this button:</span>
     <div class="flex gap-2 justify-center p-3">
@@ -54,5 +54,5 @@ async function pullFirstImage(): Promise<void> {
         on:click={pullFirstImage}>Pull your first image</Button>
     </div>
     <h1 class="text-xl text-[var(--pd-details-empty-header)]">OR</h1>
-  </div>
+  {/snippet}
 </EmptyScreen>

--- a/packages/renderer/src/lib/image/ImageEmptyScreen.svelte
+++ b/packages/renderer/src/lib/image/ImageEmptyScreen.svelte
@@ -42,7 +42,7 @@ async function pullFirstImage(): Promise<void> {
   title="No images"
   message="Pull a first image using the following command line:"
   commandline={commandLine}
-  onClick={(): Promise<void> => window.clipboardWriteText(commandLine)}>
+  onclick={(): Promise<void> => window.clipboardWriteText(commandLine)}>
   {#snippet upperContent()}
     <span class="text-[var(--pd-details-empty-sub-header)] max-w-[800px] text-pretty mx-2"
       >Pull a first image by clicking on this button:</span>

--- a/packages/renderer/src/lib/pod/PodEmptyScreen.svelte
+++ b/packages/renderer/src/lib/pod/PodEmptyScreen.svelte
@@ -54,7 +54,7 @@ async function startPod(): Promise<void> {
   title="No pods"
   message="Run a first pod using the following command line:"
   commandline={commandLine}
-  onClick={(): Promise<void> => window.clipboardWriteText(commandLine)}>
+  onclick={(): Promise<void> => window.clipboardWriteText(commandLine)}>
   {#snippet upperContent()}
     <div class="flex gap-2 justify-center p-3">
       <Button title="Start your first pod" type="primary" inProgress={inProgress} on:click={startPod}

--- a/packages/renderer/src/lib/pod/PodEmptyScreen.svelte
+++ b/packages/renderer/src/lib/pod/PodEmptyScreen.svelte
@@ -54,12 +54,12 @@ async function startPod(): Promise<void> {
   title="No pods"
   message="Run a first pod using the following command line:"
   commandline={commandLine}
-  on:click={(): Promise<void> => window.clipboardWriteText(commandLine)}>
-  <div slot="upperContent">
+  onClick={(): Promise<void> => window.clipboardWriteText(commandLine)}>
+  {#snippet upperContent()}
     <div class="flex gap-2 justify-center p-3">
       <Button title="Start your first pod" type="primary" inProgress={inProgress} on:click={startPod}
         >Start your first pod</Button>
     </div>
     <h1 class="text-xl text-[var(--pd-details-empty-header)]">OR</h1>
-  </div>
+  {/snippet}
 </EmptyScreen>

--- a/packages/renderer/src/lib/volume/VolumeEmptyScreen.svelte
+++ b/packages/renderer/src/lib/volume/VolumeEmptyScreen.svelte
@@ -11,4 +11,4 @@ const commandLine = 'podman volume create myFirstVolume';
   title="No volumes"
   message="Create a volume using the following command line:"
   commandline={commandLine}
-  on:click={(): Promise<void> => window.clipboardWriteText(commandLine)} />
+  onClick={(): Promise<void> => window.clipboardWriteText(commandLine)} />

--- a/packages/renderer/src/lib/volume/VolumeEmptyScreen.svelte
+++ b/packages/renderer/src/lib/volume/VolumeEmptyScreen.svelte
@@ -11,4 +11,4 @@ const commandLine = 'podman volume create myFirstVolume';
   title="No volumes"
   message="Create a volume using the following command line:"
   commandline={commandLine}
-  onClick={(): Promise<void> => window.clipboardWriteText(commandLine)} />
+  onclick={(): Promise<void> => window.clipboardWriteText(commandLine)} />

--- a/packages/ui/src/lib/screen/EmptyScreen.spec.ts
+++ b/packages/ui/src/lib/screen/EmptyScreen.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,12 +23,9 @@ import { expect, test, vi } from 'vitest';
 
 import EmptyScreen from './EmptyScreen.svelte';
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/no-empty-function */
-
 test('Expect copy in clipboard', async () => {
   const mock = vi.fn();
-  render(EmptyScreen, { icon: '', commandline: 'podman run hello:world', onClick: mock });
+  render(EmptyScreen, { icon: '', commandline: 'podman run hello:world', onclick: mock });
   const button = screen.getByRole('button');
   expect(button).toBeInTheDocument();
   expect(button).toBeEnabled();

--- a/packages/ui/src/lib/screen/EmptyScreen.svelte
+++ b/packages/ui/src/lib/screen/EmptyScreen.svelte
@@ -1,26 +1,48 @@
 <script lang="ts">
 import { faPaste } from '@fortawesome/free-solid-svg-icons';
-import { createEventDispatcher, onMount } from 'svelte';
+import { createEventDispatcher, onMount, type Snippet } from 'svelte';
 import Fa from 'svelte-fa';
 
 import Button from '../button/Button.svelte';
 import { isFontAwesomeIcon } from '../utils/icon-utils';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export let icon: any;
-export let title = 'No title';
-export let message = 'Message';
-export let detail = '';
-export let commandline = '';
-export let hidden = false;
+interface Props {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  icon: any;
+  title?: string;
+  message?: string;
+  detail?: string;
+  commandline?: string;
+  hidden?: boolean;
+  class?: string;
+  style?: string;
+  'aria-label'?: string;
+  upperContent?: Snippet;
+  children?: Snippet;
+  onClick?: (text: string) => void;
+}
 
-let fontAwesomeIcon = false;
-let processed = false;
+let {
+  icon = undefined,
+  title = 'No title',
+  message = '',
+  detail = '',
+  commandline = '',
+  hidden = false,
+  class: className,
+  style,
+  'aria-label': ariaLabel,
+  upperContent,
+  children,
+  onClick = (text): void => {
+    dispatch('click', text);
+  },
+}: Props = $props();
+
+let fontAwesomeIcon = $state(false);
+let processed = $state(false);
 
 const dispatch = createEventDispatcher<{ click: string }>();
-export let onClick: (text: string) => void = text => {
-  dispatch('click', text);
-};
 
 onMount(() => {
   if (isFontAwesomeIcon(icon)) {
@@ -36,26 +58,27 @@ function handleClick(): void {
   }
 }
 
-let copyTextDivElement: HTMLDivElement;
+let copyTextDivElement = $state<HTMLDivElement>();
 </script>
 
 <div
-  class="flex flex-row w-full h-full justify-center {$$props.class ?? ''}"
+  class="flex flex-row w-full h-full justify-center {className}"
   class:hidden={hidden}
-  style={$$props.style}
-  aria-label={$$props['aria-label']}>
+  style={style}
+  aria-label={ariaLabel}>
   <div class="flex flex-col h-full justify-center text-center space-y-3">
     <div class="flex justify-center text-[var(--pd-details-empty-icon)] py-2">
       {#if processed}
         {#if fontAwesomeIcon}
           <Fa icon={icon} size="4x" />
         {:else}
-          <svelte:component this={icon} size="55" />
+          {@const IconComponent = icon}
+          <IconComponent size=55 />
         {/if}
       {/if}
     </div>
     <h1 class="text-xl text-[var(--pd-details-empty-header)]">{title}</h1>
-    <slot name="upperContent" slot="upperContent" />
+    {@render upperContent?.()}
     <span class="text-[var(--pd-details-empty-sub-header)] max-w-[800px] text-pretty mx-2">{message}</span>
     {#if detail}
       <span class="text-[var(--pd-details-empty-sub-header)]">{detail}</span>
@@ -73,9 +96,9 @@ let copyTextDivElement: HTMLDivElement;
           ><Fa class="h-5 w-5 cursor-pointer text-xl text-[var(--pd-button-primary-bg)]" icon={faPaste} /></Button>
       </div>
     {/if}
-    {#if $$slots}
+    {#if children}
       <div class="py-2">
-        <slot />
+        {@render children()}
       </div>
     {/if}
   </div>

--- a/packages/ui/src/lib/screen/EmptyScreen.svelte
+++ b/packages/ui/src/lib/screen/EmptyScreen.svelte
@@ -19,7 +19,7 @@ interface Props {
   'aria-label'?: string;
   upperContent?: Snippet;
   children?: Snippet;
-  onClick?: (text: string) => void;
+  onclick?: (text: string) => void;
 }
 
 let {
@@ -34,7 +34,7 @@ let {
   'aria-label': ariaLabel,
   upperContent,
   children,
-  onClick = (text): void => {
+  onclick = (text): void => {
     dispatch('click', text);
   },
 }: Props = $props();
@@ -54,7 +54,7 @@ onMount(() => {
 function handleClick(): void {
   const text = copyTextDivElement?.textContent;
   if (text) {
-    onClick(text);
+    onclick(text);
   }
 }
 


### PR DESCRIPTION
### What does this PR do?

Migrates the empty screen to Svelte 5 using patterns already established in other components. Updated usage in /renderer to Svelte 5 syntax.

One minor cleanup to default message to fix second issue.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

First half of #11586.
Fixes #12145.

### How to test this PR?

Check empty screens to confirm behaviour.