### PR TITLE
chore(e2e): fix skip on kind tests

### DIFF
--- a/tests/playwright/src/specs/deploy-to-kubernetes.spec.ts
+++ b/tests/playwright/src/specs/deploy-to-kubernetes.spec.ts
@@ -41,7 +41,7 @@ const CONTAINER_START_PARAMS: ContainerInteractiveParams = {
 const skipKindInstallation = process.env.SKIP_KIND_INSTALL === 'true';
 const providerTypeGHA = process.env.KIND_PROVIDER_GHA ?? '';
 
-test.skip(!canRunKindTests, `This test can't run on a windows rootless machine`);
+test.skip(!canRunKindTests(), `This test can't run on a windows rootless machine`);
 
 test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
   test.setTimeout(350_000);

--- a/tests/playwright/src/specs/kind.spec.ts
+++ b/tests/playwright/src/specs/kind.spec.ts
@@ -61,7 +61,7 @@ let kindResourceCard: ResourceConnectionCardPage;
 const skipKindInstallation = process.env.SKIP_KIND_INSTALL === 'true';
 const providerTypeGHA = process.env.KIND_PROVIDER_GHA ?? '';
 
-test.skip(!canRunKindTests, `This test can't run on a windows rootless machine`);
+test.skip(!canRunKindTests(), `This test can't run on a windows rootless machine`);
 
 test.beforeAll(async ({ runner, page, welcomePage }) => {
   runner.setVideoAndTraceName('kind-e2e');

--- a/tests/playwright/src/specs/kubernetes-deployments.spec.ts
+++ b/tests/playwright/src/specs/kubernetes-deployments.spec.ts
@@ -55,7 +55,7 @@ const DEPLOYMENT_YAML_PATH = path.resolve(__dirname, '..', '..', 'resources', 'k
 const skipKindInstallation = process.env.SKIP_KIND_INSTALL === 'true';
 const providerTypeGHA = process.env.KIND_PROVIDER_GHA ?? '';
 
-test.skip(!canRunKindTests, `This test can't run on a windows rootless machine`);
+test.skip(!canRunKindTests(), `This test can't run on a windows rootless machine`);
 
 test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
   test.setTimeout(350_000);

--- a/tests/playwright/src/specs/kubernetes-port-forwarding.spec.ts
+++ b/tests/playwright/src/specs/kubernetes-port-forwarding.spec.ts
@@ -46,7 +46,7 @@ const localPort: number = 50000;
 const forwardAddress: string = `http://localhost:${localPort}/`;
 const responseMessage: string = 'Welcome to nginx!';
 
-test.skip(!canRunKindTests, `This test can't run on a windows rootless machine`);
+test.skip(!canRunKindTests(), `This test can't run on a windows rootless machine`);
 
 test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
   test.setTimeout(200_000);

--- a/tests/playwright/src/specs/kubernetes.spec.ts
+++ b/tests/playwright/src/specs/kubernetes.spec.ts
@@ -72,7 +72,7 @@ const CRONJOB_YAML_PATH = path.resolve(
 const skipKindInstallation = process.env.SKIP_KIND_INSTALL === 'true';
 const providerTypeGHA = process.env.KIND_PROVIDER_GHA ?? '';
 
-test.skip(!canRunKindTests, `This test can't run on a windows rootless machine`);
+test.skip(!canRunKindTests(), `This test can't run on a windows rootless machine`);
 
 test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
   test.setTimeout(350_000);


### PR DESCRIPTION
### What does this PR do?
Fixes https://github.com/podman-desktop/e2e/issues/351

### What issues does this PR fix or reference?
https://github.com/podman-desktop/e2e/issues/351
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
Run `pnpm run test:e2e:k8s` on a windows machine. Kubernetes tests should be skipped
<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

