### PR TITLE
feat(extension): add search by description in extension list

### DIFF
--- a/packages/renderer/src/lib/extensions/ExtensionList.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionList.svelte
@@ -29,7 +29,9 @@ const filteredInstalledExtensions: Readable<CombinedExtensionInfoUI[]> = derived
   [combinedInstalledExtensions, combinedInstalledExtensionSearchPattern],
   ([$combinedInstalledExtensions, $combinedInstalledExtensionSearchPattern]) => {
     return $combinedInstalledExtensions.filter(extension => {
-      return extension.displayName.toLowerCase().includes($combinedInstalledExtensionSearchPattern.toLowerCase());
+      return `${extension.displayName} ${extension.description}`
+        .toLowerCase()
+        .includes($combinedInstalledExtensionSearchPattern.toLowerCase());
     });
   },
 );
@@ -53,7 +55,9 @@ const filteredCatalogExtensions: Readable<CatalogExtensionInfoUI[]> = derived(
   [enhancedCatalogExtensions, catalogExtensionSearchPattern],
   ([$enhancedCatalogExtensions, $catalogExtensionSearchPattern]) => {
     return $enhancedCatalogExtensions.filter(extension => {
-      return extension.displayName.toLowerCase().includes($catalogExtensionSearchPattern.toLowerCase());
+      return `${extension.displayName} ${extension.shortDescription}`
+        .toLowerCase()
+        .includes($catalogExtensionSearchPattern.toLowerCase());
     });
   },
 );


### PR DESCRIPTION
### What does this PR do?

I tried searching for the bootc extension by typing `bootc` in the search box, but I couldn't find it. I realized that the search only looks at the display name of the extension, which doesn't contain the word bootc.

I changed the search logic to include the description of the extension in the search. Now, when I type `bootc`, it matches the extension with the display name "Bootable Container" because the description mentions bootc.

Searching only by name seems a bit strict, especially considering the currently small amount of extensions.

Ideally in the future, extensions will be able to provide a list of keywords associated with them so we can filter against those as well, instead of something arbitrary like the description.

### Screenshot / video of UI

Before

https://github.com/user-attachments/assets/700f255e-c148-4883-99e6-2fc0b884afda

After

https://github.com/user-attachments/assets/cde0b8af-6a28-4b5f-b86e-291c5c300831


### What issues does this PR fix or reference?

None

### How to test this PR?

Couldn't find where I should write the tests for this - if needed please let me know and I'll edit the PR

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature