### PR TITLE
chore: remove notarize option from electron builder config

### DIFF
--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -250,12 +250,6 @@ if (process.env.AIRGAP_DOWNLOAD) {
   };
 }
 
-if (process.env.APPLE_TEAM_ID) {
-  config.mac.notarize = {
-    teamId: process.env.APPLE_TEAM_ID,
-  };
-}
-
 /**
  * @deprecated use {@link import('electron-builder').Configuration#win#azureSignOptions}
  * @param filePath


### PR DESCRIPTION
### What does this PR do?
It removes the `notarize` option from electron builder config file as it was removed in `electron-builder` v26.
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#12718 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

After merge `next-build` workflow should start passing again.
<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
