### PR TITLE
fix: clear containers logs permanently

### DIFF
--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -1679,17 +1679,22 @@ export class ContainerProviderRegistry {
     id: string;
     callback: (name: string, data: string) => void;
     abortController?: AbortController;
+    sinceDurationInSeconds?: number;
   }): Promise<void> {
     let telemetryOptions = {};
     let firstMessage = true;
     const container = this.getMatchingContainer(logsParams.engineId, logsParams.id);
+    const apiLogsParams: Dockerode.ContainerLogsOptions & { follow: true } = {
+      follow: true,
+      stdout: true,
+      stderr: true,
+      abortSignal: logsParams.abortController?.signal,
+    };
+    if (logsParams.sinceDurationInSeconds) {
+      apiLogsParams['since'] = `${logsParams.sinceDurationInSeconds}s`;
+    }
     container
-      .logs({
-        follow: true,
-        stdout: true,
-        stderr: true,
-        abortSignal: logsParams.abortController?.signal,
-      })
+      .logs(apiLogsParams)
       .then(containerStream => {
         containerStream.on('end', () => {
           logsParams.callback('end', '');

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1151,7 +1151,13 @@ export class PluginSystem {
       'container-provider-registry:logsContainer',
       async (
         _listener,
-        logsParams: { engineId: string; containerId: string; onDataId: number; cancellableTokenId?: number },
+        logsParams: {
+          engineId: string;
+          containerId: string;
+          onDataId: number;
+          cancellableTokenId?: number;
+          sinceDurationInSeconds?: number;
+        },
       ): Promise<void> => {
         const abortController = this.createAbortControllerOnCancellationToken(
           cancellationTokenRegistry,
@@ -1170,6 +1176,7 @@ export class PluginSystem {
             );
           },
           abortController,
+          sinceDurationInSeconds: logsParams.sinceDurationInSeconds,
         });
       },
     );

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1149,7 +1149,15 @@ export class PluginSystem {
     );
     this.ipcHandle(
       'container-provider-registry:logsContainer',
-      async (_listener, logsParams: { engineId: string; containerId: string; onDataId: number }): Promise<void> => {
+      async (
+        _listener,
+        logsParams: { engineId: string; containerId: string; onDataId: number; cancellableTokenId?: number },
+      ): Promise<void> => {
+        const abortController = this.createAbortControllerOnCancellationToken(
+          cancellationTokenRegistry,
+          logsParams.cancellableTokenId,
+        );
+
         return containerProviderRegistry.logsContainer({
           engineId: logsParams.engineId,
           id: logsParams.containerId,
@@ -1161,6 +1169,7 @@ export class PluginSystem {
               data,
             );
           },
+          abortController,
         });
       },
     );

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -537,6 +537,7 @@ export function initExposure(): void {
       engineId: string;
       containerId: string;
       callback: (name: string, data: string) => void;
+      cancellableTokenId?: number;
     }): Promise<void> => {
       onDataCallbacksLogsContainerId++;
       onDataCallbacksLogsContainer.set(onDataCallbacksLogsContainerId, logsParams.callback);
@@ -544,6 +545,7 @@ export function initExposure(): void {
         engineId: logsParams.engineId,
         containerId: logsParams.containerId,
         onDataId: onDataCallbacksLogsContainerId,
+        cancellableTokenId: logsParams.cancellableTokenId,
       });
     },
   );

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -538,6 +538,7 @@ export function initExposure(): void {
       containerId: string;
       callback: (name: string, data: string) => void;
       cancellableTokenId?: number;
+      sinceDurationInSeconds?: number;
     }): Promise<void> => {
       onDataCallbacksLogsContainerId++;
       onDataCallbacksLogsContainer.set(onDataCallbacksLogsContainerId, logsParams.callback);
@@ -546,6 +547,7 @@ export function initExposure(): void {
         containerId: logsParams.containerId,
         onDataId: onDataCallbacksLogsContainerId,
         cancellableTokenId: logsParams.cancellableTokenId,
+        sinceDurationInSeconds: logsParams.sinceDurationInSeconds,
       });
     },
   );

