### PR TITLE
chore(workflow): set permissions for daily-testing-build.yaml

### DIFF
--- a/.github/workflows/daily-testing-build.yaml
+++ b/.github/workflows/daily-testing-build.yaml
@@ -27,6 +27,9 @@ env:
   GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
   DEBUG: electron-builder
 
+permissions:
+  contents: read
+
 jobs:
   tag:
     name: Tagging


### PR DESCRIPTION
### What does this PR do?

Setting permission to `content: read` for `daily-testing-build.yaml`. From what I can read, it should not create any issues, as it seems to be using the `secrets.PODMAN_DESKTOP_BOT_TOKEN` for most operations.

The only operation I have some doubt is when it pushes the tag

https://github.com/podman-desktop/podman-desktop/blob/369f789197cfd5b92fc47c3f1d2e8d62a60295ee/.github/workflows/daily-testing-build.yaml#L88-L89

I don't see which token it is using, so might be an issue, but will see I guess?

> Should I trigger it manually after this is merged?

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/12215

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- next daily should be :green_circle: 
