### PR TITLE
fix: clear caches for all resources when one informer is offline

### DIFF
--- a/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
@@ -349,8 +349,9 @@ export class ContextsManagerExperimental {
                 });
               }
             });
-            informer.onOffline((_e: OfflineEvent) => {
+            informer.onOffline((e: OfflineEvent) => {
               this.#onOfflineChange.fire();
+              this.#objectCaches.removeForContext(e.kubeconfig.getKubeConfig().currentContext);
             });
             const cache = informer.start();
             this.#objectCaches.set(contextName, resource, cache);


### PR DESCRIPTION
### What does this PR do?

Clear kubernetes caches when an informer is offline. 

The effect is to reset all counts to zero for all resources of the context for which at least one informer is offline.

### Screenshot / video of UI

### What issues does this PR fix or reference?


Fixes #12465 

### How to test this PR?

See steps to reproduce in #12465 

- [x] Tests are covering the bug fix or the new feature
