### PR TITLE
fix(extension: kubernetes): ensure currentContext and MenuItem label are string to avoid type errors

### DIFF
--- a/extensions/kube-context/src/extension.ts
+++ b/extensions/kube-context/src/extension.ts
@@ -58,7 +58,7 @@ export async function updateContext(
   const kubeConfig = jsYaml.load(kubeConfigRawContent) as KubeConfig;
 
   // get the current context
-  const currentContext = kubeConfig?.['current-context'];
+  const currentContext = String(kubeConfig?.['current-context'] ?? '');
 
   // get all contexts
   const contexts: KubeContext[] = kubeConfig?.['contexts'] ? kubeConfig['contexts'] : [];
@@ -67,7 +67,7 @@ export async function updateContext(
     // now, add each context
     const subitems: extensionApi.MenuItem[] = contexts.map(context => {
       return {
-        label: context.name,
+        label: String(context.name),
         id: 'kubecontext.switch',
         type: 'checkbox',
         checked: context.name === currentContext,


### PR DESCRIPTION
The above changes prevent errors caused by type mismatches, stopping persistent
pop-up error messages during startup from interfering with the main process.

### What does this PR do?

- Type Conversion: Ensures that both current-context and contexts.name are converted to strings. This prevents errors that occur when they are unexpectedly numbers, which causes issues in Electron’s MenuItem component, which requires string labels.

- Proposed Solution Enhancement: While the PR addresses the issue by performing type conversions, a more robust approach would involve implementing a validation function (e.g., validateKubeConfig). This function would thoroughly check the integrity of the kubeconfig file. If the validation fails (e.g., if any fields are incorrectly formatted or contain unsupported values), the system should avoid triggering the updateContext operation, preventing further errors while still allowing the Kubernetes plugin to be available if the configuration is valid.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Close podman-desktop/extension-kubernetes-contexts#399 

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

1. Modify the kubeconfig file's current-context and contexts.name to use numbers instead of strings.
2. Restart the application.
3. Verify that the persistent error pop-up no longer appears, and the Kubernetes plugin loads correctly.

- [ ] Tests are covering the bug fix or the new feature
