### PR TITLE
refactor(podman): extract `Installer` interface to dedicated file

### DIFF
--- a/extensions/podman/packages/extension/src/installer/base-installer.ts
+++ b/extensions/podman/packages/extension/src/installer/base-installer.ts
@@ -18,8 +18,8 @@
 import type { InstallCheck } from '@podman-desktop/api';
 import { compare } from 'compare-versions';
 
-import type { Installer } from '../utils/podman-install';
 import { getBundledPodmanVersion } from '../utils/podman-install';
+import type { Installer } from './installer';
 
 export abstract class BaseInstaller implements Installer {
   abstract install(): Promise<boolean>;

--- a/extensions/podman/packages/extension/src/installer/installer.ts
+++ b/extensions/podman/packages/extension/src/installer/installer.ts
@@ -1,0 +1,27 @@
+/*********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************/
+
+import type { InstallCheck } from '@podman-desktop/api';
+
+export interface Installer {
+  getPreflightChecks(): InstallCheck[] | undefined;
+  getUpdatePreflightChecks(): InstallCheck[] | undefined;
+  install(): Promise<boolean>;
+  requireUpdate(installedVersion: string): boolean;
+  update(): Promise<boolean>;
+}

--- a/extensions/podman/packages/extension/src/utils/podman-install.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-install.spec.ts
@@ -23,9 +23,10 @@ import * as extensionApi from '@podman-desktop/api';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import * as extensionObj from '../extension';
+import type { Installer } from '../installer/installer';
 import { releaseNotes } from '../podman5.json';
 import type { InstalledPodman } from './podman-cli';
-import type { Installer, PodmanInfo, UpdateCheck } from './podman-install';
+import type { PodmanInfo, UpdateCheck } from './podman-install';
 import { getBundledPodmanVersion, PodmanInstall, WinInstaller } from './podman-install';
 import * as podmanInstallObj from './podman-install';
 import * as utils from './util';

--- a/extensions/podman/packages/extension/src/utils/podman-install.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-install.ts
@@ -49,6 +49,7 @@ import {
   USER_MODE_NETWORKING_SUPPORTED_KEY,
 } from '../extension';
 import { BaseInstaller } from '../installer/base-installer';
+import type { Installer } from '../installer/installer';
 import * as podman5JSON from '../podman5.json';
 import type { InstalledPodman } from './podman-cli';
 import { getPodmanCli, getPodmanInstallation } from './podman-cli';
@@ -123,13 +124,6 @@ export class PodmanInfoImpl implements PodmanInfo {
   }
 }
 
-export interface Installer {
-  getPreflightChecks(): extensionApi.InstallCheck[] | undefined;
-  getUpdatePreflightChecks(): extensionApi.InstallCheck[] | undefined;
-  install(): Promise<boolean>;
-  requireUpdate(installedVersion: string): boolean;
-  update(): Promise<boolean>;
-}
 export interface UpdateCheck {
   hasUpdate: boolean;
   installedVersion?: string;


### PR DESCRIPTION
### What does this PR do?

Extract `Installer` class to `extensions/podman/packages/extension/src/installer/installer.ts`

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/12022
