### PR TITLE
chore: indicate failure for error notification

### DIFF
--- a/packages/api/src/taskInfo.ts
+++ b/packages/api/src/taskInfo.ts
@@ -22,7 +22,7 @@ export type TaskStatus = (typeof TASK_STATUSES)[number];
 
 export type NotificationTaskInfo = Omit<TaskInfo, 'progress' | 'error'> & {
   state: 'completed';
-  status: 'success';
+  status: 'success' | 'failure';
   body: string;
   markdownActions?: string;
 };

--- a/packages/main/src/plugin/tasks/notification-registry.spec.ts
+++ b/packages/main/src/plugin/tasks/notification-registry.spec.ts
@@ -70,6 +70,7 @@ test('expect notification added to the queue', async () => {
   expect(createNotificationtaskMock).toBeCalledWith({
     title: 'title',
     body: 'description',
+    type: 'info',
   });
 });
 

--- a/packages/main/src/plugin/tasks/notification-registry.ts
+++ b/packages/main/src/plugin/tasks/notification-registry.ts
@@ -60,6 +60,7 @@ export class NotificationRegistry {
       title: notification.title,
       body: notification.body,
       markdownActions: notification.markdownActions,
+      type: notification.type,
     });
     // we show the notification
     const electronNotification = this.showNotification({

--- a/packages/main/src/plugin/tasks/task-manager.spec.ts
+++ b/packages/main/src/plugin/tasks/task-manager.spec.ts
@@ -194,6 +194,30 @@ test('create notification task with body', async () => {
       name: task.name,
       body: task.body,
       markdownActions: task.markdownActions,
+      status: 'success',
+    }),
+  );
+});
+
+test('create error notification task', async () => {
+  const taskManager = new TaskManager(apiSender, statusBarRegistry, commandRegistry, configurationRegistry);
+  const task = taskManager.createNotificationTask({
+    title: 'title',
+    body: 'body',
+    type: 'error',
+  });
+  expect(task.id).equal('notification-1');
+  expect(task.name).equal('title');
+  expect(task.body).equal('body');
+  expect(task.markdownActions).toBeUndefined();
+  expect(apiSenderSendMock).toBeCalledWith(
+    'task-created',
+    expect.objectContaining({
+      id: task.id,
+      name: task.name,
+      body: task.body,
+      markdownActions: task.markdownActions,
+      status: 'failure',
     }),
   );
 });

--- a/packages/main/src/plugin/tasks/task-manager.ts
+++ b/packages/main/src/plugin/tasks/task-manager.ts
@@ -190,7 +190,7 @@ export class TaskManager {
         name: task.name,
         started: task.started,
         action: task.action?.name,
-        status: 'success',
+        status: task.type === 'error' ? 'failure' : 'success',
         markdownActions: task.markdownActions,
         body: task.body ?? '',
         state: 'completed',

--- a/packages/renderer/src/lib/task-manager/table/TaskManagerTableProgressColumnCompleted.spec.ts
+++ b/packages/renderer/src/lib/task-manager/table/TaskManagerTableProgressColumnCompleted.spec.ts
@@ -50,6 +50,15 @@ const failureSuccessTask: TaskInfoUI = {
   action: 'dummy',
   cancellable: false,
 } as unknown as TaskInfoUI;
+
+const failureSuccessTaskNoError: TaskInfoUI = {
+  id: '1',
+  name: 'Completed Task 1',
+  state: 'completed',
+  status: 'failure',
+  action: 'dummy',
+  cancellable: false,
+} as unknown as TaskInfoUI;
 test('Expect display success for completed task with success', async () => {
   render(TaskManagerTableProgressColumnCompleted, { task: completedSuccessTask });
 
@@ -72,7 +81,7 @@ test('Expect display success for completed task with canceled', async () => {
   expect(canceledStatus).toBeInTheDocument();
 });
 
-test('Expect display error for completed task with failure', async () => {
+test('Expect display error for completed task with failure if error exists', async () => {
   render(TaskManagerTableProgressColumnCompleted, { task: failureSuccessTask });
 
   const completedStatus = screen.getByRole('status', { name: 'completed status for task Completed Task 1' });
@@ -85,4 +94,18 @@ test('Expect display error for completed task with failure', async () => {
   // expect to see the error message
   const error = screen.getByText('(this is a custom error)');
   expect(error).toBeInTheDocument();
+});
+
+test('Expect no error for completed task with failure an no error', async () => {
+  render(TaskManagerTableProgressColumnCompleted, { task: failureSuccessTaskNoError });
+
+  const completedStatus = screen.getByRole('status', { name: 'completed status for task Completed Task 1' });
+  expect(completedStatus).toBeInTheDocument();
+
+  // expect to see the failure status
+  const failureStatus = screen.getByText('failure');
+  expect(failureStatus).toBeInTheDocument();
+
+  // no error child
+  expect(completedStatus.children.length).toBe(2);
 });

--- a/packages/renderer/src/lib/task-manager/table/TaskManagerTableProgressColumnCompleted.svelte
+++ b/packages/renderer/src/lib/task-manager/table/TaskManagerTableProgressColumnCompleted.svelte
@@ -42,7 +42,7 @@ const { icon, iconColor } = $derived.by(() => {
   </div>
   <div class="ml-1 text-[var(--pd-table-body-text)]">{task.status}</div>
 
-  {#if task.status === 'failure'}
+  {#if task.status === 'failure' && task.error}
     <div class="cursor-default ml-1 text-[var(--pd-state-error)] overflow-hidden text-ellipsis" title={task.error}>
       ({task.error})
     </div>


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
An error notification is now shown as a failure in the task manager

### Screenshot / video of UI
![Screenshot from 2025-05-05 13-26-54](https://github.com/user-attachments/assets/e034ce82-23b6-4bbb-a06c-35aab3f63ee5)

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Fixes https://github.com/podman-desktop/podman-desktop/issues/11900

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
1. Create an error notification (can do it inside the activate function of an extension like Kind)
```
extensionApi.window.showNotification({
      title: `Compatibility mode error`,
      body: `Foobar.`, 
      type: 'error',
      highlight: true,
    })
```
2. Assert that a failure is shown in the task manager for that notification

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
