### PR TITLE
fix: remove full acces to d-bus and add missing --talk-name options

### DIFF
--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -160,8 +160,6 @@ const config = {
   flatpak: {
     license: 'LICENSE',
     finishArgs: [
-      // allow to execute commands remotely
-      '--socket=session-bus',
       '--socket=wayland',
       '--socket=x11',
       '--share=ipc',
@@ -184,6 +182,11 @@ const config = {
       '--talk-name=org.freedesktop.secrets',
       // In KDE Desktop Environment
       '--talk-name=org.kde.kwalletd6',
+      // Allow registration and management of system tray icons and their associated
+      // notifications in KDE Desktop Environment
+      '--talk-name=org.kde.StatusNotifierWatcher',
+      // Allow to interact with Flatpak system to execute commands outside the application's sandbox
+      '--talk-name=org.freedesktop.Flatpak',
     ],
     useWaylandFlags: 'false',
     artifactName: 'podman-desktop-${version}.${ext}',


### PR DESCRIPTION
### What does this PR do?

This fix removes full d-bus access and adds missing --talk-name opitons
that are present in flathub build configuration.

It fixes podman detection for flatpak built on github.

Fix #11937.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

Environment: Fedora or any other supported linux
1. Switch to the `main` branch
1. Remove line 164 `'--socket=session-bus',` from .electron-builder.config.cjs file
2. Make sure podman is installed and vm is running
3. Remove `./dist` folder with previous build artifact if it exists
4. Run `pnpm compile:next`
5. Ignore `GitHub personal access token is not set` errors in the end of the build
6. Install Podman Desktop flatpak build 
```flatpak install ./dist/podman-desktop-1.20.0-next```
7. Run Podman Desktop
```flatpak run --branch=main io.podman_desktop.PodmanDesktop```
8. On dashboard Podman Desktop state is going to be `NOT INSTALLED`

![image](https://github.com/user-attachments/assets/b6f89d34-e725-45b3-97b9-649a204a99ce)
 
10. Close Podman Desktop
11. Checkout this PR branch
12. Repeat steps 4-7
13. On Dashboard Podman Desktop state should be `RUNNING`

![image](https://github.com/user-attachments/assets/8337c011-534d-46c4-a39d-835d79891b62)

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
