### PR TITLE
fix: make image build cancellable

### DIFF
--- a/packages/api/src/navigation-request.ts
+++ b/packages/api/src/navigation-request.ts
@@ -32,7 +32,7 @@ export interface NavigationParameters {
   [NavigationPage.EXISTING_IMAGE_CREATE_CONTAINER]: never;
   [NavigationPage.DEPLOY_TO_KUBE]: { id: string; engineId: string };
   [NavigationPage.IMAGES]: never;
-  [NavigationPage.IMAGE_BUILD]: never;
+  [NavigationPage.IMAGE_BUILD]: { taskId: number | undefined };
   [NavigationPage.IMAGE]: { id: string; engineId: string; tag: string };
   [NavigationPage.MANIFEST]: { id: string; engineId: string; tag: string };
   [NavigationPage.ONBOARDING]: { extensionId: string };

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1346,6 +1346,7 @@ export class PluginSystem {
         onDataCallbacksBuildImageId: number,
         cancellableTokenId?: number,
         buildargs?: { [key: string]: string },
+        taskId?: number,
       ): Promise<unknown> => {
         // create task
         const task = taskManager.createTask({
@@ -1353,17 +1354,20 @@ export class PluginSystem {
           action: {
             name: 'Go to task >',
             execute: () => {
-              navigationManager.navigateToImageBuild().catch((err: unknown) => {
+              navigationManager.navigateToImageBuild(taskId).catch((err: unknown) => {
                 console.error(`Something went wrong while trying to navigate to image build: ${String(err)}`);
               });
             },
           },
         });
 
+        task.onUpdate(e => apiSender.send(`build-image-task-${e.action}`, taskId));
+
         const abortController = this.createAbortControllerOnCancellationToken(
           cancellationTokenRegistry,
           cancellableTokenId,
         );
+
         return containerProviderRegistry
           .buildImage(
             containerBuildContextDirectory,

--- a/packages/main/src/plugin/navigation/navigation-manager.spec.ts
+++ b/packages/main/src/plugin/navigation/navigation-manager.spec.ts
@@ -146,6 +146,9 @@ test('check navigateToImageBuild', async () => {
 
   expect(apiSender.send).toHaveBeenCalledWith('navigate', {
     page: NavigationPage.IMAGE_BUILD,
+    parameters: {
+      taskId: undefined,
+    },
   });
 });
 

--- a/packages/main/src/plugin/navigation/navigation-manager.ts
+++ b/packages/main/src/plugin/navigation/navigation-manager.ts
@@ -187,9 +187,12 @@ export class NavigationManager {
     });
   }
 
-  async navigateToImageBuild(): Promise<void> {
+  async navigateToImageBuild(taskId?: number): Promise<void> {
     this.navigateTo({
       page: NavigationPage.IMAGE_BUILD,
+      parameters: {
+        taskId,
+      },
     });
   }
 

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1244,6 +1244,7 @@ export function initExposure(): void {
       eventCollect: (key: symbol, eventName: 'finish' | 'stream' | 'error', data: string) => void,
       cancellableTokenId?: number,
       buildargs?: { [key: string]: string },
+      taskId?: number,
     ): Promise<unknown> => {
       onDataCallbacksBuildImageId++;
       onDataCallbacksBuildImage.set(onDataCallbacksBuildImageId, eventCollect);
@@ -1258,6 +1259,7 @@ export function initExposure(): void {
         onDataCallbacksBuildImageId,
         cancellableTokenId,
         buildargs,
+        taskId,
       );
     },
   );

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -178,6 +178,9 @@ window.events?.receive('kubernetes-navigation', (args: unknown) => {
         <Route path="/images/existing-image-create-container" breadcrumb="Select image" >
           <CreateContainerFromExistingImage />
         </Route>
+        <Route path="/images/build" breadcrumb="Build an Image" let:meta>
+          <BuildImageFromContainerfile taskId={+meta.query.taskId}/>
+        </Route>
         <Route path="/images/:id/:engineId" breadcrumb="Images" let:meta navigationHint="root">
           <ImagesList searchTerm={meta.params.id} imageEngineId={meta.params.engineId} />
         </Route>
@@ -200,9 +203,6 @@ window.events?.receive('kubernetes-navigation', (args: unknown) => {
             imageID={meta.params.id}
             engineId={decodeURI(meta.params.engineId)}
             base64RepoTag={meta.params.base64RepoTag} />
-        </Route>
-        <Route path="/images/build" breadcrumb="Build an Image">
-          <BuildImageFromContainerfile />
         </Route>
         <Route path="/images/pull" breadcrumb="Pull an Image">
           <PullImage />

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
@@ -1,68 +1,85 @@
 <script lang="ts">
-/* eslint-disable import/no-duplicates */
+/* eslint-disable no-useless-escape */
 // https://github.com/import-js/eslint-plugin-import/issues/1479
 import { faCube, faMinusCircle, faPlusCircle } from '@fortawesome/free-solid-svg-icons';
-import type { OpenDialogOptions } from '@podman-desktop/api';
+import { type OpenDialogOptions } from '@podman-desktop/api';
 import { Button, Input } from '@podman-desktop/ui-svelte';
-import type { Terminal } from '@xterm/xterm';
-import { onDestroy, onMount } from 'svelte';
-import { get } from 'svelte/store';
+import { onDestroy } from 'svelte';
+import { get, type Unsubscriber } from 'svelte/store';
 
 import ContainerConnectionDropdown from '/@/lib/forms/ContainerConnectionDropdown.svelte';
 import FileInput from '/@/lib/ui/FileInput.svelte';
 import { handleNavigation } from '/@/navigation';
-import { type BuildImageInfo, buildImagesInfo } from '/@/stores/build-images';
+import {
+  type BuildImageInfo,
+  buildImagesInfo,
+  cloneBuildImageInfo,
+  createDefaultBuildImageInfo,
+  getNextTaskId,
+  lastUpdatedTaskId,
+} from '/@/stores/build-images';
 import { NavigationPage } from '/@api/navigation-page';
-/* eslint-enable import/no-duplicates */
-import type { ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provider-info';
+import type { ProviderInfo } from '/@api/provider-info';
 
 import { providerInfos } from '../../stores/providers';
 import EngineFormPage from '../ui/EngineFormPage.svelte';
 import TerminalWindow from '../ui/TerminalWindow.svelte';
-import {
-  type BuildImageCallback,
-  clearBuildTask,
-  disconnectUI,
-  eventCollect,
-  reconnectUI,
-  startBuild,
-} from './build-image-task';
+import { type BuildImageCallback, disconnectUI, eventCollect, reconnectUI, startBuild } from './build-image-task';
 import BuildImageFromContainerfileCards from './BuildImageFromContainerfileCards.svelte';
 import RecommendedRegistry from './RecommendedRegistry.svelte';
 
-let buildFinished = false;
-let containerImageName: string | undefined;
-let containerFilePath: string;
-let containerBuildContextDirectory: string;
-let containerBuildPlatform: string;
-
-let buildImageInfo: BuildImageInfo | undefined = undefined;
-let cancellableTokenId: number | undefined = undefined;
+export let taskId: number | undefined;
+let buildImageInfo: BuildImageInfo = createDefaultBuildImageInfo();
 let providers: ProviderInfo[] = [];
-let providerConnections: ProviderContainerConnectionInfo[] = [];
-let selectedProvider: ProviderContainerConnectionInfo | undefined = undefined;
-let logsTerminal: Terminal;
-let buildIDs = [];
 
 const containerFileDialogOptions: OpenDialogOptions = {
   title: 'Select Containerfile to build',
 };
 const contextDialogOptions: OpenDialogOptions = { title: 'Select Root Context', selectors: ['openDirectory'] };
 
-$: platforms = containerBuildPlatform ? containerBuildPlatform.split(',') : [];
+$: platforms = buildImageInfo.containerBuildPlatform ? buildImageInfo.containerBuildPlatform.split(',') : [];
+$: containerFilePath = buildImageInfo.containerFilePath;
+$: containerBuildContextDirectory = buildImageInfo.containerBuildContextDirectory;
+$: if (containerFilePath && !containerBuildContextDirectory) {
+  // select the parent directory of the file as default
+  buildImageInfo.containerBuildContextDirectory = containerFilePath.replace(/\\/g, '/').replace(/\/[^\/]*$/, '');
+}
+$: containerImageName = buildImageInfo.containerImageName;
+$: providerConnections = providers
+  .map(provider => provider.containerConnections)
+  .flat()
+  .filter(providerContainerConnection => providerContainerConnection.status === 'started');
+$: selectedProvider = providerConnections.length > 0 ? providerConnections[0] : undefined;
+$: buildImageInfo.selectedProvider = selectedProvider;
 $: hasInvalidFields =
   !containerFilePath ||
   !containerBuildContextDirectory ||
   (platforms.length > 1 && !containerImageName) ||
-  platforms.length === 0;
-$: if (containerFilePath && !containerBuildContextDirectory) {
-  // select the parent directory of the file as default
-  // eslint-disable-next-line no-useless-escape
-  containerBuildContextDirectory = containerFilePath.replace(/\\/g, '/').replace(/\/[^\/]*$/, '');
-}
+  platforms.length === 0 ||
+  !selectedProvider;
 
-let buildParentImageName: string | undefined = undefined;
-let buildError: string | undefined = undefined;
+$: if (taskId && taskId !== buildImageInfo.taskId) {
+  // switching previous task wich could be finished or still running
+  if (buildImageInfo.buildImageKey) {
+    // disconnect UI regardless of state
+    disconnectUI(buildImageInfo.buildImageKey);
+  }
+  buildImageInfo.logsTerminal?.reset(); // clean up terminal before loading the state
+  const buildImagesInfoMap = get(buildImagesInfo); // get background task states
+  const bgBuildImageInfo = buildImagesInfoMap.get(taskId); // get state for loading task
+  if (bgBuildImageInfo) {
+    bgBuildImageInfo.logsTerminal = buildImageInfo.logsTerminal;
+    if (bgBuildImageInfo.buildRunning) {
+      buildImageInfo = bgBuildImageInfo;
+    } else {
+      buildImageInfo = cloneBuildImageInfo(bgBuildImageInfo);
+      taskId = 0;
+    }
+    if (buildImageInfo.buildImageKey) {
+      reconnectUI(buildImageInfo.buildImageKey, getTerminalCallback());
+    }
+  }
+}
 
 interface BuildOutputItem {
   stream?: string;
@@ -73,55 +90,49 @@ interface BuildOutputItem {
 
 type BuildOutput = BuildOutputItem[];
 
-let buildArgs: { key: string; value: string }[] = [{ key: '', value: '' }];
 let formattedBuildArgs: Record<string, string> = {};
 
 function addBuildArg(): void {
-  buildArgs = [...buildArgs, { key: '', value: '' }];
+  buildImageInfo.buildArgs = [...buildImageInfo.buildArgs, { key: '', value: '' }];
 }
 
 function deleteBuildArg(index: number): void {
-  // Only one item in the list, clear the content
-  if (buildArgs.length === 1) {
-    buildArgs[index].key = '';
-    buildArgs[index].value = '';
-  } else {
-    // Remove the item from the array
-    buildArgs = buildArgs.filter((_, i) => i !== index);
-  }
+  buildImageInfo.buildArgs = buildImageInfo.buildArgs.filter((_, i) => i !== index);
 }
 
 function getTerminalCallback(): BuildImageCallback {
   const imageRegexp = RegExp(/docker:\/\/(?<imageName>.*?):\s/);
   return {
-    onStream: function (data: string): void {
-      logsTerminal.write(`${data}\r`);
+    onStream: function (data: string = ''): void {
+      buildImageInfo.logsTerminal?.write(`${data}\r`);
     },
     onError: function (error: string): void {
-      buildError = error;
+      buildImageInfo.buildError = error;
 
       // need to extract image from there
       // it should match the pattern 'initializing source docker://registry.redhat.io/rhel9/postgresql-13:latest' and keep the value 'registry.redhat.io/rhel9/postgresql-13:latest'
-      const imageRegexpRes = imageRegexp.exec(buildError);
+      const imageRegexpRes = imageRegexp.exec(buildImageInfo.buildError);
       // if we found the image name, we should store it
       const findingImageName = imageRegexpRes?.groups?.imageName;
       if (findingImageName) {
-        buildParentImageName = findingImageName;
+        buildImageInfo.buildParentImageName = findingImageName;
       }
-      logsTerminal.write(`Error:${error}\r`);
+      buildImageInfo.logsTerminal?.write(`Error:${error}\r\n`);
     },
     onEnd: function (): void {
-      window.dispatchEvent(new CustomEvent('image-build', { detail: { name: containerImageName } }));
+      // dispatch event to reload images list when image build is done
+      window.dispatchEvent(new CustomEvent('image-build', { detail: { name: buildImageInfo.containerImageName } }));
     },
   };
 }
 
 async function buildContainerImage(): Promise<void> {
-  buildParentImageName = undefined;
-  buildError = undefined;
+  buildImageInfo.buildParentImageName = undefined;
+  buildImageInfo.buildError = undefined;
+  buildImageInfo.logsTerminal?.reset();
 
   // Create the formatted build arguments that will be used when passing to buildImage
-  formattedBuildArgs = buildArgs.reduce<Record<string, string>>((acc, { key, value }) => {
+  formattedBuildArgs = buildImageInfo.buildArgs.reduce<Record<string, string>>((acc, { key, value }) => {
     if (key && value) {
       acc[key] = value;
     }
@@ -134,270 +145,294 @@ async function buildContainerImage(): Promise<void> {
     await buildSinglePlatformImage(); // Single platform build
   } else if (platforms.length > 1) {
     await buildMultiplePlatformImagesAndCreateManifest(); // Multiple platforms build
-  } else {
-    console.error('No platforms specified for the build.');
   }
 }
 
 // Function to handle the building of a container image for a single platform
+// Can be running in current page or in background without page
 async function buildSinglePlatformImage(): Promise<void> {
-  buildFinished = false;
+  buildImageInfo.buildFinished = false;
+  buildImageInfo.buildImageKey = startBuild(getTerminalCallback());
+  buildImageInfo.buildRunning = true;
 
-  if (containerFilePath && selectedProvider) {
-    // Extract the relative path from the containerFilePath and containerBuildContextDirectory
-    const relativeContainerfilePath = await window.pathRelative(containerBuildContextDirectory, containerFilePath);
-    buildImageInfo = startBuild(getTerminalCallback());
+  // Extract the relative path from the containerFilePath and containerBuildContextDirectory
+  const relativeContainerfilePath = await window.pathRelative(
+    buildImageInfo.containerBuildContextDirectory,
+    buildImageInfo.containerFilePath,
+  );
 
-    // Store the key
-    buildImagesInfo.set(buildImageInfo);
+  buildImageInfo.cancellableTokenId = await window.getCancellableTokenSource();
 
-    try {
-      cancellableTokenId = await window.getCancellableTokenSource();
-
-      // Build the singular image
-      await window.buildImage(
-        containerBuildContextDirectory,
-        relativeContainerfilePath,
-        containerImageName,
-        containerBuildPlatform,
-        selectedProvider,
-        buildImageInfo.buildImageKey,
-        eventCollect,
-        cancellableTokenId,
-        formattedBuildArgs,
-      );
-    } catch (error) {
-      logsTerminal.write(`Error:${error}\r`);
-    } finally {
-      cancellableTokenId = undefined;
-      buildImageInfo.buildRunning = false;
-      buildFinished = true;
+  buildImagesInfo.update(map => {
+    taskId = getNextTaskId();
+    buildImageInfo.taskId = taskId;
+    return map.set(buildImageInfo.taskId, buildImageInfo);
+  });
+  try {
+    if (!buildImageInfo.selectedProvider) {
+      throw new Error('There is no container engine available.');
     }
+    // Build the singular image
+    await window.buildImage(
+      buildImageInfo.containerBuildContextDirectory,
+      relativeContainerfilePath,
+      buildImageInfo.containerImageName,
+      buildImageInfo.containerBuildPlatform,
+      buildImageInfo.selectedProvider,
+      buildImageInfo.buildImageKey,
+      eventCollect,
+      buildImageInfo.cancellableTokenId,
+      formattedBuildArgs,
+      buildImageInfo.taskId,
+    );
+  } catch (error) {
+    eventCollect(buildImageInfo.buildImageKey, 'error', String(error));
   }
+  buildImagesInfo.update(map => {
+    buildImageInfo.cancellableTokenId = undefined;
+    buildImageInfo.buildRunning = false;
+    buildImageInfo.buildFinished = true;
+    $lastUpdatedTaskId = buildImageInfo.taskId;
+    return map.set(buildImageInfo.taskId, buildImageInfo);
+  });
+  $lastUpdatedTaskId = undefined; // in case nobody is listening
 }
 
 // Function to handle the building of container images for multiple platforms and creating a manifest
 // afterwards
 async function buildMultiplePlatformImagesAndCreateManifest(): Promise<void> {
-  buildFinished = false;
+  buildImageInfo.buildFinished = false;
+  buildImageInfo.buildImageKey = startBuild(getTerminalCallback());
+  buildImageInfo.buildRunning = true;
 
   // Collection of build IDs, this is needed for being able to create the manifest
   // as we need to know either the IDs or the names of the images that were built
-  buildIDs = [];
+  let buildIDs = [];
 
-  if (containerFilePath) {
-    if (selectedProvider) {
-      // Extract the relative path from the containerFilePath and containerBuildContextDirectory
-      const relativeContainerfilePath = containerFilePath.substring(containerBuildContextDirectory.length + 1);
+  // Extract the relative path from the containerFilePath and containerBuildContextDirectory
+  const relativeContainerfilePath = await window.pathRelative(
+    buildImageInfo.containerBuildContextDirectory,
+    buildImageInfo.containerFilePath,
+  );
 
-      // We'll iterate over each platform and build the image
-      for (const platform of platforms) {
-        // We'll be using the same terminal for all builds (getTerminalCallback)
-        // similar to how Podman CLI does it.
-        buildImageInfo = startBuild(getTerminalCallback());
+  buildImageInfo.cancellableTokenId = await window.getCancellableTokenSource();
 
-        // Store the key
-        buildImagesInfo.set(buildImageInfo);
+  // We'll be using the same terminal for all builds (getTerminalCallback)
+  // similar to how Podman CLI does it.
 
-        try {
-          cancellableTokenId = await window.getCancellableTokenSource();
+  buildImagesInfo.update(map => {
+    taskId = getNextTaskId();
+    buildImageInfo.taskId = taskId;
+    return map.set(buildImageInfo.taskId, buildImageInfo);
+  });
+  try {
+    // We'll iterate over each platform and build the image
+    for (const platform of platforms) {
+      if (!buildImageInfo.selectedProvider) {
+        throw new Error('There is no container engine available.');
+      }
+      // Store the key
+      // Build the image for the current platform
+      // NOTE: We purposely pass in '' as the container name so that the built image is
+      // <none> in the image list similar to the Podman CLI.
+      const buildOutput: BuildOutput = (await window.buildImage(
+        buildImageInfo.containerBuildContextDirectory,
+        relativeContainerfilePath,
+        undefined, // Omitting the image name for multi-platform builds, as we'll be creating a singular manifest.
+        platform,
+        buildImageInfo.selectedProvider,
+        buildImageInfo.buildImageKey,
+        eventCollect,
+        buildImageInfo.cancellableTokenId,
+        formattedBuildArgs,
+        buildImageInfo.taskId,
+      )) as BuildOutput;
 
-          // Build the image for the current platform
-          // NOTE: We purporsely pass in '' as the container name so that the built image is
-          // <none> in the image list similar to the Podman CLI.
-          const buildOutput: BuildOutput = (await window.buildImage(
-            containerBuildContextDirectory,
-            relativeContainerfilePath,
-            undefined, // Omitting the image name for multi-platform builds, as we'll be creating a singular manifest.
-            platform,
-            selectedProvider,
-            buildImageInfo.buildImageKey,
-            eventCollect,
-            cancellableTokenId,
-            formattedBuildArgs,
-          )) as BuildOutput;
+      // Extract and store the build ID as this is required for creating the manifest, only if it is available.
 
-          // Extract and store the build ID as this is required for creating the manifest, only if it is available.
-
-          if (buildOutput) {
-            const buildIdItem = buildOutput.find(o => o.aux);
-            const buildId = buildIdItem ? buildIdItem?.aux?.ID : undefined;
-            if (buildId) {
-              buildIDs.push(buildId.replace('sha256:', 'containers-storage:'));
-            }
-          }
-        } catch (error) {
-          logsTerminal.write(`Error:${error}\r`);
-        } finally {
-          cancellableTokenId = undefined;
-          buildImageInfo.buildRunning = false;
+      if (buildOutput) {
+        const buildIdItem = buildOutput.find(o => o.aux);
+        const buildId = buildIdItem ? buildIdItem?.aux?.ID : undefined;
+        if (buildId) {
+          buildIDs.push(buildId.replace('sha256:', 'containers-storage:'));
         }
       }
-
-      // Create the manifest after all builds are complete
-      // we will log to the terminal if there is an error.
-      try {
-        await window.createManifest({
-          images: buildIDs,
-          name: containerImageName!,
-        });
-      } catch (error) {
-        console.error('Error creating manifest: ', error);
-        logsTerminal.write(`Error:${error}\r`);
-      }
-
-      // Finally mark the build as finished
-      buildFinished = true;
     }
+    await window.createManifest({
+      images: buildIDs,
+      name: buildImageInfo.containerImageName!,
+    });
+  } catch (error) {
+    eventCollect(buildImageInfo.buildImageKey, 'error', `${String(error)}\r\n`);
   }
+  buildImagesInfo.update(map => {
+    buildImageInfo.cancellableTokenId = undefined;
+    buildImageInfo.buildRunning = false;
+    buildImageInfo.buildFinished = true;
+    $lastUpdatedTaskId = buildImageInfo.taskId;
+    return map.set(buildImageInfo.taskId, buildImageInfo);
+  });
+  $lastUpdatedTaskId = undefined; // in case nobody is listening
 }
 
 function cleanupBuild(): void {
-  // clear
-  if (buildImageInfo) {
-    clearBuildTask(buildImageInfo);
-    buildImageInfo = undefined;
-  }
-
-  // redirect to the image list
   handleNavigation({ page: NavigationPage.IMAGES });
 }
 
-onMount(async () => {
-  providers = get(providerInfos);
-  providerConnections = providers
-    .map(provider => provider.containerConnections)
-    .flat()
-    .filter(providerContainerConnection => providerContainerConnection.status === 'started');
-
-  const selectedProviderConnection = providerConnections.length > 0 ? providerConnections[0] : undefined;
-  selectedProvider = !selectedProvider && selectedProviderConnection ? selectedProviderConnection : selectedProvider;
-
-  // check if we have an existing build info
-  buildImageInfo = get(buildImagesInfo);
-  if (buildImageInfo) {
-    reconnectUI(buildImageInfo.buildImageKey, getTerminalCallback());
+// when subscribe callback called first time during initialization or
+// from background build the taskId is NaN
+let buildImagesInfoUnsubscriber: Unsubscriber = buildImagesInfo.subscribe(map => {
+  if ($lastUpdatedTaskId && $lastUpdatedTaskId === taskId) {
+    // change event came from loaded page
+    if (buildImageInfo.buildFinished) {
+      buildImageInfo = cloneBuildImageInfo(buildImageInfo);
+      taskId = 0;
+    }
   }
+  if (taskId && buildImageInfo.taskId === 0) {
+    // initial loading
+    const bgBuildImageInfo = map.get(taskId);
+    if (bgBuildImageInfo?.buildFinished) {
+      buildImageInfo = cloneBuildImageInfo(bgBuildImageInfo);
+      taskId = 0;
+    } else if (bgBuildImageInfo) {
+      buildImageInfo = bgBuildImageInfo;
+    }
+  }
+  $lastUpdatedTaskId = undefined;
 });
 
+let providerInfosUnsubscriber: Unsubscriber = providerInfos.subscribe(infos => {
+  providers = infos;
+});
+
+function onInit(): void {
+  if (buildImageInfo.buildImageKey) {
+    reconnectUI(buildImageInfo.buildImageKey, getTerminalCallback());
+  }
+}
+
 onDestroy(() => {
-  if (buildImageInfo) {
+  if (buildImageInfo.buildImageKey && !buildImageInfo.buildFinished) {
     disconnectUI(buildImageInfo.buildImageKey);
   }
+  buildImagesInfoUnsubscriber();
+  providerInfosUnsubscriber();
 });
 
 async function abortBuild(): Promise<void> {
-  if (cancellableTokenId) {
-    await window.cancelToken(cancellableTokenId);
-    cancellableTokenId = undefined;
+  if (buildImageInfo.cancellableTokenId) {
+    await window.cancelToken(buildImageInfo.cancellableTokenId);
+    buildImageInfo.cancellableTokenId = undefined;
   }
+  buildImageInfo.buildRunning = false;
+  buildImageInfo.buildFinished = true;
 }
 </script>
 
 <EngineFormPage
-  title="Build image from Containerfile"
-  inProgress={buildImageInfo?.buildRunning}
-  showEmptyScreen={providerConnections.length === 0}>
+  title="Build image {buildImageInfo.containerImageName} from Containerfile"
+  inProgress={buildImageInfo.buildRunning}
+  showEmptyScreen={providerConnections.length === 0 && !buildImageInfo.buildRunning}>
   {#snippet icon()}
     <i class="fas fa-cube fa-2x" aria-hidden="true"></i>
   {/snippet}
   {#snippet content()}
-  <div class="space-y-6">
-    <div hidden={buildImageInfo?.buildRunning}>
-      <label for="containerFilePath" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]"
-        >Containerfile path</label>
-      <FileInput
-        name="containerFilePath"
-        id="containerFilePath"
-        bind:value={containerFilePath}
-        placeholder="Containerfile to build"
-        options={containerFileDialogOptions}
-        class="w-full" />
-    </div>
-
-    <div hidden={buildImageInfo?.buildRunning}>
-      <label
-        for="containerBuildContextDirectory"
-        class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]">Build context directory</label>
-      <FileInput
-        name="containerBuildContextDirectory"
-        id="containerBuildContextDirectory"
-        bind:value={containerBuildContextDirectory}
-        placeholder="Directory to build in"
-        options={contextDialogOptions}
-        class="w-full" />
-    </div>
-
-    <div hidden={buildImageInfo?.buildRunning}>
-      <label for="containerImageName" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]"
-        >Image name</label>
-      <Input
-        bind:value={containerImageName}
-        name="containerImageName"
-        id="containerImageName"
-        placeholder="Image name (e.g. quay.io/namespace/my-custom-image)"
-        class="w-full"
-        required />
-    </div>
-
-    {#if providerConnections.length > 1}
-      <div hidden={buildImageInfo?.buildRunning}>
-        <label for="providerChoice" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]"
-          >Container engine</label>
-        <ContainerConnectionDropdown
-          id="providerChoice"
-          name="providerChoice"
-          bind:value={selectedProvider}
-          connections={providerConnections}/>
+    <div class="space-y-6">
+      <div hidden={buildImageInfo.buildRunning}>
+        <label for="containerFilePath" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]"
+          >Containerfile path</label>
+        <FileInput
+          name="containerFilePath"
+          id="containerFilePath"
+          bind:value={buildImageInfo.containerFilePath}
+          placeholder="Containerfile to build"
+          options={containerFileDialogOptions}
+          class="w-full" />
       </div>
-    {/if}
 
-    <div hidden={buildImageInfo?.buildRunning}>
-      <label for="inputKey" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]"
-        >Build arguments</label>
-      {#each buildArgs as buildArg, index (index)}
-        <div class="flex flex-row items-center space-x-2 mb-2">
-          <Input bind:value={buildArg.key} name="inputKey" placeholder="Key" class="grow" required />
-          <Input bind:value={buildArg.value} placeholder="Value" class="grow" required />
-          <Button
-            on:click={(): void => deleteBuildArg(index)}
-            icon={faMinusCircle}
-            disabled={buildArgs.length === 1 && buildArg.key === '' && buildArg.value === ''}
-            aria-label="Delete build argument" />
-          <Button on:click={addBuildArg} icon={faPlusCircle} title="Add build argument" />
+      <div hidden={buildImageInfo.buildRunning}>
+        <label
+          for="containerBuildContextDirectory"
+          class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]">Build context directory</label>
+        <FileInput
+          name="containerBuildContextDirectory"
+          id="containerBuildContextDirectory"
+          bind:value={buildImageInfo.containerBuildContextDirectory}
+          placeholder="Directory to build in"
+          options={contextDialogOptions}
+          class="w-full" />
+      </div>
+
+      <div hidden={buildImageInfo.buildRunning}>
+        <label for="containerImageName" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]"
+          >Image name</label>
+        <Input
+          bind:value={buildImageInfo.containerImageName}
+          name="containerImageName"
+          id="containerImageName"
+          placeholder="Image name (e.g. quay.io/namespace/my-custom-image)"
+          class="w-full" />
+      </div>
+
+      {#if providerConnections.length > 1}
+        <div hidden={buildImageInfo.buildRunning}>
+          <label for="providerChoice" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]"
+            >Container engine</label>
+          <ContainerConnectionDropdown
+            id="providerChoice"
+            name="providerChoice"
+            bind:value={buildImageInfo.selectedProvider}
+            connections={providerConnections} />
         </div>
-      {/each}
-    </div>
-
-    <div hidden={buildImageInfo?.buildRunning}>
-      <label for="containerBuildPlatform" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]"
-        >Platform</label>
-      {#if platforms.length > 1}
-        <p class="text-[var(--pd-content-text)] mb-2">Multiple platforms selected, a manifest will be created</p>
-      {/if}
-      <BuildImageFromContainerfileCards bind:platforms={containerBuildPlatform} />
-    </div>
-
-    <div class="w-full flex flex-row space-x-4">
-      {#if !buildImageInfo?.buildRunning}
-        <Button on:click={buildContainerImage} disabled={hasInvalidFields} class="w-full" icon={faCube}>
-          Build
-        </Button>
       {/if}
 
-      {#if buildFinished}
-        <Button on:click={cleanupBuild} class="w-full">Done</Button>
-      {/if}
-    </div>
+      <div hidden={buildImageInfo.buildRunning}>
+        <label for="inputKey" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]"
+          >Build arguments</label>
+        {#each buildImageInfo.buildArgs as buildArg, index (index)}
+          <div class="flex flex-row items-center space-x-2 mb-2">
+            <Input bind:value={buildArg.key} name="inputKey" placeholder="Key" class="grow" required />
+            <Input bind:value={buildArg.value} placeholder="Value" class="grow" required />
+            <Button
+              on:click={(): void => deleteBuildArg(index)}
+              icon={faMinusCircle}
+              disabled={buildImageInfo.buildArgs.length === 1 && buildArg.key === '' && buildArg.value === ''}
+              aria-label="Delete build argument" />
+            <Button on:click={addBuildArg} icon={faPlusCircle} title="Add build argument" />
+          </div>
+        {/each}
+      </div>
 
-    <RecommendedRegistry bind:imageError={buildError} imageName={buildParentImageName} />
+      <div hidden={buildImageInfo.buildRunning}>
+        <label for="containerBuildPlatform" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]"
+          >Platform</label>
+        {#if platforms.length > 1}
+          <p class="text-[var(--pd-content-text)] mb-2">Multiple platforms selected, a manifest will be created</p>
+        {/if}
+        <BuildImageFromContainerfileCards bind:platforms={buildImageInfo.containerBuildPlatform} />
+      </div>
 
-    <TerminalWindow bind:terminal={logsTerminal} />
-    <div class="w-full">
-      {#if buildImageInfo?.buildRunning}
-        <Button on:click={abortBuild} class="w-full">Cancel</Button>
-      {/if}
+      <div class="w-full flex flex-row space-x-4">
+        {#if !buildImageInfo.buildRunning}
+          <Button on:click={buildContainerImage} disabled={hasInvalidFields} class="w-full" icon={faCube}>Build</Button>
+        {/if}
+
+        {#if buildImageInfo.buildFinished}
+          <Button on:click={cleanupBuild} class="w-full">Done</Button>
+        {/if}
+      </div>
+
+      <RecommendedRegistry
+        bind:imageError={buildImageInfo.buildError}
+        imageName={buildImageInfo.buildParentImageName} />
+
+      <TerminalWindow on:init={onInit} bind:terminal={buildImageInfo.logsTerminal} />
+      <div class="w-full">
+        {#if buildImageInfo.buildRunning}
+          <Button on:click={abortBuild} class="w-full">Cancel</Button>
+        {/if}
+      </div>
     </div>
-  </div>
   {/snippet}
 </EngineFormPage>

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfileCard.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfileCard.svelte
@@ -78,7 +78,7 @@ onMount(() => {
     badges.push('Default');
   }
 
-  if (isDefault) {
+  if (checked) {
     onCard({ mode: 'add', value: value });
   }
 });

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfileCards.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfileCards.svelte
@@ -96,11 +96,27 @@ onMount(async () => {
   });
   sortedCards = DEFAULT_CARDS;
 
-  // first item should be the default
-  sortedCards[0].isDefault = true;
-  sortedCards[0].checked = true;
-
   advancedCards = ADVANCED_CARDS;
+  sortedCards[0].isDefault = true;
+  // first item should be the default if not reconnected to ongoing build
+  if (!platforms) {
+    sortedCards[0].checked = true;
+  } else {
+    let tempPlatformsArray = platforms.split(',');
+    sortedCards.forEach(card => {
+      card.checked = tempPlatformsArray.includes(card.value);
+    });
+    advancedCards.forEach(card => {
+      card.checked = tempPlatformsArray.includes(card.value);
+    });
+    // support for custom advanced platforms
+    tempPlatformsArray.forEach(platform => {
+      if (!sortedCards.some(card => card.value === platform) && !advancedCards.some(card => card.value === platform)) {
+        addCard({ value: platform });
+      }
+    });
+    showMoreOptions = advancedCards.some(card => card.checked);
+  }
 });
 
 function handleCard(card: { detail: { mode: 'add' | 'remove'; value: string } }): void {

--- a/packages/renderer/src/navigation.spec.ts
+++ b/packages/renderer/src/navigation.spec.ts
@@ -103,9 +103,9 @@ test(`Test navigationHandle for ${NavigationPage.IMAGES}`, () => {
 });
 
 test(`Test navigationHandle for ${NavigationPage.IMAGE_BUILD}`, () => {
-  handleNavigation({ page: NavigationPage.IMAGE_BUILD });
+  handleNavigation({ page: NavigationPage.IMAGE_BUILD, parameters: { taskId: 1 } });
 
-  expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/images/build');
+  expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/images/build?taskId=1');
 });
 
 test(`Test navigationHandle for ${NavigationPage.IMAGE}`, () => {

--- a/packages/renderer/src/navigation.ts
+++ b/packages/renderer/src/navigation.ts
@@ -76,7 +76,7 @@ export const handleNavigation = (request: InferredNavigationRequest<NavigationPa
       router.goto(`/images`);
       break;
     case NavigationPage.IMAGE_BUILD:
-      router.goto(`/images/build`);
+      router.goto(`/images/build?taskId=${request.parameters.taskId}`);
       break;
     case NavigationPage.IMAGE:
       router.goto(


### PR DESCRIPTION
### What does this PR do?

0. Supports cancellation and restart the build
1. Preserves build history (form field values and terminal output)
2. Restores build status when called from task manager (form field values and terminal output)
3. Removes stored status for finished builds when task is removed form task manager
4. Supports all kinds of transition to the build image page and restores build state

### Screenshot / video of UI

https://github.com/user-attachments/assets/91bfa398-8ebf-499d-92be-de352f96081f

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fix #10080

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
