### PR TITLE
fix: uncaught exceptions in ContainerList.spec.ts

### DIFF
--- a/packages/renderer/src/lib/container/ContainerList.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerList.spec.ts
@@ -39,6 +39,7 @@ beforeAll(() => {
   vi.mocked(window.listViewsContributions).mockResolvedValue([]);
   vi.mocked(window.getContributedMenus).mockResolvedValue([]);
   vi.mocked(window.getConfigurationValue).mockResolvedValue(false);
+  vi.mocked(window.onDidUpdateProviderStatus).mockResolvedValue(undefined);
   (window.events as unknown) = {
     receive: (_channel: string, func: () => void): void => {
       func();


### PR DESCRIPTION
Fix exception below

```
Failed to update providers TypeError: Cannot read properties of undefined (reading 'catch')
    at /Users/eskimo/Sources/podman-desktop/packages/renderer/src/stores/providers.ts:69:10
```

### What does this PR do?

Adds mockResolvedValue call for affected window function

### Screenshot / video of UI

N/A

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Related to #11952.

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
