### PR TITLE
chore: removed svelte check warning

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -344,6 +344,7 @@ async function connect(contextName: string): Promise<void> {
                             {#each context.errorMessage.split('\n').filter(l => l) as line, index (index)}
                               <p>{line}</p>
                             {/each}
+                          </div>
                         </Tooltip>
                       </div>
                     {:else}


### PR DESCRIPTION
### What does this PR do?

Removed svelte check warning "element is implicitly closed" in PreferencesKubernetesContextsRendering.svelte file, due to a missing closing tag.

### Screenshot / video of UI

### What issues does this PR fix or reference?

close #12857 

### How to test this PR?

run svelte:check script.

- [ ] Tests are covering the bug fix or the new feature
