### PR TITLE
chore(e2e): add scrollintoviewifneeded to ui-stress-test

### DIFF
--- a/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
+++ b/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
@@ -43,10 +43,7 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
     //count images => 1 original image + (1 tagged * numberOfObjects) + 1 localhost/podman-pause from pods = numberOfObjects + 2
     await playExpect.poll(async () => await images.countRowsFromTable(), { timeout: 10_000 }).toBe(numberOfObjects + 2);
     for (let imgNum = 1; imgNum <= numberOfObjects; imgNum++) {
-      const imgName = `localhost/my-image-${imgNum}`;
-      await playExpect.poll(async () => await images.waitForRowToExists(imgName), { timeout: 10_000 }).toBeTruthy();
-
-      await scrollRowIntoView(images, imgName);
+      await findRowAndScroll(images, `localhost/my-image-${imgNum}`);
     }
   });
 
@@ -60,12 +57,7 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
       .poll(async () => await containers.countRowsFromTable(), { timeout: 10_000 })
       .toBe(3 * numberOfObjects);
     for (let containerNum = 1; containerNum <= numberOfObjects; containerNum++) {
-      const containerName = `my-container-${containerNum}`;
-      await playExpect
-        .poll(async () => await containers.waitForRowToExists(containerName), { timeout: 0 })
-        .toBeTruthy();
-
-      await scrollRowIntoView(containers, containerName);
+      await findRowAndScroll(containers, `my-container-${containerNum}`);
     }
   });
 
@@ -77,19 +69,15 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
     //count pods => 1 manually created * numberOfObjects = numberOfObjects
     await playExpect.poll(async () => await pods.countRowsFromTable(), { timeout: 10_000 }).toBe(numberOfObjects);
     for (let podNum = 1; podNum <= numberOfObjects; podNum++) {
-      const podName = `my-pod-${podNum}`;
-      await playExpect.poll(async () => await pods.waitForRowToExists(podName), { timeout: 0 }).toBeTruthy();
-
-      await scrollRowIntoView(pods, podName);
+      await findRowAndScroll(pods, `my-pod-${podNum}`);
     }
   });
 });
 
-async function scrollRowIntoView(page: MainPage, rowName: string): Promise<void> {
+async function findRowAndScroll(page: MainPage, rowName: string): Promise<void> {
   const rowLocator = await page.getRowByName(rowName);
   if (rowLocator === undefined) {
     throw Error(`Row: '${rowName}' does not exist`);
   }
   await rowLocator.scrollIntoViewIfNeeded();
-  await playExpect(rowLocator).toBeVisible();
 }

--- a/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
+++ b/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
@@ -41,6 +41,9 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
     //count images => 1 original image + (1 tagged * numberOfObjects) + 1 localhost/podman-pause from pods = numberOfObjects + 2
     await playExpect.poll(async () => await images.countRowsFromTable(), { timeout: 10_000 }).toBe(numberOfObjects + 2);
     for (let imgNum = 1; imgNum <= numberOfObjects; imgNum++) {
+      await playExpect
+        .poll(async () => await images.waitForRowToExists(`localhost/my-image-${imgNum}`), { timeout: 0 })
+        .toBeTruthy();
       const imgRowLocator = await images.getRowByName(`localhost/my-image-${imgNum}`);
       await imgRowLocator?.scrollIntoViewIfNeeded();
     }
@@ -56,6 +59,9 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
       .poll(async () => await containers.countRowsFromTable(), { timeout: 10_000 })
       .toBe(3 * numberOfObjects);
     for (let containerNum = 1; containerNum <= numberOfObjects; containerNum++) {
+      await playExpect
+        .poll(async () => await containers.waitForRowToExists(`my-container-${containerNum}`), { timeout: 0 })
+        .toBeTruthy();
       const containerRowLocator = await containers.getRowByName(`my-container-${containerNum}`);
       await containerRowLocator?.scrollIntoViewIfNeeded();
     }
@@ -69,6 +75,7 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
     //count pods => 1 manually created * numberOfObjects = numberOfObjects
     await playExpect.poll(async () => await pods.countRowsFromTable(), { timeout: 10_000 }).toBe(numberOfObjects);
     for (let podNum = 1; podNum <= numberOfObjects; podNum++) {
+      await playExpect.poll(async () => await pods.waitForRowToExists(`my-pod-${podNum}`), { timeout: 0 }).toBeTruthy();
       const podRowLocator = await pods.getRowByName(`my-pod-${podNum}`);
       await podRowLocator?.scrollIntoViewIfNeeded();
     }

--- a/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
+++ b/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
@@ -15,8 +15,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import type { MainPage } from '/@/model/pages/main-page';
-
 import { expect as playExpect, test } from '../../utility/fixtures';
 import { waitForPodmanMachineStartup } from '../../utility/wait';
 
@@ -43,7 +41,8 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
     //count images => 1 original image + (1 tagged * numberOfObjects) + 1 localhost/podman-pause from pods = numberOfObjects + 2
     await playExpect.poll(async () => await images.countRowsFromTable(), { timeout: 10_000 }).toBe(numberOfObjects + 2);
     for (let imgNum = 1; imgNum <= numberOfObjects; imgNum++) {
-      await findRowAndScroll(images, `localhost/my-image-${imgNum}`);
+      const imgRowLocator = await images.getRowByName(`localhost/my-image-${imgNum}`);
+      await imgRowLocator?.scrollIntoViewIfNeeded();
     }
   });
 
