### PR TITLE
fix: use default padding for markdown buttons

### DIFF
--- a/packages/renderer/src/lib/markdown/Markdown.svelte
+++ b/packages/renderer/src/lib/markdown/Markdown.svelte
@@ -38,7 +38,6 @@ UI guidelines -->
   color: var(--pd-link);
   text-decoration: none;
   border-radius: 4px;
-  padding: 0.125rem;
 }
 .markdown :global(a):hover {
   background-color: var(--pd-link-hover-bg);


### PR DESCRIPTION
### What does this PR do?

Use default padding for Markdown buttons.

### Screenshot / video of UI

Notifications showed only for the demo visualisation:
<img width="1207" src="https://github.com/user-attachments/assets/b8bdf1fc-3e83-4ba4-bdc4-0bdad48eb56b" />


### What issues does this PR fix or reference?

#11994 

### How to test this PR?

Ensure that Markdown buttons have proper paddings.

- [ ] Tests are covering the bug fix or the new feature
