### PR TITLE
docs(windows): update uninstall instructions

### DIFF
--- a/website/docs/uninstall/index.md
+++ b/website/docs/uninstall/index.md
@@ -41,10 +41,10 @@ You can delete all pods, containers, and images by removing the Podman machine.
    ```
 1. Uninstall Podman from the Start menu, Settings, or Control Panel. For more details, see the [resource](https://support.microsoft.com/en-us/windows/uninstall-or-remove-apps-and-programs-in-windows-4b55f974-2cc6-2d2b-d092-5905080eaf98).
 1. Remove Podman files and configurations:
-   ```sh
-   rm -rf ~/.local/share/containers/podman
-   rm -rf ~/.config/containers/
-   rm -rf ~/AppData/Roaming/containers
+   ```powershell
+   rm -Recurse -Force ~/.local/share/containers/podman
+   rm -Recurse -Force ~/.config/containers/
+   rm -Recurse -Force ~/AppData/Roaming/containers
    ```
 
 </TabItem>
@@ -135,13 +135,13 @@ By default, Podman is available on Linux distributions, such as CentOS Stream, F
    </details>
 
 1. Remove the Podman Desktop configuration files:
-   ```sh
-   $ rm -rf ~/.local/share/containers/podman-desktop/
-   $ rm -rf ~/AppData/Roaming/Podman Desktop
+   ```powershell
+   $ rm -Recurse -Force ~/.local/share/containers/podman-desktop/
+   $ rm -Recurse -Force ~/AppData/Roaming/Podman Desktop
    ```
 1. Remove temporary files, caches, and blobs:
-   ```sh
-   $ rm -rf ~/AppData/Roaming/Podman Desktop
+   ```powershell
+   $ rm -Recurse -Force ~/AppData/Roaming/Podman Desktop
    ```
 
 </TabItem>


### PR DESCRIPTION
PS C:\Users\User> rm -rf ~/.local/share/containers/podman

Remove-Item: A parameter cannot be found that matches parameter name 'rf'.

### What does this PR do?

Update uninstall instructions on Windows

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
