### PR TITLE
chore(deps-dev): bump eslint-plugin-svelte from 3.5.1 to 3.6.0

### DIFF
--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -27,7 +27,7 @@
     "@types/validator": "^13.15.0",
     "@typescript-eslint/eslint-plugin": "^8.32.1",
     "@xterm/addon-serialize": "^0.13.0",
-    "eslint-plugin-svelte": "^3.5.1",
+    "eslint-plugin-svelte": "^3.6.0",
     "filesize": "^10.1.6",
     "humanize-duration": "^3.32.2",
     "jsdom": "^27.0.0-beta.1",

--- a/packages/renderer/src/lib/ui/ProviderInfo.svelte
+++ b/packages/renderer/src/lib/ui/ProviderInfo.svelte
@@ -14,7 +14,7 @@ interface Props {
 let { provider = '', context = '' }: Props = $props();
 
 // providerName: name of the provider in lowercase (e.g. podman, docker, kubernetes)
-let providerName: ProviderNameType = $derived(undefined);
+let providerName: ProviderNameType = $derived(getProviderName(provider));
 
 function getProviderName(providerName: string): ProviderNameType {
   switch (providerName?.toLowerCase()) {
@@ -28,10 +28,6 @@ function getProviderName(providerName: string): ProviderNameType {
       return undefined;
   }
 }
-
-$effect(() => {
-  providerName = getProviderName(provider);
-});
 </script>
 
 <Label tip={provider === 'Kubernetes' ? context : ''} name={provider} capitalize>

--- a/packages/renderer/src/lib/ui/ProviderInfo.svelte
+++ b/packages/renderer/src/lib/ui/ProviderInfo.svelte
@@ -14,7 +14,7 @@ interface Props {
 let { provider = '', context = '' }: Props = $props();
 
 // providerName: name of the provider in lowercase (e.g. podman, docker, kubernetes)
-let providerName: ProviderNameType = $state(undefined);
+let providerName: ProviderNameType = $derived(undefined);
 
 function getProviderName(providerName: string): ProviderNameType {
   switch (providerName?.toLowerCase()) {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -162,7 +162,7 @@
     "@testing-library/user-event": "^14.6.1",
     "@tsconfig/svelte": "^5.0.4",
     "@typescript-eslint/eslint-plugin": "^8.32.1",
-    "eslint-plugin-svelte": "^3.5.1",
+    "eslint-plugin-svelte": "^3.6.0",
     "jsdom": "^27.0.0-beta.1",
     "svelte": "5.28.2",
     "svelte-check": "^4.1.7",

--- a/packages/ui/src/lib/dropdown/Dropdown.svelte
+++ b/packages/ui/src/lib/dropdown/Dropdown.svelte
@@ -36,7 +36,7 @@ let {
 }: Props = $props();
 
 let opened: boolean = $state(false);
-let selectLabel: string = $state('');
+let selectLabel: string = $derived('');
 let highlightIndex: number = $state(-1);
 let comp: HTMLElement;
 

--- a/packages/ui/src/lib/dropdown/Dropdown.svelte
+++ b/packages/ui/src/lib/dropdown/Dropdown.svelte
@@ -36,7 +36,7 @@ let {
 }: Props = $props();
 
 let opened: boolean = $state(false);
-let selectLabel: string = $derived('');
+let selectLabel: string = $derived(options.find(o => o.value === value)?.label ?? value ?? '');
 let highlightIndex: number = $state(-1);
 let comp: HTMLElement;
 
@@ -46,10 +46,6 @@ onMount(() => {
   if (!value && options?.length > 0) {
     value = options[0].value;
   }
-});
-
-$effect(() => {
-  selectLabel = options.find(o => o.value === value)?.label ?? value ?? '';
 });
 
 function onKeyDown(e: KeyboardEvent): void {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -640,8 +640,8 @@ importers:
         specifier: ^5.5.0
         version: 5.5.0
       eslint-plugin-svelte:
-        specifier: ^3.5.1
-        version: 3.5.1(eslint@9.26.0(jiti@2.4.2))(svelte@5.28.2)
+        specifier: ^3.6.0
+        version: 3.6.0(eslint@9.26.0(jiti@2.4.2))(svelte@5.28.2)
       filesize:
         specifier: ^10.1.6
         version: 10.1.6
@@ -752,8 +752,8 @@ importers:
         specifier: ^8.32.1
         version: 8.32.1(@typescript-eslint/parser@8.32.1(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3)
       eslint-plugin-svelte:
-        specifier: ^3.5.1
-        version: 3.5.1(eslint@9.26.0(jiti@2.4.2))(svelte@5.28.2)
+        specifier: ^3.6.0
+        version: 3.6.0(eslint@9.26.0(jiti@2.4.2))(svelte@5.28.2)
       jsdom:
         specifier: ^27.0.0-beta.1
         version: 27.0.0-beta.1
@@ -854,8 +854,8 @@ importers:
         specifier: 7.0.3
         version: 7.0.3
       eslint-plugin-svelte:
-        specifier: ^3.5.1
-        version: 3.5.1(eslint@9.26.0(jiti@2.4.2))(svelte@5.28.2)
+        specifier: ^3.6.0
+        version: 3.6.0(eslint@9.26.0(jiti@2.4.2))(svelte@5.28.2)
       postcss:
         specifier: ^8.5.3
         version: 8.5.3
@@ -2750,12 +2750,6 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
-
-  '@eslint-community/eslint-utils@4.5.1':
-    resolution: {integrity: sha512-soEIOALTfTK6EjmKMMoLugwaP0rzkad90iIWd1hMO9ARkSAyjfMfkRRhLvD5qH7vvM0Cg72pieUfR6yh6XxC4w==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
 
   '@eslint-community/eslint-utils@4.7.0':
     resolution: {integrity: sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==}
@@ -6702,8 +6696,8 @@ packages:
     peerDependencies:
       eslint: ^8.0.0 || ^9.0.0
 
-  eslint-plugin-svelte@3.5.1:
-    resolution: {integrity: sha512-Qn1slddZHfqYiDO6IN8/iN3YL+VuHlgYjm30FT+hh0Jf/TX0jeZMTJXQMajFm5f6f6hURi+XO8P+NPYD+T4jkg==}
+  eslint-plugin-svelte@3.6.0:
+    resolution: {integrity: sha512-IIf6Cj6yQuCwL7Qd8bX13BZspz+DQsOkClozMF9EkW20FSxI75Ndd5ZzbviCn32DdXRo9FUWXn+YMIL46qPOOg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.1 || ^9.0.0
@@ -8212,8 +8206,8 @@ packages:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
 
-  known-css-properties@0.35.0:
-    resolution: {integrity: sha512-a/RAk2BfKk+WFGhhOCAYqSiFLc34k8Mt/6NWRI4joER0EYUzXIcFivjjnoD3+XU1DggLn/tZc3DOAgke7l8a4A==}
+  known-css-properties@0.36.0:
+    resolution: {integrity: sha512-A+9jP+IUmuQsNdsLdcg6Yt7voiMF/D4K83ew0OpJtpu+l34ef7LaohWV0Rc6KNvzw6ZDizkqfyB5JznZnzuKQA==}
 
   kolorist@1.8.0:
     resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
@@ -14621,11 +14615,6 @@ snapshots:
   '@esbuild/win32-x64@0.25.4':
     optional: true
 
-  '@eslint-community/eslint-utils@4.5.1(eslint@9.26.0(jiti@2.4.2))':
-    dependencies:
-      eslint: 9.26.0(jiti@2.4.2)
-      eslint-visitor-keys: 3.4.3
-
   '@eslint-community/eslint-utils@4.7.0(eslint@9.26.0(jiti@2.4.2))':
     dependencies:
       eslint: 9.26.0(jiti@2.4.2)
@@ -19327,13 +19316,13 @@ snapshots:
       semver: 7.7.1
       typescript: 5.8.3
 
-  eslint-plugin-svelte@3.5.1(eslint@9.26.0(jiti@2.4.2))(svelte@5.28.2):
+  eslint-plugin-svelte@3.6.0(eslint@9.26.0(jiti@2.4.2))(svelte@5.28.2):
     dependencies:
-      '@eslint-community/eslint-utils': 4.5.1(eslint@9.26.0(jiti@2.4.2))
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.26.0(jiti@2.4.2))
       '@jridgewell/sourcemap-codec': 1.5.0
       eslint: 9.26.0(jiti@2.4.2)
       esutils: 2.0.3
-      known-css-properties: 0.35.0
+      known-css-properties: 0.36.0
       postcss: 8.5.3
       postcss-load-config: 3.1.4(postcss@8.5.3)
       postcss-safe-parser: 7.0.1(postcss@8.5.3)
@@ -20350,7 +20339,7 @@ snapshots:
 
   history@4.10.1:
     dependencies:
-      '@babel/runtime': 7.26.10
+      '@babel/runtime': 7.27.1
       loose-envify: 1.4.0
       resolve-pathname: 3.0.0
       tiny-invariant: 1.3.3
@@ -21113,7 +21102,7 @@ snapshots:
 
   kleur@4.1.5: {}
 
-  known-css-properties@0.35.0: {}
+  known-css-properties@0.36.0: {}
 
   kolorist@1.8.0: {}
 
@@ -23635,7 +23624,7 @@ snapshots:
 
   regenerator-transform@0.15.2:
     dependencies:
-      '@babel/runtime': 7.26.10
+      '@babel/runtime': 7.27.1
 
   regexp-ast-analysis@0.7.1:
     dependencies:

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -36,7 +36,7 @@
     "@typescript-eslint/eslint-plugin": "^8.32.1",
     "autoprefixer": "^10.4.21",
     "cross-env": "7.0.3",
-    "eslint-plugin-svelte": "^3.5.1",
+    "eslint-plugin-svelte": "^3.6.0",
     "postcss": "^8.5.3",
     "postcss-load-config": "^6.0.1",
     "react": "18.2.0",


### PR DESCRIPTION
### What does this PR do?

fix: use $derived instead of $state

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

- [ ] Tests are covering the bug fix or the new feature
