### PR TITLE
fix: introduce fontId property to ProviderImages interface

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -661,8 +661,16 @@ declare module '@podman-desktop/api' {
 
   export type ProviderLinks = Link;
 
+  /**
+   * An interface to provide information about provider's images
+   * to use on Dashboard, in Resource Settings and Status Bar.
+   */
   export interface ProviderImages {
-    icon?: string | { light: string; dark: string };
+    /**
+     * fontId is a monochrome icon ID to use in Status Bar. The icon should be defined using
+     * `icons` extension point (see details here https://podman-desktop.io/docs/extensions/developing/adding-icons).
+     */
+    icon?: string | { light: string; dark: string; fontId?: string };
     logo?: string | { light: string; dark: string };
   }
 

--- a/packages/renderer/src/lib/statusbar/ProviderButton.spec.ts
+++ b/packages/renderer/src/lib/statusbar/ProviderButton.spec.ts
@@ -18,15 +18,14 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { ProviderStatus } from '@podman-desktop/api';
-import { render } from '@testing-library/svelte';
+import { render, screen } from '@testing-library/svelte';
+import { tick } from 'svelte';
 import { beforeEach, expect, test, vi } from 'vitest';
 
-import IconImage from '/@/lib/appearance/IconImage.svelte';
 import ProviderButton from '/@/lib/statusbar/ProviderButton.svelte';
 import ProviderButtonStatus from '/@/lib/statusbar/ProviderButtonStatus.svelte';
 import type { ProviderInfo } from '/@api/provider-info';
 
-vi.mock(import('/@/lib/appearance/IconImage.svelte'));
 vi.mock(import('/@/lib/statusbar/ProviderButtonStatus.svelte'));
 
 const PROVIDER_MOCK = {
@@ -44,7 +43,7 @@ beforeEach(() => {
   vi.resetAllMocks();
 });
 
-test('class props should be propagated to button', async () => {
+test('class props should be propagated to button', () => {
   const { getByRole } = render(ProviderButton, {
     provider: PROVIDER_MOCK,
     onclick: vi.fn(),
@@ -55,19 +54,37 @@ test('class props should be propagated to button', async () => {
   expect(widget).toHaveClass('potatoes');
 });
 
-test('provider with an image should render it', async () => {
+test('provider with an imageClass should render it', () => {
+  const provider = {
+    ...PROVIDER_MOCK,
+    images: {
+      icon: {
+        dark: 'image-file.png',
+        light: 'image-file.png',
+        fontId: 'provider-monochrome-icon',
+      },
+    },
+  };
+
   render(ProviderButton, {
-    provider: PROVIDER_MOCK,
+    provider,
     onclick: vi.fn(),
     class: 'potatoes',
   });
 
-  expect(IconImage).toHaveBeenCalledWith(
-    expect.anything(),
-    expect.objectContaining({
-      image: PROVIDER_MOCK.images.icon,
-    }),
-  );
+  const icon = screen.getByRole('img');
+  expect(icon.className).contains('podman-desktop-icon-provider-monochrome-icon');
+});
+
+test('provider with an image should render it', async () => {
+  render(ProviderButton, {
+    provider: PROVIDER_MOCK,
+    onclick: vi.fn(),
+  });
+  await tick();
+  const icon = screen.getByAltText(PROVIDER_MOCK.name);
+  expect(icon).toBeVisible();
+  expect(icon).toHaveAttribute('src', PROVIDER_MOCK.images.icon);
 });
 
 test('left slot should be rendered if defined', async () => {

--- a/packages/renderer/src/lib/statusbar/ProviderButton.svelte
+++ b/packages/renderer/src/lib/statusbar/ProviderButton.svelte
@@ -32,6 +32,8 @@ let providerStatus = $derived.by(() => {
     return 'unknown';
   }
 });
+
+let classes = $derived(`max-h-[15px] grayscale ${providerStatus === 'stopped' ? 'brightness-50' : ''}`);
 </script>
 
 <button
@@ -41,8 +43,14 @@ let providerStatus = $derived.by(() => {
   {@render left?.()}
   {#if provider.images.icon}
     <div class="relative flex h-full items-center">
-      <IconImage image={provider.images.icon} class="max-h-[15px] grayscale {providerStatus === 'stopped' ? 'brightness-50' : ''}" alt={provider.name}></IconImage>
-      <ProviderButtonStatus status={providerStatus} />
+    {#if typeof provider.images.icon !== 'string' && provider.images.icon.fontId}
+      <IconImage class={classes} alt={provider.name}>
+        <span role="img" class="podman-desktop-icon-{provider.images.icon.fontId}"></span>
+      </IconImage>
+    {:else if provider.images.icon}
+      <IconImage image={provider.images.icon} class={classes} alt={provider.name}></IconImage>
+    {/if}
+    <ProviderButtonStatus status={providerStatus} />
     </div>
   {/if}
   {#if provider.name}


### PR DESCRIPTION
### What does this PR do?

fix: introduce fontId property to ProviderImages interface
`iconClass` property references the icon defined
by extension in package.json using `icons` extension point.

```
...
    "icons": {
      "iconId": {
        "description": "Extension defined icon",
        "default": {
          "fontPath": "icon-file.woff2",
          "fontCharacter": "\\e900"
        }
      }
    }
...
```

### Screenshot / video of UI

Before fix

![image](https://github.com/user-attachments/assets/05b30daa-fb5f-406b-81e4-b9fcd29e3e12)

After fix

![image](https://github.com/user-attachments/assets/5a404a37-503e-44cf-8797-b29cb0083038)

See PR for sandbox extension here https://github.com/redhat-developer/podman-desktop-sandbox-ext/pull/511.

### What issues does this PR fix or reference?

Fix #12190.

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
