### PR TITLE
chore: fix github button, remove github link, add spacing.

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -446,11 +446,6 @@ const config = {
             type: 'custom-downloadButton',
             position: 'right',
           },
-          {
-            href: 'https://github.com/podman-desktop/podman-desktop',
-            className: 'header-github-link',
-            position: 'right',
-          },
         ],
       },
       footer: {

--- a/website/src/components/DownloadButton.tsx
+++ b/website/src/components/DownloadButton.tsx
@@ -68,7 +68,7 @@ export function HeaderDownloadButton(): JSX.Element {
     return (
       <div>
         <Link
-          className="hidden lg:flex font-semibold no-underline hover:no-underline items-center text-white hover:text-white bg-gradient-to-b from-violet-500 to-violet-600 border-0 py-3 px-6 focus:outline-hidden hover:from-violet-600 hover:to-violet-700 rounded-lg text-base mt-0 mb-0 ml-4"
+          className="hidden lg:flex font-semibold no-underline hover:no-underline items-center text-white hover:text-white bg-gradient-to-b from-violet-500 to-violet-600 border-0 py-3 px-6 focus:outline-hidden hover:from-violet-600 hover:to-violet-700 rounded-lg text-base mt-0 mb-0 ml-4 mr-2"
           to="/downloads">
           Download
         </Link>
@@ -81,7 +81,7 @@ export function HeaderDownloadButton(): JSX.Element {
   return (
     <div>
       <TelemetryLink
-        className="hidden lg:flex font-semibold no-underline hover:no-underline items-center text-white hover:text-white bg-gradient-to-b from-violet-500 to-violet-600 border-0 py-3 px-6 focus:outline-hidden hover:from-violet-600 hover:to-violet-700 rounded-lg text-base mt-0 mb-0 ml-4"
+        className="hidden lg:flex font-semibold no-underline hover:no-underline items-center text-white hover:text-white bg-gradient-to-b from-violet-500 to-violet-600 border-0 py-3 px-6 focus:outline-hidden hover:from-violet-600 hover:to-violet-700 rounded-lg text-base mt-0 mb-0 ml-4 mr-2"
         eventPath="landing"
         eventTitle="hero-download"
         to={`/downloads/${url}`}>

--- a/website/src/components/GitHubStarsButton.tsx
+++ b/website/src/components/GitHubStarsButton.tsx
@@ -43,11 +43,13 @@ export function GitHubStarsButton(): JSX.Element {
       href="https://github.com/podman-desktop/podman-desktop"
       target="_blank"
       rel="noopener noreferrer"
-      className="inline-flex items-center gap-2 px-4 py-[9px] border border-black dark:border-white rounded-lg navbar__item navbar__link font-medium">
+      className="hidden lg:flex items-center gap-2 px-4 py-[9px] border border-black dark:border-white rounded-lg navbar__item navbar__link font-medium min-w-[9rem]">
       <FontAwesomeIcon icon={faGithub} />
       <span>Star</span>
       {stars && (
-        <span id="github-stars-badge" className="ml-2 px-2 py-1 bg-charcoal-300 rounded text-white text-xs">
+        <span
+          id="github-stars-badge"
+          className="ml-2 px-2 py-1 bg-charcoal-300 rounded text-white text-xs min-w-[2.5rem] text-center">
           {stars}
         </span>
       )}


### PR DESCRIPTION
chore: fix github button, remove github link, add spacing.

### What does this PR do?

* Fixeds the github button by hiding on smaller screens (similar to the
  Download button)
* Removes the GitHub link since we have the button with stars now
* Adds spacing to the Download button since it was too close to the
  light/dark mode change.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->


https://github.com/user-attachments/assets/a89cb478-4bcd-4b24-b8f8-a17877ce817d



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/podman-desktop/issues/12419

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

View the website :)

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
