### PR TITLE
feat(extension-api): support cancellation token for pull image

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -3932,12 +3932,14 @@ declare module '@podman-desktop/api' {
      * @param imageName the name of the image to pull
      * @param callback the function called when new logs are emitted during the pull operation
      * @param platform the platform of the image to pull (optional, by default it will pull the same architecture as the host)
+     * @param token an optional {@link CancellationToken} to cancel the pull operation
      */
     export function pullImage(
       containerProviderConnection: ContainerProviderConnection,
       imageName: string,
       callback: (event: PullEvent) => void,
       platform?: string,
+      token?: CancellationToken,
     ): Promise<void>;
 
     /**

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -1150,8 +1150,11 @@ export class ExtensionLoader {
         token?: containerDesktopAPI.CancellationToken,
       ): Promise<void> {
         // transform the extension cancellation token to an abort controller
-        const abortController: AbortController | undefined = token ? new AbortController() : undefined;
-        token?.onCancellationRequested(() => abortController?.abort());
+        let abortController: AbortController | undefined;
+        if (token) {
+          abortController = new AbortController();
+          token.onCancellationRequested(() => abortController?.abort());
+        }
 
         return containerProviderRegistry.pullImage(
           providerContainerConnection,

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -1147,8 +1147,19 @@ export class ExtensionLoader {
         imageName: string,
         callback: (event: containerDesktopAPI.PullEvent) => void,
         platform?: string,
+        token?: containerDesktopAPI.CancellationToken,
       ): Promise<void> {
-        return containerProviderRegistry.pullImage(providerContainerConnection, imageName, callback, platform);
+        // transform the extension cancellation token to an abort controller
+        const abortController: AbortController | undefined = token ? new AbortController() : undefined;
+        token?.onCancellationRequested(() => abortController?.abort());
+
+        return containerProviderRegistry.pullImage(
+          providerContainerConnection,
+          imageName,
+          callback,
+          platform,
+          abortController,
+        );
       },
       tagImage(engineId: string, imageId: string, repo: string, tag: string | undefined): Promise<void> {
         return containerProviderRegistry.tagImage(engineId, imageId, repo, tag);


### PR DESCRIPTION
### What does this PR do?

Pulling image can be very long, and for example on AI Lab, users cannot cancel pretty long pulling, even stopping the extension, it will just run in the background. This PR aims to add a new optional parameter to the `pullImage` so extension have a way to cancel this task.

The `ContainerRegistry#pullImage` support an abort controller (like some other function)

https://github.com/podman-desktop/podman-desktop/blob/08f1e32c5aeb648fcfa3cb39a73c2fabb46082de/packages/main/src/plugin/container-registry.ts#L1147-L1153

> ℹ️  We do not want to expose abort controller to extensions, we want them to use `CancellationToken`, so I had to make a quick 2 lines, convertion. I am wondering, as some function in the ContainerRegistry support CancellationToken, some support AbortController, if we should agree to only support one? to simplify our lifes

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/12113

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
