### PR TITLE
fix: display VM status

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -675,7 +675,11 @@ function handleError(errorMessage: string): void {
             </div>
             <div class="flex mt-1" aria-label="Connection Status">
               <ConnectionStatus status={vmConnection.status} />
-            </div>            
+              {#if containerConnectionStatus.has(getProviderConnectionName(provider, vmConnection))}
+                {@const status = containerConnectionStatus.get(getProviderConnectionName(provider, vmConnection))}
+                <ConnectionErrorInfoButton status={status} />
+              {/if}
+            </div>
             <PreferencesConnectionActions
               provider={provider}
               connection={vmConnection}


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

When an error occurs during VM start/stop, the status should be displayed near the status of the VM, like it is displayed for container providers.

### Screenshot / video of UI


### What issues does this PR fix or reference?

Fixes https://github.com/redhat-developer/podman-desktop-rhel-ext/issues/93

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
