### PR TITLE
ci: completely hide github button for argos

### DIFF
--- a/website-argos/screenshot.css
+++ b/website-argos/screenshot.css
@@ -27,6 +27,6 @@ video {
 }
 
 /* Hide the GitHub stars badge, since this dynamically changes, it would create false errors in Argos */
-#github-stars-badge {
+#github-stars-button {
   visibility: hidden;
 }

--- a/website/src/components/GitHubStarsButton.tsx
+++ b/website/src/components/GitHubStarsButton.tsx
@@ -42,6 +42,7 @@ export function GitHubStarsButton(): JSX.Element {
     <a
       href="https://github.com/podman-desktop/podman-desktop"
       target="_blank"
+      id="github-stars-button"
       rel="noopener noreferrer"
       className="hidden lg:flex items-center gap-2 px-4 py-[9px] border border-black dark:border-white rounded-lg navbar__item navbar__link font-medium min-w-[9rem]">
       <FontAwesomeIcon icon={faGithub} />


### PR DESCRIPTION
ci: completely hide github button for argos

### What does this PR do?

Completely hides the GitHub button since it loads dynamically, it is
creating false positives with Argos screenshot's since the button
dynamically updates.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/podman-desktop/issues/12446

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

Argos shouldn't create false positives anymore.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