--- a/packages/renderer/src/lib/container/ContainerDetailsLogs.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsLogs.svelte
@@ -99,7 +99,6 @@ function afterTerminalInit(): void {
   const { setRevert } = mount(ContainerDetailsLogsClear, {
     target: xtermElement,
     props: {
-      terminal: logsTerminal,
       onclear: async () => {
         if (logsLength === skip) {
           setSkip(0);
@@ -114,13 +113,11 @@ function afterTerminalInit(): void {
 }
 
 function setSkip(n: number): void {
-  const storeValue = $containerLogsCleared;
   if (n) {
-    storeValue.set(getKeyValue(container.id, container.engineId), n);
+    $containerLogsCleared.set(getKeyValue(container.id, container.engineId), n);
   } else {
-    storeValue.delete(getKeyValue(container.id, container.engineId));
+    $containerLogsCleared.delete(getKeyValue(container.id, container.engineId));
   }
-  containerLogsCleared.set(storeValue);
 }
 
 function clearTerminal(): void {

--- a/packages/renderer/src/lib/container/ContainerDetailsLogs.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsLogs.svelte
@@ -4,6 +4,9 @@ import '@xterm/xterm/css/xterm.css';
 import { EmptyScreen } from '@podman-desktop/ui-svelte';
 import type { Terminal } from '@xterm/xterm';
 import { mount, onDestroy, onMount } from 'svelte';
+import type { Unsubscriber } from 'svelte/store';
+
+import { containerLogsCleared, getKeyValue } from '/@/stores/container-logs-cleared';
 
 import { isMultiplexedLog } from '../stream/stream-utils';
 import NoLogIcon from '../ui/NoLogIcon.svelte';
@@ -24,7 +27,7 @@ $: {
     refContainer &&
     (refContainer.id !== container.id || (refContainer.state !== container.state && container.state !== 'EXITED'))
   ) {
-    logsTerminal?.clear();
+    clearTerminal();
     fetchContainerLogs().catch((err: unknown) => console.error(`Error fetching container logs ${container.id}`, err));
   }
   refContainer = container;
@@ -33,17 +36,32 @@ let terminalParentDiv: HTMLDivElement;
 
 let logsTerminal: Terminal;
 
+let logsLength = 0;
+let skip = 0;
+let cancellableTokenId: number | undefined = undefined;
+let containerLogsClearedUnsubscriber: Unsubscriber | undefined = undefined;
+
+let containerDetailsLogsClearSetRevert: ((revert: boolean) => void) | undefined = undefined;
+
+$: {
+  if (skip > 0 && logsLength === skip) {
+    containerDetailsLogsClearSetRevert?.(true);
+  } else {
+    containerDetailsLogsClearSetRevert?.(false);
+  }
+}
+
 function callback(name: string, data: string): void {
   if (name === 'first-message') {
     noLogs = false;
     // clear on the first message
-    logsTerminal?.clear();
+    clearTerminal();
   } else if (name === 'data') {
     noLogs = false;
     if (isMultiplexedLog(data)) {
-      logsTerminal?.write(data.substring(8) + '\r');
+      addDataToTerminal(data.substring(8));
     } else {
-      logsTerminal?.write(data + '\r');
+      addDataToTerminal(data);
     }
   }
   if (!noLogs) {
@@ -52,8 +70,17 @@ function callback(name: string, data: string): void {
 }
 
 async function fetchContainerLogs(): Promise<void> {
+  containerLogsClearedUnsubscriber?.();
+  containerLogsClearedUnsubscriber = containerLogsCleared.subscribe(cleared => {
+    skip = cleared.get(getKeyValue(container.id, container.engineId)) ?? 0;
+  });
+
+  if (cancellableTokenId) {
+    await window.cancelToken(cancellableTokenId);
+  }
+  cancellableTokenId = await window.getCancellableTokenSource();
   // grab logs of the container
-  await window.logsContainer({ engineId: container.engineId, containerId: container.id, callback });
+  await window.logsContainer({ engineId: container.engineId, containerId: container.id, callback, cancellableTokenId });
 }
 
 function afterTerminalInit(): void {
@@ -61,20 +88,55 @@ function afterTerminalInit(): void {
   let xtermElement = terminalParentDiv.querySelector('.xterm');
   xtermElement ??= terminalParentDiv;
   // add svelte component using this xterm element
-  mount(ContainerDetailsLogsClear, {
+  const { setRevert } = mount(ContainerDetailsLogsClear, {
     target: xtermElement,
     props: {
       terminal: logsTerminal,
+      onclear: async () => {
+        if (logsLength === skip) {
+          setSkip(0);
+        } else {
+          setSkip(logsLength);
+        }
+        await fetchContainerLogs();
+      },
     },
   });
+  containerDetailsLogsClearSetRevert = setRevert;
+}
+
+function setSkip(n: number): void {
+  const storeValue = $containerLogsCleared;
+  if (n) {
+    storeValue.set(getKeyValue(container.id, container.engineId), n);
+  } else {
+    storeValue.delete(getKeyValue(container.id, container.engineId));
+  }
+  containerLogsCleared.set(storeValue);
+}
+
+function clearTerminal(): void {
+  logsTerminal?.clear();
+  logsLength = 0;
+}
+
+function addDataToTerminal(data: string): void {
+  if (logsLength >= skip) {
+    logsTerminal?.write(data + '\r');
+  }
+  logsLength += data.length + 1;
 }
 
 onMount(async () => {
   await fetchContainerLogs();
 });
 
-onDestroy(() => {
+onDestroy(async () => {
   logsTerminal?.dispose();
+  containerLogsClearedUnsubscriber?.();
+  if (cancellableTokenId) {
+    await window.cancelToken(cancellableTokenId);
+  }
 });
 </script>
 

--- a/packages/renderer/src/lib/container/ContainerDetailsLogsClear.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerDetailsLogsClear.spec.ts
@@ -19,7 +19,6 @@
 import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
-import { Terminal } from '@xterm/xterm';
 import { expect, test, vi } from 'vitest';
 
 import ContainerDetailsLogsClear from './ContainerDetailsLogsClear.svelte';
@@ -35,9 +34,8 @@ vi.mock('@xterm/xterm', () => {
 });
 
 test('expect clear button is working', async () => {
-  const terminal = new Terminal();
-
-  render(ContainerDetailsLogsClear, { terminal });
+  const onclear = vi.fn();
+  render(ContainerDetailsLogsClear, { onclear });
 
   // expect the button to clear
   const clearButton = screen.getByRole('button', { name: 'Clear logs' });
@@ -47,5 +45,25 @@ test('expect clear button is working', async () => {
   await fireEvent.click(clearButton);
 
   // check we have called the clear function
-  await waitFor(() => expect(terminal.clear).toHaveBeenCalled());
+  await waitFor(() => expect(onclear).toHaveBeenCalled());
+});
+
+test('expect clear button is changed to Restore button', async () => {
+  const onclear = vi.fn();
+  const rendered = render(ContainerDetailsLogsClear, { onclear });
+
+  // expect the button to clear
+  screen.getByRole('button', { name: 'Clear logs' });
+
+  rendered.component.setRevert(true);
+
+  await vi.waitFor(() => {
+    screen.getByRole('button', { name: 'Restore logs' });
+  });
+
+  rendered.component.setRevert(false);
+
+  await vi.waitFor(() => {
+    screen.getByRole('button', { name: 'Clear logs' });
+  });
 });

--- a/packages/renderer/src/lib/container/ContainerDetailsLogsClear.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsLogsClear.svelte
@@ -1,20 +1,25 @@
 <script lang="ts">
-import { faEraser } from '@fortawesome/free-solid-svg-icons';
-import type { Terminal } from '@xterm/xterm';
+import { faEraser, faTrashRestore } from '@fortawesome/free-solid-svg-icons';
 import Fa from 'svelte-fa';
 
-const { terminal }: { terminal: Terminal } = $props();
+const {
+  onclear,
+}: {
+  onclear: () => void;
+} = $props();
 
-function clear(): void {
-  terminal.clear();
+let revert = $state(false);
+
+export function setRevert(r: boolean): void {
+  revert = r;
 }
 </script>
 
 <div class="absolute top-0 right-2 px-1 z-50 m-1 opacity-50 space-x-1">
-  <button title="Clear logs" onclick={clear} class="">
+  <button title={revert ? 'Restore logs' : 'Clear logs'} onclick={onclear} class="">
     <Fa
       class="cursor-pointer rounded-full bg-[var(--pd-button-disabled)] min-h-8 w-8 p-1.5 hover:bg-[var(--pd-button-primary-hover-bg)]"
-      icon={faEraser}
+      icon={revert ? faTrashRestore : faEraser}
     />
   </button>
 </div>

--- a/packages/renderer/src/stores/container-logs-cleared.ts
+++ b/packages/renderer/src/stores/container-logs-cleared.ts
@@ -1,0 +1,25 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { writable } from 'svelte/store';
+
+export const containerLogsCleared = writable<Map<string, number>>(new Map());
+
+export function getKeyValue(engineId: string, containerId: string): string {
+  return JSON.stringify({ engineId, containerId });
+}


### PR DESCRIPTION
### What does this PR do?

- Clear container logs permanently
- Change the "Clear logs" button with a "Restore Logs" button when logs are cleared
 
### Screenshot / video of UI


https://github.com/user-attachments/assets/b2c853a3-ffc9-4912-99e8-b6f11efc9aeb



### What issues does this PR fix or reference?

Fixes #11782 

### How to test this PR?

- Clear logs
- go to other pages and come back, logs should still be cleared
- add some logs, only the new logs should appear
- clear again
- ...
- Check that after several clears, restoring the logs restore all the logs

- [x] Tests are covering the bug fix or the new feature
