### PR TITLE
Clear kubernetes caches when an informer is offline

### DIFF
--- a/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
@@ -349,8 +349,9 @@ export class ContextsManagerExperimental {
                 });
               }
             });
-            informer.onOffline((_e: OfflineEvent) => {
+            informer.onOffline((e: OfflineEvent) => {
               this.#onOfflineChange.fire();
+              this.#objectCaches.removeForContext(e.kubeconfig.getKubeConfig().currentContext);
             });
             const cache = informer.start();
             this.#objectCaches.set(contextName, resource, cache);

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -35,7 +35,7 @@
     "micromark-extension-directive": "^4.0.0",
     "moment": "^2.30.1",
     "monaco-editor": "^0.52.2",
-    "svelte": "5.28.2",
+    "svelte": "5.28.3",
     "svelte-check": "^4.2.1",
     "svelte-eslint-parser": "^1.2.0",
     "svelte-fa": "^4.0.4",

--- a/packages/renderer/src/lib/appearance/IconImage.spec.ts
+++ b/packages/renderer/src/lib/appearance/IconImage.spec.ts
@@ -20,6 +20,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import { render } from '@testing-library/svelte';
+import { tick } from 'svelte';
 import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
 import { AppearanceSettings } from '../../../../main/src/plugin/appearance-settings';
@@ -78,6 +79,7 @@ test('Expect valid source and alt text with light mode', async () => {
 
   // wait for image to be loaded
   await new Promise(resolve => setTimeout(resolve, 200));
+  await tick();
 
   // grab image element
   const imageElement = image.getByRole('img');
@@ -99,6 +101,7 @@ test('Expect no alt attribute if missing and default image', async () => {
 
   // wait for image to be loaded
   await new Promise(resolve => setTimeout(resolve, 200));
+  await tick();
 
   // grab image element
   const imageElement = image.getByRole('img');
@@ -116,7 +119,7 @@ test('Expect string as image', async () => {
 
   // wait for image to be loaded
   await new Promise(resolve => setTimeout(resolve, 200));
-
+  await tick();
   // grab image element
   const imageElement = image.getByRole('img');
 

--- a/packages/renderer/src/lib/appearance/IconImage.spec.ts
+++ b/packages/renderer/src/lib/appearance/IconImage.spec.ts
@@ -78,7 +78,6 @@ test('Expect valid source and alt text with light mode', async () => {
   const image = render(IconImage, { image: { light: 'light.png', dark: 'dark.png' }, alt: 'this is alt text' });
 
   // wait for image to be loaded
-  await new Promise(resolve => setTimeout(resolve, 200));
   await tick();
 
   // grab image element
@@ -100,7 +99,6 @@ test('Expect no alt attribute if missing and default image', async () => {
   const image = render(IconImage, { image: 'image.png' });
 
   // wait for image to be loaded
-  await new Promise(resolve => setTimeout(resolve, 200));
   await tick();
 
   // grab image element
@@ -118,8 +116,8 @@ test('Expect string as image', async () => {
   const image = render(IconImage, { image: 'image1', alt: 'this is alt text' });
 
   // wait for image to be loaded
-  await new Promise(resolve => setTimeout(resolve, 200));
   await tick();
+
   // grab image element
   const imageElement = image.getByRole('img');
 

--- a/packages/renderer/src/lib/container/CreateContainerFromExistingImage.spec.ts
+++ b/packages/renderer/src/lib/container/CreateContainerFromExistingImage.spec.ts
@@ -173,7 +173,8 @@ test('Expect not a local image to have an active pull image and run button', asy
   expect(inputBox).toBeInTheDocument();
   await userEvent.type(inputBox, 'image12');
 
-  await waitFor(() => {
+  await waitFor(async () => {
+    await tick();
     const list = screen.getByRole('row');
     const items = within(list).getAllByRole('button');
     expect(items.length).toBe(2);

--- a/packages/renderer/src/lib/container/CreateContainerFromExistingImage.spec.ts
+++ b/packages/renderer/src/lib/container/CreateContainerFromExistingImage.spec.ts
@@ -24,7 +24,7 @@ import userEvent from '@testing-library/user-event';
 import { tick } from 'svelte';
 import { get } from 'svelte/store';
 import { router } from 'tinro';
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { providerInfos } from '/@/stores/providers';
 import type { ImageSearchResult } from '/@api/image-registry';
@@ -117,6 +117,7 @@ const providerInfo = {
 } as unknown as ProviderInfo;
 
 beforeEach(() => {
+  vi.useFakeTimers();
   vi.resetAllMocks();
   vi.mocked(window.listImages).mockResolvedValue(localImageList);
   vi.mocked(window.searchImageInRegistry).mockResolvedValue(registryImageList);
@@ -132,6 +133,10 @@ beforeEach(() => {
   });
 
   providerInfos.set([providerInfo]);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 test('Expect that textbox and two buttons show up when page opened', async () => {
@@ -153,7 +158,10 @@ test('Expect that typeahead menu has Local Images and Registry Images headings',
 
   const inputBox = screen.getByPlaceholderText('Select or enter an image to run');
   expect(inputBox).toBeInTheDocument();
-  await userEvent.type(inputBox, 'f');
+  const user = userEvent.setup({
+    advanceTimers: vi.advanceTimersByTime,
+  });
+  await user.type(inputBox, 'f');
 
   await waitFor(() => {
     expect(screen.queryByRole('row')).toBeInTheDocument();
@@ -171,23 +179,27 @@ test('Expect not a local image to have an active pull image and run button', asy
 
   const inputBox = screen.getByPlaceholderText('Select or enter an image to run');
   expect(inputBox).toBeInTheDocument();
-  await userEvent.type(inputBox, 'image12');
-
-  await waitFor(async () => {
-    await tick();
-    const list = screen.getByRole('row');
-    const items = within(list).getAllByRole('button');
-    expect(items.length).toBe(2);
+  const user = userEvent.setup({
+    advanceTimers: vi.advanceTimersByTime,
   });
+  await user.type(inputBox, 'image12');
 
-  await userEvent.keyboard('[ArrowDown]');
+  // wait typeahead delay
+  await vi.advanceTimersByTimeAsync(250);
+
+  await tick();
+  const list = screen.getByRole('row');
+  const items = within(list).getAllByRole('button');
+  expect(items.length).toBe(2);
+
+  await user.keyboard('[ArrowDown]');
 
   const pullImagebutton = screen.getByRole('button', { name: 'Pull Image and Run' });
 
   expect(pullImagebutton).toBeInTheDocument();
   expect(pullImagebutton).not.toBeDisabled();
 
-  await userEvent.click(pullImagebutton);
+  await user.click(pullImagebutton);
   expect(window.pullImage).toHaveBeenCalledWith(pInfo, 'docker.io/image12', expect.any(Function));
 });
 
@@ -200,7 +212,10 @@ test('Expect a local image to have an active run image button', async () => {
 
   const inputBox = screen.getByPlaceholderText('Select or enter an image to run');
   expect(inputBox).toBeInTheDocument();
-  await userEvent.type(inputBox, 'fedora');
+  const user = userEvent.setup({
+    advanceTimers: vi.advanceTimersByTime,
+  });
+  await user.type(inputBox, 'fedora');
 
   await waitFor(() => expect(screen.queryByRole('row')).toBeInTheDocument());
 
@@ -208,14 +223,14 @@ test('Expect a local image to have an active run image button', async () => {
   const items = within(list).getAllByRole('button');
   expect(items.length).toBe(6);
 
-  await userEvent.keyboard('[ArrowDown]');
+  await user.keyboard('[ArrowDown]');
 
   const selectImagebutton = screen.getByRole('button', { name: 'Run Image' });
 
   expect(selectImagebutton).toBeInTheDocument();
   expect(selectImagebutton).not.toBeDisabled();
 
-  await userEvent.click(selectImagebutton);
+  await user.click(selectImagebutton);
   expect(router.goto).toHaveBeenCalledWith('/image/run/basic');
 });
 
@@ -228,7 +243,10 @@ test('Expect no user input to show only local images', async () => {
 
   const inputBox = screen.getByPlaceholderText('Select or enter an image to run');
   expect(inputBox).toBeInTheDocument();
-  await userEvent.type(inputBox, ' ');
+  const user = userEvent.setup({
+    advanceTimers: vi.advanceTimersByTime,
+  });
+  await user.type(inputBox, ' ');
 
   await waitFor(() => expect(screen.queryByRole('row')).toBeInTheDocument());
 
@@ -302,7 +320,10 @@ describe('container connections', () => {
     expect(inputBox).toBeInTheDocument();
 
     // type fedora
-    await userEvent.type(inputBox, 'fedora');
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime,
+    });
+    await user.type(inputBox, 'fedora');
 
     // Get the run button and click on it
     const runBtn = getByRole('button', { name: 'Pull Image and Run' });
@@ -311,7 +332,7 @@ describe('container connections', () => {
     const { promise } = Promise.withResolvers<void>();
     vi.mocked(window.pullImage).mockReturnValue(promise);
 
-    await userEvent.click(runBtn);
+    await user.click(runBtn);
 
     // the dropdown should be disabled while we are pulling the image
     await vi.waitFor(() => {

--- a/packages/renderer/src/lib/forms/ContainerConnectionDropdown.spec.ts
+++ b/packages/renderer/src/lib/forms/ContainerConnectionDropdown.spec.ts
@@ -119,10 +119,8 @@ test('expect binding to properly work', async () => {
 
   onChange?.(value);
 
-  alert = await vi.waitFor(async () => {
-    await tick();
-    return getByRole('alert');
-  });
+  await tick();
+  alert = getByRole('alert');
   expect(alert).toBeDefined();
   expect(alert).toHaveTextContent(CONTAINER_CONNECTION_INFO.name);
 });

--- a/packages/renderer/src/lib/forms/ContainerConnectionDropdown.spec.ts
+++ b/packages/renderer/src/lib/forms/ContainerConnectionDropdown.spec.ts
@@ -20,6 +20,7 @@ import '@testing-library/jest-dom/vitest';
 
 import { Dropdown } from '@podman-desktop/ui-svelte';
 import { render } from '@testing-library/svelte';
+import { tick } from 'svelte';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import ContainerConnectionDropdown from '/@/lib/forms/ContainerConnectionDropdown.svelte';
@@ -118,7 +119,8 @@ test('expect binding to properly work', async () => {
 
   onChange?.(value);
 
-  alert = await vi.waitFor(() => {
+  alert = await vi.waitFor(async () => {
+    await tick();
     return getByRole('alert');
   });
   expect(alert).toBeDefined();

--- a/packages/renderer/src/lib/image/ImageDetailsCheck.spec.ts
+++ b/packages/renderer/src/lib/image/ImageDetailsCheck.spec.ts
@@ -20,6 +20,7 @@ import '@testing-library/jest-dom/vitest';
 
 import type { ImageChecks } from '@podman-desktop/api';
 import { fireEvent, render, screen } from '@testing-library/svelte';
+import { tick } from 'svelte';
 import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
 import { imageCheckerProviders } from '/@/stores/image-checker-providers';
@@ -112,7 +113,8 @@ test('expect to cancel when clicking the Cancel button', async () => {
     await fireEvent.click(abortBtn);
   });
 
-  await vi.waitFor(() => {
+  await vi.waitFor(async () => {
+    await tick();
     const msg = screen.getByRole('status', { name: 'Analysis Status' });
     expect(msg).toHaveTextContent('Image analysis canceled');
   });
@@ -192,7 +194,8 @@ test('expect to not cancel again when destroying the component after manual canc
     await fireEvent.click(abortBtn);
   });
 
-  await vi.waitFor(() => {
+  await vi.waitFor(async () => {
+    await tick();
     const msg = screen.getByRole('status', { name: 'Analysis Status' });
     expect(msg).toHaveTextContent('Image analysis canceled');
   });

--- a/packages/renderer/src/lib/image/ImageDetailsCheck.spec.ts
+++ b/packages/renderer/src/lib/image/ImageDetailsCheck.spec.ts
@@ -113,11 +113,9 @@ test('expect to cancel when clicking the Cancel button', async () => {
     await fireEvent.click(abortBtn);
   });
 
-  await vi.waitFor(async () => {
-    await tick();
-    const msg = screen.getByRole('status', { name: 'Analysis Status' });
-    expect(msg).toHaveTextContent('Image analysis canceled');
-  });
+  await tick();
+  const msg = screen.getByRole('status', { name: 'Analysis Status' });
+  expect(msg).toHaveTextContent('Image analysis canceled');
 
   expect(cancelTokenSpy).toHaveBeenCalledWith(tokenID);
 });
@@ -194,11 +192,9 @@ test('expect to not cancel again when destroying the component after manual canc
     await fireEvent.click(abortBtn);
   });
 
-  await vi.waitFor(async () => {
-    await tick();
-    const msg = screen.getByRole('status', { name: 'Analysis Status' });
-    expect(msg).toHaveTextContent('Image analysis canceled');
-  });
+  await tick();
+  const msg = screen.getByRole('status', { name: 'Analysis Status' });
+  expect(msg).toHaveTextContent('Image analysis canceled');
 
   expect(cancelTokenSpy).toHaveBeenCalledWith(tokenID);
 

--- a/packages/renderer/src/lib/image/RunImage.spec.ts
+++ b/packages/renderer/src/lib/image/RunImage.spec.ts
@@ -487,6 +487,7 @@ describe('RunImage', () => {
     await new Promise(resolve => setTimeout(resolve, 600));
 
     const button = screen.getByRole('button', { name: 'Start Container' });
+    await tick();
     expect((button as HTMLButtonElement).disabled).toBeTruthy();
   });
 

--- a/packages/renderer/src/lib/kube/KubernetesEmptyPage.spec.ts
+++ b/packages/renderer/src/lib/kube/KubernetesEmptyPage.spec.ts
@@ -17,6 +17,7 @@
  ***********************************************************************/
 
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { tick } from 'svelte';
 import { router } from 'tinro';
 import { expect, test, vi } from 'vitest';
 
@@ -129,7 +130,8 @@ test('expect to have links for each Kubernetes provider', async () => {
 
   providerInfos.set([]);
   // Links should be updated (removed)
-  await waitFor(() => {
+  await waitFor(async () => {
+    await tick();
     expect(screen.queryByLabelText(/Go create/)).toBeNull();
     expect(screen.queryByLabelText(/Create new/)).toBeNull();
   });

--- a/packages/renderer/src/lib/kube/KubernetesEmptyPage.spec.ts
+++ b/packages/renderer/src/lib/kube/KubernetesEmptyPage.spec.ts
@@ -130,9 +130,7 @@ test('expect to have links for each Kubernetes provider', async () => {
 
   providerInfos.set([]);
   // Links should be updated (removed)
-  await waitFor(async () => {
-    await tick();
-    expect(screen.queryByLabelText(/Go create/)).toBeNull();
-    expect(screen.queryByLabelText(/Create new/)).toBeNull();
-  });
+  await tick();
+  expect(screen.queryByLabelText(/Go create/)).toBeNull();
+  expect(screen.queryByLabelText(/Create new/)).toBeNull();
 });

--- a/packages/renderer/src/lib/onboarding/Onboarding.spec.ts
+++ b/packages/renderer/src/lib/onboarding/Onboarding.spec.ts
@@ -655,6 +655,7 @@ test('Expect onboarding to handle two extension ids and global onboarding set to
   // Wait until 'foobar2stepcontent' is shown
   await vi.waitFor(() => expect(screen.queryAllByText('foobar2stepcontent').length).toBe(0));
 
+  await tick();
   const displayName2 = screen.queryByText('Foobar2 Onboarding');
   expect(displayName2).toBeInTheDocument();
 

--- a/packages/renderer/src/lib/preferences/ExtensionIcon.spec.ts
+++ b/packages/renderer/src/lib/preferences/ExtensionIcon.spec.ts
@@ -75,7 +75,6 @@ test('Expect faded icon for other states', async () => {
   render(ExtensionIcon, { extension: extension });
 
   // wait for image to be loaded
-  await new Promise(resolve => setTimeout(resolve, 200));
   await tick();
 
   const icon = screen.getByRole('img');

--- a/packages/renderer/src/lib/preferences/ExtensionIcon.spec.ts
+++ b/packages/renderer/src/lib/preferences/ExtensionIcon.spec.ts
@@ -19,6 +19,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import { render, screen } from '@testing-library/svelte';
+import { tick } from 'svelte';
 import { beforeAll, expect, test, vi } from 'vitest';
 
 import type { ExtensionInfo } from '/@api/extension-info';
@@ -75,6 +76,7 @@ test('Expect faded icon for other states', async () => {
 
   // wait for image to be loaded
   await new Promise(resolve => setTimeout(resolve, 200));
+  await tick();
 
   const icon = screen.getByRole('img');
   expect(icon).toBeInTheDocument();

--- a/packages/renderer/src/lib/ui/Typeahead.spec.ts
+++ b/packages/renderer/src/lib/ui/Typeahead.spec.ts
@@ -108,6 +108,7 @@ test('should list the result after the delay, and display spinner during loading
   screen.getByRole('progressbar');
 
   await new Promise(resolve => setTimeout(resolve, 100));
+  await tick();
   expect(screen.queryByRole('progressbar')).toBeNull();
   await waitFor(() => expect(searchResult.length > 0).toBeTruthy());
   await rerender({ resultItems: searchResult });

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -164,7 +164,7 @@
     "@typescript-eslint/eslint-plugin": "^8.33.0",
     "eslint-plugin-svelte": "^3.9.1",
     "jsdom": "^27.0.0-beta.1",
-    "svelte": "5.28.2",
+    "svelte": "5.28.3",
     "svelte-check": "^4.2.1",
     "svelte-eslint-parser": "^1.2.0",
     "tailwindcss": "^4.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -571,7 +571,7 @@ importers:
         version: link:../ui
       '@zerodevx/svelte-toast':
         specifier: ^0.9.6
-        version: 0.9.6(svelte@5.28.2)
+        version: 0.9.6(svelte@5.28.3)
       electron-context-menu:
         specifier: 4.1.0
         version: 4.1.0
@@ -599,7 +599,7 @@ importers:
         version: 6.7.2
       '@sveltejs/vite-plugin-svelte':
         specifier: 5.0.3
-        version: 5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))
+        version: 5.0.3(svelte@5.28.3)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))
       '@tailwindcss/vite':
         specifier: ^4.1.8
         version: 4.1.8(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))
@@ -611,7 +611,7 @@ importers:
         version: 6.6.3
       '@testing-library/svelte':
         specifier: ^5.2.8
-        version: 5.2.8(svelte@5.28.2)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))(vitest@3.1.4(@types/debug@4.1.12)(@types/node@22.15.24)(jiti@2.4.2)(jsdom@27.0.0-beta.1)(lightningcss@1.30.1)(msw@2.8.7(@types/node@22.15.24)(typescript@5.8.3))(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))
+        version: 5.2.8(svelte@5.28.3)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))(vitest@3.1.4(@types/debug@4.1.12)(@types/node@22.15.24)(jiti@2.4.2)(jsdom@27.0.0-beta.1)(lightningcss@1.30.1)(msw@2.8.7(@types/node@22.15.24)(typescript@5.8.3))(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.0)
@@ -641,7 +641,7 @@ importers:
         version: 5.5.0
       eslint-plugin-svelte:
         specifier: ^3.9.1
-        version: 3.9.1(eslint@9.28.0(jiti@2.4.2))(svelte@5.28.2)
+        version: 3.9.1(eslint@9.28.0(jiti@2.4.2))(svelte@5.28.3)
       filesize:
         specifier: ^10.1.6
         version: 10.1.6
@@ -664,17 +664,17 @@ importers:
         specifier: ^0.52.2
         version: 0.52.2
       svelte:
-        specifier: 5.28.2
-        version: 5.28.2
+        specifier: 5.28.3
+        version: 5.28.3
       svelte-check:
         specifier: ^4.2.1
-        version: 4.2.1(picomatch@4.0.2)(svelte@5.28.2)(typescript@5.8.3)
+        version: 4.2.1(picomatch@4.0.2)(svelte@5.28.3)(typescript@5.8.3)
       svelte-eslint-parser:
         specifier: ^1.2.0
-        version: 1.2.0(svelte@5.28.2)
+        version: 1.2.0(svelte@5.28.3)
       svelte-fa:
         specifier: ^4.0.4
-        version: 4.0.4(svelte@5.28.2)
+        version: 4.0.4(svelte@5.28.3)
       svelte-steps:
         specifier: 2.4.1
         version: 2.4.1
@@ -722,14 +722,14 @@ importers:
         version: 2.30.1
       svelte-fa:
         specifier: ^4.0.4
-        version: 4.0.4(svelte@5.28.2)
+        version: 4.0.4(svelte@5.28.3)
     devDependencies:
       '@sveltejs/package':
         specifier: ^2.3.11
-        version: 2.3.11(svelte@5.28.2)(typescript@5.8.3)
+        version: 2.3.11(svelte@5.28.3)(typescript@5.8.3)
       '@sveltejs/vite-plugin-svelte':
         specifier: 5.0.3
-        version: 5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))
+        version: 5.0.3(svelte@5.28.3)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))
       '@tailwindcss/vite':
         specifier: ^4.1.8
         version: 4.1.8(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))
@@ -741,7 +741,7 @@ importers:
         version: 6.6.3
       '@testing-library/svelte':
         specifier: ^5.2.8
-        version: 5.2.8(svelte@5.28.2)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))(vitest@3.1.4(@types/debug@4.1.12)(@types/node@22.15.24)(jiti@2.4.2)(jsdom@27.0.0-beta.1)(lightningcss@1.30.1)(msw@2.8.7(@types/node@22.15.24)(typescript@5.8.3))(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))
+        version: 5.2.8(svelte@5.28.3)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))(vitest@3.1.4(@types/debug@4.1.12)(@types/node@22.15.24)(jiti@2.4.2)(jsdom@27.0.0-beta.1)(lightningcss@1.30.1)(msw@2.8.7(@types/node@22.15.24)(typescript@5.8.3))(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.0)
@@ -753,19 +753,19 @@ importers:
         version: 8.33.0(@typescript-eslint/parser@8.33.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3)
       eslint-plugin-svelte:
         specifier: ^3.9.1
-        version: 3.9.1(eslint@9.28.0(jiti@2.4.2))(svelte@5.28.2)
+        version: 3.9.1(eslint@9.28.0(jiti@2.4.2))(svelte@5.28.3)
       jsdom:
         specifier: ^27.0.0-beta.1
         version: 27.0.0-beta.1
       svelte:
-        specifier: 5.28.2
-        version: 5.28.2
+        specifier: 5.28.3
+        version: 5.28.3
       svelte-check:
         specifier: ^4.2.1
-        version: 4.2.1(picomatch@4.0.2)(svelte@5.28.2)(typescript@5.8.3)
+        version: 4.2.1(picomatch@4.0.2)(svelte@5.28.3)(typescript@5.8.3)
       svelte-eslint-parser:
         specifier: ^1.2.0
-        version: 1.2.0(svelte@5.28.2)
+        version: 1.2.0(svelte@5.28.3)
       tailwindcss:
         specifier: ^4.1.8
         version: 4.1.8
@@ -806,7 +806,7 @@ importers:
         version: 9.28.0(jiti@2.4.2)
       svelte-fa:
         specifier: ^4.0.4
-        version: 4.0.4(svelte@5.28.2)
+        version: 4.0.4(svelte@5.28.3)
     devDependencies:
       '@storybook/addon-essentials':
         specifier: ^8.6.14
@@ -819,25 +819,25 @@ importers:
         version: 8.6.14(react@18.2.0)(storybook@8.6.4(prettier@3.5.3))
       '@storybook/addon-svelte-csf':
         specifier: 5.0.0-next.27
-        version: 5.0.0-next.27(@storybook/svelte@8.6.14(storybook@8.6.4(prettier@3.5.3))(svelte@5.28.2))(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0)))(storybook@8.6.4(prettier@3.5.3))(svelte@5.28.2)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))
+        version: 5.0.0-next.27(@storybook/svelte@8.6.14(storybook@8.6.4(prettier@3.5.3))(svelte@5.28.3))(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.28.3)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0)))(storybook@8.6.4(prettier@3.5.3))(svelte@5.28.3)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))
       '@storybook/blocks':
         specifier: ^8.6.14
         version: 8.6.14(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(storybook@8.6.4(prettier@3.5.3))
       '@storybook/svelte':
         specifier: ^8.6.14
-        version: 8.6.14(storybook@8.6.4(prettier@3.5.3))(svelte@5.28.2)
+        version: 8.6.14(storybook@8.6.4(prettier@3.5.3))(svelte@5.28.3)
       '@storybook/svelte-vite':
         specifier: ^8.6.14
-        version: 8.6.14(@babel/core@7.26.10)(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0)))(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.4)(tsx@4.19.4)(yaml@2.8.0))(postcss@8.5.4)(storybook@8.6.4(prettier@3.5.3))(svelte@5.28.2)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))
+        version: 8.6.14(@babel/core@7.26.10)(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.28.3)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0)))(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.4)(tsx@4.19.4)(yaml@2.8.0))(postcss@8.5.4)(storybook@8.6.4(prettier@3.5.3))(svelte@5.28.3)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))
       '@storybook/test':
         specifier: ^8.6.14
         version: 8.6.14(storybook@8.6.4(prettier@3.5.3))
       '@sveltejs/package':
         specifier: ^2.3.11
-        version: 2.3.11(svelte@5.28.2)(typescript@5.8.3)
+        version: 2.3.11(svelte@5.28.3)(typescript@5.8.3)
       '@sveltejs/vite-plugin-svelte':
         specifier: 5.0.3
-        version: 5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))
+        version: 5.0.3(svelte@5.28.3)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))
       '@tailwindcss/vite':
         specifier: ^4.1.8
         version: 4.1.8(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))
@@ -855,7 +855,7 @@ importers:
         version: 7.0.3
       eslint-plugin-svelte:
         specifier: ^3.9.1
-        version: 3.9.1(eslint@9.28.0(jiti@2.4.2))(svelte@5.28.2)
+        version: 3.9.1(eslint@9.28.0(jiti@2.4.2))(svelte@5.28.3)
       postcss:
         specifier: ^8.5.4
         version: 8.5.4
@@ -875,11 +875,11 @@ importers:
         specifier: ^4.0.2
         version: 4.0.2(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(storybook@8.6.4(prettier@3.5.3))
       svelte:
-        specifier: 5.28.2
-        version: 5.28.2
+        specifier: 5.28.3
+        version: 5.28.3
       svelte-check:
         specifier: ^4.2.1
-        version: 4.2.1(picomatch@4.0.2)(svelte@5.28.2)(typescript@5.8.3)
+        version: 4.2.1(picomatch@4.0.2)(svelte@5.28.3)(typescript@5.8.3)
       tailwindcss:
         specifier: ^4.1.8
         version: 4.1.8
@@ -11057,8 +11057,8 @@ packages:
       svelte: ^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0
       typescript: ^4.9.4 || ^5.0.0
 
-  svelte@5.28.2:
-    resolution: {integrity: sha512-FbWBxgWOpQfhKvoGJv/TFwzqb4EhJbwCD17dB0tEpQiw1XyUEKZJtgm4nA4xq3LLsMo7hu5UY/BOFmroAxKTMg==}
+  svelte@5.28.3:
+    resolution: {integrity: sha512-L19exJJQJjwLWgerb9lomqy5BiRGYl+oqshSs7uk3kJ3kCTZokPlJcCe4rSpCzk7f1RFb7bfpvDBe21r1CQ86g==}
     engines: {node: '>=18'}
 
   sveltedoc-parser@4.2.1:
@@ -15608,18 +15608,18 @@ snapshots:
       storybook: 8.6.4(prettier@3.5.3)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-svelte-csf@5.0.0-next.27(@storybook/svelte@8.6.14(storybook@8.6.4(prettier@3.5.3))(svelte@5.28.2))(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0)))(storybook@8.6.4(prettier@3.5.3))(svelte@5.28.2)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))':
+  '@storybook/addon-svelte-csf@5.0.0-next.27(@storybook/svelte@8.6.14(storybook@8.6.4(prettier@3.5.3))(svelte@5.28.3))(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.28.3)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0)))(storybook@8.6.4(prettier@3.5.3))(svelte@5.28.3)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))':
     dependencies:
       '@storybook/csf': 0.1.12
-      '@storybook/svelte': 8.6.14(storybook@8.6.4(prettier@3.5.3))(svelte@5.28.2)
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))
+      '@storybook/svelte': 8.6.14(storybook@8.6.4(prettier@3.5.3))(svelte@5.28.3)
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.28.3)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))
       dedent: 1.5.3
       es-toolkit: 1.27.0
       esrap: 1.4.5
       magic-string: 0.30.17
       storybook: 8.6.4(prettier@3.5.3)
-      svelte: 5.28.2
-      svelte-ast-print: 0.4.2(svelte@5.28.2)
+      svelte: 5.28.3
+      svelte-ast-print: 0.4.2(svelte@5.28.3)
       vite: 6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0)
       zimmerframe: 1.1.2
     transitivePeerDependencies:
