### PR TITLE
chore: fix argos screenshots github button

### DIFF
--- a/website-argos/screenshot.css
+++ b/website-argos/screenshot.css
@@ -25,3 +25,8 @@ video {
   height: 0px !important;
   width: 0px !important;
 }
+
+/* Hide the GitHub stars badge, since this dynamically changes, it would create false errors in Argos */
+#github-stars-badge {
+  visibility: hidden;
+}

--- a/website/src/components/GitHubStarsButton.tsx
+++ b/website/src/components/GitHubStarsButton.tsx
@@ -46,7 +46,11 @@ export function GitHubStarsButton(): JSX.Element {
       className="inline-flex items-center gap-2 px-4 py-[9px] border border-black dark:border-white rounded-lg navbar__item navbar__link font-medium">
       <FontAwesomeIcon icon={faGithub} />
       <span>Star</span>
-      {stars && <span className="ml-2 px-2 py-1 bg-charcoal-300 rounded text-white text-xs">{stars}</span>}
+      {stars && (
+        <span id="github-stars-badge" className="ml-2 px-2 py-1 bg-charcoal-300 rounded text-white text-xs">
+          {stars}
+        </span>
+      )}
     </a>
   );
 }


### PR DESCRIPTION
chore: fix argos screenshots github button

### What does this PR do?

Hides the "badge" section of the GitHub stars so that we do not have
false errors within Argos if the amount of stars in the repo changed.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/podman-desktop/issues/12446

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

Tests should pass now

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
