### PR TITLE
refactor(ui): migrate Table component to Svelte5

### DIFF
--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -428,11 +428,10 @@ $: containersAndGroups = containerGroups.map(group =>
       kind="container"
       bind:this={table}
       bind:selectedItemsNumber={selectedItemsNumber}
-      data={containersAndGroups}
+      bind:data={containersAndGroups}
       columns={columns}
       row={row}
-      defaultSortColumn="Name"
-      on:update={(): ContainerGroupInfoUI[] => (containerGroups = [...containerGroups])}>
+      defaultSortColumn="Name">
     </Table>
 
     {#if providerConnections.length === 0}

--- a/packages/renderer/src/lib/image/ImagesList.svelte
+++ b/packages/renderer/src/lib/image/ImagesList.svelte
@@ -318,11 +318,10 @@ const row = new TableRow<ImageInfoUI>({
       kind="image"
       bind:this={table}
       bind:selectedItemsNumber={selectedItemsNumber}
-      data={images}
+      bind:data={images}
       columns={columns}
       row={row}
-      defaultSortColumn="Age"
-      on:update={(): ImageInfoUI[] => (images = images)}>
+      defaultSortColumn="Age">
     </Table>
 
     {#if providerConnections.length === 0}

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -228,11 +228,10 @@ const row = new TableRow<PodInfoUI>({ selectable: (_pod): boolean => true });
       kind="pod"
       bind:this={table}
       bind:selectedItemsNumber={selectedItemsNumber}
-      data={pods}
+      bind:data={pods}
       columns={columns}
       row={row}
-      defaultSortColumn="Name"
-      on:update={(): PodInfoUI[] => (pods = pods)}>
+      defaultSortColumn="Name">
     </Table>
 
     {#if $filtered.length === 0 && providerConnections.length === 0}

--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -214,11 +214,10 @@ const row = new TableRow<VolumeInfoUI>({
       kind="volume"
       bind:this={table}
       bind:selectedItemsNumber={selectedItemsNumber}
-      data={volumes}
+      bind:data={volumes}
       columns={columns}
       row={row}
-      defaultSortColumn="Name"
-      on:update={(): VolumeInfoUI[] => (volumes = volumes)}>
+      defaultSortColumn="Name">
     </Table>
 
     {#if providerConnections.length === 0}

--- a/packages/ui/src/lib/table/Table.svelte
+++ b/packages/ui/src/lib/table/Table.svelte
@@ -215,7 +215,7 @@ function toggleChildren(name: string | undefined): void {
             title="Toggle all"
             bind:checked={selectedAllCheckboxes}
             disabled={!row.info.selectable || data.filter(object => row.info.selectable?.(object)).length === 0}
-            indeterminate={!selectedItemsNumber && !selectedAllCheckboxes}
+            indeterminate={!!selectedItemsNumber && !selectedAllCheckboxes}
             on:click={toggleAll} />
         </div>
       {/if}

--- a/packages/ui/src/lib/table/TestTable.svelte
+++ b/packages/ui/src/lib/table/TestTable.svelte
@@ -80,8 +80,7 @@ const row = new Row<Person>({
   data={people}
   columns={columns}
   row={row}
-  defaultSortColumn="Id"
-  on:update>
+  defaultSortColumn="Id">
 </Table>
 
 <!-- Dummy component to check if the table component is not updating this object as it contains grid-table css property -->


### PR DESCRIPTION
### What does this PR do?

This changes reveal some warning such as the following
```
[svelte] binding_property_non_reactive
`bind:checked={object.selected}` (src/lib/table/Table.svelte:279:16) is binding to a non-reactive property
```

which is the consequence of the following line

https://github.com/podman-desktop/podman-desktop/blob/b2bc90453d0b43d7afd955e66d7fa9989b843a62/packages/ui/src/lib/table/Table.svelte#L279

This warning is a _false_ positive: we still have the behaviour we expect, but this is not compliant with Svelte5: it will be a following PR to fix it.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/11586

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Existing tests are covering the changes

**Manually**
- Start Podman Desktop
- Ensure the Tables are working nicely as expected