### PR TITLE
fix: updated podman image path argument

### DIFF
--- a/extensions/podman/packages/extension/package.json
+++ b/extensions/podman/packages/extension/package.json
@@ -147,7 +147,7 @@
           "description": "Disk size",
           "when": "podman.podmanMachineDiskSupported && !podman.isCreateWSLOptionSelected"
         },
-        "podman.factory.machine.image-path": {
+        "podman.factory.machine.image": {
           "type": "string",
           "format": "file",
           "scope": "ContainerProviderConnectionFactory",

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -372,6 +372,7 @@ describe.each([
   });
 
   test.each([
+    { version: '6.3.2', image: 'image' },
     { version: '5.0.0', image: 'image' },
     { version: '4.5.0', image: 'image-path' },
   ])(`verify create command called with correct values for %s`, async ({ version, image }) => {
@@ -391,7 +392,7 @@ describe.each([
     );
     expect(vi.mocked(extensionApi.process.exec)).toBeCalledWith(
       podmanCli.getPodmanCli(),
-      ['machine', 'init', '--cpus', '2', '--memory', '1000', '--disk-size', '232', `--${image}`, 'path', '--rootful'],
+      expect.arrayContaining([`--${image}`, 'path']),
       {
         logger: undefined,
         token: undefined,
@@ -413,6 +414,7 @@ describe.each([
   });
 
   test.each([
+    { version: '6.1.0', image: 'image' },
     { version: '5.0.0', image: 'image' },
     { version: '4.5.0', image: 'image-path' },
   ])('verify create command called with correct image values with image URL %s', async ({ version, image }) => {
@@ -432,19 +434,7 @@ describe.each([
     );
     expect(vi.mocked(extensionApi.process.exec)).toBeCalledWith(
       podmanCli.getPodmanCli(),
-      [
-        'machine',
-        'init',
-        '--cpus',
-        '2',
-        '--memory',
-        '1000',
-        '--disk-size',
-        '232',
-        `--${image}`,
-        'https://host/file',
-        '--rootful',
-      ],
+      expect.arrayContaining([`--${image}`, 'https://host/file']),
       {
         logger: undefined,
         token: undefined,
@@ -466,6 +456,7 @@ describe.each([
   });
 
   test.each([
+    { version: '6.3.2', image: 'image' },
     { version: '5.0.0', image: 'image' },
     { version: '4.5.0', image: 'image-path' },
   ])('verify create command called with correct image values with registry %s', async ({ version, image }) => {
@@ -485,19 +476,7 @@ describe.each([
     );
     expect(vi.mocked(extensionApi.process.exec)).toBeCalledWith(
       podmanCli.getPodmanCli(),
-      [
-        'machine',
-        'init',
-        '--cpus',
-        '2',
-        '--memory',
-        '1000',
-        '--disk-size',
-        '232',
-        `--${image}`,
-        'docker://registry/repo/image:version',
-        '--rootful',
-      ],
+      expect.arrayContaining([`--${image}`, 'docker://registry/repo/image:version']),
       {
         logger: undefined,
         token: undefined,
@@ -519,6 +498,7 @@ describe.each([
   });
 
   test.each([
+    { version: '6.3.2', image: 'image' },
     { version: '5.0.0', image: 'image' },
     { version: '4.5.0', image: 'image-path' },
   ])('verify create command called with correct values with user mode networking %s', async ({ version, image }) => {
@@ -537,27 +517,18 @@ describe.each([
       },
       podmanConfiguration,
     );
-    const parameters = [
-      'machine',
-      'init',
-      '--cpus',
-      '2',
-      '--memory',
-      '1000',
-      '--disk-size',
-      '232',
-      `--${image}`,
-      'path',
-      '--rootful',
-      '--user-mode-networking',
-    ];
-    expect(vi.mocked(extensionApi.process.exec)).toBeCalledWith(podmanCli.getPodmanCli(), parameters, {
-      logger: undefined,
-      env: {
-        CONTAINERS_MACHINE_PROVIDER: provider,
+
+    expect(vi.mocked(extensionApi.process.exec)).toBeCalledWith(
+      podmanCli.getPodmanCli(),
+      expect.arrayContaining([`--${image}`, 'path']),
+      {
+        logger: undefined,
+        env: {
+          CONTAINERS_MACHINE_PROVIDER: provider,
+        },
+        token: undefined,
       },
-      token: undefined,
-    });
+    );
     expect(console.error).not.toBeCalled();
 
     // wait a call on telemetryLogger.logUsage
@@ -572,6 +543,7 @@ describe.each([
   });
 
   test.each([
+    { version: '6.3.2', image: 'image' },
     { version: '5.0.0', image: 'image' },
     { version: '4.5.0', image: 'image-path' },
   ])(
@@ -593,27 +565,18 @@ describe.each([
         },
         podmanConfiguration,
       );
-      const parameters = [
-        'machine',
-        'init',
-        '--cpus',
-        '2',
-        '--memory',
-        '1000',
-        '--disk-size',
-        '232',
-        `--${image}`,
-        'path',
-        '--rootful',
-        '--now',
-      ];
-      expect(vi.mocked(extensionApi.process.exec)).toBeCalledWith(podmanCli.getPodmanCli(), parameters, {
-        logger: undefined,
-        env: {
-          CONTAINERS_MACHINE_PROVIDER: provider,
+
+      expect(vi.mocked(extensionApi.process.exec)).toBeCalledWith(
+        podmanCli.getPodmanCli(),
+        expect.arrayContaining([`--${image}`, 'path']),
+        {
+          logger: undefined,
+          env: {
+            CONTAINERS_MACHINE_PROVIDER: provider,
+          },
+          token: undefined,
         },
-        token: undefined,
-      });
+      );
       expect(console.error).not.toBeCalled();
     },
   );
@@ -734,7 +697,7 @@ describe.each([
         '1000',
         '--disk-size',
         '232',
-        `--image`,
+        '--image',
         'path',
         '--playbook',
         fakePlaybookPath,

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -1845,10 +1845,10 @@ export async function start(
 export async function connectionAuditor(items: extensionApi.AuditRequestItems): Promise<extensionApi.AuditResult> {
   const records: extensionApi.AuditRecord[] = [];
 
-  if (items['podman.factory.machine.image-uri'] && items['podman.factory.machine.image-path']) {
+  if (items['podman.factory.machine.image-uri'] && items['podman.factory.machine.image']) {
     records.push({
       type: 'error',
-      record: `'Image Path' and 'Image URI' fields are both filled. Please fill only one or leave both fields empty.`,
+      record: `'Image' and 'Image URI' fields are both filled. Please fill only one or leave both fields empty.`,
     });
   }
 
@@ -2203,17 +2203,29 @@ export async function createMachine(
     telemetryRecords.diskSize = params['podman.factory.machine.diskSize'];
   }
 
-  // image-path
-  if (params['podman.factory.machine.image-path'] && typeof params['podman.factory.machine.image-path'] === 'string') {
-    parameters.push('--image-path');
-    parameters.push(params['podman.factory.machine.image-path']);
+  const installedPodman = await getPodmanInstallation();
+  const version = installedPodman?.version;
+  const isPodmanV5OrLater = version?.startsWith('5.') ?? false;
+
+  // image
+  if (params['podman.factory.machine.image'] && typeof params['podman.factory.machine.image'] === 'string') {
+    if (isPodmanV5OrLater) {
+      parameters.push('--image');
+    } else {
+      parameters.push('--image-path');
+    }
+    parameters.push(params['podman.factory.machine.image']);
     telemetryRecords.imagePath = 'custom';
   } else if (
     params['podman.factory.machine.image-uri'] &&
     typeof params['podman.factory.machine.image-uri'] === 'string'
   ) {
     const imageUri = params['podman.factory.machine.image-uri'].trim();
-    parameters.push('--image-path');
+    if (isPodmanV5OrLater) {
+      parameters.push('--image');
+    } else {
+      parameters.push('--image-path');
+    }
     if (imageUri.startsWith('https://') || imageUri.startsWith('http://')) {
       parameters.push(imageUri);
       telemetryRecords.imagePath = 'custom-url';
@@ -2225,19 +2237,15 @@ export async function createMachine(
     // check if we have an embedded asset for the image path for macOS or Windows
     const assetImagePath = path.resolve(getAssetsFolder(), `podman-image-${process.arch}.zst`);
 
-    const podmanInstallation = await getPodmanInstallation();
-
     // Use embedded image only for Podman 5 and onwards
-    if (fs.existsSync(assetImagePath) && podmanInstallation?.version.startsWith('5.')) {
-      parameters.push('--image-path');
+    if (fs.existsSync(assetImagePath) && isPodmanV5OrLater) {
+      parameters.push('--image');
       parameters.push(assetImagePath);
       telemetryRecords.imagePath = 'embedded';
     }
   }
   telemetryRecords.imagePath ??= 'default';
 
-  const installedPodman = await getPodmanInstallation();
-  const version = installedPodman?.version;
   if (params['podman.factory.machine.rootful'] === undefined) {
     // should be rootful mode if version supports this mode and only if rootful is not provided (false or true)
     if (version) {

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -2055,6 +2055,10 @@ export async function isHyperVEnabled(): Promise<boolean> {
   return hyperVCheckResult.successful;
 }
 
+export function isPodman5OrLater(podmanVersion: string): boolean {
+  return compareVersions(podmanVersion, '5.0.0') >= 0;
+}
+
 export function sendTelemetryRecords(
   eventName: string,
   telemetryRecords: Record<string, unknown>,
@@ -2203,10 +2207,10 @@ export async function createMachine(
     telemetryRecords.diskSize = params['podman.factory.machine.diskSize'];
   }
 
-  const installedPodman = await getPodmanInstallation();
-  const version = installedPodman?.version;
-  const isPodmanV5OrLater = version?.startsWith('5.') ?? false;
-
+  const podmanInstallation = await getPodmanInstallation();
+  const version = podmanInstallation?.version;
+  // check for podman major version
+  const isPodmanV5OrLater = version ? isPodman5OrLater(version) : false;
   // image
   if (params['podman.factory.machine.image'] && typeof params['podman.factory.machine.image'] === 'string') {
     if (isPodmanV5OrLater) {


### PR DESCRIPTION
### What does this PR do?
Updates podman image argument for podman v5 (if v5 `image-path` => `image`)

### Screenshot / video of UI

### What issues does this PR fix or reference?
Closes #7273 

### How to test this PR?
When creating podman machine (Mac/ Windows) using PD, specify the image.
Assert that you don't see warning message about deprecated image path

- [x] Tests are covering the bug fix or the new feature
