### PR TITLE
feat: add button to start all containers in bulk

### DIFF
--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
-import { faPlusCircle, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faPlay, faPlusCircle, faTrash } from '@fortawesome/free-solid-svg-icons';
 import {
   Button,
   FilteredEmptyScreen,
   NavPage,
   Table,
+  type Table as TableComponentType,
   TableColumn,
   TableDurationColumn,
   TableRow,
@@ -69,18 +70,24 @@ $: providerConnections = $providerInfos
   .flat()
   .filter(providerContainerConnection => providerContainerConnection.status === 'started');
 
+// filter containers by group type pod
+function filterContainersByGroupTypePod(): ContainerGroupInfoUI[] {
+  return containerGroups.filter(group => group.type === ContainerGroupInfoTypeUI.POD).filter(pod => pod.selected);
+}
+
+// filter containers by group type different than pod
+function filterContainersByGroupTypeNotPod(): ContainerInfoUI[] {
+  return containerGroups
+    .filter(group => group.type !== ContainerGroupInfoTypeUI.POD)
+    .flatMap(group => group.containers)
+    .filter(container => container.selected);
+}
+
 // delete the items selected in the list
 let bulkDeleteInProgress = false;
 async function deleteSelectedContainers(): Promise<void> {
-  const podGroups = containerGroups
-    .filter(group => group.type === ContainerGroupInfoTypeUI.POD)
-    .filter(pod => pod.selected);
-  const selectedContainers = containerGroups
-    .filter(group => group.type !== ContainerGroupInfoTypeUI.POD)
-    .map(group => group.containers)
-    .flat()
-    .filter(container => container.selected);
-
+  const podGroups = filterContainersByGroupTypePod();
+  const selectedContainers = filterContainersByGroupTypeNotPod();
   if (podGroups.length + selectedContainers.length === 0) {
     return;
   }
@@ -128,6 +135,65 @@ async function deleteSelectedContainers(): Promise<void> {
     );
   }
   bulkDeleteInProgress = false;
+}
+
+// run the items selected in the list
+let bulkRunInProgress = false;
+async function runSelectedContainers(): Promise<void> {
+  const podGroups = filterContainersByGroupTypePod();
+  const selectedContainers = filterContainersByGroupTypeNotPod();
+  if (podGroups.length + selectedContainers.length === 0) {
+    return;
+  }
+  bulkRunInProgress = true;
+  podGroups.forEach(pod => {
+    if (pod.status !== 'RUNNING') pod.status = 'STARTING';
+  });
+  selectedContainers.forEach(container => {
+    if (container.state !== 'RUNNING') container.state = 'STARTING';
+  });
+  containerGroups = [...containerGroups];
+
+  // runs pods first if any
+  if (podGroups.length > 0) {
+    await Promise.all(
+      podGroups.map(async podGroup => {
+        if (podGroup.engineId && podGroup.id && podGroup.status !== 'RUNNING') {
+          try {
+            await window.startPod(podGroup.engineId, podGroup.id);
+          } catch (e) {
+            console.error('error while running pod', e);
+          }
+        }
+      }),
+    );
+  }
+
+  // then containers (that are not inside a pod)
+  if (selectedContainers.length > 0) {
+    await Promise.all(
+      selectedContainers.map(async container => {
+        if (container.state === 'RUNNING') {
+          return; // skip already running containers
+        }
+        container.actionInProgress = true;
+        // reset error when starting task
+        container.actionError = '';
+        containerGroups = [...containerGroups];
+        try {
+          await window.startContainer(container.engineId, container.id);
+        } catch (e) {
+          console.log('error while runnings container', e);
+          container.actionError = String(e);
+          container.state = 'ERROR';
+        } finally {
+          container.actionInProgress = false;
+          containerGroups = [...containerGroups];
+        }
+      }),
+    );
+  }
+  bulkRunInProgress = false;
 }
 
 function createPodFromContainers(): void {
@@ -300,7 +366,7 @@ function setStoppedFilter(): void {
 }
 
 let selectedItemsNumber: number;
-let table: Table;
+let table: TableComponentType;
 
 let statusColumn = new TableColumn<ContainerInfoUI | ContainerGroupInfoUI>('Status', {
   align: 'center',
@@ -391,6 +457,14 @@ $: containersAndGroups = containerGroups.map(group =>
   {#snippet bottomAdditionalActions()}
     {#if selectedItemsNumber > 0}
       <div class="inline-flex space-x-2">
+        <Button
+          on:click={(): Promise<void> =>
+           runSelectedContainers()}
+          aria-label="Run selected containers and pods"
+          title="Run {selectedItemsNumber} selected items"
+          inProgress={bulkRunInProgress}
+          icon={faPlay}>
+        </Button>
         <Button
           on:click={(): void =>
             withBulkConfirmation(

--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -5,7 +5,6 @@ import {
   FilteredEmptyScreen,
   NavPage,
   Table,
-  type Table as TableComponentType,
   TableColumn,
   TableDurationColumn,
   TableRow,
@@ -161,6 +160,7 @@ async function runSelectedContainers(): Promise<void> {
         if (podGroup.engineId && podGroup.id && podGroup.status !== 'RUNNING') {
           try {
             await window.startPod(podGroup.engineId, podGroup.id);
+            podGroup.status = 'RUNNING';
           } catch (e) {
             console.error('error while running pod', e);
           }
@@ -182,6 +182,7 @@ async function runSelectedContainers(): Promise<void> {
         containerGroups = [...containerGroups];
         try {
           await window.startContainer(container.engineId, container.id);
+          container.state = 'RUNNING';
         } catch (e) {
           console.log('error while runnings container', e);
           container.actionError = String(e);
@@ -366,7 +367,6 @@ function setStoppedFilter(): void {
 }
 
 let selectedItemsNumber: number;
-let table: TableComponentType;
 
 let statusColumn = new TableColumn<ContainerInfoUI | ContainerGroupInfoUI>('Status', {
   align: 'center',
@@ -501,7 +501,6 @@ $: containersAndGroups = containerGroups.map(group =>
     <div class="flex min-w-full h-full">
       <Table
         kind="container"
-        bind:this={table}
         bind:selectedItemsNumber={selectedItemsNumber}
         data={containersAndGroups}
         columns={columns}


### PR DESCRIPTION
### What does this PR do?

This PR adds a new feature in order to have the possibility to run containers in bulk. If there are containers already running selected, the button will just apply to those who are not running.

### Screenshot / video of UI
<img width="927" alt="Captura de pantalla 2025-05-27 a las 13 33 08" src="https://github.com/user-attachments/assets/a52fb2a4-2899-4530-a49b-240dd4833c57" />

<img width="926" alt="Captura de pantalla 2025-05-27 a las 13 30 02" src="https://github.com/user-attachments/assets/eb56e7bc-76a6-4ea0-b4fb-841980ad614e" />

### What issues does this PR fix or reference?

closes #12312 

### How to test this PR?

1. Run podman desktop
2. Go to containers sections
3. Create some pods and containers
4. Select multiple containers, running and not running.
5. Click in the bulk run button at the top of the section.
6. After clicking those containers and pots that were not running should run.

- [ ] Tests are covering the bug fix or the new feature