@@ -15729,16 +15729,16 @@ snapshots:
       react-dom: 18.3.1(react@18.2.0)
       storybook: 8.6.4(prettier@3.5.3)
 
-  '@storybook/svelte-vite@8.6.14(@babel/core@7.26.10)(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0)))(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.4)(tsx@4.19.4)(yaml@2.8.0))(postcss@8.5.4)(storybook@8.6.4(prettier@3.5.3))(svelte@5.28.2)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))':
+  '@storybook/svelte-vite@8.6.14(@babel/core@7.26.10)(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.28.3)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0)))(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.4)(tsx@4.19.4)(yaml@2.8.0))(postcss@8.5.4)(storybook@8.6.4(prettier@3.5.3))(svelte@5.28.3)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))':
     dependencies:
       '@storybook/builder-vite': 8.6.14(storybook@8.6.4(prettier@3.5.3))(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))
-      '@storybook/svelte': 8.6.14(storybook@8.6.4(prettier@3.5.3))(svelte@5.28.2)
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))
+      '@storybook/svelte': 8.6.14(storybook@8.6.4(prettier@3.5.3))(svelte@5.28.3)
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.28.3)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))
       magic-string: 0.30.17
       storybook: 8.6.4(prettier@3.5.3)
-      svelte: 5.28.2
-      svelte-preprocess: 5.1.4(@babel/core@7.26.10)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.4)(tsx@4.19.4)(yaml@2.8.0))(postcss@8.5.4)(svelte@5.28.2)(typescript@5.8.3)
-      svelte2tsx: 0.7.39(svelte@5.28.2)(typescript@5.8.3)
+      svelte: 5.28.3
+      svelte-preprocess: 5.1.4(@babel/core@7.26.10)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.4)(tsx@4.19.4)(yaml@2.8.0))(postcss@8.5.4)(svelte@5.28.3)(typescript@5.8.3)
+      svelte2tsx: 0.7.39(svelte@5.28.3)(typescript@5.8.3)
       sveltedoc-parser: 4.2.1
       ts-dedent: 2.2.0
       typescript: 5.8.3
