### PR TITLE
feat: download linux binary on the docs

### DIFF
--- a/website/src/pages/downloads/linux.tsx
+++ b/website/src/pages/downloads/linux.tsx
@@ -5,11 +5,12 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import TailWindThemeSelector from '@site/src/components/TailWindThemeSelector';
 import { TelemetryLink } from '@site/src/components/TelemetryLink';
 import Layout from '@theme/Layout';
+import type { Dispatch, SetStateAction } from 'react';
 import React, { useEffect, useState } from 'react';
 
 async function grabFilenameForLinux(
-  setDownloadData: React.Dispatch<
-    React.SetStateAction<{
+  setDownloadData: Dispatch<
+    SetStateAction<{
       version: string;
       flatpak: string;
       amd64: string;

--- a/website/src/pages/downloads/linux.tsx
+++ b/website/src/pages/downloads/linux.tsx
@@ -18,13 +18,13 @@ async function grabFilenameForLinux(
     }>
   >,
 ): Promise<void> {
-  const res = await fetch('https://api.github.com/repos/containers/podman-desktop/releases/latest');
-  const json = await res.json();
+  const result = await fetch('https://api.github.com/repos/containers/podman-desktop/releases/latest');
+  const jsonContent = await result.json();
   const {
     tag_name,
     name: rawName,
     assets,
-  } = json as {
+  } = jsonContent as {
     tag_name?: string;
     name: string;
     assets: Array<{ name: string; browser_download_url: string }>;
@@ -34,19 +34,19 @@ async function grabFilenameForLinux(
 
   const flatpakAssets = assets.filter(a => a.name.endsWith('.flatpak'));
   if (flatpakAssets.length !== 1) {
-    throw new Error('Impossible de trouver l’archive .flatpak');
+    throw new Error('Unable to grab .flatpak');
   }
   const flatpakLink = flatpakAssets[0];
 
   const armAssets = assets.filter(a => a.name.endsWith('-arm64.tar.gz'));
   if (armAssets.length !== 1) {
-    throw new Error('Impossible de trouver l’archive ARM64 (.tar.gz)');
+    throw new Error('Unable to grab ARM64 (.tar.gz)');
   }
   const armLink = armAssets[0];
 
   const amdAssets = assets.filter(a => a.name.endsWith('.tar.gz') && !a.name.includes('arm64'));
   if (amdAssets.length !== 1) {
-    throw new Error('Impossible de trouver l’archive AMD64 (.tar.gz)');
+    throw new Error('Unable to grab AMD64 (.tar.gz)');
   }
   const amdLink = amdAssets[0];
 

--- a/website/src/pages/downloads/linux.tsx
+++ b/website/src/pages/downloads/linux.tsx
@@ -5,39 +5,63 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import TailWindThemeSelector from '@site/src/components/TailWindThemeSelector';
 import { TelemetryLink } from '@site/src/components/TelemetryLink';
 import Layout from '@theme/Layout';
-import type { SetStateAction } from 'react';
 import React, { useEffect, useState } from 'react';
 
-async function grabfilenameforMac(
-  setDownloadData: React.Dispatch<SetStateAction<{ version: string; binary: string; flatpak: string }>>,
+async function grabFilenameForLinux(
+  setDownloadData: React.Dispatch<
+    React.SetStateAction<{
+      version: string;
+      flatpak: string;
+      amd64: string;
+      arm64: string;
+    }>
+  >,
 ): Promise<void> {
-  const result = await fetch('https://api.github.com/repos/containers/podman-desktop/releases/latest');
-  const jsonContent = await result.json();
-  const assets = jsonContent.assets;
-  const linuxAssets = assets.filter((asset: { name: string }) => (asset.name as string).endsWith('.tar.gz'));
-  if (linuxAssets.length !== 1) {
-    throw new Error('Unable to grab .tar.gz');
-  }
-  const linuxAsset = linuxAssets[0];
-
-  const flatpakAssets = assets.filter((asset: { name: string }) => (asset.name as string).endsWith('.flatpak'));
-  if (flatpakAssets.length !== 1) {
-    throw new Error('Unable to grab .flatpak');
-  }
-  const flatpakAsset = flatpakAssets[0];
-  const data = {
-    version: jsonContent.name,
-    binary: linuxAsset.browser_download_url,
-    flatpak: flatpakAsset.browser_download_url,
+  const res = await fetch('https://api.github.com/repos/containers/podman-desktop/releases/latest');
+  const json = await res.json();
+  const {
+    tag_name,
+    name: rawName,
+    assets,
+  } = json as {
+    tag_name?: string;
+    name: string;
+    assets: Array<{ name: string; browser_download_url: string }>;
   };
 
-  setDownloadData(data);
+  const version = (tag_name ?? rawName).replace(/^v/, '');
+
+  const flatpakAssets = assets.filter(a => a.name.endsWith('.flatpak'));
+  if (flatpakAssets.length !== 1) {
+    throw new Error('Impossible de trouver l’archive .flatpak');
+  }
+  const flatpakLink = flatpakAssets[0];
+
+  const armAssets = assets.filter(a => a.name.endsWith('-arm64.tar.gz'));
+  if (armAssets.length !== 1) {
+    throw new Error('Impossible de trouver l’archive ARM64 (.tar.gz)');
+  }
+  const armLink = armAssets[0];
+
+  const amdAssets = assets.filter(a => a.name.endsWith('.tar.gz') && !a.name.includes('arm64'));
+  if (amdAssets.length !== 1) {
+    throw new Error('Impossible de trouver l’archive AMD64 (.tar.gz)');
+  }
+  const amdLink = amdAssets[0];
+
+  setDownloadData({
+    version,
+    flatpak: flatpakLink.browser_download_url,
+    arm64: armLink.browser_download_url,
+    amd64: amdLink.browser_download_url,
+  });
 }
 
 export function LinuxDownloads(): JSX.Element {
   const [downloadData, setDownloadData] = useState({
     version: '',
-    binary: '',
+    arm64: '',
+    amd64: '',
     flatpak: '',
   });
 
@@ -46,7 +70,7 @@ export function LinuxDownloads(): JSX.Element {
   };
 
   useEffect(() => {
-    grabfilenameforMac(setDownloadData).catch((err: unknown) => {
+    grabFilenameForLinux(setDownloadData).catch((err: unknown) => {
       console.error(err);
     });
   }, []);
@@ -77,9 +101,17 @@ export function LinuxDownloads(): JSX.Element {
               className="underline inline-flex dark:text-white text-purple-500 hover:text-purple-200 py-2 px-6 font-semibold text-md"
               eventPath="download"
               eventTitle="download-linux"
-              to={downloadData.binary}>
+              to={downloadData.amd64}>
               <FontAwesomeIcon size="1x" icon={faDownload} className="mr-2" />
               AMD64 binary (tar.gz)
+            </TelemetryLink>
+            <TelemetryLink
+              className="underline inline-flex dark:text-white text-purple-500 hover:text-purple-200 py-2 px-6 font-semibold text-md"
+              eventPath="download"
+              eventTitle="download-linux"
+              to={downloadData.arm64}>
+              <FontAwesomeIcon size="1x" icon={faDownload} className="mr-2" />
+              ARM64 binary (tar.gz)
             </TelemetryLink>
           </div>
           <div className="flex flex-col align-middle items-center">


### PR DESCRIPTION
Hey I allow to propose this PR I discovered a bug while trying to install podman desktop :) 

### What does this PR do?

The PR fixes the bug of not being able to download the linux binary in the docs and add for ARM64 
### Screenshot / video of UI
**BEFORE**
<img width="1468" alt="SCR-20250422-octr" src="https://github.com/user-attachments/assets/4c5d5acf-931e-4a2f-b30e-ddfe4b810b69" />

<img width="1468" alt="SCR-20250422-octr" src="https://github.com/user-attachments/assets/5067ee2d-c303-449e-8bcb-4c3e8c6753e0" />


**AFTER**
<img width="1533" alt="SCR-20250422-obqi" src="https://github.com/user-attachments/assets/fba71a34-8eed-45e2-bc2e-9598346e4ebb" />


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->
<img width="420" alt="image" src="https://github.com/user-attachments/assets/a8b3954f-3eba-4e9c-a786-eeaaab7b2630" />

### What issues does this PR fix or reference?

fixes https://github.com/podman-desktop/podman-desktop/issues/12287

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
