### PR TITLE
fix: addressed uninstall version error for kubectl installed via onboard

### DIFF
--- a/extensions/kubectl-cli/src/extension.spec.ts
+++ b/extensions/kubectl-cli/src/extension.spec.ts
@@ -87,7 +87,7 @@ vi.mock('@podman-desktop/api', () => {
 
 const downloadReleaseAssetMock = vi.fn();
 
-beforeEach(() => {
+beforeEach(async () => {
   vi.mocked(extensionApi.configuration.getConfiguration).mockReturnValue({
     update: vi.fn(),
   } as unknown as Configuration);
@@ -104,6 +104,9 @@ beforeEach(() => {
     getReleaseAssetURL: vi.fn().mockResolvedValue('dummy download url'),
     downloadReleaseAsset: downloadReleaseAssetMock,
   } as unknown as KubectlGitHubReleases);
+
+  KubectlExtension.vp_state.version = undefined;
+  KubectlExtension.vp_state.path = undefined;
 });
 
 afterEach(() => {

--- a/extensions/kubectl-cli/src/extension.spec.ts
+++ b/extensions/kubectl-cli/src/extension.spec.ts
@@ -104,7 +104,6 @@ beforeEach(() => {
     getReleaseAssetURL: vi.fn().mockResolvedValue('dummy download url'),
     downloadReleaseAsset: downloadReleaseAssetMock,
   } as unknown as KubectlGitHubReleases);
-
   KubectlExtension.vpState.version = undefined;
   KubectlExtension.vpState.path = undefined;
 });

--- a/extensions/kubectl-cli/src/extension.spec.ts
+++ b/extensions/kubectl-cli/src/extension.spec.ts
@@ -87,7 +87,7 @@ vi.mock('@podman-desktop/api', () => {
 
 const downloadReleaseAssetMock = vi.fn();
 
-beforeEach(async () => {
+beforeEach(() => {
   vi.mocked(extensionApi.configuration.getConfiguration).mockReturnValue({
     update: vi.fn(),
   } as unknown as Configuration);
@@ -105,8 +105,8 @@ beforeEach(async () => {
     downloadReleaseAsset: downloadReleaseAssetMock,
   } as unknown as KubectlGitHubReleases);
 
-  KubectlExtension.vp_state.version = undefined;
-  KubectlExtension.vp_state.path = undefined;
+  KubectlExtension.vpState.version = undefined;
+  KubectlExtension.vpState.path = undefined;
 });
 
 afterEach(() => {

--- a/extensions/kubectl-cli/src/extension.ts
+++ b/extensions/kubectl-cli/src/extension.ts
@@ -70,10 +70,6 @@ let binaryPath: string | undefined;
 
 export async function activate(extensionContext: extensionApi.ExtensionContext): Promise<void> {
   initTelemetryLogger();
-
-  binaryVersion = undefined;
-  binaryPath = undefined;
-
   // Check kubectl binary has been downloaded and update both
   // the configuration setting and the context accordingly
   await handler.updateConfigAndContextKubectlBinary(extensionContext);

--- a/extensions/kubectl-cli/src/extension.ts
+++ b/extensions/kubectl-cli/src/extension.ts
@@ -70,6 +70,9 @@ let binaryPath: string | undefined;
 
 export async function activate(extensionContext: extensionApi.ExtensionContext): Promise<void> {
   initTelemetryLogger();
+  // Global vars for version and path
+  let binaryVersion: string | undefined;
+  let binaryPath: string | undefined;
   // Check kubectl binary has been downloaded and update both
   // the configuration setting and the context accordingly
   await handler.updateConfigAndContextKubectlBinary(extensionContext);


### PR DESCRIPTION
### What does this PR do?

This pr addresses the issue of kubectl version not being updated after onboard, which caused a no version detected error when trying to uninstall kubectl in the same session

Thanks to @odockal for linking a similar issue and @dgolovin for reference for a similar fix! In the long run, maybe we should align kubectl and compose extension.ts. Here is the reference PR https://github.com/podman-desktop/podman-desktop/pull/10148

### What issues does this PR fix or reference?

fixes https://github.com/podman-desktop/podman-desktop/issues/11379

### How to test this PR?

Remove kubectl from host to simulate onboarding
i.e for windows 

go to
C:\Users\username\.local\share\containers\podman-desktop\extensions-storage
remove podman-desktop.kubectl-cli

go to
C:\Users\username\AppData\Local\Microsoft\WindowsApps
remove kubectl.exe 

Go to extension settings click on the cog to start the onboard download
Then go to cli settings and uninstall kubectl

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

Kubectl should be removed without error

- [x] Tests are covering the bug fix or the new feature