### PR TITLE
fix: avoid shell prompt duplication in container's terminal when switching between tabs

### DIFF
--- a/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
@@ -148,8 +148,24 @@ onMount(async () => {
   await executeShellIntoContainer();
 });
 
+function removePromptFromTheEnd(terminal: string): string {
+  const firstSpaceIndex = terminal.indexOf(' ');
+  if (firstSpaceIndex === -1) {
+    return terminal;
+  }
+  const firstWord = terminal.slice(0, firstSpaceIndex);
+  const suffix = firstWord + ' ';
+  if (terminal.endsWith(suffix)) {
+    return terminal.slice(0, -suffix.length);
+  }
+  return terminal;
+}
+
 onDestroy(() => {
-  terminalContent = serializeAddon.serialize();
+  // remove first prompt text to avoid prompt duplication
+  // when restoring terminal after switching between tabs
+  terminalContent = removePromptFromTheEnd(serializeAddon.serialize());
+
   // register terminal for reusing it
   registerTerminal({
     engineId: container.engineId,


### PR DESCRIPTION
### What does this PR do?

Fix adds a removal of prompt from the end of stored terminal. It is added automatically after contend of the terminal is restored.

### Screenshot / video of UI

https://github.com/user-attachments/assets/5ff6ccb3-9e0b-4702-b449-71d752490304

### What issues does this PR fix or reference?

Fix #11952.

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
