### PR TITLE
fix: error during extension install overlaps with other components

### DIFF
--- a/packages/renderer/src/lib/featured/FeaturedExtensionDownload.svelte
+++ b/packages/renderer/src/lib/featured/FeaturedExtensionDownload.svelte
@@ -71,6 +71,7 @@ async function installExtension(): Promise<void> {
 }
 </script>
 
+<ErrorMessage icon wrapMessage class="-top-[15px] right-0 absolute" error={errorInstall}/>
 <button
   aria-label="Install {extension.id} Extension"
   on:click={installExtension}
@@ -89,7 +90,4 @@ async function installExtension(): Promise<void> {
     class:hidden={!installInProgress}
     class="absolute -top-[15px] right-0 text-[var(--pd-action-button-spinner)]"
     style="font-size: 8px">{percentage}</span>
-  <div class:hidden={!errorInstall} class="absolute w-56 -top-[25px] right-0" style="font-size: 8px">
-    <ErrorMessage error={errorInstall} />
-  </div>
 </button>


### PR DESCRIPTION
### What does this PR do?

When an error occurs during the installation of an extension, the error message is currently misaligned and can overlap with other UI components, especially when the message is lengthy. 

### Screenshot / video of UI

Before:
![image](https://github.com/user-attachments/assets/24eb87aa-dba2-480c-b8e8-96c60f65290c)
After:
<img width="1176" alt="image" src="https://github.com/user-attachments/assets/502eda7d-b4fc-4cdf-af13-6be78a98a248" />


### What issues does this PR fix or reference?

Fixes #10898

### How to test this PR?
Install multiple extension at once in a fast manner.

1. Minikube, AI Lab, bootc, RH Extensions Pack (this one is important), Image Layers, etc.
2. Should show the errors.

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

The error display has been moved outside of the <Button\> component. This ensures that the tooltip's hover behavior is independent of the button
