### PR TITLE
feat: added duplicating of contexts

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -2594,6 +2594,10 @@ export class PluginSystem {
       },
     );
 
+    this.ipcHandle('kubernetes-client:duplicateContext', async (_listener, contextName: string): Promise<void> => {
+      return kubernetesClient.duplicateContext(contextName);
+    });
+
     this.ipcHandle('kubernetes-client:setContext', async (_listener, contextName: string): Promise<void> => {
       return kubernetesClient.setContext(contextName);
     });

--- a/packages/main/src/plugin/kubernetes/kubernetes-client-kubeconfig.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client-kubeconfig.spec.ts
@@ -180,7 +180,13 @@ describe('context tests', () => {
 
     const newContext1 = { name: 'ctx1-1', user: 'user1', cluster: 'cluster1', currentContext: true };
     const newContext2 = { name: 'ctx1-2', user: 'user1', cluster: 'cluster1', currentContext: true };
-    client.setContexts([newContext1, newContext2]);
+    client.setContexts([newContext1]);
+
+    newContextName = client.findNewContextName(originalContexts[0].name);
+    expect(newContextName).toBe('ctx1-2');
+
+    client.setContexts([newContext2]);
+
     newContextName = client.findNewContextName(newContext2.name);
     expect(newContextName).toBe('ctx1-2-1');
 

--- a/packages/main/src/plugin/kubernetes/kubernetes-client-kubeconfig.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client-kubeconfig.spec.ts
@@ -150,6 +150,36 @@ describe('context tests', () => {
     expect(client.getClusters().length).toBe(2);
   });
 
+  test('should duplicate context from config', async () => {
+    client.saveKubeConfig = vi.fn().mockImplementation((_config: KubeConfig) => {});
+
+    if (!originalContexts[0]?.name) {
+      throw new Error('originalContexts[0].name should be defined');
+    }
+
+    await client.duplicateContext(originalContexts[0].name);
+    let contexts = client.getContexts();
+    expect(contexts.length).toBe(3);
+    expect(client.getContexts().length).toBe(3);
+
+    if (!contexts[2]?.name) {
+      throw new Error('contexts[2].name should be defined');
+    }
+
+    expect(contexts[2].name).toBe('ctx1-1');
+
+    await client.duplicateContext(originalContexts[0].name);
+    contexts = client.getContexts();
+    expect(contexts.length).toBe(4);
+    expect(client.getContexts().length).toBe(4);
+
+    if (!contexts[3]?.name) {
+      throw new Error('contexts[3].name should be defined');
+    }
+
+    expect(contexts[3].name).toBe('ctx1-2');
+  });
+
   test('should be a no-op if the context name is not found', async () => {
     client.saveKubeConfig = vi.fn().mockImplementation((_config: KubeConfig) => {});
 

--- a/packages/main/src/plugin/kubernetes/kubernetes-client-kubeconfig.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client-kubeconfig.spec.ts
@@ -162,22 +162,30 @@ describe('context tests', () => {
     expect(contexts.length).toBe(3);
     expect(client.getContexts().length).toBe(3);
 
-    if (!contexts[2]?.name) {
-      throw new Error('contexts[2].name should be defined');
-    }
-
-    expect(contexts[2].name).toBe('ctx1-1');
-
     await client.duplicateContext(originalContexts[0].name);
     contexts = client.getContexts();
     expect(contexts.length).toBe(4);
     expect(client.getContexts().length).toBe(4);
+  });
 
-    if (!contexts[3]?.name) {
-      throw new Error('contexts[3].name should be defined');
+  test('should create unique context name', () => {
+    client.saveKubeConfig = vi.fn().mockImplementation((_config: KubeConfig) => {});
+
+    if (!originalContexts[0]?.name) {
+      throw new Error('originalContexts[0].name should be defined');
     }
 
-    expect(contexts[3].name).toBe('ctx1-2');
+    let newContextName = client.findNewContextName(originalContexts[0].name);
+    expect(newContextName).toBe('ctx1-1');
+
+    const newContext1 = { name: 'ctx1-1', user: 'user1', cluster: 'cluster1', currentContext: true };
+    const newContext2 = { name: 'ctx1-2', user: 'user1', cluster: 'cluster1', currentContext: true };
+    client.setContexts([newContext1, newContext2]);
+    newContextName = client.findNewContextName(newContext2.name);
+    expect(newContextName).toBe('ctx1-2-1');
+
+    newContextName = client.findNewContextName(newContextName);
+    expect(newContextName).toBe('ctx1-2-1-1');
   });
 
   test('should be a no-op if the context name is not found', async () => {

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1872,6 +1872,10 @@ export function initExposure(): void {
     return ipcInvoke('kubernetes-client:getDetailedContexts');
   });
 
+  contextBridge.exposeInMainWorld('kubernetesDuplicateContext', async (contextName: string): Promise<void> => {
+    return ipcInvoke('kubernetes-client:duplicateContext', contextName);
+  });
+
   contextBridge.exposeInMainWorld('kubernetesDeleteContext', async (contextName: string): Promise<Context[]> => {
     return ipcInvoke('kubernetes-client:deleteContext', contextName);
   });

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { faQuestionCircle } from '@fortawesome/free-regular-svg-icons';
-import { faRightToBracket, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faCopy, faRightToBracket, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { Button, EmptyScreen, ErrorMessage, Spinner, Tooltip } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 import Fa from 'svelte-fa';
@@ -110,6 +110,10 @@ async function handleDeleteContext(contextName: string): Promise<void> {
       $kubernetesContexts = setKubeUIContextError($kubernetesContexts, contextName, e);
     }
   }
+}
+
+async function handleDuplicateContext(contextName: string): Promise<void> {
+  await window.kubernetesDuplicateContext(contextName);
 }
 
 function isContextReachable(contextName: string, experimental: boolean): boolean {
@@ -255,6 +259,8 @@ async function connect(contextName: string): Promise<void> {
                 icon={faRightToBracket}
                 onClick={(): Promise<void> => handleSetContext(context.name)}></ListItemButtonIcon>
             {/if}
+            <ListItemButtonIcon title="Duplicate Context" icon={faCopy} onClick={(): Promise<void> => handleDuplicateContext(context.name)}
+            ></ListItemButtonIcon>
             <ListItemButtonIcon title="Delete Context" icon={faTrash} onClick={(): Promise<void> => handleDeleteContext(context.name)}
             ></ListItemButtonIcon>
           </div>


### PR DESCRIPTION
### What does this PR do?
Added duplicating of kubernetes contexts

### Screenshot / video of UI
[Screencast_20250513_071206.webm](https://github.com/user-attachments/assets/18638a9d-3ab6-4deb-842e-ef96a65c43c4)


### What issues does this PR fix or reference?
Part of https://github.com/podman-desktop/podman-desktop/issues/11283

### How to test this PR?
1. Create context (minikube/kind/etc...)
2. Go to preferences -> kubernes context
3. Try to duplicate created context

- [x] Tests are covering the bug fix or the new feature
