### PR TITLE
chore: make the file items in preferences clearable

### DIFF
--- a/extensions/podman/packages/extension/package.json
+++ b/extensions/podman/packages/extension/package.json
@@ -151,8 +151,7 @@
           "type": "string",
           "format": "file",
           "scope": "ContainerProviderConnectionFactory",
-          "description": "Image Path (Optional)",
-          "readonly": false
+          "description": "Image Path (Optional)"
         },
         "podman.factory.machine.image-uri": {
           "type": "string",

--- a/extensions/podman/packages/extension/package.json
+++ b/extensions/podman/packages/extension/package.json
@@ -151,7 +151,8 @@
           "type": "string",
           "format": "file",
           "scope": "ContainerProviderConnectionFactory",
-          "description": "Image Path (Optional)"
+          "description": "Image Path (Optional)",
+          "readonly": false
         },
         "podman.factory.machine.image-uri": {
           "type": "string",

--- a/packages/renderer/src/lib/preferences/item-formats/FileItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/FileItem.spec.ts
@@ -61,7 +61,7 @@ test('Ensure clicking on browse invokes openDialog with default selector', async
   };
 
   render(FileItem, { record, value: '' });
-  const input = screen.getByRole('button');
+  const input = screen.getByRole('button', { name: 'browse' });
   expect(input).toBeInTheDocument();
   await userEvent.click(input);
 
@@ -83,7 +83,7 @@ test('Ensure clicking on browse invokes openDialog with corresponding directory 
   };
 
   render(FileItem, { record, value: '' });
-  const input = screen.getByRole('button');
+  const input = screen.getByRole('button', { name: 'browse' });
   expect(input).toBeInTheDocument();
   await userEvent.click(input);
 
@@ -108,11 +108,36 @@ test('Ensure the onChange is called if the fileInput onChange is triggered', asy
 
   const onChangeMock = vi.fn().mockResolvedValue('');
   render(FileItem, { record, value: '', onChange: onChangeMock });
-  const browseButton = screen.getByRole('button');
+  const browseButton = screen.getByRole('button', { name: 'browse' });
   expect(browseButton).toBeInTheDocument();
   await userEvent.click(browseButton);
 
   expect(openDialogMock).toHaveBeenCalled();
 
   expect(onChangeMock).toHaveBeenCalled();
+});
+
+test('Ensure there is a clear button for the input', async () => {
+  openDialogMock.mockResolvedValue([]);
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'string',
+    format: 'file',
+  };
+
+  render(FileItem, { record, value: '/abc/123' });
+  let inputField = screen.getByLabelText('record-description');
+  expect(inputField).toBeInTheDocument();
+  expect((inputField as HTMLInputElement).value).toBe('/abc/123');
+
+  const clear = screen.getByRole('button', { name: 'clear' });
+  expect(clear).toBeInTheDocument();
+  await userEvent.click(clear);
+
+  inputField = screen.getByLabelText('record-description');
+  expect(inputField).toBeInTheDocument();
+  expect((inputField as HTMLInputElement).value).toBe('');
 });

--- a/packages/renderer/src/lib/preferences/item-formats/FileItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/FileItem.svelte
@@ -29,6 +29,7 @@ function onChangeFileInput(value: string): void {
     bind:value={value}
     onChange={onChangeFileInput}
     readonly={record.readonly ?? true}
+    clearable={true}
     placeholder={record.placeholder}
     options={dialogOptions}
     aria-invalid={invalidEntry}

--- a/packages/renderer/src/lib/ui/FileInput.svelte
+++ b/packages/renderer/src/lib/ui/FileInput.svelte
@@ -10,6 +10,7 @@ export let value: string | undefined = undefined;
 export let options: OpenDialogOptions;
 export let readonly: boolean = false;
 export let required: boolean = false;
+export let clearable: boolean = false;
 export let onChange: (value: string) => void = () => {};
 
 async function openDialog(): Promise<void> {
@@ -37,6 +38,7 @@ function onInput(event: Event): void {
     placeholder={placeholder}
     readonly={readonly}
     required={required}
+    clearable={clearable}
     aria-label={$$props['aria-label']}
     aria-invalid={$$props['aria-invalid']}>
   </Input>

--- a/packages/ui/src/lib/inputs/Input.svelte
+++ b/packages/ui/src/lib/inputs/Input.svelte
@@ -112,9 +112,10 @@ async function onClear(): Promise<void> {
     {#if clearable}
       <button
         class="px-0.5 cursor-pointer text-[color:var(--pd-input-field-icon)] group-hover:text-[color:var(--pd-input-field-hover-icon)] group-focus-within:text-[color:var(--pd-input-field-focused-icon)]"
-        class:hidden={!value || readonly || disabled}
+        class:hidden={!value || disabled}
         aria-label="clear"
-        onclick={onClear}>
+        onclick={onClear}
+        type="button">
         <Fa icon={faXmark} />
       </button>
     {/if}


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Changes the field of the image path in the Podman configuration to not be read only so that users are able to remove a file if they selected one and write/paste the path themselves

### Screenshot / video of UI

https://github.com/user-attachments/assets/652db41a-2f24-45e3-b633-dffd11ef22eb

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Fixes https://github.com/podman-desktop/podman-desktop/issues/11904

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
