### PR TITLE
fix: display VM connections in status bar

### DIFF
--- a/packages/renderer/src/lib/statusbar/ProviderWidget.spec.ts
+++ b/packages/renderer/src/lib/statusbar/ProviderWidget.spec.ts
@@ -27,6 +27,7 @@ import type {
   ProviderContainerConnectionInfo,
   ProviderInfo,
   ProviderKubernetesConnectionInfo,
+  ProviderVmConnectionInfo,
 } from '/@api/provider-info';
 
 import ProviderWidget from './ProviderWidget.svelte';
@@ -111,6 +112,22 @@ test('Expect tooltip to include Kubernetes provider connections', () => {
     { name: 'connection 1', status: 'ready' } as unknown as ProviderKubernetesConnectionInfo,
     { name: 'connection 2', status: 'ready' } as unknown as ProviderKubernetesConnectionInfo,
     { name: 'connection 3', status: 'stopped' } as unknown as ProviderKubernetesConnectionInfo,
+  ];
+  render(ProviderWidget, { entry: providerMock });
+
+  expect(screen.getAllByText('Running').length).toBe(2);
+  expect(screen.getAllByText('Off').length).toBe(1);
+
+  expect(screen.getByText(': connection 1')).toBeInTheDocument();
+  expect(screen.getByText(': connection 2')).toBeInTheDocument();
+  expect(screen.getByText(': connection 3')).toBeInTheDocument();
+});
+
+test('Expect tooltip to include VM provider connections', () => {
+  providerMock.vmConnections = [
+    { name: 'connection 1', status: 'ready' } as unknown as ProviderVmConnectionInfo,
+    { name: 'connection 2', status: 'ready' } as unknown as ProviderVmConnectionInfo,
+    { name: 'connection 3', status: 'stopped' } as unknown as ProviderVmConnectionInfo,
   ];
   render(ProviderWidget, { entry: providerMock });
 

--- a/packages/renderer/src/lib/statusbar/ProviderWidget.spec.ts
+++ b/packages/renderer/src/lib/statusbar/ProviderWidget.spec.ts
@@ -46,6 +46,7 @@ const providerMock = {
   id: 'provider1-id',
   containerConnections: [],
   kubernetesConnections: [],
+  vmConnections: [],
   status: 'ready' as ProviderStatus,
   images: {},
 } as unknown as ProviderInfo;

--- a/packages/renderer/src/lib/statusbar/ProviderWidget.svelte
+++ b/packages/renderer/src/lib/statusbar/ProviderWidget.svelte
@@ -29,6 +29,8 @@ let connections = $derived.by(() => {
     return entry.containerConnections;
   } else if (entry.kubernetesConnections.length > 0) {
     return entry.kubernetesConnections;
+  } else if (entry.vmConnections.length > 0) {
+    return entry.vmConnections;
   } else {
     return [entry];
   }


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Display VM connections in status bar

### Screenshot / video of UI
![vm-status-bar](https://github.com/user-attachments/assets/d3bd253b-ed5c-4ba8-9298-71c11604631d)


### What issues does this PR fix or reference?

Fixes #12488 

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