@@ -15755,7 +15755,7 @@ snapshots:
       - sugarss
       - supports-color
 
-  '@storybook/svelte@8.6.14(storybook@8.6.4(prettier@3.5.3))(svelte@5.28.2)':
+  '@storybook/svelte@8.6.14(storybook@8.6.4(prettier@3.5.3))(svelte@5.28.3)':
     dependencies:
       '@storybook/components': 8.6.14(storybook@8.6.4(prettier@3.5.3))
       '@storybook/csf': 0.1.12
@@ -15764,7 +15764,7 @@ snapshots:
       '@storybook/preview-api': 8.6.14(storybook@8.6.4(prettier@3.5.3))
       '@storybook/theming': 8.6.14(storybook@8.6.4(prettier@3.5.3))
       storybook: 8.6.4(prettier@3.5.3)
-      svelte: 5.28.2
+      svelte: 5.28.3
       sveltedoc-parser: 4.2.1
       ts-dedent: 2.2.0
       type-fest: 2.19.0
@@ -15798,34 +15798,34 @@ snapshots:
     dependencies:
       acorn: 8.14.1
 
-  '@sveltejs/package@2.3.11(svelte@5.28.2)(typescript@5.8.3)':
+  '@sveltejs/package@2.3.11(svelte@5.28.3)(typescript@5.8.3)':
     dependencies:
       chokidar: 4.0.3
       kleur: 4.1.5
       sade: 1.8.1
       semver: 7.7.2
