### PR TITLE
chore: remove viewDevEnvironments as it's gone from Docker extension

### DIFF
--- a/packages/preload-docker-extension/src/index.ts
+++ b/packages/preload-docker-extension/src/index.ts
@@ -271,9 +271,6 @@ export class DockerExtensionPreload {
       viewVolume: async (volume: string): Promise<void> => {
         console.error('navigationIntents.viewVolume not implemented', volume);
       },
-      viewDevEnvironments: async (): Promise<void> => {
-        console.error('navigationIntents.viewDevEnvironments not implemented');
-      },
       viewContainerTerminal: async (id: string): Promise<void> => {
         console.error('navigationIntents.viewContainerTerminal not implemented', id);
       },


### PR DESCRIPTION
### What does this PR do?
docker extension API removed an entry so need to get rid of it as well from the implementation

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

https://github.com/podman-desktop/podman-desktop/pull/12853

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
