### PR TITLE
chore: add link support in release notes parser

### DIFF
--- a/website/release-notes-parser.spec.ts
+++ b/website/release-notes-parser.spec.ts
@@ -46,13 +46,14 @@ const notesInfo =
 const notesText = 'import a\ntest1 release title!\n![test1-release](img1)\nello world\n';
 
 const notesPoints =
-  '- **line1**:line1 info\n- **line2**:line2 info\n- **line3**:line3 info\n- **line4**:line4 info\n- **line5**:line5 info\n';
+  '- **line1**:line1 info\n- **line2**:line2 info <!-- :link[action text]{href=/go/here title="action title"} -->\n- **line3**:line3 info\n- **line4**:line4 info\n- **line5**:line5 info\n';
 
 const jsonResult = {
   image: 'https://podman-desktop.io/img/blog/podman-desktop-release-test1/test1.png',
   blog: 'https://podman-desktop.io/blog/podman-desktop-release-test1',
   title: 'test1 release title!',
-  summary: '- **line1**:line1 info\n- **line2**:line2 info\n- **line3**:line3 info\n- **line4**:line4 info',
+  summary:
+    '- **line1**:line1 info\n- **line2**:line2 info :link[action text]{href=/go/here title="action title"}\n- **line3**:line3 info\n- **line4**:line4 info',
 };
 
 const defaultParseFrontMatterMock = vi.fn();
@@ -82,7 +83,7 @@ test('create release-notes directory when it does not exist', async () => {
   expect(mocks.mkdirMock).toHaveBeenCalled();
 });
 
-test('Do not create release-nnotes directory when it exists', async () => {
+test('Do not create release-notes directory when it exists', async () => {
   await createNotesFiles(params);
   expect(mocks.mkdirMock).not.toHaveBeenCalled();
 });

--- a/website/release-notes-parser.ts
+++ b/website/release-notes-parser.ts
@@ -60,7 +60,7 @@ export async function createNotesFiles(
         .split('\n');
 
       const summary = text.filter(line => line.includes('- **')); // all summary bullet points start with "- **"
-      const summaryText = summary.slice(0, 4).join('\n'); // limit the number of bullet points to 4
+      const summaryText = addExperimentalFeaturesLink(summary); // limit the number of bullet points to 4
       const titleText = text.filter(line => !line.includes('import') && line)[0];
 
       const jsonInput = { image: imageUrl, blog: blogUrl, title: titleText, summary: summaryText };
@@ -77,4 +77,16 @@ export async function createNotesFiles(
     }
   }
   return result;
+}
+
+function addExperimentalFeaturesLink(summary: string[]): string {
+  const linkCommentRegex = /<!-- :link(.+) -->/;
+  const summaryWithLinks = summary.slice(0, 4);
+  summaryWithLinks.forEach((line, index) => {
+    const regexMatch = linkCommentRegex.exec(line)?.[1];
+    if (regexMatch) {
+      summaryWithLinks[index] = line.replace(linkCommentRegex, `:link${regexMatch}`);
+    }
+  });
+  return summaryWithLinks.join('\n');
 }


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Adds link support in the release notes parser so that link would show up in the release notes banner

Usage: when writing the release notes, you can add a link that will only show up in the release note banner and not on the website by adding a comment -> `<!-- :link[ > go to expiremental status bar providers]{href='/preferences/experimental' title="Open experimental page"} -->`, in any of the first 4 points in the release summary section.

### Screenshot / video of UI
![Screenshot from 2025-05-19 11-33-00](https://github.com/user-attachments/assets/e7ba5c71-1132-41bf-a106-70696a1b2abe)


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/podman-desktop/issues/11851

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
1. Pull https://github.com/SoniaSandler/podman-desktop/tree/releaseNotes-expFeat-test
(https://github.com/podman-desktop/podman-desktop/compare/main...SoniaSandler:podman-desktop:releaseNotes-expFeat-test?expand=1)
2. Start the website locally with `pnpm website:prod`
3. Once the website is ready and running, start Podman Desktop with `pnpm watch`
4. Assert that you see `> go to expiremental status bar providers` at the end of the first bullet point in the release notes banner and that when clicking on it, it takes you to experimental preferences page

(When checking the 1.18 release notes on the website,  `> go to expiremental status bar providers` is not supposed to be seen)

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