-      svelte: 5.28.2
-      svelte2tsx: 0.7.36(svelte@5.28.2)(typescript@5.8.3)
+      svelte: 5.28.3
+      svelte2tsx: 0.7.36(svelte@5.28.3)(typescript@5.8.3)
     transitivePeerDependencies:
       - typescript
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0)))(svelte@5.28.2)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.28.3)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0)))(svelte@5.28.3)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.28.3)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))
       debug: 4.4.0
-      svelte: 5.28.2
+      svelte: 5.28.3
       vite: 6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))':
+  '@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.28.3)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.28.2)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0)))(svelte@5.28.2)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.28.3)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0)))(svelte@5.28.3)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))
       debug: 4.4.0
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.15
-      svelte: 5.28.2
+      svelte: 5.28.3
       vite: 6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0)
       vitefu: 1.0.4(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))
     transitivePeerDependencies:
@@ -16042,10 +16042,10 @@ snapshots:
       lodash: 4.17.21
       redent: 3.0.0
 
-  '@testing-library/svelte@5.2.8(svelte@5.28.2)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))(vitest@3.1.4(@types/debug@4.1.12)(@types/node@22.15.24)(jiti@2.4.2)(jsdom@27.0.0-beta.1)(lightningcss@1.30.1)(msw@2.8.7(@types/node@22.15.24)(typescript@5.8.3))(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))':
+  '@testing-library/svelte@5.2.8(svelte@5.28.3)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))(vitest@3.1.4(@types/debug@4.1.12)(@types/node@22.15.24)(jiti@2.4.2)(jsdom@27.0.0-beta.1)(lightningcss@1.30.1)(msw@2.8.7(@types/node@22.15.24)(typescript@5.8.3))(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0))':
     dependencies:
       '@testing-library/dom': 10.4.0
