### PR TITLE
chore: update social networks links

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Kubernetes questions & development:
 
 - [Follow us on Mastodon](https://fosstodon.org/@podmandesktop)
 - [Follow us on Bluesky](https://bsky.app/profile/podman-desktop.io)
-- [Follow us on X](https://x.com/Podman_io)
+- [Follow us on X](https://x.com/podmandesktop)
 - [Follow us on LinkedIn](https://www.linkedin.com/company/podman-desktop)
 
 ### Adopters

--- a/README.md
+++ b/README.md
@@ -119,6 +119,13 @@ Kubernetes questions & development:
 
 - [#podman-desktop](https://app.slack.com/client/T09NY5SBT/C04A0L7LUFM) on the [Kubernetes Slack](https://slack.k8s.io/)
 
+### Social networks
+
+- [Follow us on Mastodon](https://fosstodon.org/@podmandesktop)
+- [Follow us on Bluesky](https://bsky.app/profile/podman-desktop.io)
+- [Follow us on X](https://x.com/Podman_io)
+- [Follow us on LinkedIn](https://www.linkedin.com/company/podman-desktop)
+
 ### Adopters
 
 Check out the [list of companies](./ADOPTERS.md) already using Podman Desktop.

--- a/website/src/pages/community/index.tsx
+++ b/website/src/pages/community/index.tsx
@@ -76,7 +76,7 @@ export default function Home(): JSX.Element {
                   </a>
                 </li>
                 <li>
-                  <a href="https://x.com/Podman_io" target="_blank" rel="noopener noreferrer">
+                  <a href="https://x.com/podmandesktop" target="_blank" rel="noopener noreferrer">
                     Follow us on X
                   </a>
                 </li>

--- a/website/src/pages/community/index.tsx
+++ b/website/src/pages/community/index.tsx
@@ -53,17 +53,24 @@ export default function Home(): JSX.Element {
               <p className="dark:text-gray-700">Connect with the community through our official channels:</p>
               <ul className="list-disc list-inside space-y-2 dark:text-gray-700">
                 <li>
-                  <a href="https://discord.com/invite/x5GzFF6QH4">Discord</a>: Join our Discord.
+                  <a href="https://discord.com/invite/x5GzFF6QH4">Join us on our Discord</a>
                 </li>
                 <li>
-                  <a href="https://github.com/podman-desktop/podman-desktop/discussions">Github Discussions</a>:
-                  Participate in discussions.
+                  <a href="https://github.com/podman-desktop/podman-desktop/discussions">
+                    Participate on Github Discussions
+                  </a>
                 </li>
                 <li>
-                  <a href="https://bsky.app/profile/podman-desktop.io">Bluesky</a>: Follow us on Bluesky.
+                  <a href="https://fosstodon.org/@podmandesktop">Follow us on Mastodon</a>
                 </li>
                 <li>
-                  <a href="https://x.com/Podman_io">X</a>: Follow us on X.
+                  <a href="https://bsky.app/profile/podman-desktop.io">Follow us on Bluesky</a>
+                </li>
+                <li>
+                  <a href="https://x.com/Podman_io">Follow us on X</a>
+                </li>
+                <li>
+                  <a href="https://www.linkedin.com/company/podman-desktop">Follow us on LinkedIn</a>
                 </li>
               </ul>
             </div>

--- a/website/src/pages/community/index.tsx
+++ b/website/src/pages/community/index.tsx
@@ -53,24 +53,37 @@ export default function Home(): JSX.Element {
               <p className="dark:text-gray-700">Connect with the community through our official channels:</p>
               <ul className="list-disc list-inside space-y-2 dark:text-gray-700">
                 <li>
-                  <a href="https://discord.com/invite/x5GzFF6QH4">Join us on our Discord</a>
-                </li>
-                <li>
-                  <a href="https://github.com/podman-desktop/podman-desktop/discussions">
-                    Participate on Github Discussions
+                  <a href="https://discord.com/invite/x5GzFF6QH4" target="_blank" rel="noopener noreferrer">
+                    Join us on our Discord
                   </a>
                 </li>
                 <li>
-                  <a href="https://fosstodon.org/@podmandesktop">Follow us on Mastodon</a>
+                  <a
+                    href="https://github.com/podman-desktop/podman-desktop/discussions"
+                    target="_blank"
+                    rel="noopener noreferrer">
+                    Participate on GitHub Discussions
+                  </a>
                 </li>
                 <li>
-                  <a href="https://bsky.app/profile/podman-desktop.io">Follow us on Bluesky</a>
+                  <a href="https://fosstodon.org/@podmandesktop" target="_blank" rel="noopener noreferrer">
+                    Follow us on Mastodon
+                  </a>
                 </li>
                 <li>
-                  <a href="https://x.com/Podman_io">Follow us on X</a>
+                  <a href="https://bsky.app/profile/podman-desktop.io" target="_blank" rel="noopener noreferrer">
+                    Follow us on Bluesky
+                  </a>
                 </li>
                 <li>
-                  <a href="https://www.linkedin.com/company/podman-desktop">Follow us on LinkedIn</a>
+                  <a href="https://x.com/Podman_io" target="_blank" rel="noopener noreferrer">
+                    Follow us on X
+                  </a>
+                </li>
+                <li>
+                  <a href="https://www.linkedin.com/company/podman-desktop" target="_blank" rel="noopener noreferrer">
+                    Follow us on LinkedIn
+                  </a>
                 </li>
               </ul>
             </div>


### PR DESCRIPTION
### What does this PR do?

Updates the links to our social networks on the [Community page](https://podman-desktop.io/community), and adds the section to the podman-desktop repo `README.md`.

![CleanShot 2025-05-28 at 13 09 09@2x](https://github.com/user-attachments/assets/815aa1e4-7af4-4968-87a9-9347e9676e03)

### What issues does this PR fix or reference?

- #12607

### How to test this PR?

- [ ] Open the Community page, scroll to the "Get Involved" section. See that the links are displayed.
- [ ] Click each link to confirm it opens the correct pages.
- [ ] Read the `README.md` in the repo root (of this branch); there's a new section "Social networks", confirm it's there.
