### PR TITLE
feat: add sinceDurationInSeconds to window.logsContainer

### DIFF
--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -1679,17 +1679,22 @@ export class ContainerProviderRegistry {
     id: string;
     callback: (name: string, data: string) => void;
     abortController?: AbortController;
+    sinceDurationInSeconds?: number;
   }): Promise<void> {
     let telemetryOptions = {};
     let firstMessage = true;
     const container = this.getMatchingContainer(logsParams.engineId, logsParams.id);
+    const apiLogsParams: Dockerode.ContainerLogsOptions & { follow: true } = {
+      follow: true,
+      stdout: true,
+      stderr: true,
+      abortSignal: logsParams.abortController?.signal,
+    };
+    if (logsParams.sinceDurationInSeconds) {
+      apiLogsParams.since = `${logsParams.sinceDurationInSeconds}s`;
+    }
     container
-      .logs({
-        follow: true,
-        stdout: true,
-        stderr: true,
-        abortSignal: logsParams.abortController?.signal,
-      })
+      .logs(apiLogsParams)
       .then(containerStream => {
         containerStream.on('end', () => {
           logsParams.callback('end', '');

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1149,7 +1149,15 @@ export class PluginSystem {
     );
     this.ipcHandle(
       'container-provider-registry:logsContainer',
-      async (_listener, logsParams: { engineId: string; containerId: string; onDataId: number }): Promise<void> => {
+      async (
+        _listener,
+        logsParams: {
+          engineId: string;
+          containerId: string;
+          onDataId: number;
+          sinceDurationInSeconds?: number;
+        },
+      ): Promise<void> => {
         return containerProviderRegistry.logsContainer({
           engineId: logsParams.engineId,
           id: logsParams.containerId,
@@ -1161,6 +1169,7 @@ export class PluginSystem {
               data,
             );
           },
+          sinceDurationInSeconds: logsParams.sinceDurationInSeconds,
         });
       },
     );

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -537,6 +537,7 @@ export function initExposure(): void {
       engineId: string;
       containerId: string;
       callback: (name: string, data: string) => void;
+      sinceDurationInSeconds?: number;
     }): Promise<void> => {
       onDataCallbacksLogsContainerId++;
       onDataCallbacksLogsContainer.set(onDataCallbacksLogsContainerId, logsParams.callback);
@@ -544,6 +545,7 @@ export function initExposure(): void {
         engineId: logsParams.engineId,
         containerId: logsParams.containerId,
         onDataId: onDataCallbacksLogsContainerId,
+        sinceDurationInSeconds: logsParams.sinceDurationInSeconds,
       });
     },
   );


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Add sinceDurationInSeconds to window.logsContainer, to be able to get most recent containetr's logs 

### Screenshot / video of UI

### What issues does this PR fix or reference?

Needed for #11782

### How to test this PR?

Unit tests included

- [x] Tests are covering the bug fix or the new feature
