### PR TITLE
fix(electron-v36): gtk-version on linux

### DIFF
--- a/packages/main/src/main.spec.ts
+++ b/packages/main/src/main.spec.ts
@@ -35,6 +35,9 @@ const ELECTRON_APP_MOCK: ElectronApp = {
   setAppUserModelId: vi.fn(),
   quit: vi.fn(),
   on: vi.fn(),
+  commandLine: {
+    appendSwitch: vi.fn(),
+  },
 } as unknown as ElectronApp;
 
 let PROCESS_EXIT_ORIGINAL: typeof process.exit;
@@ -87,6 +90,26 @@ test('on windows setAppUserModelId should be called', async () => {
   code.main([]);
 
   expect(ELECTRON_APP_MOCK.setAppUserModelId).toHaveBeenCalledWith(ELECTRON_APP_MOCK.name);
+});
+
+describe('gtk-version', () => {
+  test('on linux gtk-version should be set to 3', () => {
+    vi.mocked(isLinux).mockReturnValue(true);
+
+    const code = new Main(ELECTRON_APP_MOCK);
+    code.main([]);
+
+    expect(ELECTRON_APP_MOCK.commandLine.appendSwitch).toHaveBeenCalledWith('gtk-version', '3');
+  });
+
+  test('non-linux platform should not define any gtk-version flag', async () => {
+    vi.mocked(isLinux).mockReturnValue(false);
+
+    const code = new Main(ELECTRON_APP_MOCK);
+    code.main([]);
+
+    expect(ELECTRON_APP_MOCK.commandLine.appendSwitch).not.toHaveBeenCalledWith('gtk-version', expect.anything());
+  });
 });
 
 // Utility type definition for {@link ElectronApp.on} and {@link WebContents.on}

--- a/packages/main/src/main.ts
+++ b/packages/main/src/main.ts
@@ -18,7 +18,7 @@
 import type { App as ElectronApp, BrowserWindow } from 'electron';
 
 import { SecurityRestrictions } from '/@/security-restrictions.js';
-import { isMac, isWindows } from '/@/util.js';
+import { isLinux, isMac, isWindows } from '/@/util.js';
 
 import { Deferred } from './plugin/util/deferred.js';
 import { ProtocolLauncher } from './protocol-launcher.js';
@@ -85,6 +85,16 @@ export class Main {
      */
     if (isWindows()) {
       this.app.setAppUserModelId(this.app.name);
+    }
+
+    /**
+     * Since electron v36
+     * references
+     * - https://github.com/electron/electron/issues/46538
+     * - https://chromium-review.googlesource.com/c/chromium/src/+/6310469
+     */
+    if (isLinux()) {
+      this.app.commandLine.appendSwitch('gtk-version', '3');
     }
 
     /**


### PR DESCRIPTION
### What does this PR do?

Since we upgrade to electron v36 there is an issue on Fedora 42 and gnome 48. (See related issue for details).

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/12359

### How to test this PR?

Need to be tested manually
