### PR TITLE
feat: allow provider update from resources page

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
@@ -808,3 +808,21 @@ test('Expect to see the no resource message when there is no providers', async (
   const panel = screen.getByLabelText('no-resource-panel');
   expect(panel).toBeInTheDocument();
 });
+
+test('Expect update button to show up when an update is available to a new version', async () => {
+  vi.mocked(window.runUpdatePreflightChecks).mockResolvedValue(true);
+  vi.mocked(window.updateProvider).mockResolvedValue([{ name: 'podman', status: true }]);
+  providerInfos.set([providerInfo]);
+  const component = render(PreferencesResourcesRendering, {});
+  let updateButton = screen.queryByText('Update to');
+  expect(updateButton).not.toBeInTheDocument();
+
+  providerInfos.set([{ ...providerInfo, version: '0.0.1', updateInfo: { version: '0.0.2' } }]);
+  await component.rerender({});
+  updateButton = screen.getByText('Update to 0.0.2');
+  expect(updateButton).toBeInTheDocument();
+
+  await userEvent.click(updateButton);
+  expect(window.runUpdatePreflightChecks).toHaveBeenCalled();
+  expect(window.updateProvider).toHaveBeenCalled();
+});

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -22,6 +22,7 @@ import { providerInfos } from '../../stores/providers';
 import ContributionActions from '../actions/ContributionActions.svelte';
 import type { ContextUI } from '../context/context';
 import { ContextKeyExpr } from '../context/contextKey';
+import ProviderUpdateButton from '../dashboard/ProviderUpdateButton.svelte';
 import { normalizeOnboardingWhenClause } from '../onboarding/onboarding-utils';
 import ConnectionErrorInfoButton from '../ui/ConnectionErrorInfoButton.svelte';
 import ConnectionStatus from '../ui/ConnectionStatus.svelte';