@@ -57,7 +56,8 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
       .poll(async () => await containers.countRowsFromTable(), { timeout: 10_000 })
       .toBe(3 * numberOfObjects);
     for (let containerNum = 1; containerNum <= numberOfObjects; containerNum++) {
-      await findRowAndScroll(containers, `my-container-${containerNum}`);
+      const containerRowLocator = await containers.getRowByName(`my-container-${containerNum}`);
+      await containerRowLocator?.scrollIntoViewIfNeeded();
     }
   });
 
@@ -69,15 +69,8 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
     //count pods => 1 manually created * numberOfObjects = numberOfObjects
     await playExpect.poll(async () => await pods.countRowsFromTable(), { timeout: 10_000 }).toBe(numberOfObjects);
     for (let podNum = 1; podNum <= numberOfObjects; podNum++) {
-      await findRowAndScroll(pods, `my-pod-${podNum}`);
+      const podRowLocator = await pods.getRowByName(`my-pod-${podNum}`);
+      await podRowLocator?.scrollIntoViewIfNeeded();
     }
   });
 });
-
-async function findRowAndScroll(page: MainPage, rowName: string): Promise<void> {
-  const rowLocator = await page.getRowByName(rowName);
-  if (rowLocator === undefined) {
-    throw Error(`Row: '${rowName}' does not exist`);
-  }
-  await rowLocator.scrollIntoViewIfNeeded();
-}

--- a/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
+++ b/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
@@ -41,9 +41,15 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
     //count images => 1 original image + (1 tagged * numberOfObjects) + 1 localhost/podman-pause from pods = numberOfObjects + 2
     await playExpect.poll(async () => await images.countRowsFromTable(), { timeout: 10_000 }).toBe(numberOfObjects + 2);
     for (let imgNum = 1; imgNum <= numberOfObjects; imgNum++) {
-      await playExpect
-        .poll(async () => await images.waitForRowToExists(`localhost/my-image-${imgNum}`), { timeout: 0 })
-        .toBeTruthy();
+      const imgName = `localhost/my-image-${imgNum}`;
+      await playExpect.poll(async () => await images.waitForRowToExists(imgName), { timeout: 10_000 }).toBeTruthy();
+
+      const imgRowLocator = await images.getImageRowByName(imgName);
+      if (imgRowLocator === undefined) {
+        throw Error(`Image: '${imgName}' does not exist`);
+      }
+      await imgRowLocator.scrollIntoViewIfNeeded();
+      await playExpect(imgRowLocator).toBeVisible();
     }
   });
 
@@ -57,9 +63,17 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
       .poll(async () => await containers.countRowsFromTable(), { timeout: 10_000 })
       .toBe(3 * numberOfObjects);
     for (let containerNum = 1; containerNum <= numberOfObjects; containerNum++) {
+      const containerName = `my-container-${containerNum}`;
       await playExpect
-        .poll(async () => await containers.waitForRowToExists(`my-container-${containerNum}`), { timeout: 0 })
+        .poll(async () => await containers.waitForRowToExists(containerName), { timeout: 0 })
         .toBeTruthy();
+
+      const containerRowLocator = await containers.getContainerRowByName(containerName);
+      if (containerRowLocator === undefined) {
+        throw Error(`Container: '${containerName}' does not exist`);
+      }
+      await containerRowLocator.scrollIntoViewIfNeeded();
+      await playExpect(containerRowLocator).toBeVisible();
     }
   });
 
