### PR TITLE
fix(icons): update Props interfaces

### DIFF
--- a/packages/renderer/src/lib/images/CronJobIcon.svelte
+++ b/packages/renderer/src/lib/images/CronJobIcon.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 interface Props {
-  size: string;
-  solid: boolean;
+  size?: string;
+  solid?: boolean;
 }
 
 let { size = '40', solid }: Props = $props();

--- a/packages/renderer/src/lib/images/CronJobIcon.svelte
+++ b/packages/renderer/src/lib/images/CronJobIcon.svelte
@@ -4,7 +4,7 @@ interface Props {
   solid?: boolean;
 }
 
-let { size = '40', solid }: Props = $props();
+let { size = '40', solid = false }: Props = $props();
 
 let baseStyle: string = 'stroke:currentColor;stroke-width:0.3;stroke-linecap:round;';
 let style: string = baseStyle + (solid ? 'fill:currentColor' : 'fill:none');

--- a/packages/renderer/src/lib/images/JobIcon.svelte
+++ b/packages/renderer/src/lib/images/JobIcon.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 interface Props {
-  size: string;
-  solid: boolean;
+  size?: string;
+  solid?: boolean;
 }
 
 let { size = '40', solid }: Props = $props();

--- a/packages/renderer/src/lib/images/JobIcon.svelte
+++ b/packages/renderer/src/lib/images/JobIcon.svelte
@@ -4,7 +4,7 @@ interface Props {
   solid?: boolean;
 }
 
-let { size = '40', solid }: Props = $props();
+let { size = '40', solid = false }: Props = $props();
 
 let baseStyle: string = 'stroke:currentColor;stroke-width:0.3;stroke-linecap:round;';
 let style: string = baseStyle + (solid ? 'fill:currentColor' : 'fill:none');


### PR DESCRIPTION
### What does this PR do?

When migrating the `CronJobIcon.svelte` and `JobIcon.svelte` component to Svelte5, the props where define with mandatory properties (size & solid) this was an error, as those value have default value provided, so they should be optional.

This is important, as those component have the wrong ComponentProps type then.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Required for
- https://github.com/podman-desktop/podman-desktop/pull/12210
- https://github.com/podman-desktop/podman-desktop/pull/12230

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- Pipeline should be :heavy_check_mark: 
