### PR TITLE
refactor(podman): extract WinMemoryCheck class to dedicated file

### DIFF
--- a/extensions/podman/packages/extension/src/checks/win-memory-check.spec.ts
+++ b/extensions/podman/packages/extension/src/checks/win-memory-check.spec.ts
@@ -18,9 +18,13 @@
 
 import os from 'node:os';
 
-import { expect, test, vi } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
 
 import { WinMemoryCheck } from './win-memory-check';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
 
 test('expect winMemory preflight check return successful result if the machine has more than 5GB of memory', async () => {
   const SYSTEM_MEM = 7 * 1024 * 1024 * 1024;

--- a/extensions/podman/packages/extension/src/checks/win-memory-check.spec.ts
+++ b/extensions/podman/packages/extension/src/checks/win-memory-check.spec.ts
@@ -1,0 +1,44 @@
+/**********************************************************************
+ * Copyright (C) 2022-2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import os from 'node:os';
+
+import { expect, test, vi } from 'vitest';
+
+import { WinMemoryCheck } from './win-memory-check';
+
+test('expect winMemory preflight check return successful result if the machine has more than 5GB of memory', async () => {
+  const SYSTEM_MEM = 7 * 1024 * 1024 * 1024;
+  vi.spyOn(os, 'totalmem').mockReturnValue(SYSTEM_MEM);
+
+  const winMemoryCheck = new WinMemoryCheck();
+  const result = await winMemoryCheck.execute();
+  expect(result.successful).toBeTruthy();
+});
+
+test('expect winMemory preflight check return failure result if the machine has less than 5GB of memory', async () => {
+  const SYSTEM_MEM = 4 * 1024 * 1024 * 1024;
+  vi.spyOn(os, 'totalmem').mockReturnValue(SYSTEM_MEM);
+
+  const winMemoryCheck = new WinMemoryCheck();
+  const result = await winMemoryCheck.execute();
+  expect(result.description).equal('You need at least 5GB to run Podman.');
+  expect(result.docLinksDescription).toBeUndefined();
+  expect(result.docLinks).toBeUndefined();
+  expect(result.fixCommand).toBeUndefined();
+});

--- a/extensions/podman/packages/extension/src/checks/win-memory-check.ts
+++ b/extensions/podman/packages/extension/src/checks/win-memory-check.ts
@@ -1,0 +1,39 @@
+/**********************************************************************
+ * Copyright (C) 2022-2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import os from 'node:os';
+
+import type { CheckResult } from '@podman-desktop/api';
+
+import { BaseCheck } from './base-check';
+
+export class WinMemoryCheck extends BaseCheck {
+  title = 'RAM';
+  private REQUIRED_MEM = 5 * 1024 * 1024 * 1024; // 5Gb
+
+  async execute(): Promise<CheckResult> {
+    const totalMem = os.totalmem();
+    if (this.REQUIRED_MEM <= totalMem) {
+      return this.createSuccessfulResult();
+    } else {
+      return this.createFailureResult({
+        description: 'You need at least 5GB to run Podman.',
+      });
+    }
+  }
+}

--- a/extensions/podman/packages/extension/src/utils/podman-install.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-install.spec.ts
@@ -288,31 +288,6 @@ test('expect winversion preflight check return failure result if the version is 
   expect(result.docLinks?.[0].title).equal('WSL2 Manual Installation Steps');
 });
 
-test('expect winMemory preflight check return successful result if the machine has more than 5GB of memory', async () => {
-  const SYSTEM_MEM = 7 * 1024 * 1024 * 1024;
-  vi.spyOn(os, 'totalmem').mockReturnValue(SYSTEM_MEM);
-
-  const installer = new WinInstaller(extensionContext);
-  const preflights = installer.getPreflightChecks();
-  const winMemoryCheck = preflights[2];
-  const result = await winMemoryCheck.execute();
-  expect(result.successful).toBeTruthy();
-});
-
-test('expect winMemory preflight check return failure result if the machine has less than 5GB of memory', async () => {
-  const SYSTEM_MEM = 4 * 1024 * 1024 * 1024;
-  vi.spyOn(os, 'totalmem').mockReturnValue(SYSTEM_MEM);
-
-  const installer = new WinInstaller(extensionContext);
-  const preflights = installer.getPreflightChecks();
-  const winMemoryCheck = preflights[2];
-  const result = await winMemoryCheck.execute();
-  expect(result.description).equal('You need at least 5GB to run Podman.');
-  expect(result.docLinksDescription).toBeUndefined();
-  expect(result.docLinks).toBeUndefined();
-  expect(result.fixCommand).toBeUndefined();
-});
-
 describe('getBundledPodmanVersion', () => {
   test('should return the podman 5 version', async () => {
     const version = getBundledPodmanVersion();

--- a/extensions/podman/packages/extension/src/utils/podman-install.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-install.ts
@@ -28,6 +28,7 @@ import { getDetectionChecks } from '../checks/detection-checks';
 import { HyperVCheck } from '../checks/hyperv-check';
 import { MacCPUCheck, MacMemoryCheck, MacPodmanInstallCheck, MacVersionCheck } from '../checks/macos-checks';
 import { VirtualMachinePlatformCheck } from '../checks/virtual-machine-platform-check';
+import { WinMemoryCheck } from '../checks/win-memory-check';
 import { WSLVersionCheck } from '../checks/wsl-version-check';
 import { WSL2Check } from '../checks/wsl2-check';
 import { PodmanCleanupMacOS } from '../cleanup/podman-cleanup-macos';
@@ -648,22 +649,6 @@ class WinVersionCheck extends BaseCheck {
           url: 'https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-2---check-requirements-for-running-wsl-2',
           title: 'WSL2 Manual Installation Steps',
         },
-      });
-    }
-  }
-}
-
-class WinMemoryCheck extends BaseCheck {
-  title = 'RAM';
-  private REQUIRED_MEM = 5 * 1024 * 1024 * 1024; // 5Gb
-
-  async execute(): Promise<extensionApi.CheckResult> {
-    const totalMem = os.totalmem();
-    if (this.REQUIRED_MEM <= totalMem) {
-      return this.createSuccessfulResult();
-    } else {
-      return this.createFailureResult({
-        description: 'You need at least 5GB to run Podman.',
       });
     }
   }


### PR DESCRIPTION
### What does this PR do?

Extract the `WinMemoryCheck ` class from `extensions/podman/packages/extension/src/utils/podman-install.ts` to `extensions/podman/packages/extension/src/checks/win-memory-check.ts` and corresponding tests.

### Notes

The tests in `podman-install.spec.ts` was kinda weird, and was using `WinInstaller` and was accessing the WinMemoryCheck through `getPreflightChecks()[2]`.. To avoid importing the `WinInstaller` class, we can just directly use `WinMemoryCheck`, simplifying the tests.

> I could do the simplification first, but the `WinMemoryCheck` is a very small class, so let's just have all in one.

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/12015

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