@@ -411,7 +412,7 @@ function handleError(errorMessage: string): void {
       href="/extensions"
       class="text-[var(--pd-content-text)] underline underline-offset-2">Extensions</a>
   </span>
-  <div class="h-full" role="region" aria-label="Featured Provider Resources">
+  <div class="h-full w-full" role="region" aria-label="Featured Provider Resources">
     <EmptyScreen
       aria-label="no-resource-panel"
       icon={EngineIcon}
@@ -423,12 +424,12 @@ function handleError(errorMessage: string): void {
       <div
         id={provider.id}
         bind:this={providerElementMap[provider.id]}
-        class="bg-[var(--pd-invert-content-card-bg)] mb-5 rounded-md p-3 divide-x divide-[var(--pd-content-divider)] flex"
+        class="bg-[var(--pd-invert-content-card-bg)] mb-5 rounded-md p-3 divide-x divide-[var(--pd-content-divider)] flex w-full"
         role="region"
         aria-label={provider.id}>
-        <div role="region" aria-label="Provider Setup">
+        <div role="region" aria-label="Provider Setup" class="min-w-[170px] w-[30%]">
           <!-- left col - provider icon/name + "create new" button -->
-          <div class="min-w-[170px] max-w-[200px]">
+          <div class="mr-2">
             <div class="flex">
               {#if provider.images.icon}
                 {#if typeof provider.images.icon === 'string'}
@@ -451,7 +452,7 @@ function handleError(errorMessage: string): void {
                   Setup ...
                 </Button>
               {:else}
-                <div class="flex flex-row justify-around">
+                <div class="flex flex-row justify-evenly flex-wrap w-full gap-2">
                   {#if provider.containerProviderConnectionCreation || provider.kubernetesProviderConnectionCreation || provider.vmProviderConnectionCreation}
                     {@const providerDisplayName =
                       (provider.containerProviderConnectionCreation
@@ -493,6 +494,9 @@ function handleError(errorMessage: string): void {
                       <Fa size="0.9x" icon={faGear} />
                     </Button>
                   {/if}
+                  {#if provider.updateInfo?.version && provider.version !== provider.updateInfo?.version}
+                    <ProviderUpdateButton onPreflightChecks={(checks): CheckStatus[] => (preflightChecks = checks)} provider={provider} />
+                  {/if}
                 </div>
               {/if}
             </div>
@@ -500,7 +504,7 @@ function handleError(errorMessage: string): void {
         </div>
         <!-- providers columns -->
         <div
-          class="grow flex flex-wrap divide-[var(--pd-content-divider)] ml-2 text-[var(--pd-invert-content-card-text)]"
+          class="grow flex flex-wrap divide-[var(--pd-content-divider)] ml-2 text-[var(--pd-invert-content-card-text)] w-full"
           role="region"
           aria-label="Provider Connections">
           <PreferencesConnectionsEmptyRendering

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -427,7 +427,7 @@ function handleError(errorMessage: string): void {
         class="bg-[var(--pd-invert-content-card-bg)] mb-5 rounded-md p-3 divide-x divide-[var(--pd-content-divider)] flex"
         role="region"
         aria-label={provider.id}>
-        <div role="region" aria-label="Provider Setup" class="">
+        <div role="region" aria-label="Provider Setup">
           <!-- left col - provider icon/name + "create new" button -->
           <div class="min-w-[170px] max-w-[200px]">
             <div class="flex">

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -412,7 +412,7 @@ function handleError(errorMessage: string): void {
       href="/extensions"
       class="text-[var(--pd-content-text)] underline underline-offset-2">Extensions</a>
   </span>
-  <div class="h-full w-full" role="region" aria-label="Featured Provider Resources">
+  <div class="h-full" role="region" aria-label="Featured Provider Resources">
     <EmptyScreen
       aria-label="no-resource-panel"
       icon={EngineIcon}
@@ -424,12 +424,12 @@ function handleError(errorMessage: string): void {
       <div
         id={provider.id}
         bind:this={providerElementMap[provider.id]}
-        class="bg-[var(--pd-invert-content-card-bg)] mb-5 rounded-md p-3 divide-x divide-[var(--pd-content-divider)] flex w-full"
+        class="bg-[var(--pd-invert-content-card-bg)] mb-5 rounded-md p-3 divide-x divide-[var(--pd-content-divider)] flex"
         role="region"
         aria-label={provider.id}>
-        <div role="region" aria-label="Provider Setup" class="min-w-[170px] w-[30%]">
+        <div role="region" aria-label="Provider Setup" class="">
           <!-- left col - provider icon/name + "create new" button -->
-          <div class="mr-2">
+          <div class="min-w-[170px] max-w-[200px]">
             <div class="flex">
               {#if provider.images.icon}
                 {#if typeof provider.images.icon === 'string'}
@@ -452,7 +452,7 @@ function handleError(errorMessage: string): void {
                   Setup ...
                 </Button>
               {:else}
-                <div class="flex flex-row justify-evenly flex-wrap w-full gap-2">
+                <div class="flex flex-row justify-around flex-wrap gap-2">
                   {#if provider.containerProviderConnectionCreation || provider.kubernetesProviderConnectionCreation || provider.vmProviderConnectionCreation}
                     {@const providerDisplayName =
                       (provider.containerProviderConnectionCreation
@@ -504,7 +504,7 @@ function handleError(errorMessage: string): void {
         </div>
         <!-- providers columns -->
         <div
-          class="grow flex flex-wrap divide-[var(--pd-content-divider)] ml-2 text-[var(--pd-invert-content-card-text)] w-full"
+          class="grow flex flex-wrap divide-[var(--pd-content-divider)] ml-2 text-[var(--pd-invert-content-card-text)]"
           role="region"
           aria-label="Provider Connections">
           <PreferencesConnectionsEmptyRendering


### PR DESCRIPTION
### What does this PR do?
Adds the ability to update providers from the resources page by adding the `ProviderUpdateButton` used in the dashboard page.

- Possible follow up issue: some providers like Podman and OpenShift Local have preflight check that show up on the dashboard if there is a problem with them. Will we include them in the resource page if we remove the providers from the dashboard page? and if so, how will we show them?

### Screenshot / video of UI
![Screenshot From 2025-06-03 09-53-28](https://github.com/user-attachments/assets/23fe80f9-ecab-4e92-abda-8cac682684e4)


### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/podman-desktop/issues/12189

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
