### PR TITLE
chore(npm-registry): configure provenance for published packages

### DIFF
--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -175,6 +175,8 @@ jobs:
     needs: [tag, release]
     name: Publish
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
@@ -197,29 +199,29 @@ jobs:
         run: |
           echo "Using version ${{ needs.tag.outputs.desktopVersion }}"
           sed -i  "s#version\":\ \"\(.*\)\",#version\":\ \"${{ needs.tag.outputs.desktopVersion }}\",#g" packages/extension-api/package.json
-          cd packages/extension-api && pnpm publish --tag next --no-git-checks --access public
+          cd packages/extension-api && pnpm publish --provenance --tag next --no-git-checks --access public
 
       - name: Publish Webview API to npmjs
         run: |
           echo "Using version ${{ needs.tag.outputs.desktopVersion }}"
           sed -i  "s#version\":\ \"\(.*\)\",#version\":\ \"${{ needs.tag.outputs.desktopVersion }}\",#g" packages/webview-api/package.json
-          cd packages/webview-api && pnpm publish --tag next --no-git-checks --access public
+          cd packages/webview-api && pnpm publish --provenance --tag next --no-git-checks --access public
 
       - name: Publish ui/svelte to npmjs
         run: |
           echo "Using version ${{ needs.tag.outputs.desktopVersion }}"
           sed -i  "s#version\":\ \"\(.*\)\",#version\":\ \"${{ needs.tag.outputs.desktopVersion }}\",#g" packages/ui/package.json
-          cd packages/ui && pnpm build && pnpm publish --tag next --no-git-checks --access public
+          cd packages/ui && pnpm build && pnpm publish --provenance --tag next --no-git-checks --access public
 
       - name: Publish tests-playwright to npmjs
         run: |
           echo "Using version ${{ needs.tag.outputs.desktopVersion }}"
           sed -i  "s#version\":\ \"\(.*\)\",#version\":\ \"${{ needs.tag.outputs.desktopVersion }}\",#g" tests/playwright/package.json
-          cd tests/playwright && pnpm build && pnpm publish --tag next --no-git-checks --access public
+          cd tests/playwright && pnpm build && pnpm publish --provenance --tag next --no-git-checks --access public
 
       - name: Publish Podman Extension API to npmjs
         run: |
           echo "Using version ${{ needs.tag.outputs.desktopVersion }}"
           sed -i  "s#version\":\ \"\(.*\)\",#version\":\ \"${{ needs.tag.outputs.desktopVersion }}\",#g" extensions/podman/packages/api/package.json
           cd extensions/podman/packages/api
-          pnpm publish --tag next --no-git-checks --access public
+          pnpm publish --provenance --tag next --no-git-checks --access public

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -216,6 +216,8 @@ jobs:
     needs: [tag, release]
     name: Publish
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
@@ -238,32 +240,32 @@ jobs:
         run: |
           echo "Using version ${{ needs.tag.outputs.desktopVersion }}"
           sed -i  "s#version\":\ \"\(.*\)\",#version\":\ \"${{ needs.tag.outputs.desktopVersion }}\",#g" packages/extension-api/package.json
-          cd packages/extension-api && pnpm publish --tag latest --no-git-checks --access public
+          cd packages/extension-api && pnpm publish --provenance --tag latest --no-git-checks --access public
 
       - name: Publish Webview API to npmjs
         run: |
           echo "Using version ${{ needs.tag.outputs.desktopVersion }}"
           sed -i  "s#version\":\ \"\(.*\)\",#version\":\ \"${{ needs.tag.outputs.desktopVersion }}\",#g" packages/webview-api/package.json
-          cd packages/webview-api && pnpm publish --tag latest --no-git-checks --access public
+          cd packages/webview-api && pnpm publish --provenance --tag latest --no-git-checks --access public
 
       - name: Publish ui/svelte to npmjs
         run: |
           echo "Using version ${{ needs.tag.outputs.desktopVersion }}"
           sed -i  "s#version\":\ \"\(.*\)\",#version\":\ \"${{ needs.tag.outputs.desktopVersion }}\",#g" packages/ui/package.json
