### PR TITLE
fix(StatusIcon): restrict icon type

### DIFF
--- a/packages/renderer/src/lib/container/ContainerColumnStatus.svelte
+++ b/packages/renderer/src/lib/container/ContainerColumnStatus.svelte
@@ -12,6 +12,6 @@ const containerUtils = new ContainerUtils();
 
 {#if containerUtils.isContainerGroupInfoUI(object)}
   <StatusIcon icon={PodIcon} status={object.status} />
-{:else if containerUtils.isContainerInfoUI(object) && typeof object.icon === 'string'}
+{:else if containerUtils.isContainerInfoUI(object) && object.icon}
   <StatusIcon icon={object.icon} status={object.state} />
 {/if}

--- a/packages/renderer/src/lib/container/ContainerColumnStatus.svelte
+++ b/packages/renderer/src/lib/container/ContainerColumnStatus.svelte
@@ -12,6 +12,6 @@ const containerUtils = new ContainerUtils();
 
 {#if containerUtils.isContainerGroupInfoUI(object)}
   <StatusIcon icon={PodIcon} status={object.status} />
-{:else if containerUtils.isContainerInfoUI(object)}
+{:else if containerUtils.isContainerInfoUI(object) && typeof object.icon === 'string'}
   <StatusIcon icon={object.icon} status={object.state} />
 {/if}

--- a/packages/renderer/src/lib/container/ContainerInfoUI.ts
+++ b/packages/renderer/src/lib/container/ContainerInfoUI.ts
@@ -17,6 +17,7 @@
  ***********************************************************************/
 
 import type { Port } from '@podman-desktop/api';
+import type { Component } from 'svelte';
 
 // type of groups
 export enum ContainerGroupInfoTypeUI {
@@ -68,7 +69,7 @@ export interface ContainerInfoUI {
   actionInProgress?: boolean;
   actionError?: string;
   labels: { [label: string]: string };
-  icon?: unknown;
+  icon?: string | Component;
   imageBase64RepoTag: string;
   imageHref?: string;
 }

--- a/packages/renderer/src/lib/image/ImageColumnStatus.svelte
+++ b/packages/renderer/src/lib/image/ImageColumnStatus.svelte
@@ -6,7 +6,7 @@ import type { ImageInfoUI } from './ImageInfoUI';
 export let object: ImageInfoUI;
 </script>
 
-{#if typeof object.icon === 'string'}
+{#if object.icon}
   <StatusIcon icon={object.icon} status={object.status} />
 {/if}
 

--- a/packages/renderer/src/lib/image/ImageColumnStatus.svelte
+++ b/packages/renderer/src/lib/image/ImageColumnStatus.svelte
@@ -6,4 +6,7 @@ import type { ImageInfoUI } from './ImageInfoUI';
 export let object: ImageInfoUI;
 </script>
 
-<StatusIcon icon={object.icon} status={object.status} />
+{#if typeof object.icon === 'string'}
+  <StatusIcon icon={object.icon} status={object.status} />
+{/if}
+

--- a/packages/renderer/src/lib/image/ImageDetails.svelte
+++ b/packages/renderer/src/lib/image/ImageDetails.svelte
@@ -133,7 +133,7 @@ onDestroy(() => {
 {#if image}
   <DetailsPage title={image.name} titleDetail={image.shortId} subtitle={image.tag} bind:this={detailsPage}>
     {#snippet iconSnippet()}
-      {#if image && typeof image.icon === 'string'}<StatusIcon icon={image.icon} size={24} status={image.status} />{/if}
+      {#if image?.icon}<StatusIcon icon={image.icon} size={24} status={image.status} />{/if}
     {/snippet}
     {#snippet subtitleSnippet()}
       {#if image?.badges.length}

--- a/packages/renderer/src/lib/image/ImageDetails.svelte
+++ b/packages/renderer/src/lib/image/ImageDetails.svelte
@@ -133,7 +133,7 @@ onDestroy(() => {
 {#if image}
   <DetailsPage title={image.name} titleDetail={image.shortId} subtitle={image.tag} bind:this={detailsPage}>
     {#snippet iconSnippet()}
-      {#if image}<StatusIcon icon={image.icon} size={24} status={image.status} />{/if}
+      {#if image && typeof image.icon === 'string'}<StatusIcon icon={image.icon} size={24} status={image.status} />{/if}
     {/snippet}
     {#snippet subtitleSnippet()}
       {#if image?.badges.length}

--- a/packages/renderer/src/lib/image/ImageInfoUI.ts
+++ b/packages/renderer/src/lib/image/ImageInfoUI.ts
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { Component } from 'svelte';
+
 import type { ViewContributionBadgeValue } from '/@api/view-info';
 
 export interface ImageInfoUI {
@@ -34,7 +36,7 @@ export interface ImageInfoUI {
   base64RepoTag: string;
   selected: boolean;
   status: 'USED' | 'UNUSED' | 'DELETING';
-  icon: unknown;
+  icon?: string | Component;
   labels?: { [label: string]: string };
   badges: ViewContributionBadgeValue[];
   children?: ImageInfoUI[];

--- a/packages/renderer/src/lib/image/PushImageModal.spec.ts
+++ b/packages/renderer/src/lib/image/PushImageModal.spec.ts
@@ -78,7 +78,7 @@ const fakedImage: ImageInfoUI = {
   base64RepoTag: 'base64RepoTag',
   selected: false,
   status: 'UNUSED',
-  icon: {},
+  icon: undefined,
   badges: [],
   digest: 'sha256:1234567890',
 };

--- a/packages/renderer/src/lib/image/PushManifestModal.spec.ts
+++ b/packages/renderer/src/lib/image/PushManifestModal.spec.ts
@@ -59,7 +59,7 @@ const fakedManifest: ImageInfoUI = {
   base64RepoTag: 'base64RepoTag',
   selected: false,
   status: 'UNUSED',
-  icon: {},
+  icon: undefined,
   badges: [],
   isManifest: true,
   digest: 'sha256:1234567890',

--- a/packages/renderer/src/lib/images/CronJobIcon.svelte
+++ b/packages/renderer/src/lib/images/CronJobIcon.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 interface Props {
-  size: string;
-  solid: boolean;
+  size?: string;
+  solid?: boolean;
 }
 
 let { size = '40', solid }: Props = $props();

--- a/packages/renderer/src/lib/images/JobIcon.svelte
+++ b/packages/renderer/src/lib/images/JobIcon.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 interface Props {
-  size: string;
-  solid: boolean;
+  size?: string;
+  solid?: boolean;
 }
 
 let { size = '40', solid }: Props = $props();

--- a/packages/renderer/src/lib/kubernetes-port-forward/EthernetIcon.svelte
+++ b/packages/renderer/src/lib/kubernetes-port-forward/EthernetIcon.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+import { faEthernet } from '@fortawesome/free-solid-svg-icons/faEthernet';
+import Fa from 'svelte-fa';
+</script>
+
+<Fa class="w-[20px]" scale={1.5} icon={faEthernet} />

--- a/packages/renderer/src/lib/kubernetes-port-forward/PortForwardIcon.svelte
+++ b/packages/renderer/src/lib/kubernetes-port-forward/PortForwardIcon.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-import { faEthernet } from '@fortawesome/free-solid-svg-icons';
 import { StatusIcon } from '@podman-desktop/ui-svelte';
-import Fa from 'svelte-fa';
 
 import type { ForwardConfig } from '/@api/kubernetes-port-forward-model';
+
+import EthernetIcon from './EthernetIcon.svelte';
 
 interface Props {
   object: ForwardConfig;
@@ -11,10 +11,6 @@ interface Props {
 let { object }: Props = $props();
 </script>
 
-{#snippet Ethernet()}
-  <Fa class="w-[20px]" scale={1.5} icon={faEthernet} />
-{/snippet}
-
 {#if object}
-  <StatusIcon status="RUNNING" icon={Ethernet} />
+  <StatusIcon status="RUNNING" icon={EthernetIcon} />
 {/if}

--- a/packages/ui/src/lib/statusIcon/StatusIcon.svelte
+++ b/packages/ui/src/lib/statusIcon/StatusIcon.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+import type { Component } from 'svelte';
+
 import StarIcon from '../icons/StarIcon.svelte';
 import Spinner from '../progress/Spinner.svelte';
 
@@ -6,8 +8,7 @@ interface Props {
   // status: one of RUNNING, STARTING, USED, CREATED, DELETING, or DEGRADED
   // any other status will result in a standard outlined box
   status?: 'RUNNING' | 'STARTING' | 'USED' | 'DEGRADED' | 'DELETING' | 'CREATED' | string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  icon?: any;
+  icon?: string | Component;
   size?: number;
 }
 let { status = 'UNKNOWN', icon, size = 20 }: Props = $props();


### PR DESCRIPTION
### What does this PR do?

On the Quadlet Extension I provided a snippet as icon, but this is invalid, and not a supported use case: [bug(ui): cannot render snippet using html synthax](https://github.com/podman-desktop/podman-desktop/issues/12187)

To avoid repeating this error in the future, remove the any, and replace with two allowed type `string` and `Component`.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
