### PR TITLE
fix(electron-updater): disable differential download

### DIFF
--- a/packages/main/src/plugin/updater.spec.ts
+++ b/packages/main/src/plugin/updater.spec.ts
@@ -31,8 +31,9 @@ import type { MessageBox } from '/@/plugin/message-box.js';
 import type { StatusBarRegistry } from '/@/plugin/statusbar/statusbar-registry.js';
 import type { Task } from '/@/plugin/tasks/tasks.js';
 import { Disposable } from '/@/plugin/types/disposable.js';
-import { Updater } from '/@/plugin/updater.js';
+import { DIFFERENTIAL_DOWNLOAD_PLATFORM_SUPPORT, Updater } from '/@/plugin/updater.js';
 import * as util from '/@/util.js';
+import { isLinux, isMac, isWindows } from '/@/util.js';
 
 import type { ApiSenderType } from './api.js';
 import type { TaskManager } from './tasks/task-manager.js';
@@ -59,6 +60,8 @@ vi.mock('electron-updater', () => ({
 
 vi.mock('/@/util.js', () => ({
   isLinux: vi.fn(),
+  isWindows: vi.fn(),
+  isMac: vi.fn(),
 }));
 
 const getStatusCodeMock = { statusCode: 200 } as IncomingMessage;
@@ -109,6 +112,15 @@ const apiSenderMock = {
   send: vi.fn(),
 } as unknown as ApiSenderType;
 
+function mockConfiguration(options: Record<string, unknown>): void {
+  vi.mocked(configurationMock.get).mockImplementation((section, defaultValue) => {
+    if (section in options) {
+      return options[section];
+    }
+    return defaultValue;
+  });
+}
+
 beforeEach(() => {
   vi.useFakeTimers();
   vi.resetAllMocks();
@@ -123,7 +135,9 @@ beforeEach(() => {
   vi.mocked(commandRegistryMock.executeCommand).mockResolvedValue(undefined);
   vi.mocked(util.isLinux).mockReturnValue(false);
 
-  vi.mocked(configurationMock.get).mockReturnValue('never');
+  mockConfiguration({
+    'update.reminder': 'never',
+  });
   vi.mocked(configurationMock.update).mockResolvedValue(undefined);
   vi.mocked(configurationRegistryMock.getConfiguration).mockReturnValue(configurationMock);
 
@@ -175,22 +189,78 @@ test('expect init to register configuration', () => {
   expect(configurationRegistryMock.registerConfigurations).toHaveBeenCalled();
 });
 
-test('expect init to disable differential download', () => {
-  // on import should be false
-  autoUpdater.disableDifferentialDownload = false;
+describe('differential download', () => {
+  type TestCase = {
+    platform: 'windows' | 'macos' | 'linux';
+    configuration: Array<DIFFERENTIAL_DOWNLOAD_PLATFORM_SUPPORT>;
+    expectDifferentialDownload: 'enable' | 'disable';
+  };
 
-  const updater = new Updater(
-    messageBoxMock,
-    configurationRegistryMock,
-    statusBarRegistryMock,
-    commandRegistryMock,
-    taskManagerMock,
-    apiSenderMock,
+  test.each<TestCase>([
+    {
+      platform: 'windows',
+      configuration: [],
+      expectDifferentialDownload: 'enable',
+    },
+    {
+      platform: 'windows',
+      configuration: [DIFFERENTIAL_DOWNLOAD_PLATFORM_SUPPORT.WINDOWS],
+      expectDifferentialDownload: 'disable',
+    },
+    {
+      platform: 'windows',
+      configuration: [DIFFERENTIAL_DOWNLOAD_PLATFORM_SUPPORT.MACOS],
+      expectDifferentialDownload: 'enable',
+    },
+    {
+      platform: 'macos',
+      configuration: [],
+      expectDifferentialDownload: 'enable',
+    },
+    {
+      platform: 'macos',
+      configuration: [DIFFERENTIAL_DOWNLOAD_PLATFORM_SUPPORT.WINDOWS],
+      expectDifferentialDownload: 'enable',
+    },
+    {
+      platform: 'macos',
+      configuration: [DIFFERENTIAL_DOWNLOAD_PLATFORM_SUPPORT.MACOS],
+      expectDifferentialDownload: 'disable',
+    },
+    {
+      platform: 'macos',
+      configuration: [DIFFERENTIAL_DOWNLOAD_PLATFORM_SUPPORT.WINDOWS, DIFFERENTIAL_DOWNLOAD_PLATFORM_SUPPORT.MACOS],
+      expectDifferentialDownload: 'disable',
+    },
+  ])(
+    'expect differential download to be $expectDifferentialDownload on $platform with config $configuration',
+    ({ platform, configuration, expectDifferentialDownload }) => {
+      // default should be false
+      autoUpdater.disableDifferentialDownload = false;
+
+      // mock platform
+      vi.mocked(isMac).mockReturnValue(platform === 'macos');
+      vi.mocked(isLinux).mockReturnValue(platform === 'linux');
+      vi.mocked(isWindows).mockReturnValue(platform === 'windows');
+
+      mockConfiguration({
+        'update.disableDifferentialDownload': configuration,
+      });
+
+      const updater = new Updater(
+        messageBoxMock,
+        configurationRegistryMock,
+        statusBarRegistryMock,
+        commandRegistryMock,
+        taskManagerMock,
+        apiSenderMock,
+      );
+      updater.init();
+
+      // Updater#init should set it to true
+      expect(autoUpdater.disableDifferentialDownload).toBe(expectDifferentialDownload === 'disable');
+    },
   );
-  updater.init();
-
-  // Updater#init should set it to true
-  expect(autoUpdater.disableDifferentialDownload).toBeTruthy();
 });
 
 test('expect update available entry to be displayed when expected', () => {
@@ -314,7 +384,9 @@ test('expect command update to be called when configuration value on startup', (
     return {} as unknown as AppUpdater;
   });
 
-  vi.mocked(configurationMock.get).mockReturnValue('startup');
+  mockConfiguration({
+    'update.reminder': 'startup',
+  });
 
   new Updater(
     messageBoxMock,
@@ -339,7 +411,9 @@ test('expect command update not to be called when configuration value on never',
     return {} as unknown as AppUpdater;
   });
 
-  vi.mocked(configurationMock.get).mockReturnValue('never');
+  mockConfiguration({
+    'update.reminder': 'never',
+  });
 
   new Updater(
     messageBoxMock,

--- a/packages/main/src/plugin/updater.spec.ts
+++ b/packages/main/src/plugin/updater.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,6 +53,7 @@ vi.mock('electron-updater', () => ({
     checkForUpdates: vi.fn(),
     on: vi.fn(),
     autoDownload: true,
+    disableDifferentialDownload: false,
   },
 }));
 
@@ -172,6 +173,24 @@ test('expect init to register configuration', () => {
     apiSenderMock,
   ).init();
   expect(configurationRegistryMock.registerConfigurations).toHaveBeenCalled();
+});
+
+test('expect init to disable differential download', () => {
+  // on import should be false
+  autoUpdater.disableDifferentialDownload = false;
+
+  const updater = new Updater(
+    messageBoxMock,
+    configurationRegistryMock,
+    statusBarRegistryMock,
+    commandRegistryMock,
+    taskManagerMock,
+    apiSenderMock,
+  );
+  updater.init();
+
+  // Updater#init should set it to true
+  expect(autoUpdater.disableDifferentialDownload).toBeTruthy();
 });
 
 test('expect update available entry to be displayed when expected', () => {

--- a/packages/main/src/plugin/updater.ts
+++ b/packages/main/src/plugin/updater.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -423,6 +423,13 @@ export class Updater {
   public init(): Disposable {
     // disable auto download
     autoUpdater.autoDownload = false;
+    /**
+     * Differential updates take **a lot** of memory
+     * and have lead to constant JavaScript heap out of memory on windows
+     * let's disable for all platform to have a consistent behaviour
+     * https://github.com/podman-desktop/podman-desktop/issues/12035
+     */
+    autoUpdater.disableDifferentialDownload = true;
 
     this.registerDefaultCommands();
 


### PR DESCRIPTION
### What does this PR do?

`electron-update` package uses differential download for the update. This is a problem because it consume a lot of memory to make a difference between the previous blockmap and the new one.

**We are pretty short in memory** today with Podman Desktop. This is not a _nice_ solution, as this may induce slight bigger download time (we download the full file instead of partial) but **this fixes the memory issue**.

Being able to download the update without crash in a longer time is better than nothing.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Should fixes the following issues
- https://github.com/podman-desktop/podman-desktop/issues/12035
- https://github.com/podman-desktop/podman-desktop/issues/10725

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

1. checkout https://github.com/podman-desktop/podman-desktop/tree/1.17.x
2. merge this PR changes in the 1.17.x branch
3. `pnpm install`
4. `pnpm run compile:current`
5. execute `dist/*-unpacked/Podman Desktop.exe`
6. assert podman desktop starts
7. assert an update is available
8. start the update workflow