### PR TITLE
[WIP] chore: update to docusaurus 3.8.0 and remove --no-minify

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "typecheck:extensions:registries": "tsc --noEmit --project extensions/registries",
     "typecheck:extensions:kubectl-cli": "tsc --noEmit --project extensions/kubectl-cli",
     "typecheck": "pnpm run typecheck:main && pnpm run typecheck:preload && pnpm run typecheck:ui && pnpm run typecheck:renderer && pnpm run typecheck:preload-dd-extension && pnpm run typecheck:preload-webview && pnpm run typecheck:extensions && pnpm run typecheck:extension-api",
-    "website:build": "pnpm run storybook:build && cd website && pnpm run docusaurus clear && pnpm run docusaurus build --no-minify",
+    "website:build": "pnpm run storybook:build && cd website && pnpm run docusaurus clear && pnpm run docusaurus build",
     "website:prod": "pnpm run website:build && cd website/build && pnpm serve",
     "website:dev": "pnpm run storybook:build && cd website && pnpm run docusaurus start",
     "website:screenshots": "cd website-argos && pnpm run screenshot",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,7 +222,7 @@ importers:
         version: 9.28.0(jiti@2.4.2)
       eslint-import-resolver-custom-alias:
         specifier: ^1.3.2
-        version: 1.3.2(eslint-plugin-import@2.31.0)
+        version: 1.3.2(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@4.4.2)(eslint@9.28.0(jiti@2.4.2)))
       eslint-import-resolver-typescript:
         specifier: ^4.4.2
         version: 4.4.2(eslint-plugin-import@2.31.0)(eslint@9.28.0(jiti@2.4.2))
@@ -914,20 +914,20 @@ importers:
   website:
     dependencies:
       '@docusaurus/core':
-        specifier: ^3.7.0
-        version: 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+        specifier: ^3.8.0
+        version: 3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
       '@docusaurus/plugin-client-redirects':
-        specifier: ^3.7.0
-        version: 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+        specifier: ^3.8.0
+        version: 3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
       '@docusaurus/preset-classic':
