### PR TITLE
fix(container-connection): display terminal tab when shell access is available

### DIFF
--- a/packages/api/src/provider-info.ts
+++ b/packages/api/src/provider-info.ts
@@ -37,6 +37,11 @@ export interface ProviderContainerConnectionInfo {
     socketPath: string;
   };
   lifecycleMethods?: LifecycleMethod[];
+  /**
+   * Specify if the corresponding {@link import('@podman-desktop/api').ProviderContainerConnection} instance
+   * has a shellAccess available
+   */
+  shellAccess?: boolean;
   type: 'docker' | 'podman';
   vmType?: { id: string; name: string };
 }

--- a/packages/main/src/plugin/provider-registry.spec.ts
+++ b/packages/main/src/plugin/provider-registry.spec.ts
@@ -2035,7 +2035,7 @@ describe('shellInProviderConnection', () => {
     expect(shellAccess).toBeFalsy();
   });
 
-  test('connection without shell access should have truthy info shellAccess', () => {
+  test('connection with shell access should have truthy info shellAccess', () => {
     const provider = providerRegistry.createProvider('id', 'name', {
       id: 'internal',
       name: 'internal',

--- a/packages/main/src/plugin/provider-registry.spec.ts
+++ b/packages/main/src/plugin/provider-registry.spec.ts
@@ -2007,6 +2007,65 @@ describe('startProvider', () => {
 });
 
 describe('shellInProviderConnection', () => {
+  test('connection without shell access should have falsy info shellAccess', () => {
+    const provider = providerRegistry.createProvider('id', 'name', {
+      id: 'internal',
+      name: 'internal',
+      status: 'installed',
+    });
+
+    provider.registerContainerProviderConnection({
+      name: 'connection',
+      displayName: 'connection',
+      type: 'podman',
+      endpoint: {
+        socketPath: '/endpoint1.sock',
+      },
+      status() {
+        return 'started';
+      },
+      vmType: 'libkrun',
+    });
+
+    const connections = providerRegistry.getContainerConnections();
+    expect(connections).toHaveLength(1);
+    assert(connections[0], 'connection should be defined');
+
+    const { shellAccess } = providerRegistry.getProviderContainerConnectionInfo(connections[0].connection);
+    expect(shellAccess).toBeFalsy();
+  });
+
+  test('connection without shell access should have truthy info shellAccess', () => {
+    const provider = providerRegistry.createProvider('id', 'name', {
+      id: 'internal',
+      name: 'internal',
+      status: 'installed',
+    });
+
+    provider.registerContainerProviderConnection({
+      name: 'connection',
+      displayName: 'connection',
+      type: 'podman',
+      endpoint: {
+        socketPath: '/endpoint1.sock',
+      },
+      shellAccess: {
+        open: vi.fn(),
+      },
+      status() {
+        return 'started';
+      },
+      vmType: 'libkrun',
+    });
+
+    const connections = providerRegistry.getContainerConnections();
+    expect(connections).toHaveLength(1);
+    assert(connections[0], 'connection should be defined');
+
+    const { shellAccess } = providerRegistry.getProviderContainerConnectionInfo(connections[0].connection);
+    expect(shellAccess).toBeTruthy();
+  });
+
   test('check if are all listeners disposed before calling close with container connection', async () => {
     const provider = providerRegistry.createProvider('id', 'name', {
       id: 'internal',

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -687,6 +687,7 @@ export class ProviderRegistry {
         endpoint: {
           socketPath: connection.endpoint.socketPath,
         },
+        shellAccess: !!connection.shellAccess,
         vmType: connection.vmType
           ? {
               id: connection.vmType,

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.spec.ts
@@ -33,6 +33,32 @@ import type { ProviderInfo } from '/@api/provider-info';
 import { providerInfos } from '../../stores/providers';
 import PreferencesContainerConnectionRendering from './PreferencesContainerConnectionRendering.svelte';
 
+const EMPTY_PROVIDER_MOCK: ProviderInfo = {
+  id: 'podman',
+  name: 'podman',
+  images: {
+    icon: 'img',
+  },
+  status: 'started',
+  warnings: [],
+  containerProviderConnectionCreation: true,
+  detectionChecks: [],
+  installationSupport: false,
+  internalId: '0',
+  containerConnections: [],
+  kubernetesConnections: [],
+  kubernetesProviderConnectionCreation: true,
+  vmConnections: [],
+  vmProviderConnectionCreation: false,
+  vmProviderConnectionInitialization: false,
+  links: [],
+  containerProviderConnectionInitialization: false,
+  containerProviderConnectionCreationDisplayName: 'Podman machine',
+  kubernetesProviderConnectionInitialization: false,
+  extensionId: '',
+  cleanupSupport: false,
+};
+
 test('Expect that the right machine is displayed', async () => {
   const socketPath = '/my/common-socket-path';
   const podmanMachineName1 = 'podman machine 1';
@@ -40,15 +66,7 @@ test('Expect that the right machine is displayed', async () => {
   const podmanMachineName3 = 'podman machine 3';
 
   const providerInfo: ProviderInfo = {
-    id: 'podman',
-    name: 'podman',
-    images: {
-      icon: 'img',
-    },
-    status: 'started',
-    warnings: [],
-    containerProviderConnectionCreation: true,
-    detectionChecks: [],
+    ...EMPTY_PROVIDER_MOCK,
     containerConnections: [
       {
         name: podmanMachineName1,
@@ -78,19 +96,6 @@ test('Expect that the right machine is displayed', async () => {
         type: 'podman',
       },
     ],
-    installationSupport: false,
-    internalId: '0',
-    kubernetesConnections: [],
-    kubernetesProviderConnectionCreation: true,
-    vmConnections: [],
-    vmProviderConnectionCreation: false,
-    vmProviderConnectionInitialization: false,
-    links: [],
-    containerProviderConnectionInitialization: false,
-    containerProviderConnectionCreationDisplayName: 'Podman machine',
-    kubernetesProviderConnectionInitialization: false,
-    extensionId: '',
-    cleanupSupport: false,
   };
 
   // 3 connections with the same socket path
@@ -124,15 +129,7 @@ test('Expect that removing the connection is going back to the previous page', a
   (window as any).deleteProviderConnectionLifecycle = deleteMock;
 
   const providerInfo: ProviderInfo = {
-    id: 'podman',
-    name: 'podman',
-    images: {
-      icon: 'img',
-    },
-    status: 'started',
-    warnings: [],
-    containerProviderConnectionCreation: true,
-    detectionChecks: [],
+    ...EMPTY_PROVIDER_MOCK,
     containerConnections: [
       {
         name: podmanMachineName1,
@@ -163,19 +160,6 @@ test('Expect that removing the connection is going back to the previous page', a
         type: 'podman',
       },
     ],
-    installationSupport: false,
-    internalId: '0',
-    kubernetesConnections: [],
-    kubernetesProviderConnectionCreation: true,
-    vmConnections: [],
-    vmProviderConnectionCreation: false,
-    vmProviderConnectionInitialization: false,
-    links: [],
-    containerProviderConnectionInitialization: false,
-    containerProviderConnectionCreationDisplayName: 'Podman machine',
-    kubernetesProviderConnectionInitialization: false,
-    extensionId: '',
-    cleanupSupport: false,
   };
 
   // 3 connections with the same socket path
@@ -238,15 +222,7 @@ test('Expect to see error message if action fails', async () => {
   (window as any).deleteProviderConnectionLifecycle = deleteMock;
 
   const providerInfo: ProviderInfo = {
-    id: 'podman',
-    name: 'podman',
-    images: {
-      icon: 'img',
-    },
-    status: 'started',
-    warnings: [],
-    containerProviderConnectionCreation: true,
-    detectionChecks: [],
+    ...EMPTY_PROVIDER_MOCK,
     containerConnections: [
       {
         name: podmanMachineName,
@@ -259,19 +235,6 @@ test('Expect to see error message if action fails', async () => {
         lifecycleMethods: ['delete'],
       },
     ],
-    installationSupport: false,
-    internalId: '0',
-    kubernetesConnections: [],
-    kubernetesProviderConnectionCreation: true,
-    vmConnections: [],
-    vmProviderConnectionCreation: false,
-    vmProviderConnectionInitialization: false,
-    links: [],
-    containerProviderConnectionInitialization: false,
-    containerProviderConnectionCreationDisplayName: 'Podman machine',
-    kubernetesProviderConnectionInitialization: false,
-    extensionId: '',
-    cleanupSupport: false,
   };
 
   providerInfos.set([providerInfo]);
@@ -321,15 +284,7 @@ test('Expect startContainerProvider to only be called once when restarting', asy
   (window as any).startProviderConnectionLifecycle = startConnectionMock;
 
   const providerInfo: ProviderInfo = {
-    id: 'podman',
-    name: 'podman',
-    images: {
-      icon: 'img',
-    },
-    status: 'started',
-    warnings: [],
-    containerProviderConnectionCreation: true,
-    detectionChecks: [],
+    ...EMPTY_PROVIDER_MOCK,
     containerConnections: [
       {
         name: podmanMachineName,
@@ -342,19 +297,6 @@ test('Expect startContainerProvider to only be called once when restarting', asy
         lifecycleMethods: ['start', 'stop'],
       },
     ],
-    installationSupport: false,
-    internalId: '0',
-    kubernetesConnections: [],
-    kubernetesProviderConnectionCreation: true,
-    vmConnections: [],
-    vmProviderConnectionCreation: false,
-    vmProviderConnectionInitialization: false,
-    links: [],
-    containerProviderConnectionInitialization: false,
-    containerProviderConnectionCreationDisplayName: 'Podman machine',
-    kubernetesProviderConnectionInitialization: false,
-    extensionId: '',
-    cleanupSupport: false,
   };
 
   providerInfos.set([providerInfo]);
@@ -404,15 +346,7 @@ test('Expect display name to be used in favor of name for page title', async () 
   (window as any).startProviderConnectionLifecycle = startConnectionMock;
 
   const providerInfo: ProviderInfo = {
-    id: 'podman',
-    name: 'podman',
-    images: {
-      icon: 'img',
-    },
-    status: 'started',
-    warnings: [],
-    containerProviderConnectionCreation: true,
-    detectionChecks: [],
+    ...EMPTY_PROVIDER_MOCK,
     containerConnections: [
       {
         name: podmanMachineName,
@@ -425,19 +359,6 @@ test('Expect display name to be used in favor of name for page title', async () 
         lifecycleMethods: ['start', 'stop'],
       },
     ],
-    installationSupport: false,
-    internalId: '0',
-    kubernetesConnections: [],
-    kubernetesProviderConnectionCreation: true,
-    vmConnections: [],
-    vmProviderConnectionCreation: false,
-    vmProviderConnectionInitialization: false,
-    links: [],
-    containerProviderConnectionInitialization: false,
-    containerProviderConnectionCreationDisplayName: 'Podman machine',
-    kubernetesProviderConnectionInitialization: false,
-    extensionId: '',
-    cleanupSupport: false,
   };
 
   providerInfos.set([providerInfo]);
@@ -457,4 +378,42 @@ test('Expect display name to be used in favor of name for page title', async () 
   expect(header).toBeDefined();
   expect(header instanceof HTMLHeadingElement).toBeTruthy();
   expect(header.textContent).toBe(podmanMachineDisplayName);
+});
+
+test('expect terminal tab to be visible if shellAccess is truthy', async () => {
+  const socketPath = '/my/common-socket-path';
+  const podmanMachineName = 'podman-machine-default';
+  const podmanMachineDisplayName = 'Dummy Podman Display Name';
+
+  const providerInfo: ProviderInfo = {
+    ...EMPTY_PROVIDER_MOCK,
+    containerConnections: [
+      {
+        name: podmanMachineName,
+        displayName: podmanMachineDisplayName,
+        status: 'started',
+        endpoint: {
+          socketPath,
+        },
+        shellAccess: true,
+        type: 'podman',
+      },
+    ],
+  };
+
+  providerInfos.set([providerInfo]);
+
+  // encode name with base64 of the second machine
+  const name = Buffer.from(podmanMachineName).toString('base64');
+
+  const connection = Buffer.from(socketPath).toString('base64');
+
+  const { getByText } = render(PreferencesContainerConnectionRendering, {
+    name,
+    connection,
+    providerInternalId: '0',
+  });
+
+  const tab = getByText('Terminal');
+  expect(tab.id).toBe('open-tabs-list-terminal-link');
 });

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
@@ -165,6 +165,8 @@ function setNoLogs(): void {
         <Tab title="Summary" selected={isTabSelected($router.path, 'summary')} url={getTabUrl($router.path, 'summary')} />
         {#if connectionInfo.lifecycleMethods && connectionInfo.lifecycleMethods.length > 0}
           <Tab title="Logs" selected={isTabSelected($router.path, 'logs')} url={getTabUrl($router.path, 'logs')} />
+        {/if}
+        {#if connectionInfo.shellAccess}
           <Tab
             title="Terminal"
             selected={isTabSelected($router.path, 'terminal')}


### PR DESCRIPTION
### What does this PR do?

Today, the `Terminal` tab in the `PreferencesContainerConnectionRendering.svelte` is only visible if the corresponding connection has lifecycle method attached: this is an issue as we may have connection with a shell access but no lifecycle methods (E.g; remote connections)

To avoid relying on the lifecycle method, we can add a `shellAccess` property to the info interface, and use that to display or not the terminal).

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Required for https://github.com/podman-desktop/podman-desktop/issues/12264
Fixes https://github.com/podman-desktop/podman-desktop/issues/12263

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

**Manually**

1. assert have a podman machine (E.g. WSL2)
2. checkout this branch 
3. start Podman Desktop
4. assert machine is started
5. open machine details
6. assert Terminal tab is visible
