### PR TITLE
chore: stop sending kubernetesExecIntoContainer event

### DIFF
--- a/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
@@ -1272,7 +1272,6 @@ test('Test should exec into container only once', async () => {
   await client.execIntoContainer('test-pod', 'test-container', onStdOutFn, onStdErrFn, onCloseFn);
   await client.execIntoContainer('test-pod', 'test-container', onStdOutFn, onStdErrFn, onCloseFn);
   expect(execMock).toHaveBeenCalledOnce();
-  expect(telemetry.track).toHaveBeenCalledOnce();
 });
 
 test('Test should throw an exception during exec command if resize parameters are wrong', async () => {

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.ts
@@ -1418,7 +1418,6 @@ export class KubernetesClient {
         onClose();
       });
     } else {
-      let telemetryOptions = {};
       try {
         const ns = this.getCurrentNamespace();
         const connected = await this.checkConnection();
@@ -1459,10 +1458,7 @@ export class KubernetesClient {
         });
         this.#execs.set(`${podName}-${containerName}`, { stdin, stdout, stderr, conn });
       } catch (error) {
-        telemetryOptions = { error: error };
         throw this.wrapK8sClientError(error);
-      } finally {
-        this.telemetry.track('kubernetesExecIntoContainer', telemetryOptions);
       }
     }
 


### PR DESCRIPTION
### What does this PR do?

Stop sending the kubernetesExecIntoContainer event for telemetry.

### What issues does this PR fix or reference?

fixes #12727 

- [ ] Tests are covering the bug fix or the new feature
