### PR TITLE
fix: dispatch resources counts events when context is offline

### DIFF
--- a/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.spec.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.spec.ts
@@ -58,6 +58,38 @@ test('ContextsStatesDispatcher should call updateHealthStates when onContextHeal
   expect(updatePermissionsSpy).not.toHaveBeenCalled();
 });
 
+test('ContextsStatesDispatcher should call updateHealthStates, updateResourcesCount and updateActiveResourcesCount when onOfflineChange event is fired', () => {
+  const manager: ContextsManagerExperimental = {
+    onContextHealthStateChange: vi.fn(),
+    onOfflineChange: vi.fn(),
+    onContextPermissionResult: vi.fn(),
+    onContextDelete: vi.fn(),
+    getHealthCheckersStates: vi.fn(),
+    getPermissions: vi.fn(),
+    onResourceCountUpdated: vi.fn(),
+    onResourceUpdated: vi.fn(),
+    isContextOffline: vi.fn(),
+  } as unknown as ContextsManagerExperimental;
+  const apiSender: ApiSenderType = {
+    send: vi.fn(),
+  } as unknown as ApiSenderType;
+  const dispatcher = new ContextsStatesDispatcher(manager, apiSender);
+  const updateHealthStatesSpy = vi.spyOn(dispatcher, 'updateHealthStates');
+  const updateResourcesCountSpy = vi.spyOn(dispatcher, 'updateResourcesCount');
+  const updateActiveResourcesCountSpy = vi.spyOn(dispatcher, 'updateActiveResourcesCount');
+  dispatcher.init();
+  expect(updateHealthStatesSpy).not.toHaveBeenCalled();
+  expect(updateResourcesCountSpy).not.toHaveBeenCalled();
+  expect(updateActiveResourcesCountSpy).not.toHaveBeenCalled();
+
+  vi.mocked(manager.onOfflineChange).mockImplementation(f => f() as IDisposable);
+  vi.mocked(manager.getHealthCheckersStates).mockReturnValue(new Map<string, ContextHealthState>());
+  dispatcher.init();
+  expect(updateHealthStatesSpy).toHaveBeenCalled();
+  expect(updateResourcesCountSpy).toHaveBeenCalled();
+  expect(updateActiveResourcesCountSpy).toHaveBeenCalled();
+});
+
 test('ContextsStatesDispatcher should call updatePermissions when onContextPermissionResult event is fired', () => {
   const manager: ContextsManagerExperimental = {
     onContextHealthStateChange: vi.fn(),

--- a/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.ts
@@ -36,7 +36,11 @@ export class ContextsStatesDispatcher {
 
   init(): void {
     this.manager.onContextHealthStateChange((_state: ContextHealthState) => this.updateHealthStates());
-    this.manager.onOfflineChange(() => this.updateHealthStates());
+    this.manager.onOfflineChange(() => {
+      this.updateHealthStates();
+      this.updateResourcesCount();
+      this.updateActiveResourcesCount();
+    });
     this.manager.onContextPermissionResult((_permissions: ContextPermissionResult) => this.updatePermissions());
     this.manager.onContextDelete((_state: DispatcherEvent) => {
       this.updateHealthStates();


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes #12465 

### How to test this PR?

In Kubernetes experimental mode, with a minikube/kind/minc cluster up and accessible, go to the Kubernetes dashboard, the counts should be > 0

Stay on the Kubernetes Dashboard, and stop the container running the cluster (using the cli), and verify that all counts change to 0

- [x] Tests are covering the bug fix or the new feature