-      svelte: 5.28.2
+      svelte: 5.28.3
     optionalDependencies:
       vite: 6.3.5(@types/node@22.15.24)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0)
       vitest: 3.1.4(@types/debug@4.1.12)(@types/node@22.15.24)(jiti@2.4.2)(jsdom@27.0.0-beta.1)(lightningcss@1.30.1)(msw@2.8.7(@types/node@22.15.24)(typescript@5.8.3))(terser@5.36.0)(tsx@4.19.4)(yaml@2.8.0)
@@ -17013,9 +17013,9 @@ snapshots:
 
   '@xtuc/long@4.2.2': {}
 
-  '@zerodevx/svelte-toast@0.9.6(svelte@5.28.2)':
+  '@zerodevx/svelte-toast@0.9.6(svelte@5.28.3)':
     dependencies:
-      svelte: 5.28.2
+      svelte: 5.28.3
 
   JSONStream@1.3.5:
     dependencies:
@@ -19416,7 +19416,7 @@ snapshots:
       semver: 7.7.1
       typescript: 5.8.3
 
-  eslint-plugin-svelte@3.9.1(eslint@9.28.0(jiti@2.4.2))(svelte@5.28.2):
+  eslint-plugin-svelte@3.9.1(eslint@9.28.0(jiti@2.4.2))(svelte@5.28.3):
     dependencies:
       '@eslint-community/eslint-utils': 4.7.0(eslint@9.28.0(jiti@2.4.2))
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -19428,9 +19428,9 @@ snapshots:
       postcss-load-config: 3.1.4(postcss@8.5.4)
       postcss-safe-parser: 7.0.1(postcss@8.5.4)
       semver: 7.7.2
