### PR TITLE
fix: changed props interface defintion to be exported in TestComplexT…

### DIFF
--- a/packages/ui/src/lib/table/TestComplexTable.svelte
+++ b/packages/ui/src/lib/table/TestComplexTable.svelte
@@ -9,7 +9,7 @@ interface Person {
   children: Array<Person & { children: [] }>;
 }
 
-interface Props {
+export interface Props {
   people: Array<Person>;
 }
 

--- a/packages/ui/src/lib/table/TestComplexTable.svelte
+++ b/packages/ui/src/lib/table/TestComplexTable.svelte
@@ -1,17 +1,8 @@
-<script module>
-export interface Person {
-  name: string;
-  // do not allow children to have children
-  children: Array<Person & { children: [] }>;
-}
-</script>
-
 <script lang="ts">
 import SimpleColumn from './SimpleColumn.svelte';
+import type { Person } from './table';
 import { Column, Row } from './table';
 import Table from './Table.svelte';
-
-
 
 interface Props {
   people: Array<Person>;

--- a/packages/ui/src/lib/table/TestComplexTable.svelte
+++ b/packages/ui/src/lib/table/TestComplexTable.svelte
@@ -1,15 +1,19 @@
+<script module>
+export interface Person {
+  name: string;
+  // do not allow children to have children
+  children: Array<Person & { children: [] }>;
+}
+</script>
+
 <script lang="ts">
 import SimpleColumn from './SimpleColumn.svelte';
 import { Column, Row } from './table';
 import Table from './Table.svelte';
 
-interface Person {
-  name: string;
-  // do not allow children to have children
-  children: Array<Person & { children: [] }>;
-}
 
-export interface Props {
+
+interface Props {
   people: Array<Person>;
 }
 

--- a/packages/ui/src/lib/table/TestComplexTable.svelte
+++ b/packages/ui/src/lib/table/TestComplexTable.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 import SimpleColumn from './SimpleColumn.svelte';
-import type { Person } from './table';
 import { Column, Row } from './table';
 import Table from './Table.svelte';
+import type { Person } from './test-table';
 
 interface Props {
   people: Array<Person>;

--- a/packages/ui/src/lib/table/table.ts
+++ b/packages/ui/src/lib/table/table.ts
@@ -120,12 +120,3 @@ export interface RowInformation<Type, ChildType> {
 export class Row<Type, ChildType = Type> {
   constructor(readonly info: RowInformation<Type, ChildType>) {}
 }
-
-/**
- * A person object.
- */
-export interface Person {
-  name: string;
-  // do not allow children to have children
-  children: Array<Person & { children: [] }>;
-}

--- a/packages/ui/src/lib/table/table.ts
+++ b/packages/ui/src/lib/table/table.ts
@@ -120,3 +120,12 @@ export interface RowInformation<Type, ChildType> {
 export class Row<Type, ChildType = Type> {
   constructor(readonly info: RowInformation<Type, ChildType>) {}
 }
+
+/**
+ * A person object.
+ */
+export interface Person {
+  name: string;
+  // do not allow children to have children
+  children: Array<Person & { children: [] }>;
+}

--- a/packages/ui/src/lib/table/test-table.ts
+++ b/packages/ui/src/lib/table/test-table.ts
@@ -1,0 +1,10 @@
+/**
+ * This file contains definitions used specifically for testing table components.
+ * Add any test-related object definitions here.
+ */
+
+export interface Person {
+  name: string;
+  // do not allow children to have children
+  children: Array<Person & { children: [] }>;
+}

--- a/packages/ui/src/lib/table/test-table.ts
+++ b/packages/ui/src/lib/table/test-table.ts
@@ -1,3 +1,21 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
 /**
  * This file contains definitions used specifically for testing table components.
  * Add any test-related object definitions here.


### PR DESCRIPTION
### What does this PR do?

Fixes a warning of TestComplexTable.svelte component when starting in watch mode the project

### What issues does this PR fix or reference?

[#12127](https://github.com/podman-desktop/podman-desktop/issues/12127)

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

Start the project in watch mode (pnpm run watch) and the logs shouldn't contain any warning message related to the TestComplexTable.svelte component.


- [ ] Tests are covering the bug fix or the new feature
