### PR TITLE
refactor(podman): extract BaseInstaller to a dedicated file

### DIFF
--- a/extensions/podman/packages/extension/src/installer/base-installer.ts
+++ b/extensions/podman/packages/extension/src/installer/base-installer.ts
@@ -1,0 +1,36 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { InstallCheck } from '@podman-desktop/api';
+import { compare } from 'compare-versions';
+
+import type { Installer } from '../utils/podman-install';
+import { getBundledPodmanVersion } from '../utils/podman-install';
+
+export abstract class BaseInstaller implements Installer {
+  abstract install(): Promise<boolean>;
+
+  abstract update(): Promise<boolean>;
+
+  abstract getUpdatePreflightChecks(): InstallCheck[];
+
+  abstract getPreflightChecks(): InstallCheck[];
+
+  requireUpdate(installedVersion: string): boolean {
+    return compare(installedVersion, getBundledPodmanVersion(), '<');
+  }
+}

--- a/extensions/podman/packages/extension/src/utils/podman-install.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-install.ts
@@ -48,6 +48,7 @@ import {
   START_NOW_MACHINE_INIT_SUPPORTED_KEY,
   USER_MODE_NETWORKING_SUPPORTED_KEY,
 } from '../extension';
+import { BaseInstaller } from '../installer/base-installer';
 import * as podman5JSON from '../podman5.json';
 import type { InstalledPodman } from './podman-cli';
 import { getPodmanCli, getPodmanInstallation } from './podman-cli';
@@ -456,20 +457,6 @@ export class PodmanInstall {
     }
 
     return undefined;
-  }
-}
-
-abstract class BaseInstaller implements Installer {
-  abstract install(): Promise<boolean>;
-
-  abstract update(): Promise<boolean>;
-
-  abstract getUpdatePreflightChecks(): extensionApi.InstallCheck[];
-
-  abstract getPreflightChecks(): extensionApi.InstallCheck[];
-
-  requireUpdate(installedVersion: string): boolean {
-    return compare(installedVersion, getBundledPodmanVersion(), '<');
   }
 }
 


### PR DESCRIPTION
### What does this PR do?

Extract `BaseInstaller` class from `extensions/podman/packages/extension/src/utils/podman-install.ts` to a dedicated file.

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/12020

### How to test this PR?

N/A
