### PR TITLE
chore: fix website warning + not building correctly.

### DIFF
--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -180,9 +180,9 @@ function Extensibility(): JSX.Element {
                 <svg
                   fill="none"
                   stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
                   className="w-4 h-4 ml-2"
                   viewBox="0 0 24 24">
                   <path d="M5 12h14M12 5l7 7-7 7"></path>
@@ -488,9 +488,9 @@ function MainFeatures(): JSX.Element {
               <svg
                 fill="none"
                 stroke="currentColor"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
                 className="w-4 h-4 ml-2"
                 viewBox="0 0 24 24">
                 <path d="M5 12h14M12 5l7 7-7 7"></path>
@@ -576,9 +576,9 @@ function Pods(): JSX.Element {
               <svg
                 fill="none"
                 stroke="currentColor"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
                 className="w-4 h-4 ml-2"
                 viewBox="0 0 24 24">
                 <path d="M5 12h14M12 5l7 7-7 7"></path>


### PR DESCRIPTION
### What does this PR do?

Found this out of luck, but when running `pnpm run docusaurus build --dev`,
you can see a few warnings with regards to line width, stroke width,
etc.

For some reason, this is causing other artifacts to not load correctly.

There's no active bug or anything else for that matter that I can find
on the docusaurus github, but for some really odd and weird reason,
clearing these warnings makes the site suddenly build / serve correctly
when running `pnpm website:build` and serving it.

Warnings when running with `pnpm run docusaurus build --dev`:

```
> docs@0.0.0 docusaurus /Users/cdrage/syncthing/dev/electron/podman-desktop/website
> docusaurus "build" "--dev"

[INFO] Building in dev mode
[INFO] [en] Creating an optimized production build...
[info] Loaded plugin typedoc-plugin-markdown
[info] markdown generated at ./api
[WARNING] Docusaurus found blog posts without truncation markers:
- "blog/2025-04-14-release-1.18.md"
- "blog/2025-03-06-mirror-registry-configuration-blog.md"
- "blog/2025-01-07-bootc-release-1.6.0.md"
- "blog/2024-12-16-cncf-projects.md"
- "blog/2024-12-12-release-1.15.md"
- "blog/2024-11-26-ai-lab-first-app.md"
- "blog/2024-11-14-podman-desktop-cncf.md"
- "blog/2024-11-08-bootc-microshift.md"
- "blog/2024-10-29-creating-an-extension.md"
- "blog/2024-10-05-kubernetes-blog.md"
- "blog/2024-08-01-using-rhel-wsl-podman-machine.md"
- "blog/2024-03-07-release-1.8.md"
- "blog/2024-02-20-podman-desktop-wins-devies-award.md"
- "blog/2024-01-24-release-1.7.md"
- "blog/2023-12-18-release-1.6.md"
- "blog/2023-11-03-release-1.5.md"
- "blog/2023-09-18-release-1.4.md"
- "blog/2023-08-16-release-1.3.md"
- "blog/2023-07-12-release-1.2.md"

We recommend using truncation markers (`<!-- truncate -->` or `{/* truncate */}`) in blog posts to create shorter previews on blog paginated lists.
Tip: turn this security off with the `onUntruncatedBlogPosts: 'ignore'` blog plugin option.

✔ Client
  Compiled successfully in 28.57s

✔ Server

<w> [webpack.cache.PackFileCacheStrategy] Caching failed for pack: Error: Can't resolve './storybook' in '/Users/cdrage/syncthing/dev/electron/podman-desktop/website'
<w> while resolving './storybook' in /Users/cdrage/syncthing/dev/electron/podman-desktop/website as file
<w>  at resolve esm file ./storybook
<w>  at file dependencies /Users/cdrage/syncthing/dev/electron/podman-desktop/website/docusaurus.config.js
<w>  at file /Users/cdrage/syncthing/dev/electron/podman-desktop/website/docusaurus.config.js
<w>  at resolve commonjs /Users/cdrage/syncthing/dev/electron/podman-desktop/website/docusaurus.config.js
<w> [webpack.cache.PackFileCacheStrategy] Caching failed for pack: Error: Can't resolve './storybook' in '/Users/cdrage/syncthing/dev/electron/podman-desktop/website'
<w> while resolving './storybook' in /Users/cdrage/syncthing/dev/electron/podman-desktop/website as file
<w>  at resolve esm file ./storybook
<w>  at file dependencies /Users/cdrage/syncthing/dev/electron/podman-desktop/website/docusaurus.config.js
<w>  at file /Users/cdrage/syncthing/dev/electron/podman-desktop/website/docusaurus.config.js
<w>  at resolve commonjs /Users/cdrage/syncthing/dev/electron/podman-desktop/website/docusaurus.config.js
Warning: Invalid DOM property `stroke-linecap`. Did you mean `strokeLinecap`?
    at svg
    at div
    at a
    at eval (webpack-internal:///../node_modules/react-router-dom/esm/react-router-dom.js:155:23)
    at eval (webpack-internal:///../node_modules/react-router-dom/esm/react-router-dom.js:203:31)
    at Link (webpack-internal:///../node_modules/@docusaurus/core/lib/client/exports/Link.js:25:75)
    at div
    at div
    at section
    at MainFeatures
    at ErrorBoundary (webpack-internal:///../node_modules/@docusaurus/core/lib/client/exports/ErrorBoundary.js:16:269)
    at div
    at NavbarSecondaryMenuDisplayProvider (webpack-internal:///../node_modules/@docusaurus/theme-common/lib/contexts/navbarSecondaryMenu/display.js:21:318)
    at NavbarMobileSidebarProvider (webpack-internal:///../node_modules/@docusaurus/theme-common/lib/contexts/navbarMobileSidebar.js:23:414)
    at NavbarSecondaryMenuContentProvider (webpack-internal:///../node_modules/@docusaurus/theme-common/lib/contexts/navbarSecondaryMenu/content.js:16:157)
    at NavbarProvider (webpack-internal:///../node_modules/@docusaurus/theme-common/lib/utils/navbarUtils.js:22:29)
    at HtmlClassNameProvider (webpack-internal:///../node_modules/@docusaurus/theme-common/lib/utils/metadataUtils.js:29:46)
    at PluginHtmlClassNameProvider (webpack-internal:///../node_modules/@docusaurus/theme-common/lib/utils/metadataUtils.js:32:42)
    at DocsPreferredVersionContextProviderUnsafe (webpack-internal:///../node_modules/@docusaurus/plugin-content-docs/lib/client/docsPreferredVersion.js:32:382)
    at DocsPreferredVersionContextProvider (webpack-internal:///../node_modules/@docusaurus/plugin-content-docs/lib/client/docsPreferredVersion.js:35:50)
    at ScrollControllerProvider (webpack-internal:///../node_modules/@docusaurus/theme-common/lib/utils/scrollUtils.js:21:489)
    at AnnouncementBarProvider (webpack-internal:///../node_modules/@docusaurus/theme-common/lib/contexts/announcementBar.js:26:450)
    at ColorModeProvider (webpack-internal:///../node_modules/@docusaurus/theme-common/lib/contexts/colorMode.js:27:1246)
    at eval (webpack-internal:///../node_modules/@docusaurus/theme-common/lib/utils/reactUtils.js:59:9)
    at LayoutProvider (webpack-internal:///../node_modules/@docusaurus/theme-classic/lib/theme/Layout/Provider/index.js:20:651)
    at Layout (webpack-internal:///../node_modules/@docusaurus/theme-classic/lib/theme/Layout/index.js:27:33)
    at Home
    at RouteContextProvider (webpack-internal:///../node_modules/@docusaurus/core/lib/client/routeContext.js:16:60)
    at LoadableComponent (webpack-internal:///../node_modules/react-loadable/lib/index.js:138:32)
    at Route (webpack-internal:///../node_modules/react-router/esm/react-router.js:648:29)
    at Switch (webpack-internal:///../node_modules/react-router/esm/react-router.js:850:29)
    at Route (webpack-internal:///../node_modules/react-router/esm/react-router.js:648:29)
    at ClientLifecyclesDispatcher (webpack-internal:///../node_modules/@docusaurus/core/lib/client/ClientLifecyclesDispatcher.js:15:261)
    at PendingNavigation (webpack-internal:///../node_modules/@docusaurus/core/lib/client/PendingNavigation.js:17:150)
    at AppNavigation (webpack-internal:///../node_modules/@docusaurus/core/lib/client/App.js:29:252)
    at Root (webpack-internal:///../node_modules/@docusaurus/core/lib/client/theme-fallback/Root/index.js:20:16)
    at BrowserContextProvider (webpack-internal:///../node_modules/@docusaurus/core/lib/client/browserContext.js:21:127)
    at DocusaurusContextProvider (webpack-internal:///../node_modules/@docusaurus/core/lib/client/docusaurusContext.js:21:496)
    at ErrorBoundary (webpack-internal:///../node_modules/@docusaurus/core/lib/client/exports/ErrorBoundary.js:16:269)
    at App
    at BrokenLinksProvider (webpack-internal:///../node_modules/@docusaurus/core/lib/client/BrokenLinksContext.js:18:126)
    at Router (webpack-internal:///../node_modules/react-router/esm/react-router.js:267:30)
    at StaticRouter (webpack-internal:///../node_modules/react-router/esm/react-router.js:763:35)
    at r (webpack-internal:///../node_modules/react-helmet-async/lib/index.module.js:17:7350)
    at Capture (webpack-internal:///../node_modules/react-loadable/lib/index.js:290:30)
Warning: Invalid DOM property `stroke-linejoin`. Did you mean `strokeLinejoin`?
    at svg
    at div
    at a
    at eval (webpack-internal:///../node_modules/react-router-dom/esm/react-router-dom.js:155:23)
    at eval (webpack-internal:///../node_modules/react-router-dom/esm/react-router-dom.js:203:31)
    at Link (webpack-internal:///../node_modules/@docusaurus/core/lib/client/exports/Link.js:25:75)
    at div
    at div
    at section
    at MainFeatures
    at ErrorBoundary (webpack-internal:///../node_modules/@docusaurus/core/lib/client/exports/ErrorBoundary.js:16:269)
    at div
    at NavbarSecondaryMenuDisplayProvider (webpack-internal:///../node_modules/@docusaurus/theme-common/lib/contexts/navbarSecondaryMenu/display.js:21:318)
    at NavbarMobileSidebarProvider (webpack-internal:///../node_modules/@docusaurus/theme-common/lib/contexts/navbarMobileSidebar.js:23:414)
    at NavbarSecondaryMenuContentProvider (webpack-internal:///../node_modules/@docusaurus/theme-common/lib/contexts/navbarSecondaryMenu/content.js:16:157)
    at NavbarProvider (webpack-internal:///../node_modules/@docusaurus/theme-common/lib/utils/navbarUtils.js:22:29)
    at HtmlClassNameProvider (webpack-internal:///../node_modules/@docusaurus/theme-common/lib/utils/metadataUtils.js:29:46)
    at PluginHtmlClassNameProvider (webpack-internal:///../node_modules/@docusaurus/theme-common/lib/utils/metadataUtils.js:32:42)
    at DocsPreferredVersionContextProviderUnsafe (webpack-internal:///../node_modules/@docusaurus/plugin-content-docs/lib/client/docsPreferredVersion.js:32:382)
    at DocsPreferredVersionContextProvider (webpack-internal:///../node_modules/@docusaurus/plugin-content-docs/lib/client/docsPreferredVersion.js:35:50)
    at ScrollControllerProvider (webpack-internal:///../node_modules/@docusaurus/theme-common/lib/utils/scrollUtils.js:21:489)
    at AnnouncementBarProvider (webpack-internal:///../node_modules/@docusaurus/theme-common/lib/contexts/announcementBar.js:26:450)
    at ColorModeProvider (webpack-internal:///../node_modules/@docusaurus/theme-common/lib/contexts/colorMode.js:27:1246)
    at eval (webpack-internal:///../node_modules/@docusaurus/theme-common/lib/utils/reactUtils.js:59:9)
    at LayoutProvider (webpack-internal:///../node_modules/@docusaurus/theme-classic/lib/theme/Layout/Provider/index.js:20:651)
    at Layout (webpack-internal:///../node_modules/@docusaurus/theme-classic/lib/theme/Layout/index.js:27:33)
    at Home
    at RouteContextProvider (webpack-internal:///../node_modules/@docusaurus/core/lib/client/routeContext.js:16:60)
    at LoadableComponent (webpack-internal:///../node_modules/react-loadable/lib/index.js:138:32)
    at Route (webpack-internal:///../node_modules/react-router/esm/react-router.js:648:29)
    at Switch (webpack-internal:///../node_modules/react-router/esm/react-router.js:850:29)
    at Route (webpack-internal:///../node_modules/react-router/esm/react-router.js:648:29)
    at ClientLifecyclesDispatcher (webpack-internal:///../node_modules/@docusaurus/core/lib/client/ClientLifecyclesDispatcher.js:15:261)
    at PendingNavigation (webpack-internal:///../node_modules/@docusaurus/core/lib/client/PendingNavigation.js:17:150)
    at AppNavigation (webpack-internal:///../node_modules/@docusaurus/core/lib/client/App.js:29:252)
    at Root (webpack-internal:///../node_modules/@docusaurus/core/lib/client/theme-fallback/Root/index.js:20:16)
    at BrowserContextProvider (webpack-internal:///../node_modules/@docusaurus/core/lib/client/browserContext.js:21:127)
    at DocusaurusContextProvider (webpack-internal:///../node_modules/@docusaurus/core/lib/client/docusaurusContext.js:21:496)
    at ErrorBoundary (webpack-internal:///../node_modules/@docusaurus/core/lib/client/exports/ErrorBoundary.js:16:269)
    at App
    at BrokenLinksProvider (webpack-internal:///../node_modules/@docusaurus/core/lib/client/BrokenLinksContext.js:18:126)
    at Router (webpack-internal:///../node_modules/react-router/esm/react-router.js:267:30)
    at StaticRouter (webpack-internal:///../node_modules/react-router/esm/react-router.js:763:35)
    at r (webpack-internal:///../node_modules/react-helmet-async/lib/index.module.js:17:7350)
    at Capture (webpack-internal:///../node_modules/react-loadable/lib/index.js:290:30)
Warning: Invalid DOM property `stroke-width`. Did you mean `strokeWidth`?
    at svg
    at div
    at a
    at eval (webpack-internal:///../node_modules/react-router-dom/esm/react-router-dom.js:155:23)
    at eval (webpack-internal:///../node_modules/react-router-dom/esm/react-router-dom.js:203:31)
    at Link (webpack-internal:///../node_modules/@docusaurus/core/lib/client/exports/Link.js:25:75)
    at div
    at div
    at section
    at MainFeatures
    at ErrorBoundary (webpack-internal:///../node_modules/@docusaurus/core/lib/client/exports/ErrorBoundary.js:16:269)
    at div
    at NavbarSecondaryMenuDisplayProvider (webpack-internal:///../node_modules/@docusaurus/theme-common/lib/contexts/navbarSecondaryMenu/display.js:21:318)
    at NavbarMobileSidebarProvider (webpack-internal:///../node_modules/@docusaurus/theme-common/lib/contexts/navbarMobileSidebar.js:23:414)
    at NavbarSecondaryMenuContentProvider (webpack-internal:///../node_modules/@docusaurus/theme-common/lib/contexts/navbarSecondaryMenu/content.js:16:157)
    at NavbarProvider (webpack-internal:///../node_modules/@docusaurus/theme-common/lib/utils/navbarUtils.js:22:29)
    at HtmlClassNameProvider (webpack-internal:///../node_modules/@docusaurus/theme-common/lib/utils/metadataUtils.js:29:46)
    at PluginHtmlClassNameProvider (webpack-internal:///../node_modules/@docusaurus/theme-common/lib/utils/metadataUtils.js:32:42)
    at DocsPreferredVersionContextProviderUnsafe (webpack-internal:///../node_modules/@docusaurus/plugin-content-docs/lib/client/docsPreferredVersion.js:32:382)
    at DocsPreferredVersionContextProvider (webpack-internal:///../node_modules/@docusaurus/plugin-content-docs/lib/client/docsPreferredVersion.js:35:50)
    at ScrollControllerProvider (webpack-internal:///../node_modules/@docusaurus/theme-common/lib/utils/scrollUtils.js:21:489)
    at AnnouncementBarProvider (webpack-internal:///../node_modules/@docusaurus/theme-common/lib/contexts/announcementBar.js:26:450)
    at ColorModeProvider (webpack-internal:///../node_modules/@docusaurus/theme-common/lib/contexts/colorMode.js:27:1246)
    at eval (webpack-internal:///../node_modules/@docusaurus/theme-common/lib/utils/reactUtils.js:59:9)
    at LayoutProvider (webpack-internal:///../node_modules/@docusaurus/theme-classic/lib/theme/Layout/Provider/index.js:20:651)
    at Layout (webpack-internal:///../node_modules/@docusaurus/theme-classic/lib/theme/Layout/index.js:27:33)
    at Home
    at RouteContextProvider (webpack-internal:///../node_modules/@docusaurus/core/lib/client/routeContext.js:16:60)
    at LoadableComponent (webpack-internal:///../node_modules/react-loadable/lib/index.js:138:32)
    at Route (webpack-internal:///../node_modules/react-router/esm/react-router.js:648:29)
    at Switch (webpack-internal:///../node_modules/react-router/esm/react-router.js:850:29)
    at Route (webpack-internal:///../node_modules/react-router/esm/react-router.js:648:29)
    at ClientLifecyclesDispatcher (webpack-internal:///../node_modules/@docusaurus/core/lib/client/ClientLifecyclesDispatcher.js:15:261)
    at PendingNavigation (webpack-internal:///../node_modules/@docusaurus/core/lib/client/PendingNavigation.js:17:150)
    at AppNavigation (webpack-internal:///../node_modules/@docusaurus/core/lib/client/App.js:29:252)
    at Root (webpack-internal:///../node_modules/@docusaurus/core/lib/client/theme-fallback/Root/index.js:20:16)
    at BrowserContextProvider (webpack-internal:///../node_modules/@docusaurus/core/lib/client/browserContext.js:21:127)
    at DocusaurusContextProvider (webpack-internal:///../node_modules/@docusaurus/core/lib/client/docusaurusContext.js:21:496)
    at ErrorBoundary (webpack-internal:///../node_modules/@docusaurus/core/lib/client/exports/ErrorBoundary.js:16:269)
    at App
    at BrokenLinksProvider (webpack-internal:///../node_modules/@docusaurus/core/lib/client/BrokenLinksContext.js:18:126)
    at Router (webpack-internal:///../node_modules/react-router/esm/react-router.js:267:30)
    at StaticRouter (webpack-internal:///../node_modules/react-router/esm/react-router.js:763:35)
    at r (webpack-internal:///../node_modules/react-helmet-async/lib/index.module.js:17:7350)
    at Capture (webpack-internal:///../node_modules/react-loadable/lib/index.js:290:30)
```

These should now be gone.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

![Screenshot 2025-04-25 at 9 13 37 AM](https://github.com/user-attachments/assets/d402443d-3695-469b-9c8d-48693f35bff1)



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/podman-desktop/issues/12238

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

1. View netlify
2. See Download button is now in navbar

Signed-off-by: Charlie Drage <charlie@charliedrage.com>