### PR TITLE
refactor(podman): extract WinVersionCheck to a dedicated file

### DIFF
--- a/extensions/podman/packages/extension/src/checks/win-version-check.spec.ts
+++ b/extensions/podman/packages/extension/src/checks/win-version-check.spec.ts
@@ -1,0 +1,79 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import os from 'node:os';
+
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { WinVersionCheck } from './win-version-check';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('should return successful if Windows version is 10.0 with build >= 19043', async () => {
+  const winVersionCheck = new WinVersionCheck();
+  // Mock the os.release method to return a valid build number
+  vi.spyOn(os, 'release').mockReturnValue('10.0.19044');
+
+  const result = await winVersionCheck.execute();
+
+  expect(result.successful).toBeTruthy();
+});
+
+test('should fail if Windows version is 10.0 with build < 19043', async () => {
+  const winVersionCheck = new WinVersionCheck();
+
+  // Mock the os.release method to return an older build number
+  vi.spyOn(os, 'release').mockReturnValue('10.0.19000');
+
+  const result = await winVersionCheck.execute();
+
+  expect(result).toEqual({
+    successful: false,
+    description: 'To be able to run WSL2 you need Windows 10 Build 19043 or later.',
+    docLinksDescription: 'Learn about WSL requirements:',
+    docLinks: [
+      {
+        url: 'https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-2---check-requirements-for-running-wsl-2',
+        title: 'WSL2 Manual Installation Steps',
+      },
+    ],
+  });
+});
+
+test('should fail if Windows version is not 10.0', async () => {
+  const winVersionCheck = new WinVersionCheck();
+
+  // Mock the os.release method to return a non-Windows 10 version
+  vi.spyOn(os, 'release').mockReturnValue('6.3.9600'); // Example: Windows 8.1
+
+  const result = await winVersionCheck.execute();
+
+  expect(result).toEqual({
+    successful: false,
+    description: 'WSL2 works only on Windows 10 and newest OS',
+    docLinksDescription: 'Learn about WSL requirements:',
+    docLinks: [
+      {
+        url: 'https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-2---check-requirements-for-running-wsl-2',
+        title: 'WSL2 Manual Installation Steps',
+      },
+    ],
+  });
+});

--- a/extensions/podman/packages/extension/src/checks/win-version-check.spec.ts
+++ b/extensions/podman/packages/extension/src/checks/win-version-check.spec.ts
@@ -26,54 +26,36 @@ beforeEach(() => {
   vi.resetAllMocks();
 });
 
