### PR TITLE
chore: track all changes from the extension

### DIFF
--- a/packages/main/src/plugin/extension/extension-watcher.spec.ts
+++ b/packages/main/src/plugin/extension/extension-watcher.spec.ts
@@ -59,6 +59,8 @@ const fakeActivatedExtension = {
 } as unknown as ActivatedExtension;
 
 const fileSystemOnDidChangeMock = vi.fn();
+const fileSystemOnDidCreateMock = vi.fn();
+const fileSystemOnDidDeleteMock = vi.fn();
 const fileSystemDisposeMock = vi.fn();
 
 beforeEach(() => {
@@ -68,6 +70,8 @@ beforeEach(() => {
   // mock createFileSystemWatcher
   vi.mocked(fileSystemMonitoring.createFileSystemWatcher).mockReturnValue({
     onDidChange: fileSystemOnDidChangeMock,
+    onDidCreate: fileSystemOnDidCreateMock,
+    onDidDelete: fileSystemOnDidDeleteMock,
     dispose: fileSystemDisposeMock,
   } as unknown as FileSystemWatcher);
 
@@ -84,12 +88,36 @@ describe('monitor', () => {
     // check that we called the createFileSystemWatcher method on fileSystemMonitoring
     expect(fileSystemMonitoring.createFileSystemWatcher).toHaveBeenCalled();
 
+    // check with onDidCreate
+    const onDidCreateCallback = fileSystemOnDidCreateMock.mock.calls[0]?.[0];
+    expect(onDidCreateCallback).toBeDefined();
+    // call the callback
+    onDidCreateCallback({ fsPath: 'fakePath' });
+
+    // check that we call reloadExtension method
+    await vi.waitFor(() => expect(reloadSpy).toHaveBeenCalled());
+
+    // clear the calls on reloadSpy
+    reloadSpy.mockClear();
+
     //get argument of onDidChangeMock
     const onDidChangeCallback = fileSystemOnDidChangeMock.mock.calls[0]?.[0];
     expect(onDidChangeCallback).toBeDefined();
 
     // call the callback
     onDidChangeCallback({ fsPath: 'fakePath' });
+
+    // check that we call reloadExtension method
+    await vi.waitFor(() => expect(reloadSpy).toHaveBeenCalled());
+
+    // clear the calls on reloadSpy
+    reloadSpy.mockClear();
+
+    // check with onDidDelete
+    const onDidDeleteCallback = fileSystemOnDidDeleteMock.mock.calls[0]?.[0];
+    expect(onDidDeleteCallback).toBeDefined();
+    // call the callback
+    onDidDeleteCallback({ fsPath: 'fakePath' });
 
     // check that we call reloadExtension method
     await vi.waitFor(() => expect(reloadSpy).toHaveBeenCalled());

--- a/packages/main/src/plugin/extension/extension-watcher.ts
+++ b/packages/main/src/plugin/extension/extension-watcher.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { FileSystemWatcher } from '@podman-desktop/api';
+import type { FileSystemWatcher, Uri } from '@podman-desktop/api';
 import type { FileMatcher } from 'get-tsconfig';
 
 import type { Event } from '../events/emitter.js';
@@ -83,9 +83,9 @@ export class ExtensionWatcher implements IDisposable {
     const extensionWatcher = this.#fileSystemMonitoring.createFileSystemWatcher(extension.path);
     this.#watcherExtensions.set(extension.id, extensionWatcher);
 
-    extensionWatcher.onDidChange(async event => {
-      // check if it's matching the source pattern of an existing typescript config
+    const callback = (event: Uri): void => {
       let isInSource = false;
+      // check if it's matching the source pattern of an existing typescript config
       const hasTsConfig = tsConfigFileMatcher !== undefined;
       if (tsConfigFileMatcher) {
         const matchingJsonEvent = tsConfigFileMatcher(event.fsPath);
@@ -95,6 +95,17 @@ export class ExtensionWatcher implements IDisposable {
       if (!hasTsConfig || !isInSource) {
         this.reloadExtension(extension);
       }
+    };
+
+    extensionWatcher.onDidCreate(async event => {
+      callback(event);
+    });
+    extensionWatcher.onDidDelete(async event => {
+      callback(event);
+    });
+
+    extensionWatcher.onDidChange(async event => {
+      callback(event);
     });
   }
 

--- a/packages/main/src/plugin/extension/extension-watcher.ts
+++ b/packages/main/src/plugin/extension/extension-watcher.ts
@@ -97,16 +97,9 @@ export class ExtensionWatcher implements IDisposable {
       }
     };
 
-    extensionWatcher.onDidCreate(async event => {
-      callback(event);
-    });
-    extensionWatcher.onDidDelete(async event => {
-      callback(event);
-    });
-
-    extensionWatcher.onDidChange(async event => {
-      callback(event);
-    });
+    extensionWatcher.onDidCreate(event => callback(event));
+    extensionWatcher.onDidDelete(event => callback(event));
+    extensionWatcher.onDidChange(event => callback(event));
   }
 
   protected getWatcher(extension: ActivatedExtension): FileSystemWatcher | undefined {


### PR DESCRIPTION
### What does this PR do?
now that it's no longer tracking initial files on the watcher from a previous PR we can track all changes once we create the watcher. It allows to detect more cases where for example vite will remove a folder or recreate only one file, etc

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/issues/8616


### How to test this PR?

there are unit tests but you can try to launch one extension in development mode and do changes while having the watch mode, and it should always refresh/reload the extension and be in a consistent state (and not miss some updates)

- [x] Tests are covering the bug fix or the new feature
