### PR TITLE
chore(next-build): define explicit permissions

### DIFF
--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -27,6 +27,9 @@ env:
   GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
   DEBUG: electron-builder
 
+permissions:
+  contents: read
+
 jobs:
 
   tag:


### PR DESCRIPTION
### What does this PR do?

Define explicitly the permissions the `next-build` workflow has access. We don't need to write anything on podman-desktop/podman-desktop. The workflow uses `PODMAN_DESKTOP_BOT_TOKEN`, `NPM_AUTH_TOKEN` and `SEGMENT_WRITE_KEY` secrets, I can't find a specific permissions to use secrets[^1]

[^1]: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#permissions 

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/12215

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- After merging, next build pipeline should be 💚 
