### PR TITLE
fix: uncaught exceptions in ContainerListCompose.spec.ts

### DIFF
--- a/packages/renderer/src/lib/container/ContainerListCompose.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerListCompose.spec.ts
@@ -36,7 +36,7 @@ import ContainerList from './ContainerList.svelte';
 beforeAll(() => {
   vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
   vi.mocked(window.listViewsContributions).mockResolvedValue([]);
-
+  vi.mocked(window.onDidUpdateProviderStatus).mockResolvedValue(undefined);
   (window.events as unknown) = {
     receive: (_channel: string, func: unknown): void => {
       (func as () => void)();


### PR DESCRIPTION
Fix exception below

```
Failed to update providers TypeError: Cannot read properties of undefined (reading 'catch')
    at /Users/eskimo/Sources/podman-desktop/packages/renderer/src/stores/providers.ts:69:10
```

### What does this PR do?

Adds mockResolvedValue call for affected window function.

### Screenshot / video of UI

N/A

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Related to #11952.

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature