### PR TITLE
chore(test): wait for extension to be deleted

### DIFF
--- a/tests/playwright/src/model/pages/extension-details-page.ts
+++ b/tests/playwright/src/model/pages/extension-details-page.ts
@@ -77,7 +77,10 @@ export class ExtensionDetailsPage extends BasePage {
   async removeExtension(): Promise<ExtensionsPage> {
     return test.step(`Remove extension: ${this.extensionName}`, async () => {
       await this.disableExtension();
+
+      await playExpect(this.removeExtensionButton).toBeVisible();
       await this.removeExtensionButton.click();
+      await playExpect(this.removeExtensionButton).not.toBeVisible({ timeout: 30_000 });
       return new ExtensionsPage(this.page);
     });
   }


### PR DESCRIPTION
### What does this PR do?
Waits for webelement to disappear when deleting extension.

### What issues does this PR fix or reference?

