### PR TITLE
chore(podman): remove promisify usage for `node:fs` function

### DIFF
--- a/extensions/podman/packages/extension/src/utils/podman-install.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-install.ts
@@ -16,9 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import * as fs from 'node:fs';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { promisify } from 'node:util';
 
 import * as extensionApi from '@podman-desktop/api';
 import { compare } from 'compare-versions';
@@ -46,9 +46,6 @@ import * as podman5JSON from '../podman5.json';
 import { getBundledPodmanVersion } from './podman-bundled';
 import type { InstalledPodman } from './podman-cli';
 import { getPodmanCli, getPodmanInstallation } from './podman-cli';
-
-const readFile = promisify(fs.readFile);
-const writeFile = promisify(fs.writeFile);
 
 export interface PodmanInfo {
   podmanVersion?: string;
@@ -424,7 +421,7 @@ export class PodmanInstall {
   async getLastRunInfo(): Promise<PodmanInfo | undefined> {
     const podmanInfoPath = path.resolve(this.storagePath, 'podman-ext.json');
     if (!fs.existsSync(this.storagePath)) {
-      await promisify(fs.mkdir)(this.storagePath);
+      await mkdir(this.storagePath);
     }
 
     if (!fs.existsSync(podmanInfoPath)) {


### PR DESCRIPTION
### What does this PR do?

While working on https://github.com/podman-desktop/podman-desktop/issues/12021 I noticed that we were using promisify on `node:fs` function, I don't want to duplicate those line, so replacing those by their corresponding `node:fs/promise` implementation.

### What issues does this PR fix or reference?

Required for https://github.com/podman-desktop/podman-desktop/issues/12021

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Existing tests ensure no regression
