### PR TITLE
chore(test): skip test suite until bug is fixed

### DIFF
--- a/tests/playwright/src/specs/podman-machine-onboarding.spec.ts
+++ b/tests/playwright/src/specs/podman-machine-onboarding.spec.ts
@@ -28,7 +28,7 @@ import { ResourcesPage } from '../model/pages/resources-page';
 import type { SettingsBar } from '../model/pages/settings-bar';
 import { expect as playExpect, test } from '../utility/fixtures';
 import { createPodmanMachineFromCLI, deletePodmanMachine } from '../utility/operations';
-import { isLinux } from '../utility/platform';
+import { isLinux, isMac } from '../utility/platform';
 import { waitForPodmanMachineStartup } from '../utility/wait';
 
 const PODMAN_MACHINE_STARTUP_TIMEOUT: number = 360_000;
@@ -73,6 +73,11 @@ test.afterAll(async ({ runner }) => {
 
   await runner.close();
 });
+
+test.skip(
+  isMac,
+  'Skip this part of the suite on MacOS until issue https://github.com/podman-desktop/podman-desktop/issues/12334 is fixed',
+);
 
 test.describe
   .serial('Podman Machine verification', () => {

--- a/tests/playwright/src/specs/podman-machine-onboarding.spec.ts
+++ b/tests/playwright/src/specs/podman-machine-onboarding.spec.ts
@@ -76,7 +76,7 @@ test.afterAll(async ({ runner }) => {
 
 test.skip(
   isMac,
-  'Skip this part of the suite on MacOS until issue https://github.com/podman-desktop/podman-desktop/issues/12334 is fixed',
+  'Skip this test suite on MacOS until issue https://github.com/podman-desktop/podman-desktop/issues/12334 is fixed',
 );
 
 test.describe


### PR DESCRIPTION
### What does this PR do?
Sets one of the e2e test suites to be skipped on macOS until issue https://github.com/podman-desktop/podman-desktop/issues/12334 is fixed.

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/12334
