### PR TITLE
fix: changed wrong link to docker compatibility documentation

### DIFF
--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -1431,7 +1431,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
     },
     {
       title: 'Docker compatibility guide',
-      url: 'https://podman-desktop.io/docs/troubleshooting#warning-about-docker-compatibility-mode',
+      url: 'https://podman-desktop.io/docs/migrating-from-docker/managing-docker-compatibility',
     },
     {
       title: 'Join the community',


### PR DESCRIPTION
### What does this PR do?

Changed the "Docker compatibility guide" link in the Podman card from the Dashboard, to point to https://podman-desktop.io/docs/migrating-from-docker/managing-docker-compatibility.

### Screenshot / video of UI

### What issues does this PR fix or reference?

fixes #12213 

### How to test this PR?

Go to podman-desktop dashboard, in the podman card, the link "Docker compatibility guide" should open https://podman-desktop.io/docs/migrating-from-docker/managing-docker-compatibility

- [ ] Tests are covering the bug fix or the new feature
