### PR TITLE
chore(test): update running providers assertion in troubleshooting

### DIFF
--- a/tests/playwright/src/specs/troubleshooting-smoke.spec.ts
+++ b/tests/playwright/src/specs/troubleshooting-smoke.spec.ts
@@ -44,7 +44,11 @@ test.describe.serial('Troubleshooting page verification', { tag: '@smoke' }, () 
   test('Can reconnect providers', async () => {
     await troubleshootingPage.openRepairConnections();
     const connectionStatus = await troubleshootingPage.getContainerConnectionsStatus();
-    playExpect(connectionStatus).toContain('running');
+    const regexp = new RegExp(/[1-9] running/);
+    playExpect(
+      regexp.exec(connectionStatus),
+      `Expected at least 1 running provider, got: ${connectionStatus}`,
+    ).not.toBeNull();
     const status = await troubleshootingPage.reconnectProviders();
     playExpect(status).toContain('Done');
   });

--- a/tests/playwright/src/specs/troubleshooting-smoke.spec.ts
+++ b/tests/playwright/src/specs/troubleshooting-smoke.spec.ts
@@ -44,7 +44,7 @@ test.describe.serial('Troubleshooting page verification', { tag: '@smoke' }, () 
   test('Can reconnect providers', async () => {
     await troubleshootingPage.openRepairConnections();
     const connectionStatus = await troubleshootingPage.getContainerConnectionsStatus();
-    const regexp = new RegExp(/[1-9] running/);
+    const regexp = new RegExp(/[1-9]\d* running/);
     playExpect(
       regexp.exec(connectionStatus),
       `Expected at least 1 running provider, got: ${connectionStatus}`,
@@ -62,7 +62,7 @@ test.describe.serial('Troubleshooting page verification', { tag: '@smoke' }, () 
       /Delayed startup, flushing/,
       /PluginSystem: initialization done/,
     ]) {
-      await playExpect(logs).toContainText(logEntry);
+      await playExpect(logs).toContainText(logEntry, { timeout: 10_000 });
     }
   });
 


### PR DESCRIPTION
### What does this PR do?
Improves the assertion of the running providers in the troubleshooting page.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
