### PR TITLE
refactor(podman): extract `WinInstaller` to a dedicated file

### DIFF
--- a/extensions/podman/packages/extension/src/installer/win-installer.spec.ts
+++ b/extensions/podman/packages/extension/src/installer/win-installer.spec.ts
@@ -1,0 +1,109 @@
+/*********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************/
+
+import { existsSync, readdirSync } from 'node:fs';
+
+import type { ExtensionContext } from '@podman-desktop/api';
+import * as extensionApi from '@podman-desktop/api';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { getAssetsFolder } from '../utils/util';
+import { WinInstaller } from './win-installer';
+
+vi.mock('node:fs');
+vi.mock('@podman-desktop/api', () => ({
+  commands: {},
+  env: {},
+  window: {
+    withProgress: vi.fn(),
+    showNotification: vi.fn(),
+    showErrorMessage: vi.fn(),
+  },
+  ProgressLocation: {},
+  process: {
+    exec: vi.fn(),
+  },
+}));
+
+const extensionContext = {
+  subscriptions: [],
+} as unknown as ExtensionContext;
+
+const progress = {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  report: (): void => {},
+};
+
+vi.mock(import('./../utils/util'), () => ({
+  getAssetsFolder: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  // reset array of subscriptions
+  extensionContext.subscriptions.length = 0;
+
+  vi.mocked(getAssetsFolder).mockReturnValue('');
+
+  vi.mocked(extensionApi.window.withProgress).mockImplementation((options, task) => {
+    return task(progress, {} as unknown as extensionApi.CancellationToken);
+  });
+});
+
+test('expect update on windows to show notification in case of 0 exit code', async () => {
+  vi.mocked(extensionApi.process.exec).mockImplementation(() => Promise.resolve({} as extensionApi.RunResult));
+
+  vi.mocked(existsSync).mockReturnValue(true);
+  vi.mocked(readdirSync).mockReturnValue([]);
+
+  const installer = new WinInstaller(extensionContext);
+  const result = await installer.update();
+  expect(result).toBeTruthy();
+  expect(extensionApi.window.showNotification).toHaveBeenCalled();
+});
+
+test('expect update on windows not to show notification in case of 1602 exit code', async () => {
+  const customError = { exitCode: 1602 } as extensionApi.RunError;
+  vi.spyOn(extensionApi.process, 'exec').mockImplementation(() => {
+    throw customError;
+  });
+
+  vi.mocked(existsSync).mockReturnValue(true);
+  vi.mocked(readdirSync).mockReturnValue([]);
+
+  const installer = new WinInstaller(extensionContext);
+  const result = await installer.update();
+  expect(result).toBeTruthy();
+  expect(extensionApi.window.showNotification).not.toHaveBeenCalled();
+});
+
+test('expect update on windows to throw error if non zero exit code', async () => {
+  const customError = { exitCode: -1, stderr: 'CustomError' } as extensionApi.RunError;
+
+  vi.mocked(extensionApi.process.exec).mockImplementation(() => {
+    throw customError;
+  });
+
+  vi.mocked(existsSync).mockReturnValue(true);
+  vi.mocked(readdirSync).mockReturnValue([]);
+
+  const installer = new WinInstaller(extensionContext);
+  const result = await installer.update();
+  expect(result).toBeFalsy();
+  expect(extensionApi.window.showErrorMessage).toHaveBeenCalled();
+});

--- a/extensions/podman/packages/extension/src/installer/win-installer.ts
+++ b/extensions/podman/packages/extension/src/installer/win-installer.ts
@@ -1,0 +1,98 @@
+/*********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************/
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import type { ExtensionContext, InstallCheck, RunError } from '@podman-desktop/api';
+import { process as processAPI, ProgressLocation, window } from '@podman-desktop/api';
+
+import { OrCheck, SequenceCheck } from '../checks/base-check';
+import { HyperVCheck } from '../checks/hyperv-check';
+import { VirtualMachinePlatformCheck } from '../checks/virtual-machine-platform-check';
+import { WinBitCheck } from '../checks/win-bit-check';
+import { WinMemoryCheck } from '../checks/win-memory-check';
+import { WinVersionCheck } from '../checks/win-version-check';
+import { WSLVersionCheck } from '../checks/wsl-version-check';
+import { WSL2Check } from '../checks/wsl2-check';
+import { getBundledPodmanVersion } from '../utils/podman-bundled';
+import { getAssetsFolder } from '../utils/util';
+import { BaseInstaller } from './base-installer';
+
+export class WinInstaller extends BaseInstaller {
+  constructor(private extensionContext: ExtensionContext) {
+    super();
+  }
+
+  getUpdatePreflightChecks(): InstallCheck[] {
+    return [];
+  }
+
+  getPreflightChecks(): InstallCheck[] {
+    return [
+      new WinBitCheck(),
+      new WinVersionCheck(),
+      new WinMemoryCheck(),
+      new OrCheck(
+        'Windows virtualization',
+        new SequenceCheck('WSL platform', [
+          new VirtualMachinePlatformCheck(),
+          new WSLVersionCheck(),
+          new WSL2Check(this.extensionContext),
+        ]),
+        new HyperVCheck(true),
+      ),
+    ];
+  }
+
+  update(): Promise<boolean> {
+    return this.install();
+  }
+
+  install(): Promise<boolean> {
+    return window.withProgress({ location: ProgressLocation.APP_ICON }, async progress => {
+      progress.report({ increment: 5 });
+      const setupPath = path.resolve(getAssetsFolder(), `podman-${getBundledPodmanVersion()}-setup.exe`);
+      try {
+        if (fs.existsSync(setupPath)) {
+          try {
+            await processAPI.exec(setupPath, ['/install', '/norestart']);
+            progress.report({ increment: 80 });
+            window.showNotification({ body: 'Podman is successfully installed.' });
+          } catch (err) {
+            //check if user cancelled installation see https://learn.microsoft.com/en-us/previous-versions//aa368542(v=vs.85)
+            const runError = err as RunError;
+            if (runError && runError.exitCode !== 1602 && runError.exitCode !== 0) {
+              throw new Error(runError.message);
+            }
+          }
+          return true;
+        } else {
+          throw new Error(`Can't find Podman setup package! Path: ${setupPath} doesn't exists.`);
+        }
+      } catch (err) {
+        console.error('Error during install!');
+        console.error(err);
+        await window.showErrorMessage('Unexpected error, during Podman installation: ' + err, 'OK');
+        return false;
+      } finally {
+        progress.report({ increment: -1 });
+      }
+    });
+  }
+}


### PR DESCRIPTION
### What does this PR do?

Moving the `WinInstaller` to a dedicated file, and its corresponding tests.

> Moving the tests were not easy... the MacOSInstaller test were benefiting from side effect due to `vi.mock` call inside the WinInstaller tests...

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/12019

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
