### PR TITLE
fix: use default colours for the terminal output

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsLogs.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsLogs.svelte
@@ -82,9 +82,9 @@ onMount(async () => {
   if (providerInternalId) {
     await window.startReceiveLogs(
       providerInternalId,
-      (data: unknown[]) => logHandler(data, '\x1b[37m'),
-      (data: unknown[]) => logHandler(data, '\x1b[37m'),
-      (data: unknown[]) => logHandler(data, '\x1b[37m'),
+      (data: unknown[]) => logHandler(data, ''),
+      (data: unknown[]) => logHandler(data, ''),
+      (data: unknown[]) => logHandler(data, ''),
       connectionInfo,
     );
   }


### PR DESCRIPTION
### What does this PR do?

The following PR fixes an issue with incorrect style rendering in the log display window.

### Screenshot / video of UI

<img width="1207" src="https://github.com/user-attachments/assets/6f9c4dff-845e-476b-a14c-d54889358433" />
<img width="1207" src="https://github.com/user-attachments/assets/5897c83b-a84d-45de-9618-16c7f94931f2" />
<img width="1207" src="https://github.com/user-attachments/assets/3ba73221-da83-44e6-b242-1fd3a13d2fcd" />
<img width="1207" src="https://github.com/user-attachments/assets/5cc2652c-8015-4ef8-8ac6-8c222639d950" />


### What issues does this PR fix or reference?

#11783 

### How to test this PR?

Make sure that log window displays the same as in the attached screenshots.

- [ ] Tests are covering the bug fix or the new feature