-        specifier: ^3.7.0
-        version: 3.7.0(@algolia/client-search@5.19.0)(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(@types/react@18.3.12)(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)(typescript@5.8.3)
+        specifier: ^3.8.0
+        version: 3.8.0(@algolia/client-search@5.19.0)(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(@types/react@18.3.12)(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)(typescript@5.8.3)
       '@docusaurus/theme-common':
-        specifier: ^3.7.0
-        version: 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        specifier: ^3.8.0
+        version: 3.8.0(@docusaurus/plugin-content-docs@3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       '@docusaurus/theme-mermaid':
-        specifier: ^3.7.0
-        version: 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+        specifier: ^3.8.0
+        version: 3.8.0(@docusaurus/plugin-content-docs@3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
       '@fortawesome/fontawesome-svg-core':
         specifier: ^6.7.2
         version: 6.7.2
@@ -966,14 +966,14 @@ importers:
         version: 2.16.0(react@18.2.0)
     devDependencies:
       '@docusaurus/module-type-aliases':
-        specifier: ^3.7.0
-        version: 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        specifier: ^3.8.0
+        version: 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       '@docusaurus/tsconfig':
-        specifier: ^3.7.0
-        version: 3.7.0
+        specifier: ^3.8.0
+        version: 3.8.0
       '@docusaurus/types':
-        specifier: ^3.7.0
-        version: 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        specifier: ^3.8.0
+        version: 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       '@tailwindcss/postcss':
         specifier: ^4.1.8
         version: 4.1.8
@@ -1031,22 +1031,22 @@ packages:
   '@adobe/css-tools@4.4.2':
     resolution: {integrity: sha512-baYZExFpsdkBNuvGKTKWCwKH57HRZLVtycZS05WTQNVOiXVSeAki3nU35zlRbToeMW8aHlJfyS+1C4BOv27q0A==}
 
-  '@algolia/autocomplete-core@1.17.7':
-    resolution: {integrity: sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==}
+  '@algolia/autocomplete-core@1.17.9':
+    resolution: {integrity: sha512-O7BxrpLDPJWWHv/DLA9DRFWs+iY1uOJZkqUwjS5HSZAGcl0hIVCQ97LTLewiZmZ402JYUrun+8NqFP+hCknlbQ==}
 
-  '@algolia/autocomplete-plugin-algolia-insights@1.17.7':
-    resolution: {integrity: sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==}
+  '@algolia/autocomplete-plugin-algolia-insights@1.17.9':
+    resolution: {integrity: sha512-u1fEHkCbWF92DBeB/KHeMacsjsoI0wFhjZtlCq2ddZbAehshbZST6Hs0Avkc0s+4UyBGbMDnSuXHLuvRWK5iDQ==}
     peerDependencies:
       search-insights: '>= 1 < 3'
 
-  '@algolia/autocomplete-preset-algolia@1.17.7':
-    resolution: {integrity: sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==}
+  '@algolia/autocomplete-preset-algolia@1.17.9':
+    resolution: {integrity: sha512-Na1OuceSJeg8j7ZWn5ssMu/Ax3amtOwk76u4h5J4eK2Nx2KB5qt0Z4cOapCsxot9VcEN11ADV5aUSlQF4RhGjQ==}
     peerDependencies:
       '@algolia/client-search': '>= 4.9.1 < 6'
       algoliasearch: '>= 4.9.1 < 6'
 
-  '@algolia/autocomplete-shared@1.17.7':
-    resolution: {integrity: sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==}
+  '@algolia/autocomplete-shared@1.17.9':
+    resolution: {integrity: sha512-iDf05JDQ7I0b7JEA/9IektxN/80a2MZ1ToohfmNS3rfeuQnIKI3IJlIafD0xu4StbtQTghx9T3Maa97ytkXenQ==}
     peerDependencies:
       '@algolia/client-search': '>= 4.9.1 < 6'
       algoliasearch: '>= 4.9.1 < 6'
@@ -1162,10 +1162,6 @@ packages:
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/compat-data@7.26.2':
-    resolution: {integrity: sha512-Z0WgzSEa+aUcdiJuCIqgujCshpMWgUpgOxXotrYPSA53hA3qopNaqcJpyr0hVb1FeWdnqFA35/fUtXgBK8srQg==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/compat-data@7.26.8':
     resolution: {integrity: sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==}
     engines: {node: '>=6.9.0'}
@@ -1184,10 +1180,6 @@ packages:
 
   '@babel/helper-builder-binary-assignment-operator-visitor@7.25.9':
     resolution: {integrity: sha512-C47lC7LIDCnz0h4vai/tpNOI95tCd5ZT3iBt/DBH5lXKHZsyNQv18yf1wIIg2ntiQNgmAvA+DgZ82iW8Qdym8g==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-compilation-targets@7.25.9':
-    resolution: {integrity: sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-compilation-targets@7.26.5':
@@ -1734,16 +1726,8 @@ packages:
     resolution: {integrity: sha512-t3yaEOuGu9NlIZ+hIeGbBjFtZT7j2cb2tg0fuaJKeGotchRjjLfrBA9Kwf8quhpP1EUuxModQg04q/mBwyg8uA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/template@7.25.9':
-    resolution: {integrity: sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/template@7.26.9':
     resolution: {integrity: sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/traverse@7.25.9':
-    resolution: {integrity: sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/traverse@7.26.10':
@@ -1921,30 +1905,12 @@ packages:
       '@csstools/css-parser-algorithms': ^3.0.4
       '@csstools/css-tokenizer': ^3.0.3
 
-  '@csstools/color-helpers@5.0.1':
-    resolution: {integrity: sha512-MKtmkA0BX87PKaO1NFRTFH+UnkgnmySQOvNxJubsadusqPEC2aJ9MOQiMceZJJ6oitUl/i0L6u0M1IrmAOmgBA==}
-    engines: {node: '>=18'}
-
   '@csstools/color-helpers@5.0.2':
     resolution: {integrity: sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==}
     engines: {node: '>=18'}
 
-  '@csstools/css-calc@2.1.1':
-    resolution: {integrity: sha512-rL7kaUnTkL9K+Cvo2pnCieqNpTKgQzy5f+N+5Iuko9HAoasP+xgprVh7KN/MaJVvVL1l0EzQq2MoqBHKSrDrag==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@csstools/css-parser-algorithms': ^3.0.4
-      '@csstools/css-tokenizer': ^3.0.3
-
   '@csstools/css-calc@2.1.3':
     resolution: {integrity: sha512-XBG3talrhid44BY1x3MHzUx/aTG8+x/Zi57M4aTKK9RFB4aLlF3TTSzfzn8nWVHWL3FgAXAxmupmDd6VWww+pw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@csstools/css-parser-algorithms': ^3.0.4
-      '@csstools/css-tokenizer': ^3.0.3
-
-  '@csstools/css-color-parser@3.0.7':
-    resolution: {integrity: sha512-nkMp2mTICw32uE5NN+EsJ4f5N+IGFeCFu4bGpiKgb2Pq/7J/MpyLBeQ5ry4KKtRFZaYs6sTmcMYrSRIyj5DFKA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@csstools/css-parser-algorithms': ^3.0.4
@@ -2195,15 +2161,15 @@ packages:
   '@docker/extension-api-client-types@0.3.4':
     resolution: {integrity: sha512-cDdD+dNSE0XCvQiw0R4j9aHpK+p6E7vi+z7RbKXfxwuQpfEMoeNCKFlp4W7K3XT78iWmoPz3DxQtZEAe4VJ1oQ==}
 
-  '@docsearch/css@3.8.2':
-    resolution: {integrity: sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==}
+  '@docsearch/css@3.9.0':
+    resolution: {integrity: sha512-cQbnVbq0rrBwNAKegIac/t6a8nWoUAn8frnkLFW6YARaRmAQr5/Eoe6Ln2fqkUCZ40KpdrKbpSAmgrkviOxuWA==}
 
-  '@docsearch/react@3.8.2':
-    resolution: {integrity: sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==}
+  '@docsearch/react@3.9.0':
+    resolution: {integrity: sha512-mb5FOZYZIkRQ6s/NWnM98k879vu5pscWqTLubLFBO87igYYT4VzVazh4h5o/zCvTIZgEt3PvsCOMOswOUo9yHQ==}
     peerDependencies:
-      '@types/react': '>= 16.8.0 < 19.0.0'
-      react: '>= 16.8.0 < 19.0.0'
-      react-dom: '>= 16.8.0 < 19.0.0'
+      '@types/react': '>= 16.8.0 < 20.0.0'
+      react: '>= 16.8.0 < 20.0.0'
+      react-dom: '>= 16.8.0 < 20.0.0'
       search-insights: '>= 1 < 3'
     peerDependenciesMeta:
       '@types/react':
@@ -2215,12 +2181,12 @@ packages:
       search-insights:
         optional: true
 
-  '@docusaurus/babel@3.7.0':
-    resolution: {integrity: sha512-0H5uoJLm14S/oKV3Keihxvh8RV+vrid+6Gv+2qhuzbqHanawga8tYnsdpjEyt36ucJjqlby2/Md2ObWjA02UXQ==}
+  '@docusaurus/babel@3.8.0':
+    resolution: {integrity: sha512-9EJwSgS6TgB8IzGk1L8XddJLhZod8fXT4ULYMx6SKqyCBqCFpVCEjR/hNXXhnmtVM2irDuzYoVLGWv7srG/VOA==}
     engines: {node: '>=18.0'}
 
-  '@docusaurus/bundler@3.7.0':
-    resolution: {integrity: sha512-CUUT9VlSGukrCU5ctZucykvgCISivct+cby28wJwCC/fkQFgAHRp/GKv2tx38ZmXb7nacrKzFTcp++f9txUYGg==}
+  '@docusaurus/bundler@3.8.0':
+    resolution: {integrity: sha512-Rq4Z/MSeAHjVzBLirLeMcjLIAQy92pF1OI+2rmt18fSlMARfTGLWRE8Vb+ljQPTOSfJxwDYSzsK6i7XloD2rNA==}
     engines: {node: '>=18.0'}
     peerDependencies:
       '@docusaurus/faster': '*'
@@ -2228,8 +2194,8 @@ packages:
       '@docusaurus/faster':
         optional: true
 
-  '@docusaurus/core@3.7.0':
-    resolution: {integrity: sha512-b0fUmaL+JbzDIQaamzpAFpTviiaU4cX3Qz8cuo14+HGBCwa0evEK0UYCBFY3n4cLzL8Op1BueeroUD2LYAIHbQ==}
+  '@docusaurus/core@3.8.0':
+    resolution: {integrity: sha512-c7u6zFELmSGPEP9WSubhVDjgnpiHgDqMh1qVdCB7rTflh4Jx0msTYmMiO91Ez0KtHj4sIsDsASnjwfJ2IZp3Vw==}
     engines: {node: '>=18.0'}
     hasBin: true
     peerDependencies:
@@ -2237,100 +2203,104 @@ packages:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
-  '@docusaurus/cssnano-preset@3.7.0':
-    resolution: {integrity: sha512-X9GYgruZBSOozg4w4dzv9uOz8oK/EpPVQXkp0MM6Tsgp/nRIU9hJzJ0Pxg1aRa3xCeEQTOimZHcocQFlLwYajQ==}
+  '@docusaurus/cssnano-preset@3.8.0':
+    resolution: {integrity: sha512-UJ4hAS2T0R4WNy+phwVff2Q0L5+RXW9cwlH6AEphHR5qw3m/yacfWcSK7ort2pMMbDn8uGrD38BTm4oLkuuNoQ==}
     engines: {node: '>=18.0'}
 
-  '@docusaurus/logger@3.7.0':
-    resolution: {integrity: sha512-z7g62X7bYxCYmeNNuO9jmzxLQG95q9QxINCwpboVcNff3SJiHJbGrarxxOVMVmAh1MsrSfxWkVGv4P41ktnFsA==}
+  '@docusaurus/logger@3.8.0':
+    resolution: {integrity: sha512-7eEMaFIam5Q+v8XwGqF/n0ZoCld4hV4eCCgQkfcN9Mq5inoZa6PHHW9Wu6lmgzoK5Kx3keEeABcO2SxwraoPDQ==}
     engines: {node: '>=18.0'}
 
-  '@docusaurus/mdx-loader@3.7.0':
-    resolution: {integrity: sha512-OFBG6oMjZzc78/U3WNPSHs2W9ZJ723ewAcvVJaqS0VgyeUfmzUV8f1sv+iUHA0DtwiR5T5FjOxj6nzEE8LY6VA==}
+  '@docusaurus/mdx-loader@3.8.0':
+    resolution: {integrity: sha512-mDPSzssRnpjSdCGuv7z2EIAnPS1MHuZGTaRLwPn4oQwszu4afjWZ/60sfKjTnjBjI8Vl4OgJl2vMmfmiNDX4Ng==}
     engines: {node: '>=18.0'}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
-  '@docusaurus/module-type-aliases@3.7.0':
-    resolution: {integrity: sha512-g7WdPqDNaqA60CmBrr0cORTrsOit77hbsTj7xE2l71YhBn79sxdm7WMK7wfhcaafkbpIh7jv5ef5TOpf1Xv9Lg==}
+  '@docusaurus/module-type-aliases@3.8.0':
+    resolution: {integrity: sha512-/uMb4Ipt5J/QnD13MpnoC/A4EYAe6DKNWqTWLlGrqsPJwJv73vSwkA25xnYunwfqWk0FlUQfGv/Swdh5eCCg7g==}
     peerDependencies:
       react: '*'
       react-dom: '*'
 
-  '@docusaurus/plugin-client-redirects@3.7.0':
-    resolution: {integrity: sha512-6B4XAtE5ZVKOyhPgpgMkb7LwCkN+Hgd4vOnlbwR8nCdTQhLjz8MHbGlwwvZ/cay2SPNRX5KssqKAlcHVZP2m8g==}
+  '@docusaurus/plugin-client-redirects@3.8.0':
+    resolution: {integrity: sha512-J8f5qzAlO61BnG1I91+N5WH1b/lPWqn6ifTxf/Bluz9JVe1bhFNSl0yW03p+Ff3AFOINDy2ofX70al9nOnOLyw==}
     engines: {node: '>=18.0'}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
-  '@docusaurus/plugin-content-blog@3.7.0':
-    resolution: {integrity: sha512-EFLgEz6tGHYWdPU0rK8tSscZwx+AsyuBW/r+tNig2kbccHYGUJmZtYN38GjAa3Fda4NU+6wqUO5kTXQSRBQD3g==}
+  '@docusaurus/plugin-content-blog@3.8.0':
+    resolution: {integrity: sha512-0SlOTd9R55WEr1GgIXu+hhTT0hzARYx3zIScA5IzpdekZQesI/hKEa5LPHBd415fLkWMjdD59TaW/3qQKpJ0Lg==}
     engines: {node: '>=18.0'}
     peerDependencies:
       '@docusaurus/plugin-content-docs': '*'
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
-  '@docusaurus/plugin-content-docs@3.7.0':
-    resolution: {integrity: sha512-GXg5V7kC9FZE4FkUZA8oo/NrlRb06UwuICzI6tcbzj0+TVgjq/mpUXXzSgKzMS82YByi4dY2Q808njcBCyy6tQ==}
+  '@docusaurus/plugin-content-docs@3.8.0':
+    resolution: {integrity: sha512-fRDMFLbUN6eVRXcjP8s3Y7HpAt9pzPYh1F/7KKXOCxvJhjjCtbon4VJW0WndEPInVz4t8QUXn5QZkU2tGVCE2g==}
     engines: {node: '>=18.0'}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
-  '@docusaurus/plugin-content-pages@3.7.0':
-    resolution: {integrity: sha512-YJSU3tjIJf032/Aeao8SZjFOrXJbz/FACMveSMjLyMH4itQyZ2XgUIzt4y+1ISvvk5zrW4DABVT2awTCqBkx0Q==}
+  '@docusaurus/plugin-content-pages@3.8.0':
+    resolution: {integrity: sha512-39EDx2y1GA0Pxfion5tQZLNJxL4gq6susd1xzetVBjVIQtwpCdyloOfQBAgX0FylqQxfJrYqL0DIUuq7rd7uBw==}
     engines: {node: '>=18.0'}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
-  '@docusaurus/plugin-debug@3.7.0':
-    resolution: {integrity: sha512-Qgg+IjG/z4svtbCNyTocjIwvNTNEwgRjSXXSJkKVG0oWoH0eX/HAPiu+TS1HBwRPQV+tTYPWLrUypYFepfujZA==}
+  '@docusaurus/plugin-css-cascade-layers@3.8.0':
+    resolution: {integrity: sha512-/VBTNymPIxQB8oA3ZQ4GFFRYdH4ZxDRRBECxyjRyv486mfUPXfcdk+im4S5mKWa6EK2JzBz95IH/Wu0qQgJ5yQ==}
+    engines: {node: '>=18.0'}
+
+  '@docusaurus/plugin-debug@3.8.0':
+    resolution: {integrity: sha512-teonJvJsDB9o2OnG6ifbhblg/PXzZvpUKHFgD8dOL1UJ58u0lk8o0ZOkvaYEBa9nDgqzoWrRk9w+e3qaG2mOhQ==}
     engines: {node: '>=18.0'}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
-  '@docusaurus/plugin-google-analytics@3.7.0':
-    resolution: {integrity: sha512-otIqiRV/jka6Snjf+AqB360XCeSv7lQC+DKYW+EUZf6XbuE8utz5PeUQ8VuOcD8Bk5zvT1MC4JKcd5zPfDuMWA==}
+  '@docusaurus/plugin-google-analytics@3.8.0':
+    resolution: {integrity: sha512-aKKa7Q8+3xRSRESipNvlFgNp3FNPELKhuo48Cg/svQbGNwidSHbZT03JqbW4cBaQnyyVchO1ttk+kJ5VC9Gx0w==}
     engines: {node: '>=18.0'}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
-  '@docusaurus/plugin-google-gtag@3.7.0':
-    resolution: {integrity: sha512-M3vrMct1tY65ModbyeDaMoA+fNJTSPe5qmchhAbtqhDD/iALri0g9LrEpIOwNaoLmm6lO88sfBUADQrSRSGSWA==}
+  '@docusaurus/plugin-google-gtag@3.8.0':
+    resolution: {integrity: sha512-ugQYMGF4BjbAW/JIBtVcp+9eZEgT9HRdvdcDudl5rywNPBA0lct+lXMG3r17s02rrhInMpjMahN3Yc9Cb3H5/g==}
     engines: {node: '>=18.0'}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
-  '@docusaurus/plugin-google-tag-manager@3.7.0':
-    resolution: {integrity: sha512-X8U78nb8eiMiPNg3jb9zDIVuuo/rE1LjGDGu+5m5CX4UBZzjMy+klOY2fNya6x8ACyE/L3K2erO1ErheP55W/w==}
+  '@docusaurus/plugin-google-tag-manager@3.8.0':
+    resolution: {integrity: sha512-9juRWxbwZD3SV02Jd9QB6yeN7eu+7T4zB0bvJLcVQwi+am51wAxn2CwbdL0YCCX+9OfiXbADE8D8Q65Hbopu/w==}
     engines: {node: '>=18.0'}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
-  '@docusaurus/plugin-sitemap@3.7.0':
-    resolution: {integrity: sha512-bTRT9YLZ/8I/wYWKMQke18+PF9MV8Qub34Sku6aw/vlZ/U+kuEuRpQ8bTcNOjaTSfYsWkK4tTwDMHK2p5S86cA==}
+  '@docusaurus/plugin-sitemap@3.8.0':
+    resolution: {integrity: sha512-fGpOIyJvNiuAb90nSJ2Gfy/hUOaDu6826e5w5UxPmbpCIc7KlBHNAZ5g4L4ZuHhc4hdfq4mzVBsQSnne+8Ze1g==}
     engines: {node: '>=18.0'}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
-  '@docusaurus/plugin-svgr@3.7.0':
-    resolution: {integrity: sha512-HByXIZTbc4GV5VAUkZ2DXtXv1Qdlnpk3IpuImwSnEzCDBkUMYcec5282hPjn6skZqB25M1TYCmWS91UbhBGxQg==}
+  '@docusaurus/plugin-svgr@3.8.0':
+    resolution: {integrity: sha512-kEDyry+4OMz6BWLG/lEqrNsL/w818bywK70N1gytViw4m9iAmoxCUT7Ri9Dgs7xUdzCHJ3OujolEmD88Wy44OA==}
     engines: {node: '>=18.0'}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
-  '@docusaurus/preset-classic@3.7.0':
-    resolution: {integrity: sha512-nPHj8AxDLAaQXs+O6+BwILFuhiWbjfQWrdw2tifOClQoNfuXDjfjogee6zfx6NGHWqshR23LrcN115DmkHC91Q==}
+  '@docusaurus/preset-classic@3.8.0':
+    resolution: {integrity: sha512-qOu6tQDOWv+rpTlKu+eJATCJVGnABpRCPuqf7LbEaQ1mNY//N/P8cHQwkpAU+aweQfarcZ0XfwCqRHJfjeSV/g==}
     engines: {node: '>=18.0'}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
@@ -2341,58 +2311,58 @@ packages:
     peerDependencies:
       react: '*'
 
-  '@docusaurus/theme-classic@3.7.0':
-    resolution: {integrity: sha512-MnLxG39WcvLCl4eUzHr0gNcpHQfWoGqzADCly54aqCofQX6UozOS9Th4RK3ARbM9m7zIRv3qbhggI53dQtx/hQ==}
+  '@docusaurus/theme-classic@3.8.0':
+    resolution: {integrity: sha512-nQWFiD5ZjoT76OaELt2n33P3WVuuCz8Dt5KFRP2fCBo2r9JCLsp2GJjZpnaG24LZ5/arRjv4VqWKgpK0/YLt7g==}
     engines: {node: '>=18.0'}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
-  '@docusaurus/theme-common@3.7.0':
-    resolution: {integrity: sha512-8eJ5X0y+gWDsURZnBfH0WabdNm8XMCXHv8ENy/3Z/oQKwaB/EHt5lP9VsTDTf36lKEp0V6DjzjFyFIB+CetL0A==}
+  '@docusaurus/theme-common@3.8.0':
+    resolution: {integrity: sha512-YqV2vAWpXGLA+A3PMLrOMtqgTHJLDcT+1Caa6RF7N4/IWgrevy5diY8oIHFkXR/eybjcrFFjUPrHif8gSGs3Tw==}
     engines: {node: '>=18.0'}
     peerDependencies:
       '@docusaurus/plugin-content-docs': '*'
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
-  '@docusaurus/theme-mermaid@3.7.0':
-    resolution: {integrity: sha512-7kNDvL7hm+tshjxSxIqYMtsLUPsEBYnkevej/ext6ru9xyLgCed+zkvTfGzTWNeq8rJIEe2YSS8/OV5gCVaPCw==}
+  '@docusaurus/theme-mermaid@3.8.0':
+    resolution: {integrity: sha512-ou0NJM37p4xrVuFaZp8qFe5Z/qBq9LuyRTP4KKRa0u2J3zC4f3saBJDgc56FyvvN1OsmU0189KGEPUjTr6hFxg==}
     engines: {node: '>=18.0'}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
-  '@docusaurus/theme-search-algolia@3.7.0':
-    resolution: {integrity: sha512-Al/j5OdzwRU1m3falm+sYy9AaB93S1XF1Lgk9Yc6amp80dNxJVplQdQTR4cYdzkGtuQqbzUA8+kaoYYO0RbK6g==}
+  '@docusaurus/theme-search-algolia@3.8.0':
+    resolution: {integrity: sha512-GBZ5UOcPgiu6nUw153+0+PNWvFKweSnvKIL6Rp04H9olKb475jfKjAwCCtju5D2xs5qXHvCMvzWOg5o9f6DtuQ==}
     engines: {node: '>=18.0'}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
-  '@docusaurus/theme-translations@3.7.0':
-    resolution: {integrity: sha512-Ewq3bEraWDmienM6eaNK7fx+/lHMtGDHQyd1O+4+3EsDxxUmrzPkV7Ct3nBWTuE0MsoZr3yNwQVKjllzCMuU3g==}
+  '@docusaurus/theme-translations@3.8.0':
+    resolution: {integrity: sha512-1DTy/snHicgkCkryWq54fZvsAglTdjTx4qjOXgqnXJ+DIty1B+aPQrAVUu8LiM+6BiILfmNxYsxhKTj+BS3PZg==}
     engines: {node: '>=18.0'}
 
-  '@docusaurus/tsconfig@3.7.0':
-    resolution: {integrity: sha512-vRsyj3yUZCjscgfgcFYjIsTcAru/4h4YH2/XAE8Rs7wWdnng98PgWKvP5ovVc4rmRpRg2WChVW0uOy2xHDvDBQ==}
+  '@docusaurus/tsconfig@3.8.0':
+    resolution: {integrity: sha512-utLl48nNjSYBoq47RKukZ9fPLEX3nJWThzrujb0ndQQ1jc/gh4RhTRaAqItH9nImnsgGKmLMnyoMBpfGmoop+w==}
 
-  '@docusaurus/types@3.7.0':
-    resolution: {integrity: sha512-kOmZg5RRqJfH31m+6ZpnwVbkqMJrPOG5t0IOl4i/+3ruXyNfWzZ0lVtVrD0u4ONc/0NOsS9sWYaxxWNkH1LdLQ==}
+  '@docusaurus/types@3.8.0':
+    resolution: {integrity: sha512-RDEClpwNxZq02c+JlaKLWoS13qwWhjcNsi2wG1UpzmEnuti/z1Wx4SGpqbUqRPNSd8QWWePR8Cb7DvG0VN/TtA==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
-  '@docusaurus/utils-common@3.7.0':
-    resolution: {integrity: sha512-IZeyIfCfXy0Mevj6bWNg7DG7B8G+S6o6JVpddikZtWyxJguiQ7JYr0SIZ0qWd8pGNuMyVwriWmbWqMnK7Y5PwA==}
+  '@docusaurus/utils-common@3.8.0':
+    resolution: {integrity: sha512-3TGF+wVTGgQ3pAc9+5jVchES4uXUAhAt9pwv7uws4mVOxL4alvU3ue/EZ+R4XuGk94pDy7CNXjRXpPjlfZXQfw==}
     engines: {node: '>=18.0'}
 
-  '@docusaurus/utils-validation@3.7.0':
-    resolution: {integrity: sha512-w8eiKk8mRdN+bNfeZqC4nyFoxNyI1/VExMKAzD9tqpJfLLbsa46Wfn5wcKH761g9WkKh36RtFV49iL9lh1DYBA==}
+  '@docusaurus/utils-validation@3.8.0':
+    resolution: {integrity: sha512-MrnEbkigr54HkdFeg8e4FKc4EF+E9dlVwsY3XQZsNkbv3MKZnbHQ5LsNJDIKDROFe8PBf5C4qCAg5TPBpsjrjg==}
     engines: {node: '>=18.0'}
 
-  '@docusaurus/utils@3.7.0':
-    resolution: {integrity: sha512-e7zcB6TPnVzyUaHMJyLSArKa2AG3h9+4CfvKXKKWNx6hRs+p0a+u7HHTJBgo6KW2m+vqDnuIHK4X+bhmoghAFA==}
+  '@docusaurus/utils@3.8.0':
+    resolution: {integrity: sha512-2wvtG28ALCN/A1WCSLxPASFBFzXCnP0YKCAFIPcvEb6imNu1wg7ni/Svcp71b3Z2FaOFFIv4Hq+j4gD7gA0yfQ==}
     engines: {node: '>=18.0'}
 
   '@electron/asar@3.4.1':
@@ -4276,9 +4246,6 @@ packages:
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
 
-  '@types/parse-json@4.0.2':
-    resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
-
   '@types/plist@3.0.5':
     resolution: {integrity: sha512-E6OCaRmAe4WDmWNsL/9RMqdkkzDCY1etutkflWk4c+AcjDU07Pcz1fQwTX0TQz+Pxqn9i4L1TU3UFpjnrcDgxA==}
 
@@ -5738,10 +5705,6 @@ packages:
       cosmiconfig: '>=9'
       typescript: '>=5'
 
-  cosmiconfig@6.0.0:
-    resolution: {integrity: sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==}
-    engines: {node: '>=8'}
-
   cosmiconfig@8.3.6:
     resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
     engines: {node: '>=14'}
@@ -6215,10 +6178,6 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
-  del@6.1.1:
-    resolution: {integrity: sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==}
-    engines: {node: '>=10'}
-
   delaunator@5.0.1:
     resolution: {integrity: sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==}
 
@@ -6255,11 +6214,6 @@ packages:
 
   detect-node@2.1.0:
     resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
-
-  detect-port-alt@1.1.6:
-    resolution: {integrity: sha512-5tQykt+LqfJFBEYaDITx7S7cR7mJ/zQmLXZ2qt5w04ainYZw6tBf9dBunMjVeVOdYVRUzUOE4HkY5J7+uttb5Q==}
-    engines: {node: '>= 4.2.1'}
-    hasBin: true
 
   detect-port@1.6.1:
     resolution: {integrity: sha512-CmnVc+Hek2egPx1PeTFVta2W78xy2K/9Rkf6cC4T59S50tVnzKj+tnx5mmx5lwvCkujZ4uRrpRSuV+IVs3f90Q==}
@@ -6505,10 +6459,6 @@ packages:
   end-of-stream@1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
 
-  enhanced-resolve@5.17.1:
-    resolution: {integrity: sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==}
-    engines: {node: '>=10.13.0'}
-
   enhanced-resolve@5.18.1:
     resolution: {integrity: sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==}
     engines: {node: '>=10.13.0'}
@@ -6553,9 +6503,6 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
-
-  es-module-lexer@1.5.4:
-    resolution: {integrity: sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==}
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
@@ -7018,10 +6965,6 @@ packages:
     resolution: {integrity: sha512-sJslQKU2uM33qH5nqewAwVB2QgR6w1aMNsYUp3aN5rMRyXEwJGmZvaWzeJFNTOXWlHQyBFCWrdj3fV/fsTOX8w==}
     engines: {node: '>= 10.4.0'}
 
-  filesize@8.0.7:
-    resolution: {integrity: sha512-pjmC+bkIF8XI7fWaH8KxHcZL3DPybs1roSKP4rKDvy20tAWwIObE4+JIseG2byfGKhud5ZnM4YSGKBz7Sh0ndQ==}
-    engines: {node: '>= 0.4.0'}
-
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -7037,10 +6980,6 @@ packages:
   find-up-simple@1.0.1:
     resolution: {integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==}
     engines: {node: '>=18'}
-
-  find-up@3.0.0:
-    resolution: {integrity: sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==}
-    engines: {node: '>=6'}
 
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
@@ -7090,20 +7029,6 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  fork-ts-checker-webpack-plugin@6.5.3:
-    resolution: {integrity: sha512-SbH/l9ikmMWycd5puHJKTkZJKddF4iRLyW3DeZ08HTI7NGyLS38MXd/KGgeWumQO7YNQbW2u/NtPT2YowbPaGQ==}
-    engines: {node: '>=10', yarn: '>=1.0.0'}
-    peerDependencies:
-      eslint: '>= 6'
-      typescript: '>= 2.7'
-      vue-template-compiler: '*'
-      webpack: '>= 4'
-    peerDependenciesMeta:
-      eslint:
-        optional: true
-      vue-template-compiler:
-        optional: true
-
   form-data-encoder@2.1.4:
     resolution: {integrity: sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==}
     engines: {node: '>= 14.17'}
@@ -7137,10 +7062,6 @@ packages:
   fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
     engines: {node: '>=12'}
-
-  fs-extra@11.2.0:
-    resolution: {integrity: sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==}
-    engines: {node: '>=14.14'}
 
   fs-extra@11.3.0:
     resolution: {integrity: sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==}
@@ -7289,14 +7210,6 @@ packages:
   global-dirs@3.0.1:
     resolution: {integrity: sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==}
     engines: {node: '>=10'}
-
-  global-modules@2.0.0:
-    resolution: {integrity: sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==}
-    engines: {node: '>=6'}
-
-  global-prefix@3.0.0:
-    resolution: {integrity: sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==}
-    engines: {node: '>=6'}
 
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -7632,9 +7545,6 @@ packages:
     engines: {node: '>=16.x'}
     hasBin: true
 
-  immer@9.0.21:
-    resolution: {integrity: sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==}
-
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -7702,10 +7612,6 @@ packages:
   internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
-
-  interpret@1.4.0:
-    resolution: {integrity: sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==}
-    engines: {node: '>= 0.10'}
 
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
@@ -7889,10 +7795,6 @@ packages:
     resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
     engines: {node: '>=8'}
 
-  is-path-cwd@2.2.0:
-    resolution: {integrity: sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==}
-    engines: {node: '>=6'}
-
   is-path-inside@3.0.3:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
     engines: {node: '>=8'}
@@ -7933,10 +7835,6 @@ packages:
   is-regexp@1.0.0:
     resolution: {integrity: sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==}
     engines: {node: '>=0.10.0'}
-
-  is-root@2.1.0:
-    resolution: {integrity: sha512-AGOriNp96vNBd3HtU+RzFEc75FfR5ymiYv8E553I71SCeXBiMsVDUtdio1OEFvrPyLIQ9tVR5RxXIFe5PUFjMg==}
-    engines: {node: '>=6'}
 
   is-set@2.0.3:
     resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
@@ -8077,10 +7975,6 @@ packages:
     resolution: {integrity: sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  jiti@1.21.6:
-    resolution: {integrity: sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==}
-    hasBin: true
-
   jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
@@ -8199,10 +8093,6 @@ packages:
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
-
-  katex@0.16.21:
-    resolution: {integrity: sha512-XvqR7FgOHtWupfMiigNzmh+MgUVmDGU2kXZm899ZkPfcuoPuFxyHmXsgATDpFZDAXCI8tvinaVcDo8PIIJSo4A==}
-    hasBin: true
 
   katex@0.16.22:
     resolution: {integrity: sha512-XCHRdUw4lf3SKBaJe4EvgqIuWwkPSo9XoeO8GjQW94Bp7TWv9hNhzZjZ+OH9yf1UmLygb7DIT5GSFQiyt16zYg==}
@@ -8382,20 +8272,12 @@ packages:
     resolution: {integrity: sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==}
     engines: {node: '>=8.9.0'}
 
-  loader-utils@3.3.1:
-    resolution: {integrity: sha512-FMJTLMXfCLMLfJxcX9PFqX5qD88Z5MRGaZCVzfuqeZSPsyiBzs+pahDQjbIWz2QIzPZz0NX9Zy4FX3lmK6YHIg==}
-    engines: {node: '>= 12.13.0'}
-
   local-pkg@1.0.0:
     resolution: {integrity: sha512-bbgPw/wmroJsil/GgL4qjDzs5YLTBMQ99weRsok1XCDccQeehbHA/I1oRvk2NPtr7KGZgT/Y5tPRnAtMqeG2Kg==}
     engines: {node: '>=14'}
 
   locate-character@3.0.0:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
-
-  locate-path@3.0.0:
-    resolution: {integrity: sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==}
-    engines: {node: '>=6'}
 
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
@@ -8836,10 +8718,6 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
-  mime-db@1.53.0:
-    resolution: {integrity: sha512-oHlN/w+3MQ3rba9rqFr6V/ypF10LSkdwUysQL7GkXoTgIWeV+tcXGA852TBxH+gsh8UWoyhR1hKcoMJTuWflpg==}
-    engines: {node: '>= 0.6'}
-
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
     engines: {node: '>= 0.6'}
@@ -9184,10 +9062,6 @@ packages:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
 
-  object.assign@4.1.5:
-    resolution: {integrity: sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==}
-    engines: {node: '>= 0.4'}
-
   object.assign@4.1.7:
     resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
     engines: {node: '>= 0.4'}
@@ -9282,6 +9156,10 @@ packages:
     resolution: {integrity: sha512-wBowNApzd45EIKdO1LaU+LrMBwAcjfPaYtVzV3lmfM3gf8Z4CHZsiIqlM8TZZ8okYvh5A1cP6gTfCRQtwUpaUg==}
     engines: {node: '>=14.16'}
 
+  p-finally@1.0.0:
+    resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
+    engines: {node: '>=4'}
+
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
@@ -9293,10 +9171,6 @@ packages:
   p-limit@4.0.0:
     resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  p-locate@3.0.0:
-    resolution: {integrity: sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==}
-    engines: {node: '>=6'}
 
   p-locate@4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
@@ -9314,8 +9188,16 @@ packages:
     resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
     engines: {node: '>=10'}
 
+  p-queue@6.6.2:
+    resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
+    engines: {node: '>=8'}
+
   p-retry@4.6.2:
     resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
+
+  p-timeout@3.2.0:
+    resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
     engines: {node: '>=8'}
 
   p-try@2.2.0:
@@ -9377,10 +9259,6 @@ packages:
 
   path-data-parser@0.1.0:
     resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
-
-  path-exists@3.0.0:
-    resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
-    engines: {node: '>=4'}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -9468,10 +9346,6 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
-
-  pkg-up@3.1.0:
-    resolution: {integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==}
-    engines: {node: '>=8'}
 
   playwright-core@1.52.0:
     resolution: {integrity: sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==}
@@ -10093,23 +9967,10 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
-  react-dev-utils@12.0.1:
-    resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      typescript: '>=2.7'
-      webpack: '>=4'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
       react: ^18.3.1
-
-  react-error-overlay@6.0.11:
-    resolution: {integrity: sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==}
 
   react-fast-compare@3.2.2:
     resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
@@ -10120,11 +9981,11 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
-  react-json-view-lite@1.5.0:
-    resolution: {integrity: sha512-nWqA1E4jKPklL2jvHWs6s+7Na0qNgw9HCP6xehdQJeg6nPBTFZgGwyko9Q0oj+jQWKTTVRS30u0toM5wiuL3iw==}
-    engines: {node: '>=14'}
+  react-json-view-lite@2.4.1:
+    resolution: {integrity: sha512-fwFYknRIBxjbFm0kBDrzgBy1xa5tDg2LyXXBepC5f1b+MY3BUClMCsvanMPn089JbV1Eg3nZcrp0VCuH43aXnA==}
+    engines: {node: '>=18'}
     peerDependencies:
-      react: ^16.13.1 || ^17.0.0 || ^18.0.0
+      react: ^18.0.0 || ^19.0.0
 
   react-loadable-ssr-addon-v5-slorber@1.0.1:
     resolution: {integrity: sha512-lq3Lyw1lGku8zUEJPDxsNm1AfYHBrO9Y1+olAYwpUJ2IGFBskM0DMKok97A6LWUpHm+o7IvQBOWu9MLenp9Z+A==}
@@ -10191,16 +10052,9 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
-  reading-time@1.5.0:
-    resolution: {integrity: sha512-onYyVhBNr4CmAxFsKS7bz+uTLRakypIe4R+5A824vBSkQy/hB3fZepoVEf8OVAxzLvK+H/jm9TzpI3ETSm64Kg==}
-
   recast@0.23.9:
     resolution: {integrity: sha512-Hx/BGIbwj+Des3+xy5uAtAbdCyqK9y9wbBcDFDYanLS9JnMqf7OeF87HQwUimE87OEc72mr6tkKUKMBBL+hF9Q==}
     engines: {node: '>= 4'}
-
-  rechoir@0.6.2:
-    resolution: {integrity: sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==}
-    engines: {node: '>= 0.10'}
 
   recma-build-jsx@1.0.0:
     resolution: {integrity: sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==}
@@ -10213,10 +10067,6 @@ packages:
 
   recma-stringify@1.0.0:
     resolution: {integrity: sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==}
-
-  recursive-readdir@2.2.3:
-    resolution: {integrity: sha512-8HrF5ZsXk5FAH9dgsx3BlUer73nIhuj+9OrQwEbLTPOBzGkL1lsFCR01am+v+0m2Cmbs1nP12hLDl5FA7EszKA==}
-    engines: {node: '>=6.0.0'}
 
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
@@ -10262,10 +10112,6 @@ packages:
   regexpu-core@6.1.1:
     resolution: {integrity: sha512-k67Nb9jvwJcJmVpw0jPttR1/zVfnKf8Km0IPatrU/zJ5XeG3+Slx0xLXs9HByJSzXzrlz5EDvN6yLNMDc2qdnw==}
     engines: {node: '>=4'}
-
-  registry-auth-token@5.0.2:
-    resolution: {integrity: sha512-o/3ikDxtXaA59BmZuZrJZDJv8NMDGSj+6j6XaeBmHw8eY1i1qd9+6H+LjVvQXx3HN6aRCGa1cUdJ9RaJZUugnQ==}
-    engines: {node: '>=14'}
 
   registry-auth-token@5.1.0:
     resolution: {integrity: sha512-GdekYuwLXLxMuFTwAPg5UKGLW/UXzQrZvH/Zj791BQif5T05T0RsaLfHc9q3ZOKi7n+BoprPD9mJ0O0k4xzUlw==}
@@ -10489,9 +10335,8 @@ packages:
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
-  schema-utils@2.7.0:
-    resolution: {integrity: sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==}
-    engines: {node: '>= 8.9.0'}
+  schema-dts@1.1.5:
+    resolution: {integrity: sha512-RJr9EaCmsLzBX2NDiO5Z3ux2BVosNZN5jo0gWgsyKvxKIUL5R3swNvoorulAeL9kLB0iTSX7V6aokhla2m7xbg==}
 
   schema-utils@3.3.0:
     resolution: {integrity: sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==}
@@ -10616,11 +10461,6 @@ packages:
 
   shell-quote@1.8.1:
     resolution: {integrity: sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==}
-
-  shelljs@0.8.5:
-    resolution: {integrity: sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==}
-    engines: {node: '>=4'}
-    hasBin: true
 
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -11083,14 +10923,6 @@ packages:
 
   tailwindcss@4.1.8:
     resolution: {integrity: sha512-kjeW8gjdxasbmFKpVGrGd5T4i40mV5J2Rasw48QARfYeQ8YS9x02ON9SFWax3Qf616rt4Cp3nVNIj6Hd1mP3og==}
-
-  tapable@1.1.3:
-    resolution: {integrity: sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==}
-    engines: {node: '>=6'}
-
-  tapable@2.2.1:
-    resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
-    engines: {node: '>=6'}
 
   tapable@2.2.2:
     resolution: {integrity: sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==}
@@ -12053,30 +11885,30 @@ snapshots:
 
   '@adobe/css-tools@4.4.2': {}
 
-  '@algolia/autocomplete-core@1.17.7(@algolia/client-search@5.19.0)(algoliasearch@5.19.0)(search-insights@2.17.3)':
+  '@algolia/autocomplete-core@1.17.9(@algolia/client-search@5.19.0)(algoliasearch@5.19.0)(search-insights@2.17.3)':
     dependencies:
-      '@algolia/autocomplete-plugin-algolia-insights': 1.17.7(@algolia/client-search@5.19.0)(algoliasearch@5.19.0)(search-insights@2.17.3)
-      '@algolia/autocomplete-shared': 1.17.7(@algolia/client-search@5.19.0)(algoliasearch@5.19.0)
+      '@algolia/autocomplete-plugin-algolia-insights': 1.17.9(@algolia/client-search@5.19.0)(algoliasearch@5.19.0)(search-insights@2.17.3)
+      '@algolia/autocomplete-shared': 1.17.9(@algolia/client-search@5.19.0)(algoliasearch@5.19.0)
     transitivePeerDependencies:
       - '@algolia/client-search'
       - algoliasearch
       - search-insights
 
-  '@algolia/autocomplete-plugin-algolia-insights@1.17.7(@algolia/client-search@5.19.0)(algoliasearch@5.19.0)(search-insights@2.17.3)':
+  '@algolia/autocomplete-plugin-algolia-insights@1.17.9(@algolia/client-search@5.19.0)(algoliasearch@5.19.0)(search-insights@2.17.3)':
     dependencies:
-      '@algolia/autocomplete-shared': 1.17.7(@algolia/client-search@5.19.0)(algoliasearch@5.19.0)
+      '@algolia/autocomplete-shared': 1.17.9(@algolia/client-search@5.19.0)(algoliasearch@5.19.0)
       search-insights: 2.17.3
     transitivePeerDependencies:
       - '@algolia/client-search'
       - algoliasearch
 
-  '@algolia/autocomplete-preset-algolia@1.17.7(@algolia/client-search@5.19.0)(algoliasearch@5.19.0)':
+  '@algolia/autocomplete-preset-algolia@1.17.9(@algolia/client-search@5.19.0)(algoliasearch@5.19.0)':
     dependencies:
-      '@algolia/autocomplete-shared': 1.17.7(@algolia/client-search@5.19.0)(algoliasearch@5.19.0)
+      '@algolia/autocomplete-shared': 1.17.9(@algolia/client-search@5.19.0)(algoliasearch@5.19.0)
       '@algolia/client-search': 5.19.0
       algoliasearch: 5.19.0
 
-  '@algolia/autocomplete-shared@1.17.7(@algolia/client-search@5.19.0)(algoliasearch@5.19.0)':
+  '@algolia/autocomplete-shared@1.17.9(@algolia/client-search@5.19.0)(algoliasearch@5.19.0)':
     dependencies:
       '@algolia/client-search': 5.19.0
       algoliasearch: 5.19.0
@@ -12246,14 +12078,12 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/compat-data@7.26.2': {}
-
   '@babel/compat-data@7.26.8': {}
 
   '@babel/core@7.26.10':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@babel/code-frame': 7.26.2
+      '@babel/code-frame': 7.27.1
       '@babel/generator': 7.26.10
       '@babel/helper-compilation-targets': 7.26.5
       '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.10)
@@ -12284,18 +12114,10 @@ snapshots:
 
   '@babel/helper-builder-binary-assignment-operator-visitor@7.25.9':
     dependencies:
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.26.10
       '@babel/types': 7.27.1
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/helper-compilation-targets@7.25.9':
-    dependencies:
-      '@babel/compat-data': 7.26.2
-      '@babel/helper-validator-option': 7.25.9
-      browserslist: 4.24.5
-      lru-cache: 5.1.1
-      semver: 6.3.1
 
   '@babel/helper-compilation-targets@7.26.5':
     dependencies:
@@ -12313,7 +12135,7 @@ snapshots:
       '@babel/helper-optimise-call-expression': 7.25.9
       '@babel/helper-replace-supers': 7.25.9(@babel/core@7.26.10)
       '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.26.10
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -12328,7 +12150,7 @@ snapshots:
   '@babel/helper-define-polyfill-provider@0.6.3(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-compilation-targets': 7.25.9
+      '@babel/helper-compilation-targets': 7.26.5
       '@babel/helper-plugin-utils': 7.25.9
       debug: 4.4.1
       lodash.debounce: 4.0.8
@@ -12338,14 +12160,14 @@ snapshots:
 
   '@babel/helper-member-expression-to-functions@7.25.9':
     dependencies:
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.26.10
       '@babel/types': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-module-imports@7.25.9':
     dependencies:
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.26.10
       '@babel/types': 7.27.1
     transitivePeerDependencies:
       - supports-color
@@ -12370,7 +12192,7 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-annotate-as-pure': 7.25.9
       '@babel/helper-wrap-function': 7.25.9
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.26.10
     transitivePeerDependencies:
       - supports-color
 
@@ -12379,20 +12201,20 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-member-expression-to-functions': 7.25.9
       '@babel/helper-optimise-call-expression': 7.25.9
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.26.10
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-simple-access@7.25.9':
     dependencies:
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.26.10
       '@babel/types': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-skip-transparent-expression-wrappers@7.25.9':
     dependencies:
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.26.10
       '@babel/types': 7.27.1
     transitivePeerDependencies:
       - supports-color
@@ -12407,8 +12229,8 @@ snapshots:
 
   '@babel/helper-wrap-function@7.25.9':
     dependencies:
-      '@babel/template': 7.25.9
-      '@babel/traverse': 7.25.9
+      '@babel/template': 7.26.9
+      '@babel/traverse': 7.26.10
       '@babel/types': 7.27.1
     transitivePeerDependencies:
       - supports-color
@@ -12426,7 +12248,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.25.9
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.26.10
     transitivePeerDependencies:
       - supports-color
 
@@ -12453,7 +12275,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.25.9
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.26.10
     transitivePeerDependencies:
       - supports-color
 
@@ -12502,7 +12324,7 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.25.9
       '@babel/helper-remap-async-to-generator': 7.25.9(@babel/core@7.26.10)
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.26.10
     transitivePeerDependencies:
       - supports-color
 
@@ -12545,10 +12367,10 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-annotate-as-pure': 7.25.9
-      '@babel/helper-compilation-targets': 7.25.9
+      '@babel/helper-compilation-targets': 7.26.5
       '@babel/helper-plugin-utils': 7.25.9
       '@babel/helper-replace-supers': 7.25.9(@babel/core@7.26.10)
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.26.10
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -12557,7 +12379,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.25.9
-      '@babel/template': 7.25.9
+      '@babel/template': 7.26.9
 
   '@babel/plugin-transform-destructuring@7.25.9(@babel/core@7.26.10)':
     dependencies:
@@ -12610,9 +12432,9 @@ snapshots:
   '@babel/plugin-transform-function-name@7.25.9(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-compilation-targets': 7.25.9
+      '@babel/helper-compilation-targets': 7.26.5
       '@babel/helper-plugin-utils': 7.25.9
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.26.10
     transitivePeerDependencies:
       - supports-color
 
@@ -12659,7 +12481,7 @@ snapshots:
       '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.10)
       '@babel/helper-plugin-utils': 7.25.9
       '@babel/helper-validator-identifier': 7.27.1
-      '@babel/traverse': 7.25.9
+      '@babel/traverse': 7.26.10
     transitivePeerDependencies:
       - supports-color
 
@@ -12695,7 +12517,7 @@ snapshots:
   '@babel/plugin-transform-object-rest-spread@7.25.9(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-compilation-targets': 7.25.9
+      '@babel/helper-compilation-targets': 7.26.5
       '@babel/helper-plugin-utils': 7.25.9
       '@babel/plugin-transform-parameters': 7.25.9(@babel/core@7.26.10)
 
@@ -12874,9 +12696,9 @@ snapshots:
 
   '@babel/preset-env@7.26.0(@babel/core@7.26.10)':
     dependencies:
-      '@babel/compat-data': 7.26.2
+      '@babel/compat-data': 7.26.8
       '@babel/core': 7.26.10
-      '@babel/helper-compilation-targets': 7.25.9
+      '@babel/helper-compilation-targets': 7.26.5
       '@babel/helper-plugin-utils': 7.25.9
       '@babel/helper-validator-option': 7.25.9
       '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.25.9(@babel/core@7.26.10)
@@ -12990,33 +12812,15 @@ snapshots:
 
   '@babel/runtime@7.27.4': {}
 
-  '@babel/template@7.25.9':
-    dependencies:
-      '@babel/code-frame': 7.26.2
-      '@babel/parser': 7.27.2
-      '@babel/types': 7.27.1
-
   '@babel/template@7.26.9':
     dependencies:
-      '@babel/code-frame': 7.26.2
+      '@babel/code-frame': 7.27.1
       '@babel/parser': 7.27.2
       '@babel/types': 7.27.1
-
-  '@babel/traverse@7.25.9':
-    dependencies:
-      '@babel/code-frame': 7.26.2
-      '@babel/generator': 7.26.10
-      '@babel/parser': 7.27.2
-      '@babel/template': 7.25.9
-      '@babel/types': 7.27.1
-      debug: 4.4.1
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/traverse@7.26.10':
     dependencies:
-      '@babel/code-frame': 7.26.2
+      '@babel/code-frame': 7.27.1
       '@babel/generator': 7.26.10
       '@babel/parser': 7.27.2
       '@babel/template': 7.26.9
@@ -13220,24 +13024,10 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
 
-  '@csstools/color-helpers@5.0.1': {}
-
   '@csstools/color-helpers@5.0.2': {}
-
-  '@csstools/css-calc@2.1.1(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)':
-    dependencies:
-      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
-      '@csstools/css-tokenizer': 3.0.3
 
   '@csstools/css-calc@2.1.3(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)':
     dependencies:
-      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
-      '@csstools/css-tokenizer': 3.0.3
-
-  '@csstools/css-color-parser@3.0.7(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)':
-    dependencies:
-      '@csstools/color-helpers': 5.0.1
-      '@csstools/css-calc': 2.1.3(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
 
@@ -13267,7 +13057,7 @@ snapshots:
 
   '@csstools/postcss-color-function@4.0.6(postcss@8.5.4)':
     dependencies:
-      '@csstools/css-color-parser': 3.0.7(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-color-parser': 3.0.9(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.5.4)
@@ -13276,7 +13066,7 @@ snapshots:
 
   '@csstools/postcss-color-mix-function@3.0.6(postcss@8.5.4)':
     dependencies:
-      '@csstools/css-color-parser': 3.0.7(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-color-parser': 3.0.9(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.5.4)
@@ -13293,7 +13083,7 @@ snapshots:
 
   '@csstools/postcss-exponential-functions@2.0.5(postcss@8.5.4)':
     dependencies:
-      '@csstools/css-calc': 2.1.1(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-calc': 2.1.3(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       postcss: 8.5.4
@@ -13306,14 +13096,14 @@ snapshots:
 
   '@csstools/postcss-gamut-mapping@2.0.6(postcss@8.5.4)':
     dependencies:
-      '@csstools/css-color-parser': 3.0.7(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-color-parser': 3.0.9(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       postcss: 8.5.4
 
   '@csstools/postcss-gradients-interpolation-method@5.0.6(postcss@8.5.4)':
     dependencies:
-      '@csstools/css-color-parser': 3.0.7(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-color-parser': 3.0.9(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.5.4)
@@ -13322,7 +13112,7 @@ snapshots:
 
   '@csstools/postcss-hwb-function@4.0.6(postcss@8.5.4)':
     dependencies:
-      '@csstools/css-color-parser': 3.0.7(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-color-parser': 3.0.9(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.5.4)
@@ -13379,7 +13169,7 @@ snapshots:
 
   '@csstools/postcss-media-minmax@2.0.5(postcss@8.5.4)':
     dependencies:
-      '@csstools/css-calc': 2.1.1(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-calc': 2.1.3(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       '@csstools/media-query-list-parser': 4.0.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
@@ -13405,7 +13195,7 @@ snapshots:
 
   '@csstools/postcss-oklab-function@4.0.6(postcss@8.5.4)':
     dependencies:
-      '@csstools/css-color-parser': 3.0.7(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-color-parser': 3.0.9(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.5.4)
@@ -13419,14 +13209,14 @@ snapshots:
 
   '@csstools/postcss-random-function@1.0.1(postcss@8.5.4)':
     dependencies:
-      '@csstools/css-calc': 2.1.1(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-calc': 2.1.3(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       postcss: 8.5.4
 
   '@csstools/postcss-relative-color-syntax@3.0.6(postcss@8.5.4)':
     dependencies:
-      '@csstools/css-color-parser': 3.0.7(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-color-parser': 3.0.9(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.5.4)
@@ -13440,27 +13230,27 @@ snapshots:
 
   '@csstools/postcss-sign-functions@1.1.0(postcss@8.5.4)':
     dependencies:
-      '@csstools/css-calc': 2.1.1(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-calc': 2.1.3(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       postcss: 8.5.4
 
   '@csstools/postcss-stepped-value-functions@4.0.5(postcss@8.5.4)':
     dependencies:
-      '@csstools/css-calc': 2.1.1(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-calc': 2.1.3(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       postcss: 8.5.4
 
   '@csstools/postcss-text-decoration-shorthand@4.0.1(postcss@8.5.4)':
     dependencies:
-      '@csstools/color-helpers': 5.0.1
+      '@csstools/color-helpers': 5.0.2
       postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
   '@csstools/postcss-trigonometric-functions@4.0.5(postcss@8.5.4)':
     dependencies:
-      '@csstools/css-calc': 2.1.1(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-calc': 2.1.3(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       postcss: 8.5.4
@@ -13490,13 +13280,13 @@ snapshots:
 
   '@docker/extension-api-client-types@0.3.4': {}
 
-  '@docsearch/css@3.8.2': {}
+  '@docsearch/css@3.9.0': {}
 
-  '@docsearch/react@3.8.2(@algolia/client-search@5.19.0)(@types/react@18.3.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)':
+  '@docsearch/react@3.9.0(@algolia/client-search@5.19.0)(@types/react@18.3.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)':
     dependencies:
-      '@algolia/autocomplete-core': 1.17.7(@algolia/client-search@5.19.0)(algoliasearch@5.19.0)(search-insights@2.17.3)
-      '@algolia/autocomplete-preset-algolia': 1.17.7(@algolia/client-search@5.19.0)(algoliasearch@5.19.0)
-      '@docsearch/css': 3.8.2
+      '@algolia/autocomplete-core': 1.17.9(@algolia/client-search@5.19.0)(algoliasearch@5.19.0)(search-insights@2.17.3)
+      '@algolia/autocomplete-preset-algolia': 1.17.9(@algolia/client-search@5.19.0)(algoliasearch@5.19.0)
+      '@docsearch/css': 3.9.0
       algoliasearch: 5.19.0
     optionalDependencies:
       '@types/react': 18.3.12
@@ -13506,7 +13296,7 @@ snapshots:
     transitivePeerDependencies:
       - '@algolia/client-search'
 
-  '@docusaurus/babel@3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@docusaurus/babel@3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/generator': 7.26.10
@@ -13515,13 +13305,13 @@ snapshots:
       '@babel/preset-env': 7.26.0(@babel/core@7.26.10)
       '@babel/preset-react': 7.26.3(@babel/core@7.26.10)
       '@babel/preset-typescript': 7.26.0(@babel/core@7.26.10)
-      '@babel/runtime': 7.26.10
+      '@babel/runtime': 7.27.4
       '@babel/runtime-corejs3': 7.26.10
-      '@babel/traverse': 7.25.9
-      '@docusaurus/logger': 3.7.0
-      '@docusaurus/utils': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@babel/traverse': 7.26.10
+      '@docusaurus/logger': 3.8.0
+      '@docusaurus/utils': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       babel-plugin-dynamic-import-node: 2.3.3
-      fs-extra: 11.2.0
+      fs-extra: 11.3.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@swc/core'
@@ -13533,14 +13323,14 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/bundler@3.7.0(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)':
+  '@docusaurus/bundler@3.8.0(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)':
     dependencies:
       '@babel/core': 7.26.10
-      '@docusaurus/babel': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/cssnano-preset': 3.7.0
-      '@docusaurus/logger': 3.7.0
-      '@docusaurus/types': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/babel': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/cssnano-preset': 3.8.0
+      '@docusaurus/logger': 3.8.0
+      '@docusaurus/types': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       babel-loader: 9.2.1(@babel/core@7.26.10)(webpack@5.96.1)
       clean-css: 5.3.3
       copy-webpack-plugin: 11.0.0(webpack@5.96.1)
@@ -13554,7 +13344,6 @@ snapshots:
       postcss: 8.5.4
       postcss-loader: 7.3.4(postcss@8.5.4)(typescript@5.8.3)(webpack@5.96.1)
       postcss-preset-env: 10.1.1(postcss@8.5.4)
-      react-dev-utils: 12.0.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3)(webpack@5.96.1)
       terser-webpack-plugin: 5.3.10(webpack@5.96.1)
       tslib: 2.8.1
       url-loader: 4.1.1(file-loader@6.2.0(webpack@5.96.1))(webpack@5.96.1)
@@ -13568,25 +13357,23 @@ snapshots:
       - acorn
       - csso
       - esbuild
-      - eslint
       - lightningcss
       - react
       - react-dom
       - supports-color
       - typescript
       - uglify-js
-      - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/core@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)':
+  '@docusaurus/core@3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)':
     dependencies:
-      '@docusaurus/babel': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/bundler': 3.7.0(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
-      '@docusaurus/logger': 3.7.0
-      '@docusaurus/mdx-loader': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-common': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-validation': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/babel': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/bundler': 3.8.0(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      '@docusaurus/logger': 3.8.0
+      '@docusaurus/mdx-loader': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-common': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-validation': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       '@mdx-js/react': 3.1.0(@types/react@18.3.12)(react@18.2.0)
       boxen: 6.2.1
       chalk: 4.1.2
@@ -13595,20 +13382,20 @@ snapshots:
       combine-promises: 1.2.0
       commander: 5.1.0
       core-js: 3.39.0
-      del: 6.1.1
       detect-port: 1.6.1
       escape-html: 1.0.3
       eta: 2.2.0
       eval: 0.1.8
-      fs-extra: 11.2.0
+      execa: 5.1.1
+      fs-extra: 11.3.0
       html-tags: 3.3.1
       html-webpack-plugin: 5.6.3(webpack@5.96.1)
       leven: 3.1.0
       lodash: 4.17.21
+      open: 8.4.2
       p-map: 4.0.0
       prompts: 2.4.2
       react: 18.2.0
-      react-dev-utils: 12.0.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3)(webpack@5.96.1)
       react-dom: 18.3.1(react@18.2.0)
       react-helmet-async: '@slorber/react-helmet-async@1.3.0(react-dom@18.3.1(react@18.2.0))(react@18.2.0)'
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@18.2.0)'
@@ -13618,7 +13405,7 @@ snapshots:
       react-router-dom: 5.3.4(react@18.2.0)
       semver: 7.7.2
       serve-handler: 6.1.6
-      shelljs: 0.8.5
+      tinypool: 1.0.2
       tslib: 2.8.1
       update-notifier: 6.0.2
       webpack: 5.96.1
@@ -13636,38 +13423,36 @@ snapshots:
       - csso
       - debug
       - esbuild
-      - eslint
       - lightningcss
       - supports-color
       - typescript
       - uglify-js
       - utf-8-validate
-      - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/cssnano-preset@3.7.0':
+  '@docusaurus/cssnano-preset@3.8.0':
     dependencies:
       cssnano-preset-advanced: 6.1.2(postcss@8.5.4)
       postcss: 8.5.4
       postcss-sort-media-queries: 5.2.0(postcss@8.5.4)
       tslib: 2.8.1
 
-  '@docusaurus/logger@3.7.0':
+  '@docusaurus/logger@3.8.0':
     dependencies:
       chalk: 4.1.2
       tslib: 2.8.1
 
-  '@docusaurus/mdx-loader@3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@docusaurus/mdx-loader@3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@docusaurus/logger': 3.7.0
-      '@docusaurus/utils': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-validation': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/logger': 3.8.0
+      '@docusaurus/utils': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-validation': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       '@mdx-js/mdx': 3.1.0(acorn@8.14.1)
       '@slorber/remark-comment': 1.0.0
       escape-html: 1.0.3
       estree-util-value-to-estree: 3.3.3
       file-loader: 6.2.0(webpack@5.96.1)
-      fs-extra: 11.2.0
+      fs-extra: 11.3.0
       image-size: 1.2.1
       mdast-util-mdx: 3.0.0
       mdast-util-to-string: 4.0.0
@@ -13693,9 +13478,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/module-type-aliases@3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@docusaurus/module-type-aliases@3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@docusaurus/types': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/types': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       '@types/history': 4.7.11
       '@types/react': 18.3.12
       '@types/react-router-config': 5.0.11
@@ -13712,15 +13497,15 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/plugin-client-redirects@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)':
+  '@docusaurus/plugin-client-redirects@3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
-      '@docusaurus/logger': 3.7.0
-      '@docusaurus/utils': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-common': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-validation': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/core': 3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      '@docusaurus/logger': 3.8.0
+      '@docusaurus/utils': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-common': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-validation': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       eta: 2.2.0
-      fs-extra: 11.2.0
+      fs-extra: 11.3.0
       lodash: 4.17.21
       react: 18.2.0
       react-dom: 18.3.1(react@18.2.0)
@@ -13737,33 +13522,31 @@ snapshots:
       - csso
       - debug
       - esbuild
-      - eslint
       - lightningcss
       - supports-color
       - typescript
       - uglify-js
       - utf-8-validate
-      - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-content-blog@3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)':
+  '@docusaurus/plugin-content-blog@3.8.0(@docusaurus/plugin-content-docs@3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
-      '@docusaurus/logger': 3.7.0
-      '@docusaurus/mdx-loader': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
-      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/types': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-common': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-validation': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/core': 3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      '@docusaurus/logger': 3.8.0
+      '@docusaurus/mdx-loader': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/plugin-content-docs': 3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      '@docusaurus/theme-common': 3.8.0(@docusaurus/plugin-content-docs@3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/types': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-common': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-validation': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       cheerio: 1.0.0-rc.12
       feed: 4.2.2
-      fs-extra: 11.2.0
+      fs-extra: 11.3.0
       lodash: 4.17.21
       react: 18.2.0
       react-dom: 18.3.1(react@18.2.0)
-      reading-time: 1.5.0
+      schema-dts: 1.1.5
       srcset: 4.0.0
       tslib: 2.8.1
       unist-util-visit: 5.0.0
@@ -13781,33 +13564,32 @@ snapshots:
       - csso
       - debug
       - esbuild
-      - eslint
       - lightningcss
       - supports-color
       - typescript
       - uglify-js
       - utf-8-validate
-      - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)':
+  '@docusaurus/plugin-content-docs@3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
-      '@docusaurus/logger': 3.7.0
-      '@docusaurus/mdx-loader': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/module-type-aliases': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/types': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-common': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-validation': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/core': 3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      '@docusaurus/logger': 3.8.0
+      '@docusaurus/mdx-loader': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/module-type-aliases': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/theme-common': 3.8.0(@docusaurus/plugin-content-docs@3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/types': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-common': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-validation': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       '@types/react-router-config': 5.0.11
       combine-promises: 1.2.0
-      fs-extra: 11.2.0
+      fs-extra: 11.3.0
       js-yaml: 4.1.0
       lodash: 4.17.21
       react: 18.2.0
       react-dom: 18.3.1(react@18.2.0)
+      schema-dts: 1.1.5
       tslib: 2.8.1
       utility-types: 3.11.0
       webpack: 5.96.1
@@ -13823,23 +13605,21 @@ snapshots:
       - csso
       - debug
       - esbuild
-      - eslint
       - lightningcss
       - supports-color
       - typescript
       - uglify-js
       - utf-8-validate
-      - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-content-pages@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)':
+  '@docusaurus/plugin-content-pages@3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
-      '@docusaurus/mdx-loader': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/types': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-validation': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      fs-extra: 11.2.0
+      '@docusaurus/core': 3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      '@docusaurus/mdx-loader': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/types': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-validation': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      fs-extra: 11.3.0
       react: 18.2.0
       react-dom: 18.3.1(react@18.2.0)
       tslib: 2.8.1
@@ -13856,24 +13636,18 @@ snapshots:
       - csso
       - debug
       - esbuild
-      - eslint
       - lightningcss
       - supports-color
       - typescript
       - uglify-js
       - utf-8-validate
-      - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-debug@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)':
+  '@docusaurus/plugin-css-cascade-layers@3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
-      '@docusaurus/types': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      fs-extra: 11.2.0
-      react: 18.2.0
-      react-dom: 18.3.1(react@18.2.0)
-      react-json-view-lite: 1.5.0(react@18.2.0)
+      '@docusaurus/core': 3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      '@docusaurus/types': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-validation': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@docusaurus/faster'
@@ -13887,20 +13661,49 @@ snapshots:
       - csso
       - debug
       - esbuild
-      - eslint
+      - lightningcss
+      - react
+      - react-dom
+      - supports-color
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - webpack-cli
+
+  '@docusaurus/plugin-debug@3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)':
+    dependencies:
+      '@docusaurus/core': 3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      '@docusaurus/types': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      fs-extra: 11.3.0
+      react: 18.2.0
+      react-dom: 18.3.1(react@18.2.0)
+      react-json-view-lite: 2.4.1(react@18.2.0)
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@docusaurus/faster'
+      - '@mdx-js/react'
+      - '@parcel/css'
+      - '@rspack/core'
+      - '@swc/core'
+      - '@swc/css'
+      - acorn
+      - bufferutil
+      - csso
+      - debug
+      - esbuild
       - lightningcss
       - supports-color
       - typescript
       - uglify-js
       - utf-8-validate
-      - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-analytics@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)':
+  '@docusaurus/plugin-google-analytics@3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
-      '@docusaurus/types': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-validation': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/core': 3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      '@docusaurus/types': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-validation': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.3.1(react@18.2.0)
       tslib: 2.8.1
@@ -13916,20 +13719,18 @@ snapshots:
       - csso
       - debug
       - esbuild
-      - eslint
       - lightningcss
       - supports-color
       - typescript
       - uglify-js
       - utf-8-validate
-      - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-gtag@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)':
+  '@docusaurus/plugin-google-gtag@3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
-      '@docusaurus/types': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-validation': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/core': 3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      '@docusaurus/types': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-validation': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       '@types/gtag.js': 0.0.12
       react: 18.2.0
       react-dom: 18.3.1(react@18.2.0)
@@ -13946,20 +13747,18 @@ snapshots:
       - csso
       - debug
       - esbuild
-      - eslint
       - lightningcss
       - supports-color
       - typescript
       - uglify-js
       - utf-8-validate
-      - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-tag-manager@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)':
+  '@docusaurus/plugin-google-tag-manager@3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
-      '@docusaurus/types': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-validation': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/core': 3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      '@docusaurus/types': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-validation': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.3.1(react@18.2.0)
       tslib: 2.8.1
@@ -13975,24 +13774,22 @@ snapshots:
       - csso
       - debug
       - esbuild
-      - eslint
       - lightningcss
       - supports-color
       - typescript
       - uglify-js
       - utf-8-validate
-      - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-sitemap@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)':
+  '@docusaurus/plugin-sitemap@3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
-      '@docusaurus/logger': 3.7.0
-      '@docusaurus/types': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-common': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-validation': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      fs-extra: 11.2.0
+      '@docusaurus/core': 3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      '@docusaurus/logger': 3.8.0
+      '@docusaurus/types': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-common': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-validation': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      fs-extra: 11.3.0
       react: 18.2.0
       react-dom: 18.3.1(react@18.2.0)
       sitemap: 7.1.2
@@ -14009,21 +13806,19 @@ snapshots:
       - csso
       - debug
       - esbuild
-      - eslint
       - lightningcss
       - supports-color
       - typescript
       - uglify-js
       - utf-8-validate
-      - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-svgr@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)':
+  '@docusaurus/plugin-svgr@3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
-      '@docusaurus/types': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-validation': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/core': 3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      '@docusaurus/types': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-validation': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       '@svgr/core': 8.1.0(typescript@5.8.3)
       '@svgr/webpack': 8.1.0(typescript@5.8.3)
       react: 18.2.0
@@ -14042,31 +13837,30 @@ snapshots:
       - csso
       - debug
       - esbuild
-      - eslint
       - lightningcss
       - supports-color
       - typescript
       - uglify-js
       - utf-8-validate
-      - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/preset-classic@3.7.0(@algolia/client-search@5.19.0)(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(@types/react@18.3.12)(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)(typescript@5.8.3)':
+  '@docusaurus/preset-classic@3.8.0(@algolia/client-search@5.19.0)(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(@types/react@18.3.12)(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)(typescript@5.8.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
-      '@docusaurus/plugin-content-blog': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
-      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
-      '@docusaurus/plugin-content-pages': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
-      '@docusaurus/plugin-debug': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
-      '@docusaurus/plugin-google-analytics': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
-      '@docusaurus/plugin-google-gtag': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
-      '@docusaurus/plugin-google-tag-manager': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
-      '@docusaurus/plugin-sitemap': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
-      '@docusaurus/plugin-svgr': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
-      '@docusaurus/theme-classic': 3.7.0(@types/react@18.3.12)(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
-      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/theme-search-algolia': 3.7.0(@algolia/client-search@5.19.0)(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(@types/react@18.3.12)(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)(typescript@5.8.3)
-      '@docusaurus/types': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/core': 3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      '@docusaurus/plugin-content-blog': 3.8.0(@docusaurus/plugin-content-docs@3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      '@docusaurus/plugin-content-docs': 3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      '@docusaurus/plugin-content-pages': 3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      '@docusaurus/plugin-css-cascade-layers': 3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      '@docusaurus/plugin-debug': 3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      '@docusaurus/plugin-google-analytics': 3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      '@docusaurus/plugin-google-gtag': 3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      '@docusaurus/plugin-google-tag-manager': 3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      '@docusaurus/plugin-sitemap': 3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      '@docusaurus/plugin-svgr': 3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      '@docusaurus/theme-classic': 3.8.0(@types/react@18.3.12)(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      '@docusaurus/theme-common': 3.8.0(@docusaurus/plugin-content-docs@3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/theme-search-algolia': 3.8.0(@algolia/client-search@5.19.0)(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(@types/react@18.3.12)(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)(typescript@5.8.3)
+      '@docusaurus/types': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.3.1(react@18.2.0)
     transitivePeerDependencies:
@@ -14083,14 +13877,12 @@ snapshots:
       - csso
       - debug
       - esbuild
-      - eslint
       - lightningcss
       - search-insights
       - supports-color
       - typescript
       - uglify-js
       - utf-8-validate
-      - vue-template-compiler
       - webpack-cli
 
   '@docusaurus/react-loadable@6.0.0(react@18.2.0)':
@@ -14098,21 +13890,21 @@ snapshots:
       '@types/react': 18.3.12
       react: 18.2.0
 
-  '@docusaurus/theme-classic@3.7.0(@types/react@18.3.12)(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)':
+  '@docusaurus/theme-classic@3.8.0(@types/react@18.3.12)(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
-      '@docusaurus/logger': 3.7.0
-      '@docusaurus/mdx-loader': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/module-type-aliases': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/plugin-content-blog': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
-      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
-      '@docusaurus/plugin-content-pages': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
-      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/theme-translations': 3.7.0
-      '@docusaurus/types': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-common': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-validation': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/core': 3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      '@docusaurus/logger': 3.8.0
+      '@docusaurus/mdx-loader': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/module-type-aliases': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/plugin-content-blog': 3.8.0(@docusaurus/plugin-content-docs@3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      '@docusaurus/plugin-content-docs': 3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      '@docusaurus/plugin-content-pages': 3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      '@docusaurus/theme-common': 3.8.0(@docusaurus/plugin-content-docs@3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/theme-translations': 3.8.0
+      '@docusaurus/types': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-common': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-validation': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       '@mdx-js/react': 3.1.0(@types/react@18.3.12)(react@18.2.0)
       clsx: 2.1.1
       copy-text-to-clipboard: 3.2.0
@@ -14140,22 +13932,20 @@ snapshots:
       - csso
       - debug
       - esbuild
-      - eslint
       - lightningcss
       - supports-color
       - typescript
       - uglify-js
       - utf-8-validate
-      - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/theme-common@3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@docusaurus/theme-common@3.8.0(@docusaurus/plugin-content-docs@3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@docusaurus/mdx-loader': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/module-type-aliases': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
-      '@docusaurus/utils': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-common': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/mdx-loader': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/module-type-aliases': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/plugin-content-docs': 3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      '@docusaurus/utils': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-common': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       '@types/history': 4.7.11
       '@types/react': 18.3.12
       '@types/react-router-config': 5.0.11
@@ -14174,13 +13964,13 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/theme-mermaid@3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)':
+  '@docusaurus/theme-mermaid@3.8.0(@docusaurus/plugin-content-docs@3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
-      '@docusaurus/module-type-aliases': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/types': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-validation': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/core': 3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      '@docusaurus/module-type-aliases': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/theme-common': 3.8.0(@docusaurus/plugin-content-docs@3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/types': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-validation': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       mermaid: 11.4.1
       react: 18.2.0
       react-dom: 18.3.1(react@18.2.0)
@@ -14198,30 +13988,28 @@ snapshots:
       - csso
       - debug
       - esbuild
-      - eslint
       - lightningcss
       - supports-color
       - typescript
       - uglify-js
       - utf-8-validate
-      - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/theme-search-algolia@3.7.0(@algolia/client-search@5.19.0)(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(@types/react@18.3.12)(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)(typescript@5.8.3)':
+  '@docusaurus/theme-search-algolia@3.8.0(@algolia/client-search@5.19.0)(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(@types/react@18.3.12)(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)(typescript@5.8.3)':
     dependencies:
-      '@docsearch/react': 3.8.2(@algolia/client-search@5.19.0)(@types/react@18.3.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
-      '@docusaurus/logger': 3.7.0
-      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
-      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(eslint@9.28.0(jiti@2.4.2))(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/theme-translations': 3.7.0
-      '@docusaurus/utils': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-validation': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docsearch/react': 3.9.0(@algolia/client-search@5.19.0)(@types/react@18.3.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)
+      '@docusaurus/core': 3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      '@docusaurus/logger': 3.8.0
+      '@docusaurus/plugin-content-docs': 3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
+      '@docusaurus/theme-common': 3.8.0(@docusaurus/plugin-content-docs@3.8.0(@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.2.0))(acorn@8.14.1)(lightningcss@1.30.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.8.3))(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/theme-translations': 3.8.0
+      '@docusaurus/utils': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-validation': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       algoliasearch: 5.19.0
       algoliasearch-helper: 3.22.6(algoliasearch@5.19.0)
       clsx: 2.1.1
       eta: 2.2.0
-      fs-extra: 11.2.0
+      fs-extra: 11.3.0
       lodash: 4.17.21
       react: 18.2.0
       react-dom: 18.3.1(react@18.2.0)
@@ -14241,24 +14029,22 @@ snapshots:
       - csso
       - debug
       - esbuild
-      - eslint
       - lightningcss
       - search-insights
       - supports-color
       - typescript
       - uglify-js
       - utf-8-validate
-      - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/theme-translations@3.7.0':
+  '@docusaurus/theme-translations@3.8.0':
     dependencies:
       fs-extra: 11.3.0
       tslib: 2.8.1
 
-  '@docusaurus/tsconfig@3.7.0': {}
+  '@docusaurus/tsconfig@3.8.0': {}
 
-  '@docusaurus/types@3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@docusaurus/types@3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@mdx-js/mdx': 3.1.0(acorn@8.14.1)
       '@types/history': 4.7.11
@@ -14279,9 +14065,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-common@3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@docusaurus/utils-common@3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@docusaurus/types': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/types': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@swc/core'
@@ -14293,12 +14079,12 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-validation@3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@docusaurus/utils-validation@3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@docusaurus/logger': 3.7.0
-      '@docusaurus/utils': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-common': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      fs-extra: 11.2.0
+      '@docusaurus/logger': 3.8.0
+      '@docusaurus/utils': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-common': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      fs-extra: 11.3.0
       joi: 17.13.3
       js-yaml: 4.1.0
       lodash: 4.17.21
@@ -14313,24 +14099,25 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils@3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@docusaurus/utils@3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@docusaurus/logger': 3.7.0
-      '@docusaurus/types': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-common': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/logger': 3.8.0
+      '@docusaurus/types': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-common': 3.8.0(acorn@8.14.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       escape-string-regexp: 4.0.0
+      execa: 5.1.1
       file-loader: 6.2.0(webpack@5.96.1)
-      fs-extra: 11.2.0
+      fs-extra: 11.3.0
       github-slugger: 1.5.0
       globby: 11.1.0
       gray-matter: 4.0.3
-      jiti: 1.21.6
+      jiti: 1.21.7
       js-yaml: 4.1.0
       lodash: 4.17.21
       micromatch: 4.0.8
+      p-queue: 6.6.2
       prompts: 2.4.2
       resolve-pathname: 3.0.0
-      shelljs: 0.8.5
       tslib: 2.8.1
       url-loader: 4.1.1(file-loader@6.2.0(webpack@5.96.1))(webpack@5.96.1)
       utility-types: 3.11.0
@@ -16386,8 +16173,6 @@ snapshots:
 
   '@types/normalize-package-data@2.4.4': {}
 
-  '@types/parse-json@4.0.2': {}
-
   '@types/plist@3.0.5':
     dependencies:
       '@types/node': 22.15.24
@@ -17148,7 +16933,7 @@ snapshots:
 
   app-builder-bin@5.0.0-alpha.12: {}
 
-  app-builder-lib@25.1.8(dmg-builder@26.0.15)(electron-builder-squirrel-windows@25.1.8(dmg-builder@26.0.15)):
+  app-builder-lib@25.1.8(dmg-builder@26.0.15(electron-builder-squirrel-windows@25.1.8(dmg-builder@26.0.15)))(electron-builder-squirrel-windows@25.1.8(dmg-builder@26.0.15)):
     dependencies:
       '@develar/schema-utils': 2.6.5
       '@electron/notarize': 2.5.0
@@ -17188,7 +16973,7 @@ snapshots:
       - bluebird
       - supports-color
 
-  app-builder-lib@26.0.15(dmg-builder@26.0.15)(electron-builder-squirrel-windows@25.1.8(dmg-builder@26.0.15)):
+  app-builder-lib@26.0.15(dmg-builder@26.0.15(electron-builder-squirrel-windows@25.1.8(dmg-builder@26.0.15)))(electron-builder-squirrel-windows@25.1.8(dmg-builder@26.0.15)):
     dependencies:
       '@develar/schema-utils': 2.6.5
       '@electron/asar': 3.4.1
@@ -17417,11 +17202,11 @@ snapshots:
 
   babel-plugin-dynamic-import-node@2.3.3:
     dependencies:
-      object.assign: 4.1.5
+      object.assign: 4.1.7
 
   babel-plugin-polyfill-corejs2@0.4.12(@babel/core@7.26.10):
     dependencies:
-      '@babel/compat-data': 7.26.2
+      '@babel/compat-data': 7.26.8
       '@babel/core': 7.26.10
       '@babel/helper-define-polyfill-provider': 0.6.3(@babel/core@7.26.10)
       semver: 6.3.1
@@ -17866,7 +17651,7 @@ snapshots:
       domhandler: 5.0.3
       domutils: 3.1.0
       htmlparser2: 8.0.2
-      parse5: 7.2.1
+      parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
 
   chevrotain-allstar@0.3.1(chevrotain@11.0.3):
@@ -18062,7 +17847,7 @@ snapshots:
 
   compressible@2.0.18:
     dependencies:
-      mime-db: 1.53.0
+      mime-db: 1.54.0
 
   compression@1.7.5:
     dependencies:
@@ -18194,14 +17979,6 @@ snapshots:
       cosmiconfig: 9.0.0(typescript@5.8.3)
       jiti: 2.4.2
       typescript: 5.8.3
-
-  cosmiconfig@6.0.0:
-    dependencies:
-      '@types/parse-json': 4.0.2
-      import-fresh: 3.3.1
-      parse-json: 5.2.0
-      path-type: 4.0.0
-      yaml: 1.10.2
 
   cosmiconfig@8.3.6(typescript@5.8.3):
     dependencies:
@@ -18697,17 +18474,6 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
-  del@6.1.1:
-    dependencies:
-      globby: 11.1.0
-      graceful-fs: 4.2.11
-      is-glob: 4.0.3
-      is-path-cwd: 2.2.0
-      is-path-inside: 3.0.3
-      p-map: 4.0.0
-      rimraf: 3.0.2
-      slash: 3.0.0
-
   delaunator@5.0.1:
     dependencies:
       robust-predicates: 3.0.2
@@ -18729,13 +18495,6 @@ snapshots:
   detect-libc@2.0.4: {}
 
   detect-node@2.1.0: {}
-
-  detect-port-alt@1.1.6:
-    dependencies:
-      address: 1.2.2
-      debug: 2.6.9
-    transitivePeerDependencies:
-      - supports-color
 
   detect-port@1.6.1:
     dependencies:
@@ -18759,7 +18518,7 @@ snapshots:
 
   dmg-builder@26.0.15(electron-builder-squirrel-windows@25.1.8(dmg-builder@26.0.15)):
     dependencies:
-      app-builder-lib: 26.0.15(dmg-builder@26.0.15)(electron-builder-squirrel-windows@25.1.8(dmg-builder@26.0.15))
+      app-builder-lib: 26.0.15(dmg-builder@26.0.15(electron-builder-squirrel-windows@25.1.8(dmg-builder@26.0.15)))(electron-builder-squirrel-windows@25.1.8(dmg-builder@26.0.15))
       builder-util: 26.0.13
       builder-util-runtime: 9.3.2
       fs-extra: 10.1.0
@@ -18940,7 +18699,7 @@ snapshots:
 
   electron-builder-squirrel-windows@25.1.8(dmg-builder@26.0.15):
     dependencies:
-      app-builder-lib: 25.1.8(dmg-builder@26.0.15)(electron-builder-squirrel-windows@25.1.8(dmg-builder@26.0.15))
+      app-builder-lib: 25.1.8(dmg-builder@26.0.15(electron-builder-squirrel-windows@25.1.8(dmg-builder@26.0.15)))(electron-builder-squirrel-windows@25.1.8(dmg-builder@26.0.15))
       archiver: 5.3.2
       builder-util: 25.1.7
       fs-extra: 10.1.0
@@ -18951,7 +18710,7 @@ snapshots:
 
   electron-builder@26.0.15(electron-builder-squirrel-windows@25.1.8(dmg-builder@26.0.15)):
     dependencies:
-      app-builder-lib: 26.0.15(dmg-builder@26.0.15)(electron-builder-squirrel-windows@25.1.8(dmg-builder@26.0.15))
+      app-builder-lib: 26.0.15(dmg-builder@26.0.15(electron-builder-squirrel-windows@25.1.8(dmg-builder@26.0.15)))(electron-builder-squirrel-windows@25.1.8(dmg-builder@26.0.15))
       builder-util: 26.0.13
       builder-util-runtime: 9.3.2
       chalk: 4.1.2
@@ -19072,11 +18831,6 @@ snapshots:
     dependencies:
       once: 1.4.0
 
-  enhanced-resolve@5.17.1:
-    dependencies:
-      graceful-fs: 4.2.11
-      tapable: 2.2.1
-
   enhanced-resolve@5.18.1:
     dependencies:
       graceful-fs: 4.2.11
@@ -19160,8 +18914,6 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
-
-  es-module-lexer@1.5.4: {}
 
   es-module-lexer@1.7.0: {}
 
@@ -19299,7 +19051,7 @@ snapshots:
     optionalDependencies:
       unrs-resolver: 1.7.8
 
-  eslint-import-resolver-custom-alias@1.3.2(eslint-plugin-import@2.31.0):
+  eslint-import-resolver-custom-alias@1.3.2(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@4.4.2)(eslint@9.28.0(jiti@2.4.2))):
     dependencies:
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@4.4.2)(eslint@9.28.0(jiti@2.4.2))
       glob-parent: 6.0.2
@@ -19328,7 +19080,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.2)(eslint@9.28.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.2(eslint-plugin-import@2.31.0)(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -19369,7 +19121,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.28.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.2)(eslint@9.28.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.2(eslint-plugin-import@2.31.0)(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -19826,8 +19578,6 @@ snapshots:
 
   filesize@10.1.6: {}
 
-  filesize@8.0.7: {}
-
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -19850,10 +19600,6 @@ snapshots:
       pkg-dir: 7.0.0
 
   find-up-simple@1.0.1: {}
-
-  find-up@3.0.0:
-    dependencies:
-      locate-path: 3.0.0
 
   find-up@4.1.0:
     dependencies:
@@ -19904,26 +19650,6 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@6.5.3(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3)(webpack@5.96.1):
-    dependencies:
-      '@babel/code-frame': 7.26.2
-      '@types/json-schema': 7.0.15
-      chalk: 4.1.2
-      chokidar: 3.6.0
-      cosmiconfig: 6.0.0
-      deepmerge: 4.3.1
-      fs-extra: 9.1.0
-      glob: 7.2.3
-      memfs: 3.5.3
-      minimatch: 3.1.2
-      schema-utils: 2.7.0
-      semver: 7.7.2
-      tapable: 1.1.3
-      typescript: 5.8.3
-      webpack: 5.96.1
-    optionalDependencies:
-      eslint: 9.28.0(jiti@2.4.2)
-
   form-data-encoder@2.1.4: {}
 
   form-data-encoder@4.0.2: {}
@@ -19946,12 +19672,6 @@ snapshots:
   fs-constants@1.0.0: {}
 
   fs-extra@10.1.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 6.1.0
-      universalify: 2.0.1
-
-  fs-extra@11.2.0:
     dependencies:
       graceful-fs: 4.2.11
       jsonfile: 6.1.0
@@ -20139,16 +19859,6 @@ snapshots:
     dependencies:
       ini: 2.0.0
 
-  global-modules@2.0.0:
-    dependencies:
-      global-prefix: 3.0.0
-
-  global-prefix@3.0.0:
-    dependencies:
-      ini: 1.3.8
-      kind-of: 6.0.3
-      which: 1.3.1
-
   globals@11.12.0: {}
 
   globals@13.24.0:
@@ -20316,7 +20026,7 @@ snapshots:
       hast-util-to-parse5: 8.0.0
       html-void-elements: 3.0.0
       mdast-util-to-hast: 13.2.0
-      parse5: 7.2.1
+      parse5: 7.3.0
       unist-util-position: 5.0.0
       unist-util-visit: 5.0.0
       vfile: 6.0.3
@@ -20456,7 +20166,7 @@ snapshots:
       html-minifier-terser: 6.1.0
       lodash: 4.17.21
       pretty-error: 4.0.0
-      tapable: 2.2.1
+      tapable: 2.2.2
     optionalDependencies:
       webpack: 5.96.1
 
@@ -20610,8 +20320,6 @@ snapshots:
     dependencies:
       queue: 6.0.2
 
-  immer@9.0.21: {}
-
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -20659,8 +20367,6 @@ snapshots:
   internmap@1.0.1: {}
 
   internmap@2.0.3: {}
-
-  interpret@1.4.0: {}
 
   invariant@2.2.4:
     dependencies:
@@ -20821,8 +20527,6 @@ snapshots:
 
   is-obj@2.0.0: {}
 
-  is-path-cwd@2.2.0: {}
-
   is-path-inside@3.0.3: {}
 
   is-path-inside@4.0.0: {}
@@ -20855,8 +20559,6 @@ snapshots:
       hasown: 2.0.2
 
   is-regexp@1.0.0: {}
-
-  is-root@2.1.0: {}
 
   is-set@2.0.3: {}
 
@@ -20992,8 +20694,6 @@ snapshots:
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
-
-  jiti@1.21.6: {}
 
   jiti@1.21.7: {}
 
@@ -21134,10 +20834,6 @@ snapshots:
       array.prototype.flat: 1.3.3
       object.assign: 4.1.7
       object.values: 1.2.1
-
-  katex@0.16.21:
-    dependencies:
-      commander: 8.3.0
 
   katex@0.16.22:
     dependencies:
@@ -21296,19 +20992,12 @@ snapshots:
       emojis-list: 3.0.0
       json5: 2.2.3
 
-  loader-utils@3.3.1: {}
-
   local-pkg@1.0.0:
     dependencies:
       mlly: 1.7.4
       pkg-types: 1.3.1
 
   locate-character@3.0.0: {}
-
-  locate-path@3.0.0:
-    dependencies:
-      p-locate: 3.0.0
-      path-exists: 3.0.0
 
   locate-path@5.0.0:
     dependencies:
@@ -21744,7 +21433,7 @@ snapshots:
       dagre-d3-es: 7.0.11
       dayjs: 1.11.13
       dompurify: 3.2.4
-      katex: 0.16.21
+      katex: 0.16.22
       khroma: 2.1.0
       lodash-es: 4.17.21
       marked: 13.0.3
@@ -22083,8 +21772,6 @@ snapshots:
 
   mime-db@1.52.0: {}
 
-  mime-db@1.53.0: {}
-
   mime-db@1.54.0: {}
 
   mime-types@2.1.18:
@@ -22114,7 +21801,7 @@ snapshots:
   mini-css-extract-plugin@2.9.2(webpack@5.96.1):
     dependencies:
       schema-utils: 4.2.0
-      tapable: 2.2.1
+      tapable: 2.2.2
       webpack: 5.96.1
 
   minimalistic-assert@1.0.1: {}
@@ -22420,13 +22107,6 @@ snapshots:
 
   object-keys@1.1.1: {}
 
-  object.assign@4.1.5:
-    dependencies:
-      call-bind: 1.0.8
-      define-properties: 1.2.1
-      has-symbols: 1.1.0
-      object-keys: 1.1.1
-
   object.assign@4.1.7:
     dependencies:
       call-bind: 1.0.8
@@ -22560,6 +22240,8 @@ snapshots:
 
   p-cancelable@4.0.1: {}
 
+  p-finally@1.0.0: {}
+
   p-limit@2.3.0:
     dependencies:
       p-try: 2.2.0
@@ -22571,10 +22253,6 @@ snapshots:
   p-limit@4.0.0:
     dependencies:
       yocto-queue: 1.2.1
-
-  p-locate@3.0.0:
-    dependencies:
-      p-limit: 2.3.0
 
   p-locate@4.1.0:
     dependencies:
@@ -22592,10 +22270,19 @@ snapshots:
     dependencies:
       aggregate-error: 3.1.0
 
+  p-queue@6.6.2:
+    dependencies:
+      eventemitter3: 4.0.7
+      p-timeout: 3.2.0
+
   p-retry@4.6.2:
     dependencies:
       '@types/retry': 0.12.0
       retry: 0.13.1
+
+  p-timeout@3.2.0:
+    dependencies:
+      p-finally: 1.0.0
 
   p-try@2.2.0: {}
 
@@ -22611,7 +22298,7 @@ snapshots:
   package-json@8.1.1:
     dependencies:
       got: 12.6.1
-      registry-auth-token: 5.0.2
+      registry-auth-token: 5.1.0
       registry-url: 6.0.1
       semver: 7.7.2
 
@@ -22673,8 +22360,6 @@ snapshots:
 
   path-data-parser@0.1.0: {}
 
-  path-exists@3.0.0: {}
-
   path-exists@4.0.0: {}
 
   path-exists@5.0.0: {}
@@ -22734,10 +22419,6 @@ snapshots:
       mlly: 1.7.4
       pathe: 2.0.3
 
-  pkg-up@3.1.0:
-    dependencies:
-      find-up: 3.0.0
-
   playwright-core@1.52.0: {}
 
   playwright@1.52.0:
@@ -22785,7 +22466,7 @@ snapshots:
 
   postcss-color-functional-notation@7.0.6(postcss@8.5.4):
     dependencies:
-      '@csstools/css-color-parser': 3.0.7(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-color-parser': 3.0.9(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.5.4)
@@ -22902,7 +22583,7 @@ snapshots:
 
   postcss-lab-function@7.0.6(postcss@8.5.4):
     dependencies:
-      '@csstools/css-color-parser': 3.0.7(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-color-parser': 3.0.9(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.5.4)
@@ -23116,7 +22797,7 @@ snapshots:
       '@csstools/postcss-trigonometric-functions': 4.0.5(postcss@8.5.4)
       '@csstools/postcss-unset-value': 4.0.0(postcss@8.5.4)
       autoprefixer: 10.4.21(postcss@8.5.4)
-      browserslist: 4.24.4
+      browserslist: 4.24.5
       css-blank-pseudo: 7.0.1(postcss@8.5.4)
       css-has-pseudo: 7.0.1(postcss@8.5.4)
       css-prefers-color-scheme: 10.0.0(postcss@8.5.4)
@@ -23372,47 +23053,11 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  react-dev-utils@12.0.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3)(webpack@5.96.1):
-    dependencies:
-      '@babel/code-frame': 7.26.2
-      address: 1.2.2
-      browserslist: 4.24.4
-      chalk: 4.1.2
-      cross-spawn: 7.0.6
-      detect-port-alt: 1.1.6
-      escape-string-regexp: 4.0.0
-      filesize: 8.0.7
-      find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.3(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3)(webpack@5.96.1)
-      global-modules: 2.0.0
-      globby: 11.1.0
-      gzip-size: 6.0.0
-      immer: 9.0.21
-      is-root: 2.1.0
-      loader-utils: 3.3.1
-      open: 8.4.2
-      pkg-up: 3.1.0
-      prompts: 2.4.2
-      react-error-overlay: 6.0.11
-      recursive-readdir: 2.2.3
-      shell-quote: 1.8.1
-      strip-ansi: 6.0.1
-      text-table: 0.2.0
-      webpack: 5.96.1
-    optionalDependencies:
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - eslint
-      - supports-color
-      - vue-template-compiler
-
   react-dom@18.3.1(react@18.2.0):
     dependencies:
       loose-envify: 1.4.0
       react: 18.2.0
       scheduler: 0.23.2
-
-  react-error-overlay@6.0.11: {}
 
   react-fast-compare@3.2.2: {}
 
@@ -23420,13 +23065,13 @@ snapshots:
 
   react-is@17.0.2: {}
 
-  react-json-view-lite@1.5.0(react@18.2.0):
+  react-json-view-lite@2.4.1(react@18.2.0):
     dependencies:
       react: 18.2.0
 
   react-loadable-ssr-addon-v5-slorber@1.0.1(@docusaurus/react-loadable@6.0.0(react@18.2.0))(webpack@5.96.1):
     dependencies:
-      '@babel/runtime': 7.26.10
+      '@babel/runtime': 7.27.4
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@18.2.0)'
       webpack: 5.96.1
 
@@ -23441,13 +23086,13 @@ snapshots:
 
   react-router-config@5.1.1(react-router@5.3.4(react@18.2.0))(react@18.2.0):
     dependencies:
-      '@babel/runtime': 7.26.10
+      '@babel/runtime': 7.27.4
       react: 18.2.0
       react-router: 5.3.4(react@18.2.0)
 
   react-router-dom@5.3.4(react@18.2.0):
     dependencies:
-      '@babel/runtime': 7.26.10
+      '@babel/runtime': 7.27.4
       history: 4.10.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -23458,7 +23103,7 @@ snapshots:
 
   react-router@5.3.4(react@18.2.0):
     dependencies:
-      '@babel/runtime': 7.26.10
+      '@babel/runtime': 7.27.4
       history: 4.10.1
       hoist-non-react-statics: 3.3.2
       loose-envify: 1.4.0
@@ -23525,8 +23170,6 @@ snapshots:
 
   readdirp@4.1.2: {}
 
-  reading-time@1.5.0: {}
-
   recast@0.23.9:
     dependencies:
       ast-types: 0.16.1
@@ -23534,10 +23177,6 @@ snapshots:
       source-map: 0.6.1
       tiny-invariant: 1.3.3
       tslib: 2.8.1
-
-  rechoir@0.6.2:
-    dependencies:
-      resolve: 1.22.10
 
   recma-build-jsx@1.0.0:
     dependencies:
@@ -23568,10 +23207,6 @@ snapshots:
       estree-util-to-js: 2.0.0
       unified: 11.0.5
       vfile: 6.0.3
-
-  recursive-readdir@2.2.3:
-    dependencies:
-      minimatch: 3.1.2
 
   redent@3.0.0:
     dependencies:
@@ -23631,10 +23266,6 @@ snapshots:
       regjsparser: 0.11.2
       unicode-match-property-ecmascript: 2.0.0
       unicode-match-property-value-ecmascript: 2.2.0
-
-  registry-auth-token@5.0.2:
-    dependencies:
-      '@pnpm/npm-conf': 2.3.1
 
   registry-auth-token@5.1.0:
     dependencies:
@@ -23927,11 +23558,7 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  schema-utils@2.7.0:
-    dependencies:
-      '@types/json-schema': 7.0.15
-      ajv: 6.12.6
-      ajv-keywords: 3.5.2(ajv@6.12.6)
+  schema-dts@1.1.5: {}
 
   schema-utils@3.3.0:
     dependencies:
@@ -24116,12 +23743,6 @@ snapshots:
       shell-env: 4.0.1
 
   shell-quote@1.8.1: {}
-
-  shelljs@0.8.5:
-    dependencies:
-      glob: 7.2.3
-      interpret: 1.4.0
-      rechoir: 0.6.2
 
   side-channel-list@1.0.0:
     dependencies:
@@ -24635,10 +24256,6 @@ snapshots:
   symbol-tree@3.2.4: {}
 
   tailwindcss@4.1.8: {}
-
-  tapable@1.1.3: {}
-
-  tapable@2.2.1: {}
 
   tapable@2.2.2: {}
 
@@ -25517,7 +25134,7 @@ snapshots:
       sockjs: 0.3.24
       spdy: 4.0.2
       webpack-dev-middleware: 5.3.4(webpack@5.96.1)
-      ws: 8.18.1
+      ws: 8.18.2
     optionalDependencies:
       webpack: 5.96.1
     transitivePeerDependencies:
@@ -25550,10 +25167,10 @@ snapshots:
       '@webassemblyjs/wasm-edit': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1
       acorn: 8.14.1
-      browserslist: 4.24.4
+      browserslist: 4.24.5
       chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.17.1
-      es-module-lexer: 1.5.4
+      enhanced-resolve: 5.18.1
+      es-module-lexer: 1.7.0
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1
@@ -25563,7 +25180,7 @@ snapshots:
       mime-types: 2.1.35
       neo-async: 2.6.2
       schema-utils: 3.3.0
-      tapable: 2.2.1
+      tapable: 2.2.2
       terser-webpack-plugin: 5.3.10(webpack@5.96.1)
       watchpack: 2.4.2
       webpack-sources: 3.2.3

--- a/website/package.json
+++ b/website/package.json
@@ -22,11 +22,11 @@
     "lint:clean": "rimraf .eslintcache"
   },
   "dependencies": {
-    "@docusaurus/core": "^3.7.0",
-    "@docusaurus/plugin-client-redirects": "^3.7.0",
-    "@docusaurus/preset-classic": "^3.7.0",
-    "@docusaurus/theme-mermaid": "^3.7.0",
-    "@docusaurus/theme-common": "^3.7.0",
+    "@docusaurus/core": "^3.8.0",
+    "@docusaurus/plugin-client-redirects": "^3.8.0",
+    "@docusaurus/preset-classic": "^3.8.0",
+    "@docusaurus/theme-mermaid": "^3.8.0",
+    "@docusaurus/theme-common": "^3.8.0",
     "@fortawesome/fontawesome-svg-core": "^6.7.2",
     "@fortawesome/free-brands-svg-icons": "^6.7.2",
     "@fortawesome/free-solid-svg-icons": "^6.7.2",
@@ -41,9 +41,9 @@
     "react-player": "^2.16.0"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "^3.7.0",
-    "@docusaurus/tsconfig": "^3.7.0",
-    "@docusaurus/types": "^3.7.0",
+    "@docusaurus/module-type-aliases": "^3.8.0",
+    "@docusaurus/tsconfig": "^3.8.0",
+    "@docusaurus/types": "^3.8.0",
     "@tailwindcss/postcss": "^4.1.8",
     "markdownlint": "^0.38.0",
     "markdownlint-cli2": "^0.18.1",


### PR DESCRIPTION
chore: update to docusaurus 3.8.0 and remove --no-minify

### What does this PR do?

* Upgrades to 3.8.0
* Removes `--no-minify`, to resolve building issue.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/podman-desktop/issues/12744
(Maybe) Closes https://github.com/podman-desktop/podman-desktop/issues/12238

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

Check Argos

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