-      svelte-eslint-parser: 1.2.0(svelte@5.28.2)
+      svelte-eslint-parser: 1.2.0(svelte@5.28.3)
     optionalDependencies:
-      svelte: 5.28.2
+      svelte: 5.28.3
     transitivePeerDependencies:
       - ts-node
 
@@ -23598,7 +23598,7 @@ snapshots:
 
   regenerator-transform@0.15.2:
     dependencies:
-      '@babel/runtime': 7.26.10
+      '@babel/runtime': 7.27.4
 
   regexp-ast-analysis@0.7.1:
     dependencies:
@@ -24527,25 +24527,25 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-ast-print@0.4.2(svelte@5.28.2):
+  svelte-ast-print@0.4.2(svelte@5.28.3):
     dependencies:
       esrap: 1.2.2
-      svelte: 5.28.2
+      svelte: 5.28.3
       zimmerframe: 1.1.2
 
-  svelte-check@4.2.1(picomatch@4.0.2)(svelte@5.28.2)(typescript@5.8.3):
+  svelte-check@4.2.1(picomatch@4.0.2)(svelte@5.28.3)(typescript@5.8.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       chokidar: 4.0.3
       fdir: 6.4.4(picomatch@4.0.2)
       picocolors: 1.1.1
       sade: 1.8.1
-      svelte: 5.28.2
+      svelte: 5.28.3
       typescript: 5.8.3
     transitivePeerDependencies:
       - picomatch
 
-  svelte-eslint-parser@1.2.0(svelte@5.28.2):
+  svelte-eslint-parser@1.2.0(svelte@5.28.3):
     dependencies:
       eslint-scope: 8.3.0
       eslint-visitor-keys: 4.2.0
@@ -24554,20 +24554,20 @@ snapshots:
       postcss-scss: 4.0.9(postcss@8.5.3)
       postcss-selector-parser: 7.1.0
     optionalDependencies:
-      svelte: 5.28.2
+      svelte: 5.28.3
 
-  svelte-fa@4.0.4(svelte@5.28.2):
+  svelte-fa@4.0.4(svelte@5.28.3):
     dependencies:
-      svelte: 5.28.2
+      svelte: 5.28.3
 
-  svelte-preprocess@5.1.4(@babel/core@7.26.10)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.4)(tsx@4.19.4)(yaml@2.8.0))(postcss@8.5.4)(svelte@5.28.2)(typescript@5.8.3):
+  svelte-preprocess@5.1.4(@babel/core@7.26.10)(postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.4)(tsx@4.19.4)(yaml@2.8.0))(postcss@8.5.4)(svelte@5.28.3)(typescript@5.8.3):
     dependencies:
       '@types/pug': 2.0.10
       detect-indent: 6.1.0
       magic-string: 0.30.17
       sorcery: 0.11.1
       strip-indent: 3.0.0
