### PR TITLE
fix: logs filename has undefined extension

### DIFF
--- a/packages/main/src/plugin/troubleshooting.spec.ts
+++ b/packages/main/src/plugin/troubleshooting.spec.ts
@@ -198,11 +198,15 @@ test('Should return getWindowsSystemLogs if the platform is win32', async () => 
   );
 });
 
-test('test generateLogFileName', async () => {
+// test generateLogFileName for different cases
+test.each([
+  { file: 'test', extension: undefined, expected: /test-\d{14}\.txt/ }, // default to txt
+  { file: 'test', extension: 'customExtension', expected: /test-\d{14}\.customExtension/ }, // use provided extension
+  { file: 'test.log', extension: undefined, expected: /test-\d{14}\.log/ }, // use extension from filename
+  { file: 'test.log', extension: 'customExtension', expected: /test-\d{14}\.customExtension/ }, //use provided extension
+])('test generateLogFileName, file: $file, extension: $extension', async ({ file, extension, expected }) => {
   const ts = new Troubleshooting();
-  const filename = ts.generateLogFileName('test');
-
-  // Simple regex to check that the file name is in the correct format (YYYMMDDHHmmss)
-  expect(filename).toMatch(/\d{14}/);
-  expect(filename).toContain('test');
+  const filename = ts.generateLogFileName(file, extension);
+  // Check the format of "name"-"date(14digits)"-"extension"
+  expect(filename).toMatch(new RegExp(expected));
 });

--- a/packages/main/src/plugin/troubleshooting.ts
+++ b/packages/main/src/plugin/troubleshooting.ts
@@ -104,7 +104,7 @@ export class Troubleshooting {
     // otherwise just use .txt
     const filenameParts = filename.split('.');
     // Use the file extension if it's provided, otherwise use the one from the file name, or default to txt
-    const fileExtension = (extension ?? filenameParts.length > 1) ? filenameParts[1] : 'txt';
+    const fileExtension = extension ?? (filenameParts.length > 1 ? filenameParts[1] : 'txt');
     return `${filenameParts[0]}-${moment().format('YYYYMMDDHHmmss')}.${fileExtension}`;
   }
 }


### PR DESCRIPTION
### What does this PR do?
This PR fixes the bug where logs have an .undefined as an extension. The logic behind the filename should work as following (based on the code and comments)

the generateLogFileName takes 'filename' and 'extension':

- If "extension" parameter is set, use it
- If "extension" parameter is not set and:
  - "filename" contains an extension ie. ".log" - parse and put it at the end of the filename
  - "filename" does not contain an extension - default to .txt

Tests have been updated to test each scenario

Reproducer steps in https://github.com/podman-desktop/podman-desktop/issues/12447

Fixes: #12447