### PR TITLE
fix(frontend): group containers by groupId

### DIFF
--- a/packages/renderer/src/lib/container/container-utils.ts
+++ b/packages/renderer/src/lib/container/container-utils.ts
@@ -188,7 +188,6 @@ export class ContainerUtils {
     const composeProject = containerInfo.Labels?.['com.docker.compose.project'];
     if (composeProject) {
       return {
-        id: composeProject,
         name: composeProject,
         id: `${containerInfo.engineId}:${composeProject}`, // the ID must be unique per engineId, so let's concatenate the engineId and the compose project
         type: ContainerGroupInfoTypeUI.COMPOSE,
@@ -212,8 +211,6 @@ export class ContainerUtils {
 
     // else, standalone
     return {
-      id: containerInfo.Id,
-      engineId: containerInfo.engineId,
       name: this.getName(containerInfo),
       type: ContainerGroupInfoTypeUI.STANDALONE,
       status: (containerInfo.Status ?? '').toUpperCase(),
@@ -223,8 +220,6 @@ export class ContainerUtils {
   }
 
   getContainerGroups(containerInfos: ContainerInfoUI[]): ContainerGroupInfoUI[] {
-    console.log('getContainerGroups', containerInfos);
-
     // create a map from containers having the same group field
     const groups = new Map<string, ContainerGroupInfoUI>();
     containerInfos.forEach(containerInfo => {

--- a/packages/renderer/src/lib/container/container-utils.ts
+++ b/packages/renderer/src/lib/container/container-utils.ts
@@ -188,6 +188,7 @@ export class ContainerUtils {
     const composeProject = containerInfo.Labels?.['com.docker.compose.project'];
     if (composeProject) {
       return {
+        id: composeProject,
         name: composeProject,
         id: `${containerInfo.engineId}:${composeProject}`, // the ID must be unique per engineId, so let's concatenate the engineId and the compose project
         type: ContainerGroupInfoTypeUI.COMPOSE,
@@ -211,6 +212,8 @@ export class ContainerUtils {
 
     // else, standalone
     return {
+      id: containerInfo.Id,
+      engineId: containerInfo.engineId,
       name: this.getName(containerInfo),
       type: ContainerGroupInfoTypeUI.STANDALONE,
       status: (containerInfo.Status ?? '').toUpperCase(),
@@ -220,6 +223,8 @@ export class ContainerUtils {
   }
 
   getContainerGroups(containerInfos: ContainerInfoUI[]): ContainerGroupInfoUI[] {
+    console.log('getContainerGroups', containerInfos);
+
     // create a map from containers having the same group field
     const groups = new Map<string, ContainerGroupInfoUI>();
     containerInfos.forEach(containerInfo => {
@@ -234,8 +239,8 @@ export class ContainerUtils {
           allContainersCount: 1,
         });
       } else {
-        if (!groups.has(group.name)) {
-          groups.set(group.name, {
+        if (!groups.has(group.id)) {
+          groups.set(group.id, {
             selected: false,
             expanded: true,
             name: group.name,
@@ -248,7 +253,7 @@ export class ContainerUtils {
             containers: [],
           });
         }
-        groups.get(group.name)?.containers.push(containerInfo);
+        groups.get(group.id)?.containers.push(containerInfo);
       }
     });
     groups.forEach(group => (group.allContainersCount = group.containers.length));


### PR DESCRIPTION
### What does this PR do?

To group containers (compose, pods) before the `GroupInfo#name` was used, but this is not unique accros engines, this PR changes to use the `GroupInfo#id`, which is now a mandatory and unique field thanks to https://github.com/podman-desktop/podman-desktop/pull/12896

### Screenshot / video of UI

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/8aa5f09f-e654-4286-9a57-05a96f61df5e) | ![image](https://github.com/user-attachments/assets/55e120c7-69cf-4247-9fd0-c08313eac2a4) |


### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/12842

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature

**Testing manually**

1. assert have two podman connection (have two machines)
2. create a `pod.yaml` file
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: nginx-pod
spec:
  containers:
    - name: nginx-container
      image: docker.io/library/nginx:latest
      ports:
        - name: http
          containerPort: 80
```
3. deploy the pod on each machine
````
$: podman --connection="podman-a" kube play ./pod.yaml
$: podman --connection="podman-b" kube play ./pod.yaml
````
4. open ContainerList page
5. assert you have two pods
