### PR TITLE
refactor(podman): extract getBundledPodmanVersion interface to a file

### DIFF
--- a/extensions/podman/packages/extension/src/installer/base-installer.ts
+++ b/extensions/podman/packages/extension/src/installer/base-installer.ts
@@ -18,7 +18,7 @@
 import type { InstallCheck } from '@podman-desktop/api';
 import { compare } from 'compare-versions';
 
-import { getBundledPodmanVersion } from '../utils/podman-install';
+import { getBundledPodmanVersion } from '../utils/podman-bundled';
 import type { Installer } from './installer';
 
 export abstract class BaseInstaller implements Installer {

--- a/extensions/podman/packages/extension/src/utils/podman-bundled.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-bundled.spec.ts
@@ -1,0 +1,29 @@
+/*********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************/
+
+import { describe, expect, test } from 'vitest';
+
+import { getBundledPodmanVersion } from './podman-bundled';
+
+describe('getBundledPodmanVersion', () => {
+  test('should return the podman 5 version', async () => {
+    const version = getBundledPodmanVersion();
+    expect(version.startsWith('5')).toBeTruthy();
+    expect(version.startsWith('4')).toBeFalsy();
+  });
+});

--- a/extensions/podman/packages/extension/src/utils/podman-bundled.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-bundled.ts
@@ -1,0 +1,23 @@
+/*********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************/
+
+import * as podman5JSON from '../podman5.json';
+
+export function getBundledPodmanVersion(): string {
+  return podman5JSON.version;
+}

--- a/extensions/podman/packages/extension/src/utils/podman-install.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-install.spec.ts
@@ -25,10 +25,10 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import * as extensionObj from '../extension';
 import type { Installer } from '../installer/installer';
 import { releaseNotes } from '../podman5.json';
+import { getBundledPodmanVersion } from './podman-bundled';
 import type { InstalledPodman } from './podman-cli';
 import type { PodmanInfo, UpdateCheck } from './podman-install';
-import { getBundledPodmanVersion, PodmanInstall, WinInstaller } from './podman-install';
-import * as podmanInstallObj from './podman-install';
+import { PodmanInstall, WinInstaller } from './podman-install';
 import * as utils from './util';
 
 const originalConsoleError = console.error;
@@ -208,14 +208,6 @@ test('expect update on windows to throw error if non zero exit code', async () =
   expect(extensionApi.window.showErrorMessage).toHaveBeenCalled();
 });
 
-describe('getBundledPodmanVersion', () => {
-  test('should return the podman 5 version', async () => {
-    const version = getBundledPodmanVersion();
-    expect(version.startsWith('5')).toBeTruthy();
-    expect(version.startsWith('4')).toBeFalsy();
-  });
-});
-
 class TestPodmanInstall extends PodmanInstall {
   async stopPodmanMachinesIfAnyBeforeUpdating(): Promise<boolean> {
     return super.stopPodmanMachinesIfAnyBeforeUpdating();
@@ -385,7 +377,7 @@ test('checkForUpdate should return installed version and no update if the instal
   expect(result).toStrictEqual({
     installedVersion: '1.1',
     hasUpdate: false,
-    bundledVersion: podmanInstallObj.getBundledPodmanVersion(),
+    bundledVersion: getBundledPodmanVersion(),
   });
 });
 
@@ -403,7 +395,7 @@ test('checkForUpdate should return installed version and update if the installed
   expect(result).toStrictEqual({
     installedVersion: '1.1',
     hasUpdate: true,
-    bundledVersion: podmanInstallObj.getBundledPodmanVersion(),
+    bundledVersion: getBundledPodmanVersion(),
   });
 });
 

--- a/extensions/podman/packages/extension/src/utils/podman-install.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-install.ts
@@ -51,16 +51,13 @@ import {
 import { BaseInstaller } from '../installer/base-installer';
 import type { Installer } from '../installer/installer';
 import * as podman5JSON from '../podman5.json';
+import { getBundledPodmanVersion } from './podman-bundled';
 import type { InstalledPodman } from './podman-cli';
 import { getPodmanCli, getPodmanInstallation } from './podman-cli';
 import { getAssetsFolder } from './util';
 
 const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
-
-export function getBundledPodmanVersion(): string {
-  return podman5JSON.version;
-}
 
 export interface PodmanInfo {
   podmanVersion?: string;


### PR DESCRIPTION
### What does this PR do?

Moving `getBundledPodmanVersion` to a dedicated file, and its corresponding test

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/12025
