### PR TITLE
feat: added editing of contexts

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -2599,12 +2599,7 @@ export class PluginSystem {
     });
     this.ipcHandle(
       'kubernetes-client:updateContext',
-      async (
-        _listener,
-        contextName: string,
-        newContextName: string,
-        newContextNamespace: string,
-      ): Promise<void> => {
+      async (_listener, contextName: string, newContextName: string, newContextNamespace: string): Promise<void> => {
         return kubernetesClient.updateContext(contextName, newContextName, newContextNamespace);
       },
     );

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -2597,6 +2597,17 @@ export class PluginSystem {
     this.ipcHandle('kubernetes-client:duplicateContext', async (_listener, contextName: string): Promise<void> => {
       return kubernetesClient.duplicateContext(contextName);
     });
+    this.ipcHandle(
+      'kubernetes-client:updateContext',
+      async (
+        _listener,
+        contextName: string,
+        newContextName: string,
+        newContextNamespace: string,
+      ): Promise<KubernetesContext[]> => {
+        return kubernetesClient.updateContext(contextName, newContextName, newContextNamespace);
+      },
+    );
 
     this.ipcHandle('kubernetes-client:setContext', async (_listener, contextName: string): Promise<void> => {
       return kubernetesClient.setContext(contextName);

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -2604,7 +2604,7 @@ export class PluginSystem {
         contextName: string,
         newContextName: string,
         newContextNamespace: string,
-      ): Promise<KubernetesContext[]> => {
+      ): Promise<void> => {
         return kubernetesClient.updateContext(contextName, newContextName, newContextNamespace);
       },
     );

--- a/packages/main/src/plugin/kubernetes/kubernetes-client-kubeconfig.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client-kubeconfig.spec.ts
@@ -194,6 +194,26 @@ describe('context tests', () => {
     expect(newContextName).toBe('ctx1-2-1-1');
   });
 
+  test('should update context from config', async () => {
+    client.saveKubeConfig = vi.fn().mockImplementation((_config: KubeConfig) => {});
+
+    if (!originalContexts[0]?.name) {
+      throw new Error('originalContexts[0].name should be defined');
+    }
+
+    await client.updateContext(originalContexts[0].name, 'new-name', 'new-namespace');
+    const contexts = client.getContexts();
+    expect(contexts.length).toBe(2);
+    expect(client.getContexts().length).toBe(2);
+
+    if (!contexts[0]?.name) {
+      throw new Error('contexts[0].name should be defined');
+    }
+
+    expect(contexts[0].name).toBe('new-name');
+    expect(contexts[0].namespace).toBe('new-namespace');
+  });
+
   test('should be a no-op if the context name is not found', async () => {
     client.saveKubeConfig = vi.fn().mockImplementation((_config: KubeConfig) => {});
 

--- a/packages/main/src/plugin/kubernetes/kubernetes-client-kubeconfig.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client-kubeconfig.spec.ts
@@ -53,7 +53,7 @@ describe('context tests', () => {
     { name: 'cluster2', server: 'server2' } as Cluster,
   ];
   const originalContexts = [
-    { name: 'ctx1', user: 'user1', cluster: 'cluster1', currentContext: true },
+    { name: 'ctx1', user: 'user1', cluster: 'cluster1', currentContext: true, namespace: 'namespace1' },
     { name: 'ctx1bis', user: 'user1', cluster: 'cluster1' },
   ];
 
@@ -212,6 +212,26 @@ describe('context tests', () => {
 
     expect(contexts[0].name).toBe('new-name');
     expect(contexts[0].namespace).toBe('new-namespace');
+  });
+
+  test('should remove the namespace when updating context from config', async () => {
+    client.saveKubeConfig = vi.fn().mockImplementation((_config: KubeConfig) => {});
+
+    if (!originalContexts[0]?.name) {
+      throw new Error('originalContexts[0].name should be defined');
+    }
+
+    await client.updateContext(originalContexts[0].name, originalContexts[0].name, '');
+    const contexts = client.getContexts();
+    expect(contexts.length).toBe(2);
+    expect(client.getContexts().length).toBe(2);
+
+    if (!contexts[0]?.name) {
+      throw new Error('contexts[0].name should be defined');
+    }
+
+    expect(contexts[0].name).toBe(originalContexts[0].name);
+    expect(contexts[0].namespace).toBeUndefined();
   });
 
   test('should be a no-op if the context name is not found', async () => {

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.ts
@@ -411,20 +411,22 @@ export class KubernetesClient {
     if (!originalContext) throw new Error('Context name was not found in kube config');
 
     const namespaceField = newContextNamespace !== '' ? { namespace: newContextNamespace } : {};
-    delete (originalContext as { namespace?: string }).namespace;
+
+    const editedContext = {
+      ...originalContext,
+      name: newContextName,
+      ...namespaceField,
+    };
+
+    if (newContextNamespace === '') {
+      delete editedContext.namespace;
+    }
 
     newConfig.loadFromOptions({
       clusters: this.kubeConfig.clusters,
       users: this.kubeConfig.users,
       currentContext: this.currentContextName === contextName ? newContextName : this.kubeConfig.currentContext,
-      contexts: [
-        {
-          ...originalContext,
-          name: newContextName,
-          ...namespaceField,
-        },
-        ...newContexts,
-      ],
+      contexts: [editedContext, ...newContexts],
     });
 
     await this.saveKubeConfig(newConfig);

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.ts
@@ -403,6 +403,35 @@ export class KubernetesClient {
     this.apiSender.send('kubernetes-context-update');
   }
 
+  async updateContext(contextName: string, newContextName: string, newContextNamespace: string): Promise<void> {
+    const newConfig = new KubeConfig();
+
+    const originalContext = this.kubeConfig.contexts.find(context => context.name === contextName);
+    const newContexts = this.kubeConfig.contexts.filter(ctx => ctx.name !== contextName);
+    if (!originalContext) return;
+
+    newConfig.loadFromOptions({
+      clusters: this.kubeConfig.clusters,
+      users: this.kubeConfig.users,
+      currentContext: this.currentContextName === contextName ? newContextName : this.kubeConfig.currentContext,
+      contexts: [
+        {
+          ...originalContext,
+          name: newContextName,
+          namespace: newContextNamespace,
+        },
+        ...newContexts,
+      ],
+    });
+
+    await this.saveKubeConfig(newConfig);
+    // the config is saved back only if saving the file succeeds
+    this.kubeConfig = newConfig;
+    // We send an update event here, even if another one will be sent after the file change is detected,
+    // because that one can get some time to be sent (as cluster connectivity will be tested)
+    this.apiSender.send('kubernetes-context-update');
+  }
+
   async deleteContext(contextName: string): Promise<Context[]> {
     const previousContexts = this.kubeConfig.contexts;
     const newContexts = this.kubeConfig.contexts.filter(ctx => ctx.name !== contextName);

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.ts
@@ -408,7 +408,10 @@ export class KubernetesClient {
 
     const originalContext = this.kubeConfig.contexts.find(context => context.name === contextName);
     const newContexts = this.kubeConfig.contexts.filter(ctx => ctx.name !== contextName);
-    if (!originalContext) return;
+    if (!originalContext) throw new Error('Context name was not found in kube config');
+
+    const namespaceField = newContextNamespace !== '' ? { namespace: newContextNamespace } : {};
+    delete (originalContext as { namespace?: string }).namespace;
 
     newConfig.loadFromOptions({
       clusters: this.kubeConfig.clusters,
@@ -418,7 +421,7 @@ export class KubernetesClient {
         {
           ...originalContext,
           name: newContextName,
-          namespace: newContextNamespace,
+          ...namespaceField,
         },
         ...newContexts,
       ],

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1875,7 +1875,12 @@ export function initExposure(): void {
   contextBridge.exposeInMainWorld('kubernetesDuplicateContext', async (contextName: string): Promise<void> => {
     return ipcInvoke('kubernetes-client:duplicateContext', contextName);
   });
-
+  contextBridge.exposeInMainWorld(
+    'kubernetesUpdateContext',
+    async (contextName: string, newContextName: string, newContextNamespace: string): Promise<Context[]> => {
+      return ipcInvoke('kubernetes-client:updateContext', contextName, newContextName, newContextNamespace);
+    },
+  );
   contextBridge.exposeInMainWorld('kubernetesDeleteContext', async (contextName: string): Promise<Context[]> => {
     return ipcInvoke('kubernetes-client:deleteContext', contextName);
   });

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1877,7 +1877,7 @@ export function initExposure(): void {
   });
   contextBridge.exposeInMainWorld(
     'kubernetesUpdateContext',
-    async (contextName: string, newContextName: string, newContextNamespace: string): Promise<Context[]> => {
+    async (contextName: string, newContextName: string, newContextNamespace: string): Promise<void> => {
       return ipcInvoke('kubernetes-client:updateContext', contextName, newContextName, newContextNamespace);
     },
   );

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
@@ -193,21 +193,6 @@ test('when deleting the non current context, no popup should ask confirmation', 
   expect(showMessageBoxMock).not.toHaveBeenCalled();
 });
 
-test('when duplicating context, kubernetesDuplicateContext should be called', async () => {
-  vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextGeneralState>>(new Map());
-  vi.mocked(kubernetesContextsState).kubernetesContextsCheckingStateDelayed = readable<Map<string, boolean>>(new Map());
-  render(PreferencesKubernetesContextsRendering, {});
-  // Get first context
-  const currentContext = screen.getAllByRole('row')[0];
-  expect(currentContext).toBeInTheDocument();
-
-  const duplicateBtn = within(currentContext).getByRole('button', { name: 'Duplicate Context' });
-  expect(duplicateBtn).toBeInTheDocument();
-  await fireEvent.click(duplicateBtn);
-
-  expect(kubernetesDuplicateContextMock).toHaveBeenCalledOnce();
-});
-
 test('when editing context a modal dialog should be oppened', async () => {
   vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextGeneralState>>(new Map());
   vi.mocked(kubernetesContextsState).kubernetesContextsCheckingStateDelayed = readable<Map<string, boolean>>(new Map());

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
@@ -97,12 +97,15 @@ const kubernetesGetCurrentContextNameMock = vi.fn();
 
 const showMessageBoxMock = vi.fn();
 
+const kubernetesDuplicateContextMock = vi.fn();
+
 beforeAll(() => {
   Object.defineProperty(window, 'kubernetesGetContextsGeneralState', {
     value: vi.fn().mockResolvedValue(new Map<string, ContextGeneralState>()),
   });
   Object.defineProperty(window, 'kubernetesGetCurrentContextName', { value: kubernetesGetCurrentContextNameMock });
   Object.defineProperty(window, 'showMessageBox', { value: showMessageBoxMock });
+  Object.defineProperty(window, 'kubernetesDuplicateContext', { value: kubernetesDuplicateContextMock });
 });
 
 beforeEach(() => {
@@ -188,6 +191,36 @@ test('when deleting the non current context, no popup should ask confirmation', 
   expect(deleteBtn).toBeInTheDocument();
   await fireEvent.click(deleteBtn);
   expect(showMessageBoxMock).not.toHaveBeenCalled();
+});
+
+test('when duplicating context, kubernetesDuplicateContext should be called', async () => {
+  vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextGeneralState>>(new Map());
+  vi.mocked(kubernetesContextsState).kubernetesContextsCheckingStateDelayed = readable<Map<string, boolean>>(new Map());
+  render(PreferencesKubernetesContextsRendering, {});
+  // Get first context
+  const currentContext = screen.getAllByRole('row')[0];
+  expect(currentContext).toBeInTheDocument();
+
+  const duplicateBtn = within(currentContext).getByRole('button', { name: 'Duplicate Context' });
+  expect(duplicateBtn).toBeInTheDocument();
+  await fireEvent.click(duplicateBtn);
+
+  expect(kubernetesDuplicateContextMock).toHaveBeenCalledOnce();
+});
+
+test('when editing context a modal dialog should be oppened', async () => {
+  vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextGeneralState>>(new Map());
+  vi.mocked(kubernetesContextsState).kubernetesContextsCheckingStateDelayed = readable<Map<string, boolean>>(new Map());
+  render(PreferencesKubernetesContextsRendering, {});
+  // Get first context
+  const currentContext = screen.getAllByRole('row')[0];
+  expect(currentContext).toBeInTheDocument();
+
+  const editBtn = within(currentContext).getByRole('button', { name: 'Edit Context' });
+  expect(editBtn).toBeInTheDocument();
+  await fireEvent.click(editBtn);
+
+  expect(screen.getByRole('dialog', { name: 'Edit Context' })).toBeVisible();
 });
 
 describe.each([

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { faQuestionCircle } from '@fortawesome/free-regular-svg-icons';
-import { faCopy, faPenToSquare, faRightToBracket, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faPenToSquare, faRightToBracket, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { Button, EmptyScreen, ErrorMessage, Spinner, Tooltip } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 import Fa from 'svelte-fa';
@@ -117,10 +117,6 @@ let editContextModal: boolean = $state(false);
 let contextToEdit: KubeContext | undefined = $state();
 function closeModals(): void {
   editContextModal = false;
-}
-
-async function handleDuplicateContext(contextName: string): Promise<void> {
-  await window.kubernetesDuplicateContext(contextName);
 }
 
 async function handleEditContext(context: KubeContextWithStates): Promise<void> {
@@ -272,8 +268,6 @@ async function connect(contextName: string): Promise<void> {
                 onClick={(): Promise<void> => handleSetContext(context.name)}></ListItemButtonIcon>
             {/if}
             <ListItemButtonIcon title="Edit Context" icon={faPenToSquare} onClick={(): Promise<void> => handleEditContext(context)}
-              ></ListItemButtonIcon>
-            <ListItemButtonIcon title="Duplicate Context" icon={faCopy} onClick={(): Promise<void> => handleDuplicateContext(context.name)}
               ></ListItemButtonIcon>
             <ListItemButtonIcon title="Delete Context" icon={faTrash} onClick={(): Promise<void> => handleDeleteContext(context.name)}
             ></ListItemButtonIcon>

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { faQuestionCircle } from '@fortawesome/free-regular-svg-icons';
-import { faPenToSquare, faRightToBracket, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faCopy, faPenToSquare, faRightToBracket, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { Button, EmptyScreen, ErrorMessage, Spinner, Tooltip } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 import Fa from 'svelte-fa';
@@ -117,6 +117,10 @@ let editContextModal: boolean = $state(false);
 let contextToEdit: KubeContext | undefined = $state();
 function closeModals(): void {
   editContextModal = false;
+}
+
+async function handleDuplicateContext(contextName: string): Promise<void> {
+  await window.kubernetesDuplicateContext(contextName);
 }
 
 async function handleEditContext(context: KubeContextWithStates): Promise<void> {
@@ -267,6 +271,8 @@ async function connect(contextName: string): Promise<void> {
                 icon={faRightToBracket}
                 onClick={(): Promise<void> => handleSetContext(context.name)}></ListItemButtonIcon>
             {/if}
+            <ListItemButtonIcon title="Duplicate Context" icon={faCopy} onClick={(): Promise<void> => handleDuplicateContext(context.name)}
+            ></ListItemButtonIcon>
             <ListItemButtonIcon title="Edit Context" icon={faPenToSquare} onClick={(): Promise<void> => handleEditContext(context)}
               ></ListItemButtonIcon>
             <ListItemButtonIcon title="Delete Context" icon={faTrash} onClick={(): Promise<void> => handleDeleteContext(context.name)}

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { faQuestionCircle } from '@fortawesome/free-regular-svg-icons';
-import { faCopy, faRightToBracket, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faCopy, faPenToSquare, faRightToBracket, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { Button, EmptyScreen, ErrorMessage, Spinner, Tooltip } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 import Fa from 'svelte-fa';
@@ -17,6 +17,7 @@ import { kubernetesContexts } from '../../stores/kubernetes-contexts';
 import { clearKubeUIContextErrors, setKubeUIContextError } from '../kube/KubeContextUI';
 import EngineIcon from '../ui/EngineIcon.svelte';
 import ListItemButtonIcon from '../ui/ListItemButtonIcon.svelte';
+import PreferencesKubernetesContextsRenderingEditModal from './PreferencesKubernetesContextsRenderingEditModal.svelte';
 import SettingsPage from './SettingsPage.svelte';
 
 interface KubeContextWithStates extends KubeContext {
@@ -112,8 +113,19 @@ async function handleDeleteContext(contextName: string): Promise<void> {
   }
 }
 
+let editContextModal: boolean = $state(false);
+let contextToEdit: KubeContext | undefined = $state();
+function closeModals(): void {
+  editContextModal = false;
+}
+
 async function handleDuplicateContext(contextName: string): Promise<void> {
   await window.kubernetesDuplicateContext(contextName);
+}
+
+async function handleEditContext(context: KubeContextWithStates): Promise<void> {
+  contextToEdit = context as KubeContext;
+  editContextModal = true;
 }
 
 function isContextReachable(contextName: string, experimental: boolean): boolean {
@@ -259,8 +271,10 @@ async function connect(contextName: string): Promise<void> {
                 icon={faRightToBracket}
                 onClick={(): Promise<void> => handleSetContext(context.name)}></ListItemButtonIcon>
             {/if}
+            <ListItemButtonIcon title="Edit Context" icon={faPenToSquare} onClick={(): Promise<void> => handleEditContext(context)}
+              ></ListItemButtonIcon>
             <ListItemButtonIcon title="Duplicate Context" icon={faCopy} onClick={(): Promise<void> => handleDuplicateContext(context.name)}
-            ></ListItemButtonIcon>
+              ></ListItemButtonIcon>
             <ListItemButtonIcon title="Delete Context" icon={faTrash} onClick={(): Promise<void> => handleDeleteContext(context.name)}
             ></ListItemButtonIcon>
           </div>
@@ -391,4 +405,10 @@ async function connect(contextName: string): Promise<void> {
       </div>
     {/each}
   </div>
+  {#if editContextModal && contextToEdit}
+    <PreferencesKubernetesContextsRenderingEditModal
+      contextToEdit={contextToEdit}
+      detailed={true}
+      closeCallback={closeModals} />
+  {/if}
 </SettingsPage>

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRenderingEditModal.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRenderingEditModal.spec.ts
@@ -1,0 +1,157 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { KubeContext } from '/@api/kubernetes-context';
+
+import PreferencesKubernetesContextsRenderingEditModal from './PreferencesKubernetesContextsRenderingEditModal.svelte';
+
+const mockContext1: KubeContext = {
+  name: 'context-name',
+  cluster: 'cluster-name',
+  namespace: 'context-namespace',
+  user: 'user-name',
+  clusterInfo: {
+    name: 'cluster-name',
+    server: 'https://server-name',
+  },
+};
+const closeCallback = (): void => {};
+
+const kubernetesUpdateContextMock = vi.fn();
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  Object.defineProperty(window, 'kubernetesUpdateContext', { value: kubernetesUpdateContextMock });
+});
+
+describe('UpdateContext', () => {
+  test('Expect that modal has and save button displays', async () => {
+    render(PreferencesKubernetesContextsRenderingEditModal, {
+      contextToEdit: mockContext1,
+      closeCallback: closeCallback,
+    });
+
+    const contextNameEntry = screen.getByLabelText('Name');
+    expect(contextNameEntry).toBeInTheDocument();
+    const contextNamespaceEntry = screen.getByLabelText('Namespace');
+    expect(contextNamespaceEntry).toBeInTheDocument();
+    const saveButton = screen.getByRole('button', { name: 'Save' });
+    expect(saveButton).toBeInTheDocument();
+  });
+
+  test('Expect that save button is disabled by default', async () => {
+    render(PreferencesKubernetesContextsRenderingEditModal, {
+      contextToEdit: mockContext1,
+      closeCallback: closeCallback,
+    });
+
+    const saveButton = screen.getByRole('button', { name: 'Save' });
+    expect(saveButton).toBeInTheDocument();
+    expect(saveButton).toBeDisabled();
+  });
+
+  test('Expect that empty context name disables save button', async () => {
+    render(PreferencesKubernetesContextsRenderingEditModal, {
+      contextToEdit: mockContext1,
+      closeCallback: closeCallback,
+    });
+
+    const saveButton = screen.getByRole('button', { name: 'Save' });
+    expect(saveButton).toBeInTheDocument();
+    expect(saveButton).toBeDisabled();
+
+    const contextName = screen.getByLabelText('Name');
+    await userEvent.click(contextName);
+    await userEvent.paste('');
+
+    expect(saveButton).toBeDisabled();
+  });
+
+  test('Expect that empty context namespace disables save button', async () => {
+    render(PreferencesKubernetesContextsRenderingEditModal, {
+      contextToEdit: mockContext1,
+      closeCallback: closeCallback,
+    });
+
+    const saveButton = screen.getByRole('button', { name: 'Save' });
+    expect(saveButton).toBeInTheDocument();
+    expect(saveButton).toBeDisabled();
+
+    const contextNamespace = screen.getByLabelText('Namespace');
+    await userEvent.click(contextNamespace);
+    await userEvent.paste('');
+
+    expect(saveButton).toBeDisabled();
+  });
+
+  test('Expect that valid context name enables save button', async () => {
+    render(PreferencesKubernetesContextsRenderingEditModal, {
+      contextToEdit: mockContext1,
+      closeCallback: closeCallback,
+    });
+
+    const saveButton = screen.getByRole('button', { name: 'Save' });
+    expect(saveButton).toBeInTheDocument();
+    expect(saveButton).toBeDisabled();
+
+    const contextName = screen.getByLabelText('Name');
+    await userEvent.click(contextName);
+    await userEvent.paste('some-valid-name');
+
+    expect(saveButton).toBeEnabled();
+  });
+
+  test('basic contexts should have inputs prefill', async () => {
+    render(PreferencesKubernetesContextsRenderingEditModal, {
+      contextToEdit: mockContext1,
+      closeCallback: closeCallback,
+    });
+
+    const contextName: HTMLInputElement = screen.getByRole('textbox', {
+      name: 'contextName',
+    });
+    expect(contextName.value).toBe(mockContext1.name);
+
+    const contextNamespace: HTMLInputElement = screen.getByRole('textbox', {
+      name: 'contextNamespace',
+    });
+    expect(contextNamespace.value).toBe(mockContext1.namespace);
+  });
+
+  test('Expect error message if context name is cleared after it was initially prefilled', async () => {
+    render(PreferencesKubernetesContextsRenderingEditModal, {
+      contextToEdit: mockContext1,
+      closeCallback: closeCallback,
+    });
+
+    expect(screen.queryByText('Please enter a value')).not.toBeInTheDocument();
+
+    const contextName = screen.getByLabelText('Name');
+    expect((contextName as HTMLInputElement).value).toBe(mockContext1.name);
+
+    await userEvent.clear(contextName);
+
+    expect(await screen.findByText('Please enter a value')).toBeInTheDocument();
+  });
+});

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRenderingEditModal.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRenderingEditModal.svelte
@@ -28,7 +28,7 @@ let kubeConfig = $state('~/.kube/config');
 $effect(() => {
   const context = contexts?.find(ctx => ctx.name === contextName);
   // Show error when is the new name identical with any other context name in the kubeConfig
-  if (context) {
+  if (context && context.name !== contextToEdit.name) {
     contextNameErrorMessage = `This context name already exists in ${kubeConfig}`;
   } else {
     contextNameErrorMessage = contextName === '' ? 'Please enter a value' : '';
@@ -69,7 +69,7 @@ async function editContext(contextName: string, contextNamespace: string): Promi
     title="Edit Context"
     on:close={closeCallback}>
     <div slot="content" class="w-full">
-    <label for="contextName" class="block my-2 text-sm font-bold text-[var(--pd-modal-text)]">Context Name</label>
+    <label for="contextName" class="block my-2 text-sm font-bold text-[var(--pd-modal-text)]">Name</label>
     <Input
         bind:value={contextName}
         name="contextName"
@@ -82,7 +82,7 @@ async function editContext(contextName: string, contextNamespace: string): Promi
         <ErrorMessage error={contextNameErrorMessage} />
     {/if}
 
-    <label for="contextNamespace" class="block my-2 text-sm font-bold text-[var(--pd-modal-text)]">Context Namespace</label>
+    <label for="contextNamespace" class="block my-2 text-sm font-bold text-[var(--pd-modal-text)]">Namespace</label>
     <Input
         bind:value={contextNamespace}
         name="contextNamespace"

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRenderingEditModal.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRenderingEditModal.svelte
@@ -1,0 +1,111 @@
+<script lang="ts">
+import { Button, ErrorMessage, Input } from '@podman-desktop/ui-svelte';
+import { onMount } from 'svelte';
+import { router } from 'tinro';
+
+import { kubernetesContexts } from '/@/stores/kubernetes-contexts';
+import type { KubeContext } from '/@api/kubernetes-context';
+
+import Dialog from '../dialogs/Dialog.svelte';
+
+interface Props {
+  detailed?: boolean;
+  contextToEdit: KubeContext;
+  closeCallback: () => void;
+}
+
+let { detailed = false, contextToEdit, closeCallback }: Props = $props();
+
+let contextName = $state('');
+let contextNamespace = $state('');
+
+let contextNameErrorMessage = $state('');
+let contextNamespaceErrorMessage = $state('');
+
+let contexts: KubeContext[] = $state($kubernetesContexts);
+let kubeConfig = $state('~/.kube/config');
+
+$effect(() => {
+  const context = contexts?.find(ctx => ctx.name === contextName);
+  // Show error when is the new name identical with any other context name in the kubeConfig
+  if (context) {
+    contextNameErrorMessage = `This context name already exists in ${kubeConfig}`;
+  } else {
+    contextNameErrorMessage = contextName === '' ? 'Please enter a value' : '';
+  }
+});
+
+onMount(async () => {
+  contextName = contextToEdit?.name;
+  contextNamespace = contextToEdit?.namespace ?? '';
+  kubeConfig = (await window.getConfigurationValue('kubernetes.Kubeconfig')) ?? kubeConfig;
+});
+
+function disableSave(name: string): boolean {
+  return (
+    name.trim() === '' || contexts?.find(ctx => ctx.name === contextName) !== undefined || name === contextToEdit.name
+  );
+}
+
+async function editContext(contextName: string, contextNamespace: string): Promise<void> {
+  const context = contexts?.find(ctx => ctx.name === contextName);
+  if (context) return;
+
+  try {
+    await window.kubernetesUpdateContext(contextToEdit.name, contextName, contextNamespace);
+    closeCallback();
+  } catch (error: unknown) {
+    contextNameErrorMessage =
+      error && typeof error === 'object' && 'message' in error && error.message ? String(error.message) : String(error);
+  }
+
+  if (detailed) {
+    router.goto('/preferences/kubernetes-contexts');
+  }
+}
+</script>
+
+<Dialog
+    title="Edit Context"
+    on:close={closeCallback}>
+    <div slot="content" class="w-full">
+    <label for="contextName" class="block my-2 text-sm font-bold text-[var(--pd-modal-text)]">Context Name</label>
+    <Input
+        bind:value={contextName}
+        name="contextName"
+        id="contextName"
+        placeholder="Enter context name (e.g. kind-context-name-1)"
+        aria-invalid={contextNameErrorMessage !== ''}
+        aria-label="contextName"
+        required />
+    {#if contextNameErrorMessage}
+        <ErrorMessage error={contextNameErrorMessage} />
+    {/if}
+
+    <label for="contextNamespace" class="block my-2 text-sm font-bold text-[var(--pd-modal-text)]">Context Namespace</label>
+    <Input
+        bind:value={contextNamespace}
+        name="contextNamespace"
+        id="contextNamespace"
+        placeholder="Enter context namespace (e.g. production)"
+        aria-invalid={contextNamespaceErrorMessage !== ''}
+        aria-label="contextNamespace"
+        required />
+    {#if contextNamespaceErrorMessage}
+        <ErrorMessage error={contextNamespaceErrorMessage} />
+    {/if}
+    </div>
+    <svelte:fragment slot="buttons">
+    <Button
+        class="pcol-start-3"
+        type="link"
+        on:click={closeCallback}>Cancel</Button>
+    <Button
+        class="col-start-4"
+        disabled={disableSave(contextName)}
+        on:click={async (): Promise<void> => {
+        await editContext(contextName, contextNamespace);
+        }}>Save</Button>
+    </svelte:fragment>
+</Dialog>
+    


### PR DESCRIPTION
### What does this PR do?
Adds editing of name and namespace

There should be now 4 buttons (delete context, duplicate context, sometimes set as current) and new edit button which should allow to update name and namespace - choosing cluster and user will be another PR - https://github.com/podman-desktop/podman-desktop/pull/12445

### Screenshot / video of UI

[Screencast_20250507_140626.webm](https://github.com/user-attachments/assets/f5c57fb7-51ce-4e88-a594-530965354c5a) 


 just without duplicating


### What issues does this PR fix or reference?
Part of #11283 
Required for https://github.com/podman-desktop/podman-desktop/pull/12445

### How to test this PR?
1. Create context (minikube/kind/etc...)
2. Go to preferences -> kubernes context
3. Try to edit context

- [x] Tests are covering the bug fix or the new feature
