### PR TITLE
chore(workflows): set permission for downloads-count.yaml

### DIFF
--- a/.github/workflows/downloads-count.yaml
+++ b/.github/workflows/downloads-count.yaml
@@ -49,8 +49,8 @@ jobs:
             let totalLinux = 0;
 
             // count the total number of downloads for each release for mac,windows,linux assests
-            releases.forEach((release) => { 
-                release.assets = release.assets.filter((asset) => { 
+            releases.forEach((release) => {
+                release.assets = release.assets.filter((asset) => {
                     if (asset.name.endsWith(".dmg") || (asset.name.endsWith("arm64.zip") || asset.name.endsWith("x64.zip") || asset.name.endsWith("universal.zip")) ){
                         totalMac += asset.download_count;
                     } else if (asset.name.endsWith(".exe")){
@@ -68,7 +68,7 @@ jobs:
             core.exportVariable('totalMac', totalMac);
             core.exportVariable('totalWin', totalWin);
             core.exportVariable('totalLinux', totalLinux);
-        
+
       - name: send-event-4
         run: |
             curl https://api.segment.io/v1/track \

--- a/.github/workflows/downloads-count.yaml
+++ b/.github/workflows/downloads-count.yaml
@@ -23,6 +23,9 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
 
   get-all-releases-count:


### PR DESCRIPTION
### What does this PR do?

The downloads count only read and publish to segment using a secret. It does not require any other permission.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/12215

