### PR TITLE
fix: flaky test in BuildImageFromContainerfile.spec.ts

### DIFF
--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
@@ -26,7 +26,7 @@ import { get } from 'svelte/store';
 import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
 import BuildImageFromContainerfile from '/@/lib/image/BuildImageFromContainerfile.svelte';
-import { buildImagesInfo } from '/@/stores/build-images';
+import { buildImagesInfo, getNextTaskId } from '/@/stores/build-images';
 import { providerInfos } from '/@/stores/providers';
 import { recommendedRegistries } from '/@/stores/recommendedRegistries';
 import type { ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provider-info';
@@ -554,7 +554,8 @@ test('Expect build page to load a state for a build requested by taskId', async 
   expect(buildButton).toBeVisible();
   expect(cancelButton).not.toBeVisible();
 
-  await rendering.rerender({ taskId: 9 });
+  //
+  await rendering.rerender({ taskId: getNextTaskId() - 2 });
 
   await waitFor(() => {
     expect(containerFilePath).not.toBeVisible();
@@ -586,4 +587,4 @@ test('Expect build page to load a state for a build requested by taskId', async 
   expect(containerFilePath).toHaveValue('/somepath/containerfile');
   expect(buildFolder).toHaveValue('/somepath');
   expect(containerImageName).toHaveValue('foobar');
-}, 100000);
+});


### PR DESCRIPTION
The fix removes explicit 100000 timeout for test method and a 'magic' takskId used in test.

It turned out the taskId was incorrect for first try and only passed for a consecutive retry.
The fix makes it to work without retry. 

### What does this PR do?

Eliminates one of the flaky tests.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fix #10405.

### How to test this PR?

comment out `retry:3,` from `test` section of `vite.config.js` configuration and run it with command below:

```
npx vitest --run --project=renderer BuildImageFromContainerfile.spec.ts
```

- [ ] Tests are covering the bug fix or the new feature
