### PR TITLE
feat(ui): created universal icon

### DIFF
--- a/packages/ui/src/lib/icons/Icon.spec.ts
+++ b/packages/ui/src/lib/icons/Icon.spec.ts
@@ -65,15 +65,6 @@ describe('font awesome', () => {
     const path = img.querySelector('path');
     expect(path).toHaveAttribute('fill', 'currentColor');
   });
-
-  test('icon should reflect selected color', () => {
-    render(Icon, { icon: faGithub, color: 'blue' });
-
-    const img = screen.getByRole('img', { hidden: true });
-    expect(img).toBeInTheDocument();
-    const path = img.querySelector('path');
-    expect(path).toHaveAttribute('fill', 'blue');
-  });
 });
 
 describe('class icon', () => {

--- a/packages/ui/src/lib/icons/Icon.spec.ts
+++ b/packages/ui/src/lib/icons/Icon.spec.ts
@@ -1,0 +1,133 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import '@testing-library/jest-dom/vitest';
+
+import { faGithub } from '@fortawesome/free-brands-svg-icons';
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, test } from 'vitest';
+
+import { ContainerIcon } from '.';
+import Icon from './Icon.svelte';
+
+describe('font awesome', () => {
+  test('basic icon should be created', () => {
+    render(Icon, { icon: faGithub });
+
+    const img = screen.getByRole('img', { hidden: true });
+    expect(img).toBeInTheDocument();
+    expect(img).not.toHaveAttribute('style');
+  });
+
+  test('icon should reflect prefered {number}x size', () => {
+    render(Icon, { icon: faGithub, size: '2x' });
+
+    const img = screen.getByRole('img', { hidden: true });
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute('style', expect.stringContaining('font-size: 2em;'));
+  });
+
+  test('icon should reflect prefered sm size', () => {
+    render(Icon, { icon: faGithub, size: 'sm' });
+
+    const img = screen.getByRole('img', { hidden: true });
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveClass('svelte-fa-size-sm');
+  });
+
+  test('icon should have class', () => {
+    render(Icon, { icon: faGithub, class: 'some-class' });
+
+    const img = screen.getByRole('img', { hidden: true });
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveClass('some-class');
+  });
+
+  test('icon should have color defined by parent', () => {
+    render(Icon, { icon: faGithub });
+
+    const img = screen.getByRole('img', { hidden: true });
+    expect(img).toBeInTheDocument();
+    const path = img.querySelector('path');
+    expect(path).toHaveAttribute('fill', 'currentColor');
+  });
+
+  test('icon should reflect selected color', () => {
+    render(Icon, { icon: faGithub, color: 'blue' });
+
+    const img = screen.getByRole('img', { hidden: true });
+    expect(img).toBeInTheDocument();
+    const path = img.querySelector('path');
+    expect(path).toHaveAttribute('fill', 'blue');
+  });
+});
+
+describe('class icon', () => {
+  test('basic icon should be created', () => {
+    render(Icon, { icon: 'fas fa-icon' });
+
+    const img = screen.getByRole('img', { hidden: true });
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveClass('fas fa-icon');
+  });
+
+  test('icon should reflect prefered fa-{number}x size', () => {
+    render(Icon, { icon: 'fas fa-icon', size: 'fa-2x' });
+
+    const img = screen.getByRole('img', { hidden: true });
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveClass('fas fa-icon');
+    expect(img).toHaveClass('fa-2x');
+  });
+
+  test('icon should have class', () => {
+    render(Icon, { icon: 'fas fa-icon', class: 'some-class' });
+
+    const img = screen.getByRole('img', { hidden: true });
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveClass('fas fa-icon');
+    expect(img).toHaveClass('some-class');
+  });
+});
+
+describe('component icon', () => {
+  test('basic icon should be created', () => {
+    render(Icon, { icon: ContainerIcon });
+
+    const img = screen.getByRole('img', { hidden: true });
+    expect(img).toBeInTheDocument();
+  });
+
+  test('icon should reflect prefered {number} size', () => {
+    render(Icon, { icon: ContainerIcon, size: '42' });
+
+    const img = screen.getByRole('img', { hidden: true });
+    const imgComponent = img.firstChild;
+    expect(imgComponent).toBeInTheDocument();
+    expect(imgComponent).toHaveAttribute('width', '42');
+    expect(imgComponent).toHaveAttribute('height', '42');
+  });
+
+  test('icon should have class', () => {
+    render(Icon, { icon: ContainerIcon, class: 'some-class' });
+
+    const img = screen.getByRole('img', { hidden: true });
+    const imgComponent = img.firstChild;
+    expect(imgComponent).toBeInTheDocument();
+    expect(imgComponent).toHaveClass('some-class');
+  });
+});

--- a/packages/ui/src/lib/icons/Icon.svelte
+++ b/packages/ui/src/lib/icons/Icon.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
+import type { Component } from 'svelte';
+import { Fa, type IconSize } from 'svelte-fa';
+
+import { isFontAwesomeIcon, isFontAwesomeSize } from '../utils/icon-utils';
+
+interface Props {
+  icon: IconDefinition | Component | string;
+  size?: IconSize | number | string;
+  class?: string;
+  color?: string;
+  'aria-label'?: string;
+  'aria-hidden'?: string;
+  role?: string;
+  solid?: boolean;
+}
+
+let {
+  icon,
+  size,
+  class: className,
+  color,
+  'aria-label': ariaLabel,
+  'aria-hidden': ariaHidden,
+  role = 'img',
+  solid = true,
+}: Props = $props();
+
+const IconComponent = icon;
+</script>
+
+
+{#if isFontAwesomeIcon(icon) && (typeof size === 'undefined' || isFontAwesomeSize(size))}
+    <Fa {icon} {size} class={className} {color}/>
+{:else if typeof icon === 'string' && (icon.startsWith('fas fa-') || icon.startsWith('far fa-'))}
+    <i class={`${icon} ${size} ${className}`} aria-label={ariaLabel} aria-hidden={ariaHidden ? Boolean(ariaHidden) : false} {role}></i>
+{:else if IconComponent && typeof IconComponent !== 'string' && !isFontAwesomeIcon(IconComponent)}
+    <IconComponent class={className} {size} {role} {solid}/>
+{/if}

--- a/packages/ui/src/lib/icons/Icon.svelte
+++ b/packages/ui/src/lib/icons/Icon.svelte
@@ -9,32 +9,19 @@ interface Props {
   icon: IconDefinition | Component | string;
   size?: IconSize | number | string;
   class?: string;
-  color?: string;
-  'aria-label'?: string;
-  'aria-hidden'?: string;
-  role?: string;
-  solid?: boolean;
 }
 
-let {
-  icon,
-  size,
-  class: className,
-  color,
-  'aria-label': ariaLabel,
-  'aria-hidden': ariaHidden,
-  role = 'img',
-  solid = false,
-}: Props = $props();
+let { icon, size, class: className }: Props = $props();
 
+const role = 'img';
 const IconComponent = icon;
 </script>
 
 
 {#if isFontAwesomeIcon(icon) && (typeof size === 'undefined' || isFontAwesomeSize(size))}
-    <Fa {icon} {size} class={className} {color}/>
+    <Fa {icon} {size} class={className}/>
 {:else if typeof icon === 'string' && (icon.startsWith('fas fa-') || icon.startsWith('far fa-'))}
-    <i class={`${icon} ${size} ${className}`} aria-label={ariaLabel} aria-hidden={ariaHidden ? Boolean(ariaHidden) : false} {role}></i>
+    <i class={`${icon} ${size} ${className}`} {role}></i>
 {:else if IconComponent && typeof IconComponent !== 'string' && !isFontAwesomeIcon(IconComponent)}
-    <span {role}><IconComponent class={className} {size} {solid}/></span>
+    <span {role}><IconComponent class={className} {size}/></span>
 {/if}

--- a/packages/ui/src/lib/icons/Icon.svelte
+++ b/packages/ui/src/lib/icons/Icon.svelte
@@ -24,7 +24,7 @@ let {
   'aria-label': ariaLabel,
   'aria-hidden': ariaHidden,
   role = 'img',
-  solid = true,
+  solid = false,
 }: Props = $props();
 
 const IconComponent = icon;
@@ -36,5 +36,5 @@ const IconComponent = icon;
 {:else if typeof icon === 'string' && (icon.startsWith('fas fa-') || icon.startsWith('far fa-'))}
     <i class={`${icon} ${size} ${className}`} aria-label={ariaLabel} aria-hidden={ariaHidden ? Boolean(ariaHidden) : false} {role}></i>
 {:else if IconComponent && typeof IconComponent !== 'string' && !isFontAwesomeIcon(IconComponent)}
-    <IconComponent class={className} {size} {role} {solid}/>
+    <span {role}><IconComponent class={className} {size} {solid}/></span>
 {/if}

--- a/packages/ui/src/lib/icons/Icon.svelte
+++ b/packages/ui/src/lib/icons/Icon.svelte
@@ -18,10 +18,16 @@ const IconComponent = icon;
 </script>
 
 
-{#if isFontAwesomeIcon(icon) && (typeof size === 'undefined' || isFontAwesomeSize(size))}
-    <Fa {icon} {size} class={className}/>
-{:else if typeof icon === 'string' && (icon.startsWith('fas fa-') || icon.startsWith('far fa-'))}
-    <i class={`${icon} ${size} ${className}`} {role}></i>
-{:else if IconComponent && typeof IconComponent !== 'string' && !isFontAwesomeIcon(IconComponent)}
-    <span {role}><IconComponent class={className} {size}/></span>
+{#if isFontAwesomeIcon(icon)}
+    {#if typeof size === 'undefined' || isFontAwesomeSize(size)}
+        <Fa {icon} {size} class={className}/>
+    {/if}
+{:else if typeof icon === 'string'}
+    {#if icon.startsWith('fas fa-') || icon.startsWith('far fa-')}
+        <i class={`${icon} ${size} ${className}`} {role}></i>
+    {/if}
+{:else}
+    {#if IconComponent && typeof IconComponent !== 'string' && !isFontAwesomeIcon(IconComponent)}
+        <span {role}><IconComponent class={className} {size}/></span>
+    {/if}
 {/if}

--- a/packages/ui/src/lib/icons/index.ts
+++ b/packages/ui/src/lib/icons/index.ts
@@ -17,6 +17,7 @@
  ***********************************************************************/
 
 import ContainerIcon from './ContainerIcon.svelte';
+import Icon from './Icon.svelte';
 import StarIcon from './StarIcon.svelte';
 
-export { ContainerIcon, StarIcon };
+export { ContainerIcon, Icon, StarIcon };

--- a/packages/ui/src/lib/utils/icon-utils.spec.ts
+++ b/packages/ui/src/lib/utils/icon-utils.spec.ts
@@ -20,7 +20,7 @@ import { faGithub } from '@fortawesome/free-brands-svg-icons';
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
 import { expect, test } from 'vitest';
 
-import { isFontAwesomeIcon } from './icon-utils';
+import { isFontAwesomeIcon, isFontAwesomeSize } from './icon-utils';
 
 test('ensure fas prefix is recognized', () => {
   expect(isFontAwesomeIcon(faTrash)).toBeTruthy();
@@ -28,4 +28,10 @@ test('ensure fas prefix is recognized', () => {
 
 test('ensure fab prefix is recognized', () => {
   expect(isFontAwesomeIcon(faGithub)).toBeTruthy();
+});
+
+test('ensure fontawesome size is recognized', () => {
+  expect(isFontAwesomeSize('xs')).toBeTruthy();
+  expect(isFontAwesomeSize('1x')).toBeTruthy();
+  expect(isFontAwesomeSize('4.2x')).toBeTruthy();
 });

--- a/packages/ui/src/lib/utils/icon-utils.ts
+++ b/packages/ui/src/lib/utils/icon-utils.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
  ***********************************************************************/
 
 import type { IconDefinition } from '@fortawesome/fontawesome-common-types';
+import type { IconSize } from 'svelte-fa';
 
 export const isFontAwesomeIcon = (icon: unknown): icon is IconDefinition => {
   return (
@@ -26,4 +27,10 @@ export const isFontAwesomeIcon = (icon: unknown): icon is IconDefinition => {
     typeof icon.prefix === 'string' &&
     icon.prefix.startsWith('fa')
   );
+};
+
+export const isFontAwesomeSize = (size: unknown): size is IconSize => {
+  const fontAwesomeSizes = ['xs', 'sm', 'lg'];
+  const fontAwesomePattern = /^\d+(?:\.\d+)?x$/;
+  return !!size && typeof size === 'string' && (fontAwesomePattern.test(size) || fontAwesomeSizes.includes(size));
 };


### PR DESCRIPTION
### What does this PR do?
Adds universal icon to Podman Desktop UI lib

We are using 3 different types of rendering images: 
1. Using Fa
2. Using classes
3. Rendering component

All over the PD repo there are those 3 options randomly used, this Component will replace all those places by this component 

Required for https://github.com/podman-desktop/podman-desktop/pull/12661

### Screenshot / video of UI

### What issues does this PR fix or reference?
Can be tried out in https://github.com/podman-desktop/podman-desktop/pull/12678

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
