### PR TITLE
chore(test): install ingress controller on Kind cluster only if needed

### DIFF
--- a/tests/playwright/src/specs/kind.spec.ts
+++ b/tests/playwright/src/specs/kind.spec.ts
@@ -121,16 +121,13 @@ test.describe('Kind End-to-End Tests', { tag: '@k8s_e2e' }, () => {
     });
   test.describe
     .serial('Kind cluster validation tests', () => {
-      test('Create a Kind cluster', async ({ page }) => {
+      test('Create a Kind cluster - With Ingress controller', async ({ page }) => {
         test.setTimeout(CLUSTER_CREATION_TIMEOUT);
-        if (process.env.GITHUB_ACTIONS && process.env.RUNNER_OS === 'Linux') {
-          await createKindCluster(page, CLUSTER_NAME, false, CLUSTER_CREATION_TIMEOUT, {
-            providerType: providerTypeGHA,
-            useIngressController: false,
-          });
-        } else {
-          await createKindCluster(page, CLUSTER_NAME, true, CLUSTER_CREATION_TIMEOUT);
-        }
+
+        await createKindCluster(page, CLUSTER_NAME, CLUSTER_CREATION_TIMEOUT, {
+          providerType: providerTypeGHA,
+          useIngressController: true,
+        });
       });
 
       test('Check resources added with the Kind cluster', async ({ page }) => {
@@ -186,16 +183,13 @@ test.describe('Kind End-to-End Tests', { tag: '@k8s_e2e' }, () => {
     });
   test.describe
     .serial('Kind cluster operations - Details', () => {
-      test('Create a Kind cluster', async ({ page }) => {
+      test('Create a Kind cluster - Without Ingress controller', async ({ page }) => {
         test.setTimeout(CLUSTER_CREATION_TIMEOUT);
-        if (process.env.GITHUB_ACTIONS && process.env.RUNNER_OS === 'Linux') {
-          await createKindCluster(page, CLUSTER_NAME, false, CLUSTER_CREATION_TIMEOUT, {
-            providerType: providerTypeGHA,
-            useIngressController: false,
-          });
-        } else {
-          await createKindCluster(page, CLUSTER_NAME, true, CLUSTER_CREATION_TIMEOUT);
-        }
+
+        await createKindCluster(page, CLUSTER_NAME, CLUSTER_CREATION_TIMEOUT, {
+          providerType: providerTypeGHA,
+          useIngressController: false,
+        });
       });
 
       test('Kind cluster operations details - STOP', async ({ page }) => {
@@ -236,17 +230,12 @@ test.describe('Kind End-to-End Tests', { tag: '@k8s_e2e' }, () => {
     .serial('Kind cluster creation with custom config file', () => {
       test('Create a Kind cluster using the custom config file', async ({ page }) => {
         test.setTimeout(CLUSTER_CREATION_TIMEOUT);
-        if (process.env.GITHUB_ACTIONS && process.env.RUNNER_OS === 'Linux') {
-          await createKindCluster(page, CUSTOM_CONFIG_CLUSTER_NAME, false, CLUSTER_CREATION_TIMEOUT, {
-            configFilePath: CUSTOM_CONFIG_FILE_PATH,
-            providerType: providerTypeGHA,
-            useIngressController: false,
-          });
-        } else {
-          await createKindCluster(page, CUSTOM_CONFIG_CLUSTER_NAME, false, CLUSTER_CREATION_TIMEOUT, {
-            configFilePath: CUSTOM_CONFIG_FILE_PATH,
-          });
-        }
+
+        await createKindCluster(page, CUSTOM_CONFIG_CLUSTER_NAME, CLUSTER_CREATION_TIMEOUT, {
+          configFilePath: CUSTOM_CONFIG_FILE_PATH,
+          providerType: providerTypeGHA,
+          useIngressController: false,
+        });
         await checkClusterResources(page, CUSTOM_CONFIG_KIND_CONTAINER);
       });
       test('Delete the Kind cluster', async ({ page }) => {

--- a/tests/playwright/src/specs/kubernetes-image-push.spec.ts
+++ b/tests/playwright/src/specs/kubernetes-image-push.spec.ts
@@ -69,14 +69,10 @@ test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
     await ensureCliInstalled(page, 'Kind');
   }
 
-  if (process.env.GITHUB_ACTIONS && process.env.RUNNER_OS === 'Linux') {
-    await createKindCluster(page, CLUSTER_NAME, false, CLUSTER_CREATION_TIMEOUT, {
-      providerType: providerTypeGHA,
-      useIngressController: false,
-    });
-  } else {
-    await createKindCluster(page, CLUSTER_NAME, true, CLUSTER_CREATION_TIMEOUT);
-  }
+  await createKindCluster(page, CLUSTER_NAME, CLUSTER_CREATION_TIMEOUT, {
+    providerType: providerTypeGHA,
+    useIngressController: false,
+  });
 });
 
 test.afterAll(async ({ runner, page }) => {

--- a/tests/playwright/src/specs/kubernetes-networking.spec.ts
+++ b/tests/playwright/src/specs/kubernetes-networking.spec.ts
@@ -107,14 +107,10 @@ test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
     await ensureCliInstalled(page, 'Kind');
   }
 
-  if (process.env.GITHUB_ACTIONS && process.env.RUNNER_OS === 'Linux') {
-    await createKindCluster(page, CLUSTER_NAME, false, CLUSTER_CREATION_TIMEOUT, {
-      providerType: providerTypeGHA,
-      useIngressController: true,
-    });
-  } else {
-    await createKindCluster(page, CLUSTER_NAME, true, CLUSTER_CREATION_TIMEOUT);
-  }
+  await createKindCluster(page, CLUSTER_NAME, CLUSTER_CREATION_TIMEOUT, {
+    providerType: providerTypeGHA,
+    useIngressController: true,
+  });
 });
 
 test.afterAll(async ({ runner, page }) => {

--- a/tests/playwright/src/specs/kubernetes-status-bar-providers.spec.ts
+++ b/tests/playwright/src/specs/kubernetes-status-bar-providers.spec.ts
@@ -128,14 +128,10 @@ test.describe.serial('Status bar providers feature verification', { tag: '@k8s_e
   test('Create new provider (Kind) and verify providers updated', async ({ page, statusBar }) => {
     test.skip(!canRunKindTests(), `This test can't run on a windows rootless machine`);
     test.setTimeout(600_000);
-    if (process.env.GITHUB_ACTIONS && process.env.RUNNER_OS === 'Linux') {
-      await createKindCluster(page, kindClusterName, false, 550_000, {
-        providerType: providerTypeGHA,
-        useIngressController: false,
-      });
-    } else {
-      await createKindCluster(page, kindClusterName, true, 550_000);
-    }
+    await createKindCluster(page, kindClusterName, 550_000, {
+      providerType: providerTypeGHA,
+      useIngressController: false,
+    });
 
     //Verify its not pinned by default
     const kindStatusBarProviderButton = await statusBar.getProviderButton(kindProviderName);

--- a/tests/playwright/src/specs/kubernetes.spec.ts
+++ b/tests/playwright/src/specs/kubernetes.spec.ts
@@ -119,14 +119,10 @@ test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
     await ensureCliInstalled(page, 'Kind');
   }
 
-  if (process.env.GITHUB_ACTIONS && process.env.RUNNER_OS === 'Linux') {
-    await createKindCluster(page, CLUSTER_NAME, false, CLUSTER_CREATION_TIMEOUT, {
-      providerType: providerTypeGHA,
-      useIngressController: false,
-    });
-  } else {
-    await createKindCluster(page, CLUSTER_NAME, true, CLUSTER_CREATION_TIMEOUT);
-  }
+  await createKindCluster(page, CLUSTER_NAME, CLUSTER_CREATION_TIMEOUT, {
+    providerType: providerTypeGHA,
+    useIngressController: false,
+  });
 });
 
 test.afterAll(async ({ runner, page }) => {

--- a/tests/playwright/src/utility/cluster-operations.ts
+++ b/tests/playwright/src/utility/cluster-operations.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2024 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,11 +34,12 @@ import { getVolumeNameForContainer } from './operations';
 export async function createKindCluster(
   page: Page,
   clusterName: string,
-  usedefaultOptions: boolean,
   timeout: number = 300_000,
   { configFilePath, providerType, httpPort, httpsPort, useIngressController, containerImage }: KindClusterOptions = {},
 ): Promise<void> {
-  return test.step('Create Kind cluster', async () => {
+  return test.step(`Create Kind cluster with settings: configFilePath=${configFilePath}, 
+    providerType=${providerType}, httpPort=${httpPort},
+    httpsPort=${httpsPort}, ingressController=${useIngressController}`, async () => {
     const navigationBar = new NavigationBar(page);
     const statusBar = new StatusBar(page);
     const kindResourceCard = new ResourceConnectionCardPage(page, 'kind', clusterName);
@@ -61,22 +62,18 @@ export async function createKindCluster(
     }
 
     await kindResourceCard.createButton.click();
-    if (usedefaultOptions) {
-      await createKindClusterPage.createClusterDefault(clusterName, timeout);
-    } else {
-      await createKindClusterPage.createClusterParametrized(
-        clusterName,
-        {
-          configFilePath: configFilePath,
-          providerType: providerType,
-          httpPort: httpPort,
-          httpsPort: httpsPort,
-          useIngressController: useIngressController,
-          containerImage: containerImage,
-        },
-        timeout,
-      );
-    }
+    await createKindClusterPage.createKindCluster(
+      clusterName,
+      {
+        configFilePath: configFilePath,
+        providerType: providerType,
+        httpPort: httpPort,
+        httpsPort: httpsPort,
+        useIngressController: useIngressController,
+        containerImage: containerImage,
+      },
+      timeout,
+    );
     await playExpect(kindResourceCard.resourceElement).toBeVisible();
     await playExpect(kindResourceCard.resourceElementConnectionStatus).toHaveText(ResourceElementState.Running, {
       timeout: 15_000,


### PR DESCRIPTION
### What does this PR do?
Skips ingress controller installation on Kind clusters if it is not required by tests. This avoids potential issues with the ingress controller and improves k8s e2e test reliability by preventing failures during cluster setup.
### Screenshot / video of UI

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/12816

### How to test this PR?

https://github.com/podman-desktop/e2e/actions/runs/15593572158
