### PR TITLE
chore(workflows): set permission for e2e-kubernetes-main.yaml

### DIFF
--- a/.github/workflows/e2e-kubernetes-main.yaml
+++ b/.github/workflows/e2e-kubernetes-main.yaml
@@ -46,10 +46,15 @@ on:
         - podman
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   e2e-tests:
     name: Run All E2E tests
     runs-on: ubuntu-24.04
+    permissions:
+      checks: write # required for mikepenz/action-junit-report
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
### What does this PR do?

The only permission seems to be required for mikepenz/action-junit-report which set a check

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/12215

