### PR TITLE
chore: add generate sbom job in release workflow

### DIFF
--- a/.github/workflows/release-generate-sbom.yaml
+++ b/.github/workflows/release-generate-sbom.yaml
@@ -1,0 +1,52 @@
+#
+# Copyright (C) 2025 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Generate sbom for release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version for sbom generation (e.g. v0.0.1)'
+        required: true
+
+jobs:
+  generate-sbom:
+    name: Generate SBOM file
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: write
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.version }}
+
+      - name: Generate sbom file
+        uses: anchore/sbom-action@v0
+        with:
+          path: ./
+          output-file: ./podman-desktop-sbom.spdx.json
+          artifact-name: podman-desktop-sbom.spdx.json
+
+      - name: Upload sbom file to release
+        uses: svenstaro/upload-release-action@04733e069f2d7f7f0b4aebc4fbdbce8613b03ccd # v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ./podman-desktop-sbom.spdx.json
+          tag: ${{ inputs.version }}

--- a/.github/workflows/release-generate-sbom.yaml
+++ b/.github/workflows/release-generate-sbom.yaml
@@ -21,8 +21,11 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Release version for sbom generation (e.g. v0.0.1)'
+        description: 'Release version for sbom generation (e.g. 0.0.1)'
         required: true
+
+env:
+  RELEASE_TAG: v${{ inputs.version }}
 
 jobs:
   generate-sbom:
@@ -35,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ inputs.version }}
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Generate sbom file
         uses: anchore/sbom-action@v0
@@ -49,4 +52,4 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ./podman-desktop-sbom.spdx.json
-          tag: ${{ inputs.version }}
+          tag: ${{ env.RELEASE_TAG }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -308,30 +308,3 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: store-cache-pnpm-${{ matrix.arch }}.tgz
           tag: ${{ needs.tag.outputs.githubTag }}
-
-  generate-sbom:
-    name: Generate SBOM file
-    needs: [tag, release]
-    runs-on: ubuntu-24.04
-    permissions:
-      actions: read
-      contents: write
-
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-        with:
-          ref: ${{ needs.tag.outputs.githubTag}}
-
-      - name: Generate sbom file
-        uses: anchore/sbom-action@v0
-        with:
-          path: ./
-          output-file: ./podman-desktop-sbom.spdx.json
-          artifact-name: podman-desktop-sbom.spdx.json
-
-      - name: Upload sbom file to release
-        uses: svenstaro/upload-release-action@04733e069f2d7f7f0b4aebc4fbdbce8613b03ccd # v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ./podman-desktop-sbom.spdx.json
-          tag: ${{ needs.tag.outputs.githubTag }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -333,5 +333,5 @@ jobs:
         uses: svenstaro/upload-release-action@04733e069f2d7f7f0b4aebc4fbdbce8613b03ccd # v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: podman-desktop-sbom.spdx.json
+          file: ./podman-desktop-sbom.spdx.json
           tag: ${{ needs.tag.outputs.githubTag }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -308,3 +308,30 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: store-cache-pnpm-${{ matrix.arch }}.tgz
           tag: ${{ needs.tag.outputs.githubTag }}
+
+  generate-sbom:
+    name: Generate SBOM file
+    needs: [tag, release]
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: write
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          ref: ${{ needs.tag.outputs.githubTag}}
+
+      - name: Generate sbom file
+        uses: anchore/sbom-action@v0
+        with:
+          path: ./
+          output-file: ./podman-desktop-sbom.spdx.json
+          artifact-name: podman-desktop-sbom.spdx.json
+
+      - name: Upload sbom file to release
+        uses: svenstaro/upload-release-action@04733e069f2d7f7f0b4aebc4fbdbce8613b03ccd # v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: podman-desktop-sbom.spdx.json
+          tag: ${{ needs.tag.outputs.githubTag }}


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Adds an job that generates a SBOM for Podman Desktop and uploads it to the release assets 

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/podman-desktop/issues/12218

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

Tested on the fork of the rhel repo
test release workflow: https://github.com/SoniaSandler/podman-desktop-rhel-ext/actions/runs/15196806261
Test release with sbom asset: https://github.com/SoniaSandler/podman-desktop-rhel-ext/releases/tag/v1.3.7
- [ ] Tests are covering the bug fix or the new feature
