### PR TITLE
chore: add border with more contrast in the table component

### DIFF
--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -599,6 +599,11 @@ export class ColorRegistry {
       dark: colorPalette.dustypurple[700],
       light: colorPalette.purple[600],
     });
+
+    this.registerColor(`${ct}table-border`, {
+      dark: colorPalette.charcoal[400],
+      light: colorPalette.gray[300],
+    });
   }
 
   // input boxes

--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -595,11 +595,6 @@ export class ColorRegistry {
       light: colorPalette.gray[200],
     });
 
-    this.registerColor(`${ct}card-contrast-border`, {
-      dark: colorPalette.gray[800],
-      light: colorPalette.charcoal[100],
-    });
-
     this.registerColor(`${ct}card-border-selected`, {
       dark: colorPalette.dustypurple[700],
       light: colorPalette.purple[600],

--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -595,6 +595,11 @@ export class ColorRegistry {
       light: colorPalette.gray[200],
     });
 
+    this.registerColor(`${ct}card-contrast-border`, {
+      dark: colorPalette.gray[800],
+      light: colorPalette.charcoal[100],
+    });
+
     this.registerColor(`${ct}card-border-selected`, {
       dark: colorPalette.dustypurple[700],
       light: colorPalette.purple[600],

--- a/packages/ui/src/lib/table/Table.svelte
+++ b/packages/ui/src/lib/table/Table.svelte
@@ -234,7 +234,7 @@ function toggleChildren(name: string | undefined): void {
   <div role="rowgroup">
     {#each data as object (object)}
       {@const children = row.info.children?.(object) ?? []}
-      <div class="min-h-[48px] h-fit bg-[var(--pd-content-card-bg)] rounded-lg mb-2">
+      <div class="min-h-[48px] h-fit bg-[var(--pd-content-card-bg)] rounded-lg mb-2 border-1 border-[var(--pd-content-card-contrast-border)]">
         <div
           class="grid grid-table gap-x-0.5 min-h-[48px] hover:bg-[var(--pd-content-card-hover-bg)]"
           class:rounded-t-lg={object.name &&

--- a/packages/ui/src/lib/table/Table.svelte
+++ b/packages/ui/src/lib/table/Table.svelte
@@ -234,7 +234,7 @@ function toggleChildren(name: string | undefined): void {
   <div role="rowgroup">
     {#each data as object (object)}
       {@const children = row.info.children?.(object) ?? []}
-      <div class="min-h-[48px] h-fit bg-[var(--pd-content-card-bg)] rounded-lg mb-2 border border-[var(--pd-content-divider)]">
+      <div class="min-h-[48px] h-fit bg-[var(--pd-content-card-bg)] rounded-lg mb-2 border border-[var(--pd-content-table-border)]">
         <div
           class="grid grid-table gap-x-0.5 min-h-[48px] hover:bg-[var(--pd-content-card-hover-bg)]"
           class:rounded-t-lg={object.name &&

--- a/packages/ui/src/lib/table/Table.svelte
+++ b/packages/ui/src/lib/table/Table.svelte
@@ -234,7 +234,7 @@ function toggleChildren(name: string | undefined): void {
   <div role="rowgroup">
     {#each data as object (object)}
       {@const children = row.info.children?.(object) ?? []}
-      <div class="min-h-[48px] h-fit bg-[var(--pd-content-card-bg)] rounded-lg mb-2 border-1 border-[var(--pd-content-card-contrast-border)]">
+      <div class="min-h-[48px] h-fit bg-[var(--pd-content-card-bg)] rounded-lg mb-2 border border-[var(--pd-content-card-contrast-border)]">
         <div
           class="grid grid-table gap-x-0.5 min-h-[48px] hover:bg-[var(--pd-content-card-hover-bg)]"
           class:rounded-t-lg={object.name &&

--- a/packages/ui/src/lib/table/Table.svelte
+++ b/packages/ui/src/lib/table/Table.svelte
@@ -234,7 +234,7 @@ function toggleChildren(name: string | undefined): void {
   <div role="rowgroup">
     {#each data as object (object)}
       {@const children = row.info.children?.(object) ?? []}
-      <div class="min-h-[48px] h-fit bg-[var(--pd-content-card-bg)] rounded-lg mb-2 border border-[var(--pd-content-card-contrast-border)]">
+      <div class="min-h-[48px] h-fit bg-[var(--pd-content-card-bg)] rounded-lg mb-2 border border-[var(--pd-content-divider)]">
         <div
           class="grid grid-table gap-x-0.5 min-h-[48px] hover:bg-[var(--pd-content-card-hover-bg)]"
           class:rounded-t-lg={object.name &&


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Adds a border with higher contrast to the groups of the table component using the new `content-table-border` color 
dark: charcoal[400]
light: gray[300]

### Screenshot / video of UI
![Screenshot From 2025-06-11 09-35-18](https://github.com/user-attachments/assets/08e265aa-df67-47b0-a4ae-aef5358be5ce)
![Screenshot From 2025-06-11 09-35-07](https://github.com/user-attachments/assets/6a6bac73-b7af-4b8e-a19c-650670ffba17)



<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Fixes https://github.com/podman-desktop/podman-desktop/issues/11884

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
