### PR TITLE
feat(podman): support shell access for remote

### DIFF
--- a/extensions/podman/packages/extension/src/remote/podman-remote-connections.ts
+++ b/extensions/podman/packages/extension/src/remote/podman-remote-connections.ts
@@ -201,7 +201,7 @@ export class PodmanRemoteConnections {
     for (const connection of connections) {
       const remoteConnection = this.#currentConnections.get(connection.name);
       if (remoteConnection) {
-        remoteConnection.sshTunnel.disconnect();
+        remoteConnection.sshTunnel.dispose();
         this.#currentConnections.delete(connection.name);
         // unregister the connection
         remoteConnection.connectionDisposable.dispose();

--- a/extensions/podman/packages/extension/src/remote/podman-remote-connections.ts
+++ b/extensions/podman/packages/extension/src/remote/podman-remote-connections.ts
@@ -182,6 +182,7 @@ export class PodmanRemoteConnections {
         endpoint: {
           socketPath: localPath,
         },
+        shellAccess: sshTunnel,
       });
       this.#extensionContext.subscriptions.push(connectionDisposable);
       const remoteConnection: RemoteSystemConnection = {

--- a/extensions/podman/packages/extension/src/remote/podman-remote-ssh-tunnel.spec.ts
+++ b/extensions/podman/packages/extension/src/remote/podman-remote-ssh-tunnel.spec.ts
@@ -131,14 +131,14 @@ beforeEach(async () => {
     socketOrNpipePathLocal = join(tmpdir(), 'test-local.sock');
     socketOrNpipePathRemote = join(tmpdir(), 'test-remote.sock');
   }
-});
-
-afterEach(async () => {
-  sshServer.close();
 
   // delete file if exists
   await rm(socketOrNpipePathLocal, { force: true });
   await rm(socketOrNpipePathRemote, { force: true });
+});
+
+afterEach(() => {
+  sshServer.close();
 });
 
 test('should be able to connect', async () => {
@@ -248,6 +248,8 @@ describe('shell', () => {
     await vi.waitFor(() => {
       expect(shellDataListener).toHaveBeenCalledWith(Buffer.from('ping'));
     });
+
+    podmanRemoteSshTunnel.dispose();
   });
 
   test('server to client data', async () => {
@@ -273,6 +275,8 @@ describe('shell', () => {
         data: Buffer.from('ping'),
       });
     });
+
+    podmanRemoteSshTunnel.dispose();
   });
 
   test('shell closing should trigger onEnd', async () => {
@@ -296,6 +300,8 @@ describe('shell', () => {
     await vi.waitFor(() => {
       expect(shellDataListener).toHaveBeenCalledOnce();
     });
+
+    podmanRemoteSshTunnel.dispose();
   });
 
   test('resize should request resize', async () => {
@@ -323,5 +329,7 @@ describe('shell', () => {
 
     expect(info.rows).toEqual(88);
     expect(info.cols).toEqual(32);
+
+    podmanRemoteSshTunnel.dispose();
   });
 });

--- a/extensions/podman/packages/extension/src/remote/podman-remote-ssh-tunnel.spec.ts
+++ b/extensions/podman/packages/extension/src/remote/podman-remote-ssh-tunnel.spec.ts
@@ -131,14 +131,14 @@ beforeEach(async () => {
     socketOrNpipePathLocal = join(tmpdir(), 'test-local.sock');
     socketOrNpipePathRemote = join(tmpdir(), 'test-remote.sock');
   }
+});
+
+afterEach(async () => {
+  sshServer.close();
 
   // delete file if exists
   await rm(socketOrNpipePathLocal, { force: true });
   await rm(socketOrNpipePathRemote, { force: true });
-});
-
-afterEach(() => {
-  sshServer.close();
 });
 
 test('should be able to connect', async () => {

--- a/extensions/podman/packages/extension/src/remote/podman-remote-ssh-tunnel.ts
+++ b/extensions/podman/packages/extension/src/remote/podman-remote-ssh-tunnel.ts
@@ -70,8 +70,6 @@ export class PodmanRemoteSshTunnel implements ProviderConnectionShellAccess, Dis
   }
 
   open(): ProviderConnectionShellAccessSession {
-    if (!this.isListening()) throw new Error('cannot create shell session: not connected');
-
     let mStream: ClientChannel | undefined;
 
     // create event emitters

--- a/extensions/podman/packages/extension/src/remote/podman-remote-ssh-tunnel.ts
+++ b/extensions/podman/packages/extension/src/remote/podman-remote-ssh-tunnel.ts
@@ -126,7 +126,7 @@ export class PodmanRemoteSshTunnel implements ProviderConnectionShellAccess, Dis
 
   dispose(): void {
     this.#shells.forEach(shell => shell.dispose());
-    this.disconnect();
+    this.disconnect().catch(console.error);
   }
 
   status(): ProviderConnectionStatus {
@@ -229,11 +229,12 @@ export class PodmanRemoteSshTunnel implements ProviderConnectionShellAccess, Dis
     }
   }
 
-  disconnect(): void {
+  protected async disconnect(): Promise<void> {
     // Set the reconnect flag to false to prevent reconnecting
     this.#reconnect = false;
     this.#client?.end();
-    this.#server?.close();
+    this.#client = undefined;
+    await this.#server?.[Symbol.asyncDispose]();
   }
 
   isConnected(): Promise<boolean> {

--- a/extensions/podman/packages/extension/src/remote/podman-remote-ssh-tunnel.ts
+++ b/extensions/podman/packages/extension/src/remote/podman-remote-ssh-tunnel.ts
@@ -17,11 +17,19 @@
  ***********************************************************************/
 import * as net from 'node:net';
 
-import type { ProviderConnectionStatus } from '@podman-desktop/api';
-import type { ConnectConfig } from 'ssh2';
+import type {
+  ProviderConnectionShellAccess,
+  ProviderConnectionShellAccessData,
+  ProviderConnectionShellAccessError,
+  ProviderConnectionShellAccessSession,
+  ProviderConnectionShellDimensions,
+  ProviderConnectionStatus,
+} from '@podman-desktop/api';
+import { Disposable, EventEmitter } from '@podman-desktop/api';
+import type { ClientChannel, ConnectConfig } from 'ssh2';
 import { Client } from 'ssh2';
 
-export class PodmanRemoteSshTunnel {
+export class PodmanRemoteSshTunnel implements ProviderConnectionShellAccess, Disposable {
   #sshConfig: ConnectConfig;
 
   #client: Client | undefined;
@@ -39,6 +47,8 @@ export class PodmanRemoteSshTunnel {
   #connected: Promise<boolean>;
 
   #listening: boolean = false;
+
+  #shells: Array<Disposable> = [];
 
   constructor(
     private host: string,
@@ -59,7 +69,65 @@ export class PodmanRemoteSshTunnel {
     });
   }
 
+  open(): ProviderConnectionShellAccessSession {
+    if (!this.isListening()) throw new Error('cannot create shell session: not connected');
+
+    let mStream: ClientChannel | undefined;
+
+    // create event emitters
+    const onDataEmit = new EventEmitter<ProviderConnectionShellAccessData>();
+    const onErrorEmit = new EventEmitter<ProviderConnectionShellAccessError>();
+    const onEndEmit = new EventEmitter<void>();
+
+    // create disposable
+    const disposable = Disposable.create(() => {
+      mStream?.close();
+      mStream?.destroy();
+
+      onDataEmit.dispose();
+      onErrorEmit.dispose();
+      onEndEmit.dispose();
+
+      mStream = undefined;
+    });
+
+    this.#shells.push(disposable);
+
+    this.#client?.shell((err, stream) => {
+      if (err) {
+        console.error(err);
+        onErrorEmit.fire({ error: err.message });
+        return;
+      }
+      mStream = stream;
+
+      stream
+        .on('close', () => {
+          onEndEmit.fire();
+          // dispose on close
+          disposable?.dispose();
+        })
+        .on('data', (data: string) => {
+          onDataEmit.fire({ data: data });
+        });
+    });
+
+    return {
+      onData: onDataEmit.event,
+      onError: onErrorEmit.event,
+      onEnd: onEndEmit.event,
+      write: (data): void => {
+        mStream?.write(data);
+      },
+      resize: (dimensions: ProviderConnectionShellDimensions): void => {
+        mStream?.setWindow(dimensions.rows, dimensions.cols, 0, 0);
+      },
+      close: disposable.dispose,
+    };
+  }
+
   dispose(): void {
+    this.#shells.forEach(shell => shell.dispose());
     this.disconnect();
   }
 


### PR DESCRIPTION
### What does this PR do?

Let's reuse the already existing logic of the `PodmanRemoteSshTunnel` class. (We could rename it maybe?) but anyway, we can just make it implements the `ProviderConnectionShellAccess` and reuse its `import('ssh2').Client`, which has all the connect and reconnect logic.

The `Client` has a handy `shell` method, that we already use for local machines.

https://github.com/podman-desktop/podman-desktop/blob/3a9dcf9a652a6e86aaa81e922def97fc9ad20259/extensions/podman/packages/extension/src/utils/podman-machine-stream.ts#L99

I adapted the code of @gastoner to works with the podman machines, the difference, for remote we reuse the Client instead of creating a new one for each shell. (maybe we should do the same for machines? I don't know).

### Screenshot / video of UI

https://github.com/user-attachments/assets/156df119-e87a-49ba-9746-0f730becb7f8

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/12264

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

**Manually**

1. configure a podman remote connection[^1]
2. go to resources
3. assert `Terminal` tab is visible
4. try to type some command
5. assert this is nicely executed inside the remote machine

[^1]: https://podman-desktop.io/docs/podman/podman-remote
