### PR TITLE
refactor(core): move default protocol configuration to Main

### DIFF
--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -87,14 +87,6 @@ app.on('will-finish-launching', () => {
 
 app.whenReady().then(
   async () => {
-    if (import.meta.env.PROD) {
-      if (isWindows()) {
-        app.setAsDefaultProtocolClient('podman-desktop', process.execPath, process.argv);
-      } else {
-        app.setAsDefaultProtocolClient('podman-desktop');
-      }
-    }
-
     // We must create the window first before initialization so that we can load the
     // configuration as well as plugins
     // The window is hiddenly created and shown when ready

--- a/packages/main/src/main.spec.ts
+++ b/packages/main/src/main.spec.ts
@@ -182,8 +182,7 @@ describe('ElectronApp#on window-all-closed', () => {
 });
 
 describe('AppPlugin', () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const plugins: Array<new (...args: any[]) => AppPlugin> = [DefaultProtocolClient];
+  const plugins: Array<AppPlugin> = [DefaultProtocolClient.prototype];
 
   let promiseWithResolvers: PromiseWithResolvers<void>;
 
@@ -204,8 +203,7 @@ describe('AppPlugin', () => {
   test('expect AppPlugin#onReady to be called when ElectronApp#whenReady resolved', async () => {
     // expect each plugin to have been instantiated
     plugins.forEach(plugin => {
-      expect(plugin).toHaveBeenCalledOnce();
-      expect(plugin.prototype.onReady).not.toHaveBeenCalled();
+      expect(plugin.onReady).not.toHaveBeenCalled();
     });
 
     // simulate on ready
@@ -214,7 +212,7 @@ describe('AppPlugin', () => {
     await vi.waitFor(() => {
       // expect each plugin to have been instantiated
       plugins.forEach(plugin => {
-        expect(plugin.prototype.onReady).toHaveBeenCalled();
+        expect(plugin.onReady).toHaveBeenCalled();
       });
     });
   });
@@ -222,8 +220,7 @@ describe('AppPlugin', () => {
   test('expect AppPlugin#dispose to be called when ElectronApp#on("before-quit") is emitted ', async () => {
     // expect each plugin to have been instantiated
     plugins.forEach(plugin => {
-      expect(plugin).toHaveBeenCalledOnce();
-      expect(plugin.prototype.dispose).not.toHaveBeenCalled();
+      expect(plugin.dispose).not.toHaveBeenCalled();
     });
 
     const listener = getElectronAppListener('before-quit');
@@ -232,7 +229,7 @@ describe('AppPlugin', () => {
     await vi.waitFor(() => {
       // expect each plugin to be disposed
       plugins.forEach(plugin => {
-        expect(plugin.prototype.dispose).toHaveBeenCalled();
+        expect(plugin.dispose).toHaveBeenCalled();
       });
     });
   });

--- a/packages/main/src/main.ts
+++ b/packages/main/src/main.ts
@@ -101,6 +101,37 @@ export class Main {
      * Setup {@link ElectronApp.on} listeners
      */
     this.app.on('window-all-closed', this.onWindowAllClosed.bind(this));
+
+    /**
+     * Register {@link Main#whenReady} for ready event
+     */
+    this.app.whenReady().then(this.whenReady.bind(this)).catch(console.error);
+  }
+
+  /**
+   * Executes the necessary setup or configuration once the application is ready..
+   * @return {Promise<void>} A promise that resolves when the configuration is complete.
+   */
+  protected async whenReady(): Promise<void> {
+    this.configureDefaultProtocolClient();
+  }
+
+  /**
+   * Configures the application as the default protocol client for handling 'podman-desktop' protocol links.
+   *
+   * Throws an error if the application is not ready before configuration.
+   * @return {void} Does not return a value.
+   */
+  protected configureDefaultProtocolClient(): void {
+    if (!this.app.isReady()) throw new Error('app is not ready');
+
+    if (!import.meta.env.PROD) return;
+
+    if (isWindows()) {
+      this.app.setAsDefaultProtocolClient('podman-desktop', process.execPath, process.argv);
+    } else {
+      this.app.setAsDefaultProtocolClient('podman-desktop');
+    }
   }
 
   /**

--- a/packages/main/src/plugin/app-ready/app-plugin.ts
+++ b/packages/main/src/plugin/app-ready/app-plugin.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { IDisposable } from '/@api/disposable.js';
+
+export interface AppPlugin extends IDisposable {
+  onReady(): Promise<void>;
+}

--- a/packages/main/src/plugin/app-ready/default-protocol-client.spec.ts
+++ b/packages/main/src/plugin/app-ready/default-protocol-client.spec.ts
@@ -1,0 +1,79 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { App as ElectronApp } from 'electron';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+
+import type { AppPlugin } from '/@/plugin/app-ready/app-plugin.js';
+import { isWindows } from '/@/util.js';
+
+import { DefaultProtocolClient } from './default-protocol-client.js';
+
+vi.mock('/@/util.js');
+
+const ELECTRON_APP_MOCK: ElectronApp = {
+  setAsDefaultProtocolClient: vi.fn(),
+} as unknown as ElectronApp;
+
+let originalExecPath: string;
+let originalProcessArgv: string[];
+
+let plugin: AppPlugin;
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  originalExecPath = process.execPath;
+  originalProcessArgv = process.argv;
+  process.execPath = '/foo/bar';
+  process.argv = ['foo', 'bar'];
+
+  // mock import.meta.env.PROD env
+  vi.stubEnv('PROD', true);
+
+  plugin = new DefaultProtocolClient(ELECTRON_APP_MOCK);
+});
+
+afterEach(() => {
+  plugin?.dispose();
+
+  process.execPath = originalExecPath;
+  process.argv = originalProcessArgv;
+});
+
+test('ElectronApp#setAsDefaultProtocolClient should not have been called before application is ready', async () => {
+  expect(ELECTRON_APP_MOCK.setAsDefaultProtocolClient).not.toHaveBeenCalled();
+});
+
+test('ElectronApp#setAsDefaultProtocolClient should be called when application is ready', async () => {
+  await plugin.onReady();
+
+  expect(ELECTRON_APP_MOCK.setAsDefaultProtocolClient).toHaveBeenCalledOnce();
+  expect(ELECTRON_APP_MOCK.setAsDefaultProtocolClient).toHaveBeenCalledWith('podman-desktop');
+});
+
+test('on windows ElectronApp#setAsDefaultProtocolClient should be called with process args', async () => {
+  vi.mocked(isWindows).mockReturnValue(true);
+
+  await plugin.onReady();
+
+  expect(ELECTRON_APP_MOCK.setAsDefaultProtocolClient).toHaveBeenCalledOnce();
+  expect(ELECTRON_APP_MOCK.setAsDefaultProtocolClient).toHaveBeenCalledWith('podman-desktop', '/foo/bar', [
+    'foo',
+    'bar',
+  ]);
+});

--- a/packages/main/src/plugin/app-ready/default-protocol-client.ts
+++ b/packages/main/src/plugin/app-ready/default-protocol-client.ts
@@ -1,0 +1,41 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { App as ElectronApp } from 'electron';
+
+import type { AppPlugin } from '/@/plugin/app-ready/app-plugin.js';
+import { isWindows } from '/@/util.js';
+
+/**
+ * Configures the application as the default protocol client for handling 'podman-desktop' protocol links.
+ */
+export class DefaultProtocolClient implements AppPlugin {
+  constructor(private readonly app: ElectronApp) {}
+
+  async onReady(): Promise<void> {
+    if (!import.meta.env.PROD) return;
+
+    if (isWindows()) {
+      this.app.setAsDefaultProtocolClient('podman-desktop', process.execPath, process.argv);
+    } else {
+      this.app.setAsDefaultProtocolClient('podman-desktop');
+    }
+  }
+
+  dispose(): void {}
+}


### PR DESCRIPTION
### What does this PR do?

Moving the default protocol configuration from `packages/main/src/index.ts` to the Main class. I also added unit tests to cover this feature, as this was not covered.

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/12812

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
