### PR TITLE
fix(workflow): release permission

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -128,6 +128,8 @@ jobs:
   build:
     name: Build / ${{ matrix.os }} ${{ matrix.airgap == 'true' && '(Air Gap)' || ''  }}
     needs: tag
+    permissions:
+      contents: write
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -196,7 +198,7 @@ jobs:
           echo "AZURE_KEY_VAULT_TENANT_ID=${{secrets.AZURE_KEY_VAULT_TENANT_ID}}" | Out-File -FilePath $env:GITHUB_ENV -Append
           echo "AZURE_KEY_VAULT_URL=${{secrets.AZURE_KEY_VAULT_URL}}" | Out-File -FilePath $env:GITHUB_ENV -Append
 
-      - name: Run Build
+      - name: Build & Publish artifacts
         timeout-minutes: 40
         env:
           AIRGAP_DOWNLOAD: ${{ matrix.airgap == 'true' && '1' || ''  }}


### PR DESCRIPTION
### What does this PR do?

Release is failing due to lack of permission when using electron-builder. (ref https://github.com/podman-desktop/podman-desktop/actions/runs/15165214605/job/42641227311).

This problem is a consequence of https://github.com/podman-desktop/podman-desktop/pull/12532 

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Blocking the release workflow

