### PR TITLE
chore: correctly type guard e.target for micromark listener

### DIFF
--- a/packages/renderer/src/lib/markdown/micromark-listener-handler.spec.ts
+++ b/packages/renderer/src/lib/markdown/micromark-listener-handler.spec.ts
@@ -1,0 +1,140 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
+
+import { createListener } from './micromark-listener-handler';
+
+let mockCommandCallback: ReturnType<typeof vi.fn>;
+let listener: ReturnType<typeof createListener>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+beforeAll(() => {
+  mockCommandCallback = vi.fn();
+  listener = createListener(mockCommandCallback);
+  vi.mocked(window.executeCommand).mockResolvedValue(vi.fn());
+
+  // scrollIntoView is a native method, so we don't use vi.mocked, we just set it as vi.fn().
+  // we don't care about the elements (it just scrolls), we just want to ensure it was called.
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+test('command button check: calls executeButtonCommand if data was passed in', () => {
+  const target = document.createElement('button');
+  target.dataset.command = 'foo';
+
+  // Define an event
+  const event = new MouseEvent('click', { bubbles: true });
+  Object.defineProperty(event, 'target', { value: target });
+
+  // Append and listen
+  document.body.appendChild(target);
+  listener(event);
+
+  // Expect that the callback was called with "foo" and "starting"
+  // since this is running the inProgressMarkdownCommandExecutionCallback function
+  expect(mockCommandCallback).toHaveBeenCalledWith('foo', 'starting');
+
+  // Check that window.executeCommand was called with the command
+  expect(window.executeCommand).toHaveBeenCalledWith('foo', undefined);
+});
+
+test('command button check: calls executeButtonCommand with args if data (with args) was passed in', () => {
+  const target = document.createElement('button');
+  target.dataset.command = 'foo';
+  target.dataset.args = 'foo,bar,baz';
+
+  // Define an event
+  const event = new MouseEvent('click', { bubbles: true });
+  Object.defineProperty(event, 'target', { value: target });
+
+  // Append and listen
+  document.body.appendChild(target);
+  listener(event);
+
+  // Expect that the callback was called with "foo" and "starting"
+  expect(mockCommandCallback).toHaveBeenCalledWith('foo', 'starting');
+
+  // Check that window.executeCommand was called with the command and args
+  expect(window.executeCommand).toHaveBeenCalledWith('foo', 'foo,bar,baz');
+});
+
+test('expect executeCommand is called if target is HTMLAnchorElement with NO commmand data', () => {
+  const target = document.createElement('a');
+  target.dataset.command = 'foo';
+  target.href = 'https://example.com';
+
+  // Define an event
+  const event = new MouseEvent('click', { bubbles: true });
+  Object.defineProperty(event, 'target', { value: target });
+
+  // Append and listen
+  document.body.appendChild(target);
+  listener(event);
+
+  // Check that window.executeCommand was called with the command
+  expect(window.executeCommand).toHaveBeenCalledWith('foo', undefined);
+});
+
+test('does nothing if dataset is empty', () => {
+  const target = document.createElement('span');
+  const event = new MouseEvent('click', { bubbles: true });
+  Object.defineProperty(event, 'target', { value: target });
+
+  // Expect nothing to be called.
+  listener(event);
+  expect(mockCommandCallback).not.toHaveBeenCalled();
+});
+
+test('expect an immediate return if the target is not an HTMLElement', () => {
+  const event = new MouseEvent('click', { bubbles: true });
+  Object.defineProperty(event, 'target', { value: null });
+
+  // Expect nothing to be called.
+  listener(event);
+  expect(mockCommandCallback).not.toHaveBeenCalled();
+});
+
+test('data-pd-jump-in-page: scrolls to the element with the matching ID', () => {
+  const target = document.createElement('a');
+  target.setAttribute('data-pd-jump-in-page', 'target-id');
+  target.href = '#';
+
+  // Create a target element to scroll to
+  const targetElement = document.createElement('div');
+  targetElement.id = 'target-id';
+  document.body.appendChild(targetElement);
+
+  // Define an event
+  const event = new MouseEvent('click', { bubbles: true });
+  Object.defineProperty(event, 'target', { value: target });
+
+  // Append and listen
+  document.body.appendChild(target);
+  listener(event);
+
+  // Check that the element was scrolled into view (href was found and clicked on)
+  expect(targetElement.scrollIntoView).toHaveBeenCalledWith({
+    behavior: 'smooth',
+    block: 'start',
+    inline: 'nearest',
+  });
+});

--- a/packages/renderer/src/lib/markdown/micromark-listener-handler.ts
+++ b/packages/renderer/src/lib/markdown/micromark-listener-handler.ts
@@ -19,6 +19,8 @@
 import { executeButtonCommand } from './component/micromark-button';
 import { executeExpandableToggle } from './component/micromark-expandable-section';
 
+// createListener "listens" to button clicks and executes the appropriate command or action based on the button's dataset attributes.
+// for example.. "command" will execute the extensions associated command correctly.
 export function createListener(
   inProgressMarkdownCommandExecutionCallback: (
     command: string,
@@ -27,39 +29,21 @@ export function createListener(
   ) => void,
 ): EventListener {
   return (e: Event): void => {
-    let eventTarget: EventTarget;
-
-    if (e.target && typeof e.target === 'object') {
-      eventTarget = e.target;
-    } else {
+    // If the target is NOT an HTMLElement we should immediately return, this is because we listen to ALL events, but we
+    // are only interested in events that are triggered by HTML elements.
+    if (!(e.target instanceof HTMLElement)) {
       return;
     }
 
-    // Retrieve the command and expandable within the dataset
-    let command: string | undefined;
-    let args: string | undefined;
-    let expandable: string | undefined;
+    // Retrieve the command and "expandable" within the dataset
+    const command = e.target.dataset?.command;
+    const expandable = e.target.dataset?.expandable;
 
-    if ('dataset' in eventTarget && eventTarget.dataset && typeof eventTarget.dataset === 'object') {
-      const targetDataset = eventTarget.dataset;
-      if ('command' in targetDataset && typeof targetDataset.command === 'string') {
-        command = targetDataset.command;
-      }
-      // The targetDataset.args is a JS object but represented as a string
-      // typeof targetDataset.args === 'object' => false
-      // console.log(targetDataset.args) => [object Object]
-      if ('args' in targetDataset && targetDataset.args && typeof targetDataset.args === 'string') {
-        args = targetDataset.args;
-      }
-      if ('expandable' in targetDataset && typeof targetDataset.expandable === 'string') {
-        expandable = targetDataset.expandable;
-      }
-    }
-
+    // BUTTON CHECK: 'data-pd-jump-in-page'
     // if the user click on a a href link containing data-pd-jump-in-page attribute
-    if (eventTarget instanceof HTMLAnchorElement) {
+    if (e.target instanceof HTMLAnchorElement) {
       // get a matching attribute ?
-      const hrefId = eventTarget.getAttribute('data-pd-jump-in-page');
+      const hrefId = e.target.getAttribute('data-pd-jump-in-page');
 
       // get a linked ID
       if (hrefId) {
@@ -76,44 +60,55 @@ export function createListener(
       }
     }
 
+    // BUTTON CHECK: 'expandable'
     // if the user clicked on the toggle of an expandable section
     if (expandable) {
       executeExpandableToggle(expandable);
       return;
     }
 
+    // BUTTON CHECK: 'generic' button click (not a command)
     // if the user clicked on a button (new way)
-    if (!command && eventTarget instanceof HTMLButtonElement) {
-      const targetId = eventTarget.id;
+    if (!command && e.target instanceof HTMLButtonElement) {
+      const targetId = e.target.id;
       executeButtonCommand(targetId).catch((err: unknown) => console.error(`Error executing command ${targetId}`, err));
       return;
     }
 
+    // Get args, we do it here since we only use it in the below if / else if block.
+    // Args are passed in as a string in the dataset, so they cannot be json / must be string.
+    let args: string | undefined;
+    const dataset = e.target.dataset;
+    if ('args' in dataset && dataset.args && typeof dataset.args === 'string') {
+      args = dataset.args;
+    }
+
+    // BUTTON CHECK: 'command' button click (used in onboarding package.json)
     // Only check if the command exists and the target is not disabled
-    if (command && 'disabled' in eventTarget && !eventTarget.disabled) {
+    if (command) {
       // If the target is an instance of a button element, we know that we are going to execute either
       // a command or hyperlink
-      if (eventTarget instanceof HTMLButtonElement) {
-        const targetButton = eventTarget as HTMLButtonElement;
+      if (e.target instanceof HTMLButtonElement && !e.target.disabled) {
         // If the command exists and the button is not disabled, we execute the command
         // we'll also be updating the inProgressMarkdownCommandExecutionCallback so we have
         // real-time updates on the button
         inProgressMarkdownCommandExecutionCallback(command, 'starting');
-        targetButton.disabled = true;
-        if (targetButton.firstChild && targetButton.firstChild instanceof HTMLElement) {
-          targetButton.firstChild.style.display = 'inline-block';
+        e.target.disabled = true;
+        if (e.target instanceof HTMLElement && e.target.firstChild instanceof HTMLElement) {
+          e.target.firstChild.style.display = 'inline-block';
         }
+
         window
           .executeCommand(command, args)
           .then(value => inProgressMarkdownCommandExecutionCallback(command, 'successful', value))
           .catch((reason: unknown) => inProgressMarkdownCommandExecutionCallback(command, 'failed', reason))
           .finally(() => {
-            targetButton.disabled = false;
-            if (targetButton.firstChild && targetButton.firstChild instanceof HTMLElement) {
-              targetButton.firstChild.style.display = 'none';
+            (e.target as HTMLButtonElement).disabled = false;
+            if (e.target instanceof HTMLElement && e.target.firstChild instanceof HTMLElement) {
+              e.target.firstChild.style.display = 'none';
             }
           });
-      } else if (eventTarget instanceof HTMLAnchorElement) {
+      } else if (e.target instanceof HTMLAnchorElement) {
         // Execute the command since it's a simple "link" to it
         // usually associated with a dialog / quickpick action.
         window.executeCommand(command, args).catch((reason: unknown) => console.error(String(reason)));


### PR DESCRIPTION
chore: correctly type guard e.target for micromark listener

### What does this PR do?

This PR refactors the `micromark-listener-handler` file that handles the
"opening a command" implementation for onboarding.

When this was refactored as the result of https://github.com/podman-desktop/podman-desktop/pull/11038
`eventTarget` was using type-narrowing manually, which does not allow
accessibility to properties like dataset, disabled, etc which is needed
for the "command" functionality to work.

This PR fixes that by safely checking / type guarding e.target.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

Should now work:

https://github.com/user-attachments/assets/3e8a7836-2cf0-4663-866e-f98ee3fa0d12



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/podman-desktop/issues/12211

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

1. Start onboarding
2. Go to Compose or Kubectl
3. Click the "Want to download a different version?" button and see that
   it works correctly now with no errors.
