### PR TITLE
chore: remove error prone metadata for k8 creation from YAML

### DIFF
--- a/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
@@ -2348,6 +2348,85 @@ test('test sync resources was called with no resourceVersion, uid, selfLink, or 
   );
 });
 
+test('test sync resources uses create without resourceVersion, uid, selfLink, or creationTimestamp', async () => {
+  const client = createTestClient('default');
+  const context = 'test-context';
+  const namespace = 'default';
+  const manifests: KubernetesObject[] = [
+    {
+      apiVersion: 'v1',
+      kind: 'Pod',
+      metadata: {
+        name: 'test-pod',
+        resourceVersion: '123',
+        uid: 'uid123',
+        selfLink: '/api/v1/namespaces/default/pods/test-pod',
+        creationTimestamp: new Date(42),
+      },
+    },
+  ];
+
+  const mockedCreate = vi.fn();
+  makeApiClientMock.mockReturnValue({
+    read: vi.fn().mockRejectedValue(new Error('NotFound')), // Force create
+    create: mockedCreate,
+    patch: vi.fn(),
+  });
+
+  await client.syncResources(context, manifests, 'create', namespace);
+
+  expect(mockedCreate).toHaveBeenCalledWith({
+    apiVersion: 'v1',
+    kind: 'Pod',
+    metadata: {
+      annotations: {
+        'kubectl.kubernetes.io/last-applied-configuration': expect.stringContaining('"resourceVersion":"123"'),
+      },
+      name: 'test-pod',
+      namespace: 'default',
+    },
+  });
+});
+
+test('test sync resources uses create and removes status', async () => {
+  const client = createTestClient('default');
+  const context = 'test-context';
+  const namespace = 'default';
+  const manifests = [
+    {
+      apiVersion: 'v1',
+      kind: 'Pod',
+      metadata: {
+        name: 'test-pod',
+        resourceVersion: '123',
+        uid: 'uid123',
+        selfLink: '/api/v1/namespaces/default/pods/test-pod',
+        creationTimestamp: new Date(42),
+      },
+      status: {
+        phase: 'Running',
+        conditions: [
+          {
+            type: 'Ready',
+            status: 'True',
+          },
+        ],
+      },
+    },
+  ];
+
+  const mockedCreate = vi.fn();
+  makeApiClientMock.mockReturnValue({
+    read: vi.fn().mockRejectedValue(new Error('NotFound')),
+    create: mockedCreate,
+    patch: vi.fn(),
+  });
+
+  await client.syncResources(context, manifests, 'create', namespace);
+
+  expect(mockedCreate).toHaveBeenCalledWith(expect.not.objectContaining({ status: expect.anything() }));
+});
+
 test('test sync resources was called with no status being passed through', async () => {
   const client = createTestClient('default');
   const context = 'test-context';

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.ts
@@ -148,6 +148,14 @@ function isScalableControllerType(string: unknown): string is ScalableController
   return typeof string === 'string' && SCALABLE_CONTROLLER_TYPES.includes(string);
 }
 
+function sanitizeMetadata(spec: KubernetesObject): void {
+  delete spec.metadata?.resourceVersion;
+  delete spec.metadata?.uid;
+  delete spec.metadata?.selfLink;
+  delete spec.metadata?.creationTimestamp;
+  delete spec.metadata?.managedFields;
+}
+
 export interface PodCreationSource {
   isManuallyCreated: boolean;
   controllerType: ControllerType;
@@ -1313,6 +1321,15 @@ export class KubernetesClient {
         spec.metadata.annotations['kubectl.kubernetes.io/last-applied-configuration'] = JSON.stringify(spec);
 
         spec.metadata.namespace ??= namespace ?? DEFAULT_NAMESPACE;
+
+        // When patching a resource or creating a new one, we do not need certain metadata fields to be present such as resourceVersion, uid, selfLink, and creationTimestamp
+        // these cause conflicts when patching a resource since client.patch will serialize these fields and the server will reject the request
+        // this change is due to changes on how client.patch / client.create works with the latest serialization changes in:
+        // https://github.com/kubernetes-client/javascript/pull/1695 with regards to date
+        // we also remove resourceVersion so we may apply multiple edits to the same resource without having to entirely retrieve and reload the YAML
+        // from the server before applying.
+        sanitizeMetadata(spec);
+
         try {
           // try to get the resource, if it does not exist an error will be thrown and we will
           // end up in the catch block


### PR DESCRIPTION
### What does this PR do?

extends the patch to remove metadata for k8 apply for creation as well to fix serialization error

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
fixes https://github.com/podman-desktop/podman-desktop/issues/12627

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
see issue above for claritiy ill list the test to check functionality 

Steps to test
Install Kind, create cluster, switch to kind cluster kube context
Pull image nginx
Create and start a nginx container
Create a pod from nginx container
Generate a Kube from nginx pod -> save to a file nginx-pod.yaml
Test 1:  On the Pods tab, click on Play Kubernetes Yaml, choose Kind cluster runtime when deploying the yaml
Test 2: under the Kubernetes tab in its Pods tab click on Apply YAML

Make sure no error like data.toIOString happens

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
