### PR TITLE
chore(e2e): change expected img num in stress test depending on OS

### DIFF
--- a/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
+++ b/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import { expect as playExpect, test } from '../../utility/fixtures';
+import { isLinux } from '../../utility/platform';
 import { waitForPodmanMachineStartup } from '../../utility/wait';
 
 const numberOfObjects = Number(process.env.OBJECT_NUM) || 100;
@@ -38,8 +39,9 @@ test.describe.serial('Verification of UI handling lots of objects', { tag: ['@ui
 
     const images = await navigationBar.openImages();
     await playExpect(images.heading).toBeVisible({ timeout: 10_000 });
-    //count images => 1 original image + (1 tagged * numberOfObjects) + 1 localhost/podman-pause from pods = numberOfObjects + 2
-    await playExpect.poll(async () => await images.countRowsFromTable(), { timeout: 10_000 }).toBe(numberOfObjects + 2);
+    //count images => 1 original image + (1 tagged * numberOfObjects) + 1 localhost/podman-pause from pods (only ubuntu!) = numberOfObjects + 2
+    const expectedImages = isLinux ? numberOfObjects + 2 : numberOfObjects + 1;
+    await playExpect.poll(async () => await images.countRowsFromTable(), { timeout: 10_000 }).toBe(expectedImages);
     for (let imgNum = 1; imgNum <= numberOfObjects; imgNum++) {
       await playExpect
         .poll(async () => await images.waitForRowToExists(`localhost/my-image-${imgNum}`), { timeout: 0 })


### PR DESCRIPTION
### What does this PR do?
This PR fixes the problem with the expected number of images in the ui-stress-test spec file by changing the expected amount depending on the operating system it's been ran

### What issues does this PR fix or reference?
https://github.com/podman-desktop/e2e/issues/362
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
Run the windows stress test workflow: https://github.com/podman-desktop/e2e/actions/workflows/podman-desktop-e2e-stress-ui-windows.yaml
<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->
