### PR TITLE
chore(optimize): telemetry - remove createProvider for createdProviders

### DIFF
--- a/packages/main/src/plugin/provider-registry.spec.ts
+++ b/packages/main/src/plugin/provider-registry.spec.ts
@@ -121,11 +121,6 @@ test('should initialize provider if there is kubernetes connection provider', as
   if (providerInternalId) {
     await providerRegistry.initializeProvider(providerInternalId);
 
-    expect(telemetryTrackMock).toHaveBeenNthCalledWith(1, 'createProvider', {
-      name: 'internal',
-      status: 'installed',
-    });
-
     expect(initalizeCalled).toBe(true);
     expect(apiSenderSendMock).toBeCalled();
   } else {
@@ -148,11 +143,6 @@ test('should initialize provider if there is VM connection provider', async () =
   });
 
   await providerRegistry.initializeProvider(providerInternalId);
-
-  expect(telemetryTrackMock).toHaveBeenNthCalledWith(1, 'createProvider', {
-    name: 'internal',
-    status: 'installed',
-  });
 
   expect(initializeMock).toHaveBeenCalled();
   expect(apiSenderSendMock).toHaveBeenCalledWith('provider-create', '0');
@@ -187,11 +177,6 @@ test('should send version event if update', async () => {
   if (providerInternalId) {
     await providerRegistry.updateProvider(providerInternalId);
 
-    expect(telemetryTrackMock).toHaveBeenNthCalledWith(1, 'createProvider', {
-      name: 'internal',
-      status: 'installed',
-    });
-
     expect(updateCalled).toBe(true);
     expect(apiSenderSendMock).toBeCalledTimes(3);
   } else {
@@ -224,11 +209,6 @@ test('should initialize provider if there is container connection provider', asy
   expect(providerInternalId).toBeDefined();
   if (providerInternalId) {
     await providerRegistry.initializeProvider(providerInternalId);
-
-    expect(telemetryTrackMock).toHaveBeenNthCalledWith(1, 'createProvider', {
-      name: 'internal',
-      status: 'installed',
-    });
 
     expect(initalizeCalled).toBe(true);
     expect(apiSenderSendMock).toBeCalled();

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -212,14 +212,6 @@ export class ProviderRegistry {
     this.count++;
     this.providers.set(id, providerImpl);
     this.listeners.forEach(listener => listener('provider:create', this.toProviderInfo(providerImpl)));
-    const trackOpts: { name: string; status: string; version?: string } = {
-      name: providerOptions.name,
-      status: providerOptions.status.toString(),
-    };
-    if (providerOptions.version) {
-      trackOpts.version = providerOptions.version;
-    }
-    this.telemetryService.track('createProvider', trackOpts);
     this.apiSender.send('provider-create', id);
     providerImpl.onDidUpdateVersion(() => this.apiSender.send('provider:update-version'));
     return providerImpl;


### PR DESCRIPTION
chore(optimize): telemetry - remove createProvider for createdProviders

### What does this PR do?

* Use the new telemetry call createdProviders which sends a list of all
  the providers as well as the information (id, name, status, version)
  similar to the previous telemetry call.
* Above call is done after the loading of extensions.
* Removes createProvider call since it is being called multiple times on
  start

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/podman-desktop/issues/12634

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
