### PR TITLE
chore(test): don't create machine on linux

### DIFF
--- a/tests/playwright/src/utility/operations.ts
+++ b/tests/playwright/src/utility/operations.ts
@@ -31,6 +31,7 @@ import { ResourcesPage } from '../model/pages/resources-page';
 import { SettingsBar } from '../model/pages/settings-bar';
 import { VolumeDetailsPage } from '../model/pages/volume-details-page';
 import { NavigationBar } from '../model/workbench/navigation';
+import { isLinux } from './platform';
 import { waitUntil, waitWhile } from './wait';
 
 /**
@@ -317,6 +318,8 @@ export async function ensureCliInstalled(
 
 export async function createPodmanMachineFromCLI(): Promise<void> {
   return test.step('Create Podman machine from CLI', async () => {
+    if (isLinux) return;
+
     try {
       // eslint-disable-next-line sonarjs/no-os-command-from-path
       execSync('podman machine init --rootful');


### PR DESCRIPTION
### What does this PR do?
Test framework will no longer try to create podman machine on linux

### What issues does this PR fix or reference?
