### PR TITLE
chore: adjust website light mode text color to be darker

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -29,6 +29,7 @@
   --ifm-navbar-height: 85px;
   --ifm-navbar-shadow: none;
   --ifm-divider: #e2e2e3;
+  --ifm-footer-link-color: #464649;
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */

--- a/website/src/pages/downloads/index.tsx
+++ b/website/src/pages/downloads/index.tsx
@@ -13,7 +13,7 @@ export default function Home(): JSX.Element {
       <section className="container mx-auto flex justify-left flex-col bg-hero-pattern bg-no-repeat bg-center bg-cover">
         <div className="bg-white/30 dark:bg-transparent">
           <div className="lg:w-2/3 w-full">
-            <h1 className="flex flex-col title-font sm:text-3xl text-2xl lg:text-5xl mb-10 font-medium text-gray-900 dark:text-white">
+            <h1 className="flex flex-col title-font sm:text-3xl text-2xl lg:text-5xl mb-10 font-medium text-charcoal-300 dark:text-white">
               Downloads
             </h1>
           </div>

--- a/website/src/pages/downloads/linux.tsx
+++ b/website/src/pages/downloads/linux.tsx
@@ -77,7 +77,7 @@ export function LinuxDownloads(): JSX.Element {
   }, []);
 
   return (
-    <div className="basis-1/3 py-2 rounded-lg dark:text-gray-400 text-gray-900  bg-zinc-300/25 dark:bg-zinc-700/25 bg-blend-multiply text-center items-center">
+    <div className="basis-1/3 py-2 rounded-lg dark:text-gray-400 text-charcoal-300  bg-zinc-300/25 dark:bg-zinc-700/25 bg-blend-multiply text-center items-center">
       <FontAwesomeIcon size="4x" icon={faLinux} className="my-4" />
       <h2 className="w-full text-center text-4xl title-font font-medium pb-3 border-purple-500 border-b-2">Linux</h2>
       <div className="flex p-1 flex-col md:flex-col items-center align-top">
@@ -167,7 +167,7 @@ export default function Home(): JSX.Element {
       <TailWindThemeSelector />
       <section className="container mx-auto flex justify-center flex-col">
         <div className="w-full flex flex-col">
-          <h1 className="title-font sm:text-3xl text-2xl lg:text-5xl mb-10 font-medium text-gray-900 dark:text-white">
+          <h1 className="title-font sm:text-3xl text-2xl lg:text-5xl mb-10 font-medium text-charcoal-300 dark:text-white">
             Linux Downloads
           </h1>
           <main className="h-screen">

--- a/website/src/pages/downloads/macos.tsx
+++ b/website/src/pages/downloads/macos.tsx
@@ -108,7 +108,7 @@ export function MacOSDownloads(): JSX.Element {
     });
   }, []);
   return (
-    <div className="basis-1/3 py-2 rounded-lg dark:text-gray-400 text-gray-900  bg-zinc-300/25 dark:bg-zinc-700/25 bg-blend-multiply text-center items-center">
+    <div className="basis-1/3 py-2 rounded-lg dark:text-gray-400 text-charcoal-300 bg-zinc-300/25 dark:bg-zinc-700/25 bg-blend-multiply text-center items-center">
       <FontAwesomeIcon size="4x" icon={faApple} className="my-4" />
       <h2 className="w-full text-center text-4xl title-font font-medium pb-3 border-purple-500 border-b-2">macOS</h2>
       <div className="flex p-1 flex-col md:flex-col items-center align-top">
@@ -213,7 +213,7 @@ export default function Home(): JSX.Element {
       <TailWindThemeSelector />
       <section className="container mx-auto flex justify-center flex-col">
         <div className="w-full flex flex-col">
-          <h1 className="title-font sm:text-3xl text-2xl lg:text-5xl mb-10 font-medium text-gray-900 dark:text-white">
+          <h1 className="title-font sm:text-3xl text-2xl lg:text-5xl mb-10 font-medium text-charcoal-300 dark:text-white">
             macOS Downloads
           </h1>
           <main className="h-screen">

--- a/website/src/pages/downloads/windows.tsx
+++ b/website/src/pages/downloads/windows.tsx
@@ -108,7 +108,7 @@ export function WindowsDownloads(): JSX.Element {
   }, []);
 
   return (
-    <div className="basis-1/3 py-2 rounded-lg dark:text-gray-400 text-gray-900  bg-zinc-300/25 dark:bg-zinc-700/25 bg-blend-multiply text-center items-center">
+    <div className="basis-1/3 py-2 rounded-lg dark:text-gray-400 text-charcoal-300  bg-zinc-300/25 dark:bg-zinc-700/25 bg-blend-multiply text-center items-center">
       <FontAwesomeIcon size="4x" icon={faWindows} className="my-4" />
       <h2 className="w-full text-center text-4xl title-font font-medium pb-3 border-purple-500 border-b-2">Windows</h2>
       <div className="flex p-1 flex-col md:flex-col items-center align-top">
@@ -250,7 +250,7 @@ export default function Home(): JSX.Element {
       <TailWindThemeSelector />
       <section className="container mx-auto flex justify-center flex-col">
         <div className="w-full flex flex-col">
-          <h1 className="title-font sm:text-3xl text-2xl lg:text-5xl mb-10 font-medium text-gray-900 dark:text-white">
+          <h1 className="title-font sm:text-3xl text-2xl lg:text-5xl mb-10 font-medium text-charcoal-300 dark:text-white">
             Windows Downloads
           </h1>
           <main className="h-screen">

--- a/website/src/pages/extend/index.tsx
+++ b/website/src/pages/extend/index.tsx
@@ -14,10 +14,10 @@ export default function Home(): JSX.Element {
     <Layout title={siteConfig.title} description="Extensibility">
       <TailWindThemeSelector />
 
-      <section className="text-gray-900 dark:text-gray-700 body-font">
+      <section className="text-charcoal-300 dark:text-gray-700 body-font">
         <div className="container mx-auto flex px-5 py-24 items-center justify-center flex-col">
           <div className="text-center lg:w-2/3 w-full">
-            <h1 className="title-font sm:text-4xl text-3xl lg:text-6xl mb-4 font-medium text-gray-900 dark:text-white">
+            <h1 className="title-font sm:text-4xl text-3xl lg:text-6xl mb-4 font-medium text-charcoal-300 dark:text-white">
               Extensibility Documentation and Resources
             </h1>
             <p>Explore our comprehensive guides on extending Podman Desktop:</p>
@@ -46,7 +46,7 @@ export default function Home(): JSX.Element {
               </ul>
             </div>
 
-            <h1 className="mt-24 title-font sm:text-4xl text-3xl lg:text-6xl mb-4 font-medium text-gray-900 dark:text-white">
+            <h1 className="mt-24 title-font sm:text-4xl text-3xl lg:text-6xl mb-4 font-medium text-charcoal-300 dark:text-white">
               What are Extensions?
             </h1>
             <p>
@@ -60,7 +60,7 @@ export default function Home(): JSX.Element {
               <li>Automating tasks and integrating with external services.</li>
             </ul>
 
-            <h1 className="mt-24 title-font sm:text-4xl text-3xl lg:text-6xl mb-4 font-medium text-gray-900 dark:text-white">
+            <h1 className="mt-24 title-font sm:text-4xl text-3xl lg:text-6xl mb-4 font-medium text-charcoal-300 dark:text-white">
               Getting Started with Extensions
             </h1>
             <p>
@@ -94,7 +94,7 @@ export default function Home(): JSX.Element {
               .
             </p>
 
-            <h1 className="mt-24 title-font sm:text-4xl text-3xl lg:text-6xl mb-4 font-medium text-gray-900 dark:text-white">
+            <h1 className="mt-24 title-font sm:text-4xl text-3xl lg:text-6xl mb-4 font-medium text-charcoal-300 dark:text-white">
               Visualizing Extension Capabilities
             </h1>
             <ThemedImage
@@ -106,7 +106,7 @@ export default function Home(): JSX.Element {
               }}
             />
 
-            <h1 className="mt-24 title-font sm:text-4xl text-3xl lg:text-6xl mb-4 font-medium text-gray-900 dark:text-white">
+            <h1 className="mt-24 title-font sm:text-4xl text-3xl lg:text-6xl mb-4 font-medium text-charcoal-300 dark:text-white">
               Extend Podman Desktop with Docker Desktop Extensions
             </h1>
             <p>

--- a/website/src/pages/features/index.tsx
+++ b/website/src/pages/features/index.tsx
@@ -8,14 +8,14 @@ import React from 'react';
 function FeatureManageContainers(): JSX.Element {
   return (
     <div>
-      <section className="text-gray-900 bg-zinc-200 dark:bg-charcoal-600 dark:text-gray-700 body-font">
+      <section className="text-charcoal-300 bg-zinc-200 dark:bg-charcoal-600 dark:text-gray-700 body-font">
         <div className="container mx-auto flex px-5 py-24 md:flex-row flex-col items-center">
           <div className="lg:grow md:w-1/2 lg:pr-24 md:pr-16 flex flex-col md:items-start md:text-left mb-16 md:mb-0 items-center text-center">
-            <h1 className="title-font sm:text-4xl text-3xl mb-4 font-medium text-gray-900 dark:text-white">
+            <h1 className="title-font sm:text-4xl text-3xl mb-4 font-medium text-charcoal-300 dark:text-white">
               Manage containers
               <br className="hidden lg:inline-block" />
             </h1>
-            <p className="mb-8 leading-relaxed dark:text-gray-300 text-gray-900">
+            <p className="mb-8 leading-relaxed dark:text-gray-300 text-charcoal-300">
               List, Search, Inspect, Connect, Run and Stop containers.
             </p>
           </div>
@@ -37,7 +37,7 @@ function FeatureManageContainers(): JSX.Element {
 
 function FeatureManageImages(): JSX.Element {
   return (
-    <section className="text-gray-900 bg-zinc-100 dark:text-gray-700 dark:bg-charcoal-800 body-font">
+    <section className="text-charcoal-300 bg-zinc-100 dark:text-gray-700 dark:bg-charcoal-800 body-font">
       <div className="container mx-auto flex px-5 py-24 md:flex-row flex-col items-center">
         <div className="w-5/6 mb-10 md:mb-0">
           <ThemedImage
@@ -50,15 +50,17 @@ function FeatureManageImages(): JSX.Element {
           />
         </div>
         <div className="lg:grow md:w-1/2 lg:pl-24 md:pl-16 flex flex-col md:items-start md:text-left items-center text-center">
-          <h1 className="title-font sm:text-4xl text-3xl mb-4 font-medium text-gray-900 dark:text-white">
+          <h1 className="title-font sm:text-4xl text-3xl mb-4 font-medium text-charcoal-300 dark:text-white">
             Build, Pull and Push images
           </h1>
 
-          <p className="leading-relaxed list-item dark:text-gray-300 text-gray-900">Build images from the tool.</p>
-          <p className="leading-relaxed list-item dark:text-gray-300 text-gray-900">
+          <p className="leading-relaxed list-item dark:text-gray-300 text-charcoal-300">Build images from the tool.</p>
+          <p className="leading-relaxed list-item dark:text-gray-300 text-charcoal-300">
             Pull and push images by managing registries.
           </p>
-          <p className="leading-relaxed list-item dark:text-gray-300 text-gray-900">Run containers from these images</p>
+          <p className="leading-relaxed list-item dark:text-gray-300 text-charcoal-300">
+            Run containers from these images
+          </p>
         </div>
       </div>
     </section>
@@ -68,20 +70,20 @@ function FeatureManageImages(): JSX.Element {
 function FeatureManagementFromTrayIcon(): JSX.Element {
   return (
     <div>
-      <section className="text-gray-900 bg-zinc-200 dark:bg-charcoal-600 dark:text-gray-700 body-font">
+      <section className="text-charcoal-300 bg-zinc-200 dark:bg-charcoal-600 dark:text-gray-700 body-font">
         <div className="container mx-auto flex px-5 py-24 md:flex-row flex-col items-center">
           <div className="lg:grow md:w-1/2 lg:pr-24 md:pr-16 flex flex-col md:items-start md:text-left mb-16 md:mb-0 items-center text-center">
-            <h1 className="title-font sm:text-4xl text-3xl mb-4 font-medium text-gray-900 dark:text-white">
+            <h1 className="title-font sm:text-4xl text-3xl mb-4 font-medium text-charcoal-300 dark:text-white">
               Management from the tray icon
               <br className="hidden lg:inline-block" />
             </h1>
-            <p className="leading-relaxed list-item dark:text-gray-300 text-gray-900">
+            <p className="leading-relaxed list-item dark:text-gray-300 text-charcoal-300">
               Check status and start/stop container engines.
             </p>
-            <p className="leading-relaxed list-item dark:text-gray-300 text-gray-900">
+            <p className="leading-relaxed list-item dark:text-gray-300 text-charcoal-300">
               Create new machine if needed as well as start or stop Podman machines directly from the tray icon.
             </p>
-            <p className="leading-relaxed list-item dark:text-gray-300 text-gray-900">
+            <p className="leading-relaxed list-item dark:text-gray-300 text-charcoal-300">
               Quickly check activity status and stay updated without losing focus from other tasks.
             </p>
           </div>
@@ -104,7 +106,7 @@ function FeatureManagementFromTrayIcon(): JSX.Element {
 function FeatureManageResources(): JSX.Element {
   return (
     <div>
-      <section className="text-gray-900 bg-zinc-100 dark:bg-charcoal-800 dark:text-gray-700 body-font">
+      <section className="text-charcoal-300 bg-zinc-100 dark:bg-charcoal-800 dark:text-gray-700 body-font">
         <div className="container mx-auto flex px-5 py-24 md:flex-row flex-col items-center">
           <div className="lg:w-5/6 md:w-4/5 w-5/6 flex flex:col gap-10">
             <ThemedImage
@@ -117,14 +119,16 @@ function FeatureManageResources(): JSX.Element {
             />
           </div>
           <div className="lg:grow md:w-1/2 lg:pl-24 md:pl-16 flex flex-col md:items-start md:text-left items-center text-center">
-            <h1 className="title-font sm:text-4xl text-3xl mb-4 font-medium text-gray-900 dark:text-white">
+            <h1 className="title-font sm:text-4xl text-3xl mb-4 font-medium text-charcoal-300 dark:text-white">
               Manage Podman resources
               <br className="hidden lg:inline-block" />
             </h1>
-            <p className="leading-relaxed list-item dark:text-gray-300 text-gray-900">
+            <p className="leading-relaxed list-item dark:text-gray-300 text-charcoal-300">
               View allocated memory, CPU and storage.
             </p>
-            <p className="leading-relaxed list-item dark:text-gray-300 text-gray-900">Create new machine if needed</p>
+            <p className="leading-relaxed list-item dark:text-gray-300 text-charcoal-300">
+              Create new machine if needed
+            </p>
           </div>
         </div>
       </section>
@@ -135,20 +139,20 @@ function FeatureManageResources(): JSX.Element {
 function FeatureManagePods(): JSX.Element {
   return (
     <div>
-      <section className="text-gray-900 bg-zinc-200 dark:bg-charcoal-600 dark:text-gray-700 body-font">
+      <section className="text-charcoal-300 bg-zinc-200 dark:bg-charcoal-600 dark:text-gray-700 body-font">
         <div className="container mx-auto flex px-5 py-24 md:flex-row flex-col items-center">
           <div className="lg:grow md:w-1/2 lg:pr-24 md:pr-16 flex flex-col md:items-start md:text-left mb-16 md:mb-0 items-center text-center">
-            <h1 className="title-font sm:text-4xl text-3xl mb-4 font-medium text-gray-900 dark:text-white">
+            <h1 className="title-font sm:text-4xl text-3xl mb-4 font-medium text-charcoal-300 dark:text-white">
               Create and start Pods with Podman
               <br className="hidden lg:inline-block" />
             </h1>
-            <p className="leading-relaxed list-item dark:text-gray-300 text-gray-900">
+            <p className="leading-relaxed list-item dark:text-gray-300 text-charcoal-300">
               Select containers to run as a Pod.
             </p>
-            <p className="leading-relaxed list-item dark:text-gray-300 text-gray-900">
+            <p className="leading-relaxed list-item dark:text-gray-300 text-charcoal-300">
               Play Kubernetes YAML locally without Kubernetes.
             </p>
-            <p className="leading-relaxed list-item dark:text-gray-300 text-gray-900">
+            <p className="leading-relaxed list-item dark:text-gray-300 text-charcoal-300">
               Generate Kubernetes YAML from Pods.
             </p>
           </div>
@@ -170,7 +174,7 @@ function FeatureManagePods(): JSX.Element {
 
 function FeatureDDExtensions(): JSX.Element {
   return (
-    <section className="text-gray-900 bg-zinc-100 dark:bg-charcoal-800 dark:text-gray-700 body-font">
+    <section className="text-charcoal-300 bg-zinc-100 dark:bg-charcoal-800 dark:text-gray-700 body-font">
       <div className="container mx-auto flex px-5 py-24 md:flex-row flex-col items-center">
         <div className="lg:w-5/6 md:w-4/5 w-5/6 flex flex:col gap-10">
           <ThemedImage
@@ -183,14 +187,14 @@ function FeatureDDExtensions(): JSX.Element {
           />
         </div>
         <div className="lg:grow md:w-1/2 lg:pl-24 md:pl-16 flex flex-col md:items-start md:text-left items-center text-center">
-          <h1 className="title-font sm:text-4xl text-3xl mb-4 font-medium text-gray-900 dark:text-white">
+          <h1 className="title-font sm:text-4xl text-3xl mb-4 font-medium text-charcoal-300 dark:text-white">
             Import Docker Desktop extensions
           </h1>
           <br className="hidden lg:inline-block" />
-          <p className="leading-relaxed list-item dark:text-gray-300 text-gray-900">
+          <p className="leading-relaxed list-item dark:text-gray-300 text-charcoal-300">
             Specify OCI image of a Docker Desktop extension to import it.
           </p>
-          <p className="leading-relaxed list-item dark:text-gray-300 text-gray-900">
+          <p className="leading-relaxed list-item dark:text-gray-300 text-charcoal-300">
             For example: security scanner or deploy to OpenShift extensions.
           </p>
         </div>


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Updates the light mode text color in the footer and the downloads, extend, and features pages to be darker for better contrast

### Screenshot / video of UI
![Screenshot from 2025-05-19 12-16-28](https://github.com/user-attachments/assets/05c628fd-c9f4-4c80-9efa-23a3a70ce99a)
![Screenshot from 2025-05-19 12-16-12](https://github.com/user-attachments/assets/268ec40c-4e81-4db4-b29d-d5ac93ce03e4)
![Screenshot from 2025-05-19 12-16-05](https://github.com/user-attachments/assets/2f6b0a23-3bab-4337-894d-26df4ba2a0ea)
![Screenshot from 2025-05-19 12-15-46](https://github.com/user-attachments/assets/92cc3550-fdcc-47d4-8713-798d21a6adf1)


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Fixes https://github.com/podman-desktop/podman-desktop/issues/12517

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
