### PR TITLE
fix(website): updated sizes of headings in kubernetes section

### DIFF
--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -364,7 +364,7 @@ function Pods(): JSX.Element {
                   dark: useBaseUrl('img/developtest.svg'),
                 }}
               />
-              <h2 className="title-font sm:text-3xl text-2xl py-3 font-bold text-charcoal-300 dark:text-white mb-0">
+              <h2 className="title-font sm:text-3xl text-2xl py-3 font-medium text-charcoal-300 dark:text-white mb-0">
                 Develop and Test
               </h2>
               <p className="leading-relaxed py-3 dark:text-gray-300 text-charcoal-300">
@@ -381,7 +381,7 @@ function Pods(): JSX.Element {
                   dark: useBaseUrl('img/grow.svg'),
                 }}
               />
-              <h2 className="title-font sm:text-3xl text-2xl py-3 font-bold text-charcoal-300 dark:text-white mb-0">
+              <h2 className="title-font sm:text-3xl text-2xl py-3 font-medium text-charcoal-300 dark:text-white mb-0">
                 Grow Skills at Your Pace
               </h2>
               <p className="leading-relaxed py-3 dark:text-gray-300 text-charcoal-300">
@@ -398,7 +398,7 @@ function Pods(): JSX.Element {
                   dark: useBaseUrl('img/troubleshoot1.svg'),
                 }}
               />
-              <h2 className="title-font sm:text-3xl text-2xl py-3 font-bold text-charcoal-300 dark:text-white mb-0">
+              <h2 className="title-font sm:text-3xl text-2xl py-3 font-medium text-charcoal-300 dark:text-white mb-0">
                 Troubleshoot with Ease
               </h2>
               <p className="leading-relaxed py-3 dark:text-gray-300 text-charcoal-300">
@@ -415,7 +415,7 @@ function Pods(): JSX.Element {
                   dark: useBaseUrl('img/troubleshoot2.svg'),
                 }}
               />
-              <h2 className="title-font sm:text-3xl text-2xl py-3 font-bold text-charcoal-300 dark:text-white mb-0">
+              <h2 className="title-font sm:text-3xl text-2xl py-3 font-medium text-charcoal-300 dark:text-white mb-0">
                 Troubleshoot with Ease
               </h2>
               <p className="leading-relaxed py-3 dark:text-gray-300 text-charcoal-300">


### PR DESCRIPTION
### What does this PR do?
Chages font bold to font medium to unify headings between kubernetes and containers sections
Container section now:


<img width="1317" alt="image" src="https://github.com/user-attachments/assets/56a96480-937a-4c95-bcb6-e5f648fd08e4" />


### Screenshot / video of UI
Now:

<img width="1317" alt="image" src="https://github.com/user-attachments/assets/8295b1f0-73d5-45f7-a632-f25777f3626e" />


This PR:

<img width="1317" alt="image" src="https://github.com/user-attachments/assets/469f7542-877b-4582-9d45-797f67699a28" />


### What issues does this PR fix or reference?


### How to test this PR?


- [ ] Tests are covering the bug fix or the new feature