-      svelte: 5.28.2
+      svelte: 5.28.3
     optionalDependencies:
       '@babel/core': 7.26.10
       postcss: 8.5.4
@@ -24576,21 +24576,21 @@ snapshots:
 
   svelte-steps@2.4.1: {}
 
-  svelte2tsx@0.7.36(svelte@5.28.2)(typescript@5.8.3):
+  svelte2tsx@0.7.36(svelte@5.28.3)(typescript@5.8.3):
     dependencies:
       dedent-js: 1.0.1
       pascal-case: 3.1.2
-      svelte: 5.28.2
+      svelte: 5.28.3
       typescript: 5.8.3
 
-  svelte2tsx@0.7.39(svelte@5.28.2)(typescript@5.8.3):
+  svelte2tsx@0.7.39(svelte@5.28.3)(typescript@5.8.3):
     dependencies:
       dedent-js: 1.0.1
       pascal-case: 3.1.2
-      svelte: 5.28.2
+      svelte: 5.28.3
       typescript: 5.8.3
 
-  svelte@5.28.2:
+  svelte@5.28.3:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@jridgewell/sourcemap-codec': 1.5.0

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -43,7 +43,7 @@
     "react-dom": "18.3.1",
     "storybook": "^8.6.4",
     "storybook-dark-mode": "^4.0.2",
-    "svelte": "5.28.2",
+    "svelte": "5.28.3",
     "svelte-check": "^4.2.1",
     "tailwindcss": "^4.1.8",
     "typescript": "^5.8.3",


### PR DESCRIPTION
### What does this PR do?

Clear kubernetes caches when an informer is offline. 

The effect is to reset all counts to zero for all resources of the context for which at least one informer is offline.

### Screenshot / video of UI

### What issues does this PR fix or reference?


related to #12465 

### How to test this PR?

See steps to reproduce in #12465 

- [x] Tests are covering the bug fix or the new feature
