### PR TITLE
chore(vitest): enable default reporter on CI

### DIFF
--- a/vitest.config.js
+++ b/vitest.config.js
@@ -34,7 +34,7 @@ export default defineConfig({
       '!**/builtin/**',
     ],
     // use GitHub action reporters when running in CI
-    reporters: process.env.GITHUB_ACTIONS ? [['junit', { includeConsoleOutput: false }], 'default'] : ['default'],
+    reporters: process.env.CI ? [['junit', { includeConsoleOutput: false }], 'default'] : ['default'],
     outputFile: process.env.CI ? { junit: 'coverage/junit-results.xml' } : {},
     coverage: {
       all: true,

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -34,7 +34,7 @@ export default defineConfig({
       '!**/builtin/**',
     ],
     // use GitHub action reporters when running in CI
-    reporters: process.env.CI ? [['junit', { includeConsoleOutput: false }]] : ['default'],
+    reporters: process.env.GITHUB_ACTIONS ? [['junit', { includeConsoleOutput: false }], 'default'] : ['default'],
     outputFile: process.env.CI ? { junit: 'coverage/junit-results.xml' } : {},
     coverage: {
       all: true,


### PR DESCRIPTION
### What does this PR do?

When I finalized the vitest workspace setup, I removed the default reporter, because I thought it was useless, (oupsi), we don't see the failing tests in the CI since.

Adding it back :)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- We should see all the tests running in the unit tests / {platform}
