### PR TITLE
feat: added switching users and clusters

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -27,6 +27,7 @@ import type {
   Cluster,
   Context as KubernetesContext,
   KubernetesObject,
+  User,
   V1ConfigMap,
   V1CronJob,
   V1Deployment,
@@ -2579,6 +2580,10 @@ export class PluginSystem {
       return kubernetesClient.getClusters();
     });
 
+    this.ipcHandle('kubernetes-client:getUsers', async (): Promise<User[]> => {
+      return kubernetesClient.getUsers();
+    });
+
     this.ipcHandle('kubernetes-client:getCurrentNamespace', async (): Promise<string | undefined> => {
       return kubernetesClient.getCurrentNamespace();
     });
@@ -2599,8 +2604,21 @@ export class PluginSystem {
     });
     this.ipcHandle(
       'kubernetes-client:updateContext',
-      async (_listener, contextName: string, newContextName: string, newContextNamespace: string): Promise<void> => {
-        return kubernetesClient.updateContext(contextName, newContextName, newContextNamespace);
+      async (
+        _listener,
+        contextName: string,
+        newContextName: string,
+        newContextNamespace: string,
+        newContextCluster: string,
+        newContextUser: string,
+      ): Promise<void> => {
+        return kubernetesClient.updateContext(
+          contextName,
+          newContextName,
+          newContextNamespace,
+          newContextCluster,
+          newContextUser,
+        );
       },
     );
 

--- a/packages/main/src/plugin/kubernetes/kubernetes-client-kubeconfig.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client-kubeconfig.spec.ts
@@ -38,9 +38,6 @@ class TestKubernetesClient extends KubernetesClient {
   public setContexts(contexts: Context[]): void {
     this.kubeConfig.contexts = contexts;
   }
-  public getUsers(): User[] {
-    return this.kubeConfig.users;
-  }
   public setCurrentContext(name: string): void {
     this.currentContextName = name;
   }
@@ -201,7 +198,7 @@ describe('context tests', () => {
       throw new Error('originalContexts[0].name should be defined');
     }
 
-    await client.updateContext(originalContexts[0].name, 'new-name', 'new-namespace');
+    await client.updateContext(originalContexts[0].name, 'new-name', 'new-namespace', '', '');
     const contexts = client.getContexts();
     expect(contexts.length).toBe(2);
     expect(client.getContexts().length).toBe(2);
@@ -221,7 +218,7 @@ describe('context tests', () => {
       throw new Error('originalContexts[0].name should be defined');
     }
 
-    await client.updateContext(originalContexts[0].name, originalContexts[0].name, '');
+    await client.updateContext(originalContexts[0].name, originalContexts[0].name, '', '', '');
     const contexts = client.getContexts();
     expect(contexts.length).toBe(2);
     expect(client.getContexts().length).toBe(2);
@@ -232,6 +229,44 @@ describe('context tests', () => {
 
     expect(contexts[0].name).toBe(originalContexts[0].name);
     expect(contexts[0].namespace).toBeUndefined();
+  });
+
+  test('should update the cluster updating context from config', async () => {
+    client.saveKubeConfig = vi.fn().mockImplementation((_config: KubeConfig) => {});
+
+    if (!originalContexts[0]?.name) {
+      throw new Error('originalContexts[0].name should be defined');
+    }
+
+    await client.updateContext(originalContexts[0].name, originalContexts[0].name, 'namespace', 'cluster2', 'user1');
+    const contexts = client.getContexts();
+    expect(contexts.length).toBe(2);
+    expect(client.getContexts().length).toBe(2);
+
+    if (!contexts[0]?.name) {
+      throw new Error('contexts[0].name should be defined');
+    }
+
+    expect(contexts[0].cluster).toBe('cluster2');
+  });
+
+  test('should update the user updating context from config', async () => {
+    client.saveKubeConfig = vi.fn().mockImplementation((_config: KubeConfig) => {});
+
+    if (!originalContexts[0]?.name) {
+      throw new Error('originalContexts[0].name should be defined');
+    }
+
+    await client.updateContext(originalContexts[0].name, originalContexts[0].name, 'namespace', 'cluster1', 'user2');
+    const contexts = client.getContexts();
+    expect(contexts.length).toBe(2);
+    expect(client.getContexts().length).toBe(2);
+
+    if (!contexts[0]?.name) {
+      throw new Error('contexts[0].name should be defined');
+    }
+
+    expect(contexts[0].user).toBe('user2');
   });
 
   test('should be a no-op if the context name is not found', async () => {

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.ts
@@ -29,6 +29,7 @@ import type {
   KubernetesObject,
   RequestContext,
   ResponseContext,
+  User,
   V1APIGroup,
   V1APIResource,
   V1ConfigMap,
@@ -331,6 +332,10 @@ export class KubernetesClient {
     return this.kubeConfig.clusters;
   }
 
+  getUsers(): User[] {
+    return this.kubeConfig.users;
+  }
+
   getCurrentNamespace(): string | undefined {
     return this.currentNamespace;
   }
@@ -403,7 +408,13 @@ export class KubernetesClient {
     this.apiSender.send('kubernetes-context-update');
   }
 
-  async updateContext(contextName: string, newContextName: string, newContextNamespace: string): Promise<void> {
+  async updateContext(
+    contextName: string,
+    newContextName: string,
+    newContextNamespace: string,
+    newContextCluster: string,
+    newContextUser: string,
+  ): Promise<void> {
     const newConfig = new KubeConfig();
 
     const originalContext = this.kubeConfig.contexts.find(context => context.name === contextName);
@@ -415,6 +426,8 @@ export class KubernetesClient {
     const editedContext = {
       ...originalContext,
       name: newContextName,
+      cluster: newContextCluster,
+      user: newContextUser,
       ...namespaceField,
     };
 

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -26,6 +26,7 @@ import type {
   Cluster,
   Context,
   KubernetesObject,
+  User,
   V1ConfigMap,
   V1CronJob,
   V1Deployment,
@@ -1877,8 +1878,21 @@ export function initExposure(): void {
   });
   contextBridge.exposeInMainWorld(
     'kubernetesUpdateContext',
-    async (contextName: string, newContextName: string, newContextNamespace: string): Promise<void> => {
-      return ipcInvoke('kubernetes-client:updateContext', contextName, newContextName, newContextNamespace);
+    async (
+      contextName: string,
+      newContextName: string,
+      newContextNamespace: string,
+      newContextCluster: string,
+      newContextUser: string,
+    ): Promise<void> => {
+      return ipcInvoke(
+        'kubernetes-client:updateContext',
+        contextName,
+        newContextName,
+        newContextNamespace,
+        newContextCluster,
+        newContextUser,
+      );
     },
   );
   contextBridge.exposeInMainWorld('kubernetesDeleteContext', async (contextName: string): Promise<Context[]> => {
@@ -1934,6 +1948,10 @@ export function initExposure(): void {
 
   contextBridge.exposeInMainWorld('kubernetesGetClusters', async (): Promise<Cluster[]> => {
     return ipcInvoke('kubernetes-client:getClusters');
+  });
+
+  contextBridge.exposeInMainWorld('kubernetesGetUsers', async (): Promise<User[]> => {
+    return ipcInvoke('kubernetes-client:getUsers');
   });
 
   contextBridge.exposeInMainWorld('kubernetesGetCurrentNamespace', async (): Promise<string | undefined> => {

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRenderingEditModal.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRenderingEditModal.svelte
@@ -118,19 +118,6 @@ function onUserStateChange(key: unknown): void {
         <ErrorMessage error={contextNameErrorMessage} />
     {/if}
 
-    <label for="contextNamespace" class="block my-2 text-sm font-bold text-[var(--pd-modal-text)]">Namespace</label>
-    <Input
-        bind:value={contextNamespace}
-        name="contextNamespace"
-        id="contextNamespace"
-        placeholder="Enter context namespace (e.g. production)"
-        aria-invalid={contextNamespaceErrorMessage !== ''}
-        aria-label="contextNamespace"
-        required />
-    {#if contextNamespaceErrorMessage}
-        <ErrorMessage error={contextNamespaceErrorMessage} />
-    {/if}
-
     <label for="contextCluster" class="block my-2 text-sm font-bold text-[var(--pd-modal-text)]">Cluster</label>
     <Dropdown
       class="text-sm"
@@ -154,6 +141,19 @@ function onUserStateChange(key: unknown): void {
         label: user.name,
       }))}>
     </Dropdown>
+
+    <label for="contextNamespace" class="block my-2 text-sm font-bold text-[var(--pd-modal-text)]">Namespace</label>
+    <Input
+        bind:value={contextNamespace}
+        name="contextNamespace"
+        id="contextNamespace"
+        placeholder="Enter context namespace (e.g. production)"
+        aria-invalid={contextNamespaceErrorMessage !== ''}
+        aria-label="contextNamespace"
+        required />
+    {#if contextNamespaceErrorMessage}
+        <ErrorMessage error={contextNamespaceErrorMessage} />
+    {/if}
     </div>
     <svelte:fragment slot="buttons">
     <Button

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRenderingEditModal.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRenderingEditModal.svelte
@@ -41,10 +41,10 @@ $effect(() => {
 });
 
 onMount(async () => {
-  contextName = contextToEdit?.name;
-  contextNamespace = contextToEdit?.namespace ?? '';
-  contextCluster = contextToEdit?.cluster;
-  contextUser = contextToEdit?.user;
+  contextName = contextToEdit.name;
+  contextNamespace = contextToEdit.namespace ?? '';
+  contextCluster = contextToEdit.cluster;
+  contextUser = contextToEdit.user;
   clusters = await window.kubernetesGetClusters();
   users = await window.kubernetesGetUsers();
   kubeConfig = (await window.getConfigurationValue('kubernetes.Kubeconfig')) ?? kubeConfig;
@@ -63,10 +63,12 @@ function disableSave(name: string, namespace: string): boolean {
   return invalidName && invalidNamespace && invalidCluster && invalidUser;
 }
 
-async function editContext(contextName: string, contextNamespace: string): Promise<void> {
-  const context = contexts?.find(ctx => ctx.name === contextName);
-  if (context && context.namespace === contextNamespace) return;
-
+async function editContext(
+  contextName: string,
+  contextNamespace: string,
+  contextUser: string,
+  contextCluster: string,
+): Promise<void> {
   try {
     await window.kubernetesUpdateContext(
       contextToEdit.name,
@@ -164,7 +166,7 @@ function onUserStateChange(key: unknown): void {
         class="col-start-4"
         disabled={disableSave(contextName, contextNamespace)}
         on:click={async (): Promise<void> => {
-        await editContext(contextName, contextNamespace);
+        await editContext(contextName, contextNamespace, contextUser, contextCluster);
         }}>Save</Button>
     </svelte:fragment>
 </Dialog>


### PR DESCRIPTION
### What does this PR do?
Adds editing of users and clusters

- [x] Needs rebase after https://github.com/podman-desktop/podman-desktop/pull/12415
### Screenshot / video of UI



### What issues does this PR fix or reference?
Closes #11283 

### How to test this PR?
1. Create context (minikube/kind/etc...)
2. Go to preferences -> kubernes context
3. Try to change user and cluster

- [x] Tests are covering the bug fix or the new feature
