### PR TITLE
refactor(ui): migrate DurationColumn to svelte5

### DIFF
--- a/packages/ui/src/lib/table/DurationColumn.svelte
+++ b/packages/ui/src/lib/table/DurationColumn.svelte
@@ -5,9 +5,14 @@ import { onDestroy, onMount } from 'svelte';
 
 import SimpleColumn from './SimpleColumn.svelte';
 
-export let object: Date | undefined;
-let duration: string = '';
-let refreshTimeouts: number[] = [];
+interface Props {
+  object?: Date;
+}
+
+let { object }: Props = $props();
+
+let duration: string = $state('');
+let refreshTimeouts: number[] = $state([]);
 
 export function computeInterval(uptimeInMs: number): number {
   const SECOND = 1000;


### PR DESCRIPTION
### What does this PR do?

Migrate `DurationColumn` to svelte5

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/11586

### How to test this PR?

- [x] existing tests ensure no regression
