### PR TITLE
chore: addProviderMenuItem - add provider if it does not exist

### DIFF
--- a/packages/main/src/plugin/tray-menu-registry.spec.ts
+++ b/packages/main/src/plugin/tray-menu-registry.spec.ts
@@ -49,6 +49,8 @@ beforeAll(() => {
     addProviderListener: vi.fn(),
     addProviderLifecycleListener: vi.fn(),
     addProviderContainerConnectionLifecycleListener: vi.fn(),
+    getProviderInfo: vi.fn(),
+    getMatchingProviderInternalId: vi.fn(),
   } as unknown as ProviderRegistry;
   const telemetryService = {} as Telemetry;
   menuRegistry = new TrayMenuRegistry(trayMenu, commandRegistry, providerRegistry, telemetryService);
@@ -59,6 +61,18 @@ beforeEach(() => {
 });
 
 test('Should pass proper providerId field', () => {
+  // Mock providerInfo to return a specific internalId
+  const providerInfo: ProviderInfo = {
+    internalId: '1',
+    id: 'testId',
+  } as unknown as ProviderInfo;
+
+  // Mock getMatchingProviderInternalId to return '1'
+  vi.mocked(menuRegistry.providerRegistry.getMatchingProviderInternalId).mockReturnValue(providerInfo.internalId);
+
+  // Mock getProviderInfo to return the mocked providerInfo
+  vi.mocked(menuRegistry.providerRegistry.getProviderInfo).mockReturnValue(providerInfo);
+
   const ipcEmit = vi.spyOn(ipcMain, 'emit');
   menuRegistry.registerProvider({
     internalId: 'internalId',
@@ -72,7 +86,7 @@ test('Should pass proper providerId field', () => {
   expect(lastIpcArguments).not.toBeUndefined();
   expect(lastIpcArguments[0]).eqls('tray:add-provider-menu-item');
   expect(lastIpcArguments[1]).eqls('');
-  expect(lastIpcArguments[2]).eqls({ providerId: 'testId', menuItem: menuItem });
+  expect(lastIpcArguments[2]).eqls({ providerId: 'testId', menuItem: menuItem, providerInfo: providerInfo });
 });
 
 test('Should remove menu item on dispose', () => {

--- a/packages/main/src/plugin/tray-menu-registry.ts
+++ b/packages/main/src/plugin/tray-menu-registry.ts
@@ -145,8 +145,15 @@ export class TrayMenuRegistry {
   }
 
   registerProviderMenuItem(providerId: string, menuItem: MenuItem): Disposable {
+    // Retrieve the provider info from the registry,
+    // this is necessary so that we can pass in the provider information
+    // in case we need to update / create a provider menu section.
+
+    // Get the matching internal provider id
+    const providerInternalId = this.providerRegistry.getMatchingProviderInternalId(providerId);
+    const providerInfo = this.providerRegistry.getProviderInfo(providerInternalId);
     this.menuItems.set(menuItem.id, menuItem);
-    ipcMain.emit('tray:add-provider-menu-item', '', { providerId, menuItem });
+    ipcMain.emit('tray:add-provider-menu-item', '', { providerId, providerInfo, menuItem });
     return Disposable.create(() => {
       this.trayMenu.deleteProviderItem(providerId, menuItem.id);
       this.menuItems.delete(menuItem.id);


### PR DESCRIPTION
### What does this PR do?

**Context information:**

addProviderMenuItem is an API call that is used to "group" tray menu
items together to one provider.

There is a problem however... The API call depends that we registered the
provider with registerLifecycle in the API... since the tray menu calls
"addProviderLifecycleListener".

However, "registerLifecycle" was improved and had no longer been
required in 2022 for extensions:
https://github.com/podman-desktop/podman-desktop/pull/69

registerLifecycle is also NOT used at all for external extensions
(public GitHub search reveals... nothing.)

We also cannot "pre-emptively" give provider information since tray is
initialized very early:
https://github.com/cdrage/podman-desktop/blob/6f591c25b97c7ad6d8794699bf1f15cd5ff92325/packages/main/src/index.ts#L141-L142

As our API is designed to always be backwards compatible, in the case
that we use "addProviderMenuItem" call, we will add the provider to the
list (menuProviderItems).

**This PR does the following:**
* Removes "temp" sections as they will no longer be needed. Provider
  information should always be passed in, if there is no provider
  information (worst case scenario), we console.error out.
* Keep backwards compatibility for any non-public extensions still using
  registerLifecycle and addProviderMenuItem API calls.
* Passed in provider information when doing addProviderMenuItem (makes
  sense right?) in the scenario that the extension calls
  addProviderMenuItem WITHOUT doing `registerLifecycle` first in their
  extension
* Added lots of tests to cover all scenarios.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

https://github.com/user-attachments/assets/e77da468-50d3-47f6-b117-118e7f6ff821




### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/podman-desktop/issues/6915
Closes https://github.com/podman-desktop/podman-desktop/issues/4624

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

1. Download the openshift local extension
2. Install
3. Right click on the podman desktop icon, see that OpenShift Local is
   there now (no longer "temp").

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
