### PR TITLE
fix(website): updated icon sizes in kubernetes section 

### DIFF
--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -289,7 +289,7 @@ function Pods(): JSX.Element {
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2 space-x-4 pt-16">
             <div className="flex flex-col md:items-start md:text-left items-center text-center">
               <ThemedImage
-                className="py-4 w-1/4"
+                className="py-4 h-[90px]"
                 alt="Develop and Test"
                 sources={{
                   light: useBaseUrl('img/developtest.svg'),
@@ -306,7 +306,7 @@ function Pods(): JSX.Element {
             </div>
             <div className="flex flex-col md:items-start md:text-left items-center text-center">
               <ThemedImage
-                className="py-4 w-1/4"
+                className="py-4 h-[90px]"
                 alt="Grow Your Skills at Your Pace"
                 sources={{
                   light: useBaseUrl('img/grow.svg'),
@@ -323,7 +323,7 @@ function Pods(): JSX.Element {
             </div>
             <div className="flex flex-col md:items-start md:text-left items-center text-center">
               <ThemedImage
-                className="py-4 w-1/4"
+                className="py-4 h-[90px]"
                 alt="Troubleshoot with Ease"
                 sources={{
                   light: useBaseUrl('img/troubleshoot1.svg'),
@@ -340,7 +340,7 @@ function Pods(): JSX.Element {
             </div>
             <div className="flex flex-col md:items-start md:text-left items-center text-center">
               <ThemedImage
-                className="py-4 w-1/4"
+                className="py-4 h-[90px]"
                 alt="Troubleshoot with Ease"
                 sources={{
                   light: useBaseUrl('img/troubleshoot2.svg'),


### PR DESCRIPTION
### What does this PR do?
Updates icon sizes in kubernetes section to match the ones in container section

Container section for icon ref:

<img width="1317" alt="image" src="https://github.com/user-attachments/assets/727f0630-d43b-4fc7-bb1b-89f697186f16" />


### Screenshot / video of UI
Prev: 

<img width="1317" alt="image" src="https://github.com/user-attachments/assets/bea94786-3a84-4f2e-a553-b87ca82f297a" />


This PR:

<img width="1317" alt="image" src="https://github.com/user-attachments/assets/922a288c-cba5-4177-a9f6-bbacff813d0f" />


### What issues does this PR fix or reference?


### How to test this PR?


- [ ] Tests are covering the bug fix or the new feature