@@ -71,7 +85,15 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
     //count pods => 1 manually created * numberOfObjects = numberOfObjects
     await playExpect.poll(async () => await pods.countRowsFromTable(), { timeout: 10_000 }).toBe(numberOfObjects);
     for (let podNum = 1; podNum <= numberOfObjects; podNum++) {
-      await playExpect.poll(async () => await pods.waitForRowToExists(`my-pod-${podNum}`), { timeout: 0 }).toBeTruthy();
+      const podName = `my-pod-${podNum}`;
+      await playExpect.poll(async () => await pods.waitForRowToExists(podName), { timeout: 0 }).toBeTruthy();
+
+      const podRowLocator = await pods.getPodRowByName(podName);
+      if (podRowLocator === undefined) {
+        throw Error(`Pod: '${podName}' does not exist`);
+      }
+      await podRowLocator.scrollIntoViewIfNeeded();
+      await playExpect(podRowLocator).toBeVisible();
     }
   });
 });

--- a/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
+++ b/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
@@ -15,6 +15,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
+import type { MainPage } from '/@/model/pages/main-page';
+
 import { expect as playExpect, test } from '../../utility/fixtures';
 import { waitForPodmanMachineStartup } from '../../utility/wait';
 
@@ -44,12 +46,7 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
       const imgName = `localhost/my-image-${imgNum}`;
       await playExpect.poll(async () => await images.waitForRowToExists(imgName), { timeout: 10_000 }).toBeTruthy();
 
-      const imgRowLocator = await images.getImageRowByName(imgName);
-      if (imgRowLocator === undefined) {
-        throw Error(`Image: '${imgName}' does not exist`);
-      }
-      await imgRowLocator.scrollIntoViewIfNeeded();
-      await playExpect(imgRowLocator).toBeVisible();
+      await scrollRowIntoView(images, imgName);
     }
   });
 
@@ -68,12 +65,7 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
         .poll(async () => await containers.waitForRowToExists(containerName), { timeout: 0 })
         .toBeTruthy();
 
-      const containerRowLocator = await containers.getContainerRowByName(containerName);
-      if (containerRowLocator === undefined) {
-        throw Error(`Container: '${containerName}' does not exist`);
-      }
-      await containerRowLocator.scrollIntoViewIfNeeded();
-      await playExpect(containerRowLocator).toBeVisible();
+      await scrollRowIntoView(containers, containerName);
     }
   });
 
@@ -88,12 +80,16 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
       const podName = `my-pod-${podNum}`;
       await playExpect.poll(async () => await pods.waitForRowToExists(podName), { timeout: 0 }).toBeTruthy();
 
-      const podRowLocator = await pods.getPodRowByName(podName);
-      if (podRowLocator === undefined) {
-        throw Error(`Pod: '${podName}' does not exist`);
-      }
-      await podRowLocator.scrollIntoViewIfNeeded();
-      await playExpect(podRowLocator).toBeVisible();
+      await scrollRowIntoView(pods, podName);
     }
   });
 });
+
+async function scrollRowIntoView(page: MainPage, rowName: string): Promise<void> {
+  const rowLocator = await page.getRowByName(rowName);
+  if (rowLocator === undefined) {
+    throw Error(`Row: '${rowName}' does not exist`);
+  }
+  await rowLocator.scrollIntoViewIfNeeded();
+  await playExpect(rowLocator).toBeVisible();
+}


### PR DESCRIPTION
Signed-off-by: Daniel Villanueva <davillan@redhat.com>

### What does this PR do?
Adds the scrollIntoViewIfNeeded() functionality to the ui-stress-test spec file so that, if the execution of test case fails, the problematic row appears on the video afterwards.

### What issues does this PR fix or reference?
[#362](https://github.com/podman-desktop/e2e/issues/362)
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
Run `pnpm test:e2e:ui-stress`
<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
