### PR TITLE
chore(e2e): refactor extension-installation-smoke test case

### DIFF
--- a/tests/playwright/src/model/core/extensions.ts
+++ b/tests/playwright/src/model/core/extensions.ts
@@ -181,4 +181,9 @@ export const extensionsExternalList = [
   openshiftCheckerExtension,
   openshiftLocalExtension,
 ];
+export const extensionsInstallationSmokeList = [
+  developerSandboxExtension,
+  openshiftLocalExtension,
+  openshiftCheckerExtension,
+];
 export const extensionsAllExternalList = [...extensionsExternalList, headlampExtension];

--- a/tests/playwright/src/model/core/states.ts
+++ b/tests/playwright/src/model/core/states.ts
@@ -62,3 +62,10 @@ export enum KubernetesResourceState {
   Unknown = 'UNKNOWN',
   Succeeded = 'SUCCEEDED',
 }
+export enum ExtensionState {
+  Disabled = 'DISABLED',
+  Active = 'ACTIVE',
+  Running = 'RUNNING',
+  NotInstalled = 'NOT-INSTALLED',
+  Downloadable = 'DOWNLOADABLE',
+}


### PR DESCRIPTION
Signed-off-by: Daniel Villanueva <davillan@redhat.com>

### What does this PR do?
This PR refactors the extension-installation-smoke test case so that it uses centralized values from extensions.ts and states.ts rather than hardcoded ones


### What issues does this PR fix or reference?
#12483 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
Run `pnpm test:e2e:smoke`
<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->
