### PR TITLE
fix: avoid to send status field when patching a resource

### DIFF
--- a/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
@@ -2348,6 +2348,66 @@ test('test sync resources was called with no resourceVersion, uid, selfLink, or 
   );
 });
 
+test('test sync resources was called with no status being passed through', async () => {
+  const client = createTestClient('default');
+  const context = 'test-context';
+  const namespace = 'default';
+  const manifests = [
+    {
+      apiVersion: 'v1',
+      kind: 'Pod',
+      metadata: {
+        name: 'test-pod',
+        resourceVersion: '123',
+        uid: 'uid123',
+        selfLink: '/api/v1/namespaces/default/pods/test-pod',
+        creationTimestamp: new Date(42),
+      },
+      status: {
+        phase: 'Running',
+        conditions: [
+          {
+            type: 'Ready',
+            status: 'True',
+          },
+        ],
+      },
+    },
+  ];
+
+  const mockedPatch = vi.fn();
+
+  makeApiClientMock.mockReturnValue({
+    read: vi.fn(),
+    create: vi.fn(),
+    patch: mockedPatch,
+  });
+
+  // Call the syncResources method with 'create' action
+  await client.syncResources(context, manifests, 'apply', namespace);
+
+  // Expect patch method to have been called
+  expect(mockedPatch).toHaveBeenCalled();
+
+  // Expect it to be called with NO status
+  expect(mockedPatch).toHaveBeenCalledWith(
+    {
+      apiVersion: 'v1',
+      kind: 'Pod',
+      metadata: {
+        annotations: {
+          'kubectl.kubernetes.io/last-applied-configuration': expect.anything(),
+        },
+        name: 'test-pod',
+        namespace: 'default',
+      },
+    },
+    undefined,
+    undefined,
+    'podman-desktop',
+  );
+});
+
 describe('port forward', () => {
   const serviceMock: KubernetesPortForwardService = {
     createForward: vi.fn(),

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
@@ -2386,9 +2386,6 @@ test('test sync resources was called with no status being passed through', async
   // Call the syncResources method with 'create' action
   await client.syncResources(context, manifests, 'apply', namespace);
 
-  // Expect patch method to have been called
-  expect(mockedPatch).toHaveBeenCalled();
-
   // Expect it to be called with NO status
   expect(mockedPatch).toHaveBeenCalledWith(
     {

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.ts
@@ -126,6 +126,7 @@ function isV1ObjectMetaWithName(m: unknown): m is V1ObjectMetaWithName {
 interface KubernetesObjectWithKindAndName extends KubernetesObject {
   kind: string;
   metadata: V1ObjectMetaWithName;
+  status?: V1Status;
 }
 
 function isKubernetesObjectWithKindAndName(o: unknown): o is KubernetesObjectWithKindAndName {
@@ -1333,6 +1334,7 @@ export class KubernetesClient {
             delete spec.metadata?.uid;
             delete spec.metadata?.selfLink;
             delete spec.metadata?.creationTimestamp;
+            delete spec.status; // status is usually updated by the system, ignore it
 
             const response = await client.patch(
               spec,


### PR DESCRIPTION
### What does this PR do?
status can contain fields like conditions having date, and then the kube library has issues with parsing the date (we used to remove the fields with date)

here, remove the status field before sending to the patch command

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/podman-desktop/podman-desktop/issues/12751

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
