### PR TITLE
chore: clear build and cache folders before running website build

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "typecheck:extensions:registries": "tsc --noEmit --project extensions/registries",
     "typecheck:extensions:kubectl-cli": "tsc --noEmit --project extensions/kubectl-cli",
     "typecheck": "pnpm run typecheck:main && pnpm run typecheck:preload && pnpm run typecheck:ui && pnpm run typecheck:renderer && pnpm run typecheck:preload-dd-extension && pnpm run typecheck:preload-webview && pnpm run typecheck:extensions && pnpm run typecheck:extension-api",
-    "website:build": "pnpm run storybook:build && cd website && pnpm run docusaurus build",
+    "website:build": "pnpm run storybook:build && cd website && pnpm run docusaurus clear && pnpm run docusaurus build",
     "website:prod": "pnpm run website:build && cd website/build && pnpm serve",
     "website:dev": "pnpm run storybook:build && cd website && pnpm run docusaurus start",
     "website:screenshots": "cd website-argos && pnpm run screenshot",


### PR DESCRIPTION
chore: clear build and cache folders before running website build

### What does this PR do?

There are some caching issues related to when we build.

Adding `pnpm run docusaurus clear` ensures that the cache files are
cleared before pushing the website.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A, artifacts / website should build correctly.

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Part of https://github.com/podman-desktop/podman-desktop/issues/12238

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

N/A, should see the changes propagate to website fine now.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