-test('should return successful if Windows version is 10.0 with build >= 19043', async () => {
+test('expect winversion preflight check return successful result if the version is greater than min valid version', async () => {
+  vi.spyOn(os, 'release').mockReturnValue('10.0.19043');
+
   const winVersionCheck = new WinVersionCheck();
-  // Mock the os.release method to return a valid build number
-  vi.spyOn(os, 'release').mockReturnValue('10.0.19044');
-
   const result = await winVersionCheck.execute();
-
   expect(result.successful).toBeTruthy();
 });
 
-test('should fail if Windows version is 10.0 with build < 19043', async () => {
+test('expect winversion preflight check return failure result if the version is greater than 9. and less than min build version', async () => {
+  vi.spyOn(os, 'release').mockReturnValue('10.0.19042');
+
   const winVersionCheck = new WinVersionCheck();
-
-  // Mock the os.release method to return an older build number
-  vi.spyOn(os, 'release').mockReturnValue('10.0.19000');
-
   const result = await winVersionCheck.execute();
-
-  expect(result).toEqual({
-    successful: false,
-    description: 'To be able to run WSL2 you need Windows 10 Build 19043 or later.',
-    docLinksDescription: 'Learn about WSL requirements:',
-    docLinks: [
-      {
-        url: 'https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-2---check-requirements-for-running-wsl-2',
-        title: 'WSL2 Manual Installation Steps',
-      },
-    ],
-  });
+  expect(result.description).equal('To be able to run WSL2 you need Windows 10 Build 19043 or later.');
+  expect(result.docLinksDescription).equal('Learn about WSL requirements:');
+  expect(result.docLinks?.[0].url).equal(
+    'https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-2---check-requirements-for-running-wsl-2',
+  );
+  expect(result.docLinks?.[0].title).equal('WSL2 Manual Installation Steps');
 });
 
-test('should fail if Windows version is not 10.0', async () => {
+test('expect winversion preflight check return failure result if the version is less than 10.0.0', async () => {
+  vi.spyOn(os, 'release').mockReturnValue('9.0.19000');
+
   const winVersionCheck = new WinVersionCheck();
-
-  // Mock the os.release method to return a non-Windows 10 version
-  vi.spyOn(os, 'release').mockReturnValue('6.3.9600'); // Example: Windows 8.1
-
   const result = await winVersionCheck.execute();
-
-  expect(result).toEqual({
-    successful: false,
-    description: 'WSL2 works only on Windows 10 and newest OS',
-    docLinksDescription: 'Learn about WSL requirements:',
-    docLinks: [
-      {
-        url: 'https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-2---check-requirements-for-running-wsl-2',
-        title: 'WSL2 Manual Installation Steps',
-      },
-    ],
-  });
+  expect(result.description).equal('WSL2 works only on Windows 10 and newest OS');
+  expect(result.docLinksDescription).equal('Learn about WSL requirements:');
+  expect(result.docLinks?.[0].url).equal(
+    'https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-2---check-requirements-for-running-wsl-2',
+  );
+  expect(result.docLinks?.[0].title).equal('WSL2 Manual Installation Steps');
 });

--- a/extensions/podman/packages/extension/src/checks/win-version-check.ts
+++ b/extensions/podman/packages/extension/src/checks/win-version-check.ts
@@ -1,0 +1,57 @@
+/**********************************************************************
+ * Copyright (C) 2022-2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import os from 'node:os';
+
+import type { CheckResult } from '@podman-desktop/api';
+
+import { BaseCheck } from './base-check';
+
+export class WinVersionCheck extends BaseCheck {
+  title = 'Windows Version';
+
+  private MIN_BUILD = 19043; //it represents version 21H1 windows 10
+  async execute(): Promise<CheckResult> {
+    const winRelease = os.release();
+    if (winRelease.startsWith('10.0.')) {
+      const splitRelease = winRelease.split('.');
+      const winBuild = splitRelease[2];
+      if (Number.parseInt(winBuild) >= this.MIN_BUILD) {
+        return { successful: true };
+      } else {
+        return this.createFailureResult({
+          description: `To be able to run WSL2 you need Windows 10 Build ${this.MIN_BUILD} or later.`,
+          docLinksDescription: 'Learn about WSL requirements:',
+          docLinks: {
+            url: 'https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-2---check-requirements-for-running-wsl-2',
+            title: 'WSL2 Manual Installation Steps',
+          },
+        });
+      }
+    } else {
+      return this.createFailureResult({
+        description: 'WSL2 works only on Windows 10 and newest OS',
+        docLinksDescription: 'Learn about WSL requirements:',
+        docLinks: {
+          url: 'https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-2---check-requirements-for-running-wsl-2',
+          title: 'WSL2 Manual Installation Steps',
+        },
+      });
+    }
+  }
+}

--- a/extensions/podman/packages/extension/src/utils/podman-install.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-install.spec.ts
@@ -248,46 +248,6 @@ test('expect winbit preflight check return failure result if the arch is not sup
   expect(result.docLinks?.[0].title).equal('WSL2 Manual Installation Steps');
 });
 
-test('expect winversion preflight check return successful result if the version is greater than min valid version', async () => {
-  vi.spyOn(os, 'release').mockReturnValue('10.0.19043');
-
-  const installer = new WinInstaller(extensionContext);
-  const preflights = installer.getPreflightChecks();
-  const winVersionCheck = preflights[1];
-  const result = await winVersionCheck.execute();
-  expect(result.successful).toBeTruthy();
-});
-
-test('expect winversion preflight check return failure result if the version is greater than 9. and less than min build version', async () => {
-  vi.spyOn(os, 'release').mockReturnValue('10.0.19042');
-
-  const installer = new WinInstaller(extensionContext);
-  const preflights = installer.getPreflightChecks();
-  const winVersionCheck = preflights[1];
-  const result = await winVersionCheck.execute();
-  expect(result.description).equal('To be able to run WSL2 you need Windows 10 Build 19043 or later.');
-  expect(result.docLinksDescription).equal('Learn about WSL requirements:');
-  expect(result.docLinks?.[0].url).equal(
-    'https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-2---check-requirements-for-running-wsl-2',
-  );
-  expect(result.docLinks?.[0].title).equal('WSL2 Manual Installation Steps');
-});
-
-test('expect winversion preflight check return failure result if the version is less than 10.0.0', async () => {
-  vi.spyOn(os, 'release').mockReturnValue('9.0.19000');
-
-  const installer = new WinInstaller(extensionContext);
-  const preflights = installer.getPreflightChecks();
-  const winVersionCheck = preflights[1];
-  const result = await winVersionCheck.execute();
-  expect(result.description).equal('WSL2 works only on Windows 10 and newest OS');
-  expect(result.docLinksDescription).equal('Learn about WSL requirements:');
-  expect(result.docLinks?.[0].url).equal(
-    'https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-2---check-requirements-for-running-wsl-2',
-  );
-  expect(result.docLinks?.[0].title).equal('WSL2 Manual Installation Steps');
-});
-
 describe('getBundledPodmanVersion', () => {
   test('should return the podman 5 version', async () => {
     const version = getBundledPodmanVersion();

--- a/extensions/podman/packages/extension/src/utils/podman-install.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-install.ts
@@ -29,6 +29,7 @@ import { HyperVCheck } from '../checks/hyperv-check';
 import { MacCPUCheck, MacMemoryCheck, MacPodmanInstallCheck, MacVersionCheck } from '../checks/macos-checks';
 import { VirtualMachinePlatformCheck } from '../checks/virtual-machine-platform-check';
 import { WinMemoryCheck } from '../checks/win-memory-check';
+import { WinVersionCheck } from '../checks/win-version-check';
 import { WSLVersionCheck } from '../checks/wsl-version-check';
 import { WSL2Check } from '../checks/wsl2-check';
 import { PodmanCleanupMacOS } from '../cleanup/podman-cleanup-macos';
@@ -610,40 +611,6 @@ class WinBitCheck extends BaseCheck {
     } else {
       return this.createFailureResult({
         description: 'WSL2 works only on 64bit OS.',
-        docLinksDescription: 'Learn about WSL requirements:',
-        docLinks: {
-          url: 'https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-2---check-requirements-for-running-wsl-2',
-          title: 'WSL2 Manual Installation Steps',
-        },
-      });
-    }
-  }
-}
-
-class WinVersionCheck extends BaseCheck {
-  title = 'Windows Version';
-
-  private MIN_BUILD = 19043; //it represents version 21H1 windows 10
-  async execute(): Promise<extensionApi.CheckResult> {
-    const winRelease = os.release();
-    if (winRelease.startsWith('10.0.')) {
-      const splitRelease = winRelease.split('.');
-      const winBuild = splitRelease[2];
-      if (Number.parseInt(winBuild) >= this.MIN_BUILD) {
-        return { successful: true };
-      } else {
-        return this.createFailureResult({
-          description: `To be able to run WSL2 you need Windows 10 Build ${this.MIN_BUILD} or later.`,
-          docLinksDescription: 'Learn about WSL requirements:',
-          docLinks: {
-            url: 'https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-2---check-requirements-for-running-wsl-2',
-            title: 'WSL2 Manual Installation Steps',
-          },
-        });
-      }
-    } else {
-      return this.createFailureResult({
-        description: 'WSL2 works only on Windows 10 and newest OS',
         docLinksDescription: 'Learn about WSL requirements:',
         docLinks: {
           url: 'https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-2---check-requirements-for-running-wsl-2',


### PR DESCRIPTION
### What does this PR do?

Extract the `WinVersionCheck ` class from `extensions/podman/packages/extension/src/utils/podman-install.ts` to `extensions/podman/packages/extension/src/checks/win-version-check.ts`.

Tests for `WinVersionCheck` were a bit weird, same as https://github.com/podman-desktop/podman-desktop/pull/12702, so I applied the same little change.

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/12016

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
