### PR TITLE
chore(workflows): set permission for publish-website-pr-cloudflare.yaml

### DIFF
--- a/.github/workflows/publish-website-pr-cloudflare.yaml
+++ b/.github/workflows/publish-website-pr-cloudflare.yaml
@@ -26,6 +26,9 @@ on:
     types:
       - completed
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     name: Publish content of the website pull request on cloudflare pages


### PR DESCRIPTION
### What does this PR do?

Setting permission for `publish-website-pr-cloudflare.yaml`

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/12215
