### PR TITLE
fix(webview-api): missing repository and provenance

### DIFF
--- a/packages/webview-api/package.json
+++ b/packages/webview-api/package.json
@@ -2,7 +2,9 @@
   "name": "@podman-desktop/webview-api",
   "version": "0.0.1",
   "description": "API for Podman Desktop extensions",
+  "repository": "https://github.com/podman-desktop/podman-desktop",
   "publishConfig": {
+    "provenance": true,
     "access": "public"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
### What does this PR do?

Following https://github.com/podman-desktop/podman-desktop/pull/12398, a small mistake, I forgot about the `@podman-desktop/webview-api` package. This has lead to the `next-release` workflow to fails (ref https://github.com/podman-desktop/podman-desktop/actions/runs/14882599859/job/41795048662)

### Screenshot / video of UI

It works for the other packages hihihi

![image](https://github.com/user-attachments/assets/cc5f6181-9640-4f3c-a093-19b3f7b3b1e8)

![image](https://github.com/user-attachments/assets/a5cca523-e4d6-47f0-b6ce-176fccb4eb22)


### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
