### PR TITLE
chore: generate linux tgz for Arm64

### DIFF
--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -188,7 +188,7 @@ const config = {
   linux: {
     category: 'Development',
     icon: './buildResources/icon-512x512.png',
-    target: ['flatpak', 'tar.gz'],
+    target: ['flatpak', { target: 'tar.gz', arch: ['x64', 'arm64'] }],
   },
   mac: {
     artifactName: `podman-desktop${artifactNameSuffix}-\${version}-\${arch}.\${ext}`,


### PR DESCRIPTION
### What does this PR do?
Add the arm64 version for the linux tgz binary. For now they're only for x64

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

https://github.com/containers/podman-desktop-internal/issues/530

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
