### PR TITLE
chore(website): added option to specify link in read the docs button

### DIFF
--- a/website/src/components/ReadTheDocsButton.tsx
+++ b/website/src/components/ReadTheDocsButton.tsx
@@ -1,11 +1,11 @@
 import Link from '@docusaurus/Link';
 
-export function ReadTheDocsButton(): JSX.Element {
+export function ReadTheDocsButton(props: Readonly<{ to: string }>): JSX.Element {
   return (
     <div>
       <Link
         className="no-underline hover:no-underline inline-flex text-white font-bold hover:text-white bg-purple-600 border-0 py-2 px-4 mt-6 mb-1 focus:outline-hidden hover:bg-purple-700 rounded-lg text-base"
-        to="/docs/intro">
+        to={props.to}>
         Read the Docs
       </Link>
     </div>


### PR DESCRIPTION
### What does this PR do?
Adds link/to property for specifying link for the button 

### Screenshot / video of UI

### What issues does this PR fix or reference?
Required for https://github.com/podman-desktop/podman-desktop/pull/12304
https://github.com/podman-desktop/podman-desktop/pull/12305

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
