### PR TITLE
fix: update docker compatibility link in compose onboarding

### DIFF
--- a/extensions/compose/package.json
+++ b/extensions/compose/package.json
@@ -54,7 +54,7 @@
             ],
             [
               {
-                "value": "> ℹ️ **Note:** If you would like to use `docker compose up` or `docker-compose` with Podman, [enable Docker Compatibility](/preferences/default/preferences.podman-desktop.podman).",
+                "value": "> ℹ️ **Note:** If you would like to use `docker compose up` or `docker-compose` with Podman, [enable Docker Compatibility](/preferences/default/preferences.dockerCompatibility).",
                 "highlight": true
               }
             ],


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Updates the link in the compose onboarding to take to user to the Docker compatibility setting instead of the Podman preferences page

### Screenshot / video of UI

https://github.com/user-attachments/assets/d12e582e-7408-4a08-bcce-5093c1a7a307



<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Fixes https://github.com/podman-desktop/podman-desktop/issues/12219

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