-          cd packages/ui && pnpm build && pnpm publish --tag latest --no-git-checks --access public
+          cd packages/ui && pnpm build && pnpm publish --provenance --tag latest --no-git-checks --access public
 
       - name: Publish tests-playwright to npmjs
         run: |
           echo "Using version ${{ needs.tag.outputs.desktopVersion }}"
           sed -i  "s#version\":\ \"\(.*\)\",#version\":\ \"${{ needs.tag.outputs.desktopVersion }}\",#g" tests/playwright/package.json
-          cd tests/playwright && pnpm build && pnpm publish --tag latest --no-git-checks --access public
+          cd tests/playwright && pnpm build && pnpm publish --provenance --tag latest --no-git-checks --access public
 
       - name: Publish Podman Extension API to npmjs
         run: |
           echo "Using version ${{ needs.tag.outputs.desktopVersion }}"
           sed -i  "s#version\":\ \"\(.*\)\",#version\":\ \"${{ needs.tag.outputs.desktopVersion }}\",#g" extensions/podman/packages/api/package.json
           cd extensions/podman/packages/api
-          pnpm publish --tag latest --no-git-checks --access public
+          pnpm publish --provenance --tag latest --no-git-checks --access public
 
   # publish the pnpm store for flathub builds
   pnpm-store:

--- a/extensions/podman/packages/api/package.json
+++ b/extensions/podman/packages/api/package.json
@@ -2,7 +2,9 @@
   "name": "@podman-desktop/podman-extension-api",
   "version": "0.0.1",
   "description": "API for Podman Desktop Podman extension",
+  "repository": "https://github.com/podman-desktop/podman-desktop",
   "publishConfig": {
+    "provenance": true,
     "access": "public"
   },
   "license": "Apache-2.0",

--- a/packages/extension-api/package.json
+++ b/packages/extension-api/package.json
@@ -2,7 +2,9 @@
   "name": "@podman-desktop/api",
   "version": "0.0.1",
   "description": "API for Podman Desktop extensions",
+  "repository": "https://github.com/podman-desktop/podman-desktop",
   "publishConfig": {
+    "provenance": true,
     "access": "public"
   },
   "license": "Apache-2.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -2,7 +2,12 @@
   "name": "@podman-desktop/ui-svelte",
   "version": "0.0.1",
   "type": "module",
+  "repository": "https://github.com/podman-desktop/podman-desktop",
   "license": "Apache-2.0",
+  "publishConfig": {
+    "provenance": true,
+    "access": "public"
+  },
   "scripts": {
     "build": "svelte-package",
     "watch": "svelte-package -w",

--- a/tests/playwright/package.json
+++ b/tests/playwright/package.json
@@ -3,7 +3,9 @@
   "version": "1.9.0-next",
   "description": "Playwright-based testing libraries for Podman Desktop and its extensions",
   "type": "module",
+  "repository": "https://github.com/podman-desktop/podman-desktop",
   "publishConfig": {
+    "provenance": true,
     "access": "public"
   },
   "main": "dist/index.js",


### PR DESCRIPTION
### What does this PR do?

Some of our public packages do not provide the [provenance](https://docs.npmjs.com/generating-provenance-statements) and the repository. (This seems to be pretty common ref https://github.com/search?q=path%3A.github+pnpm+--provenance&type=code)

> ℹ️ The provenance is a nice banner here is an example:
> ![image](https://github.com/user-attachments/assets/0dbe484b-3da1-480d-8277-e15f821185df)


⚠️ I had to add the `write` permission, this is a requirement from the npm tooling (https://docs.npmjs.com/generating-provenance-statements#prerequisites)

#### `@podman-desktop/podman-extension-api`[^1]

[^1]: https://www.npmjs.com/package/@podman-desktop/podman-extension-api

![image](https://github.com/user-attachments/assets/ca30ea4d-62e8-42be-a9a0-6006f897d310)

#### `@podman-desktop/ui-svelte`[^2]

[^2]: https://www.npmjs.com/package/@podman-desktop/ui-svelte

![image](https://github.com/user-attachments/assets/d23a7501-6298-496e-a839-40d6550cb29f)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
