### PR TITLE
chore(test): parameterize runner close timeout

### DIFF
--- a/tests/playwright/src/runner/podman-desktop-runner.ts
+++ b/tests/playwright/src/runner/podman-desktop-runner.ts
@@ -199,7 +199,7 @@ export class Runner {
     }
   }
 
-  public async close(): Promise<void> {
+  public async close(timeout: number = 30_000): Promise<void> {
     // Stop playwright tracing
     await this.stopTracing();
 
@@ -209,7 +209,6 @@ export class Runner {
 
     if (this.getElectronApp()) {
       const pid = this.getElectronApp()?.process()?.pid;
-      const timeout = 30000;
       console.log(`Closing Podman Desktop with a timeout of ${timeout} ms`);
       try {
         await Promise.race([


### PR DESCRIPTION
Signed-off-by: Anton Misskii <amisskii@redhat.com>

### What does this PR do?

This PR makes the runner close timeout configurable. This is useful in scenarios where shutdown times may vary due to different system configurations or runtime conditions.