### PR TITLE
chore: update when field for podman machine editable properties

### DIFF
--- a/extensions/podman/packages/extension/package.json
+++ b/extensions/podman/packages/extension/package.json
@@ -68,15 +68,14 @@
           "maximum": "HOST_TOTAL_CPU",
           "scope": "ContainerConnection",
           "description": "CPU(s)",
-          "when": "isMac"
+          "when": "podman.podmanMachineEditCPUSupported"
         },
         "podman.machine.cpusUsage": {
           "type": "number",
           "format": "cpuUsage",
           "scope": "ContainerConnection",
           "description": "CPU(s) usage",
-          "readonly": true,
-          "when": "isMac"
+          "readonly": true
         },
         "podman.machine.memory": {
           "type": "number",
@@ -87,15 +86,14 @@
           "scope": "ContainerConnection",
           "step": 500000000,
           "description": "Memory",
-          "when": "isMac"
+          "when": "podman.podmanMachineEditMemorySupported"
         },
         "podman.machine.memoryUsage": {
           "type": "number",
           "format": "memoryUsage",
           "scope": "ContainerConnection",
           "description": "Memory usage",
-          "readonly": true,
-          "when": "isMac"
+          "readonly": true
         },
         "podman.machine.diskSize": {
           "type": "number",
@@ -105,15 +103,14 @@
           "scope": "ContainerConnection",
           "step": 500000000,
           "description": "Disk size",
-          "when": "isMac"
+          "when": "podman.podmanMachineEditDiskSizeSupported"
         },
         "podman.machine.diskSizeUsage": {
           "type": "number",
           "format": "diskSizeUsage",
           "scope": "ContainerConnection",
           "description": "Disk size usage",
-          "readonly": true,
-          "when": "isMac"
+          "readonly": true
         },
         "podman.factory.machine.name": {
           "type": "string",

--- a/extensions/podman/packages/extension/package.json
+++ b/extensions/podman/packages/extension/package.json
@@ -67,14 +67,16 @@
           "default": "HOST_HALF_CPU_CORES",
           "maximum": "HOST_TOTAL_CPU",
           "scope": "ContainerConnection",
-          "description": "CPU(s)"
+          "description": "CPU(s)",
+          "when": "isMac"
         },
         "podman.machine.cpusUsage": {
           "type": "number",
           "format": "cpuUsage",
           "scope": "ContainerConnection",
           "description": "CPU(s) usage",
-          "readonly": true
+          "readonly": true,
+          "when": "isMac"
         },
         "podman.machine.memory": {
           "type": "number",
@@ -84,14 +86,16 @@
           "maximum": "HOST_TOTAL_MEMORY",
           "scope": "ContainerConnection",
           "step": 500000000,
-          "description": "Memory"
+          "description": "Memory",
+          "when": "isMac"
         },
         "podman.machine.memoryUsage": {
           "type": "number",
           "format": "memoryUsage",
           "scope": "ContainerConnection",
           "description": "Memory usage",
-          "readonly": true
+          "readonly": true,
+          "when": "isMac"
         },
         "podman.machine.diskSize": {
           "type": "number",
@@ -100,14 +104,16 @@
           "maximum": "HOST_TOTAL_DISKSIZE",
           "scope": "ContainerConnection",
           "step": 500000000,
-          "description": "Disk size"
+          "description": "Disk size",
+          "when": "isMac"
         },
         "podman.machine.diskSizeUsage": {
           "type": "number",
           "format": "diskSizeUsage",
           "scope": "ContainerConnection",
           "description": "Disk size usage",
-          "readonly": true
+          "readonly": true,
+          "when": "isMac"
         },
         "podman.factory.machine.name": {
           "type": "string",

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -1532,7 +1532,7 @@ test('provider is registered without edit capabilities on (non-HyperV) Windows',
   expect(extensionApi.context.setValue).toBeCalledWith(extension.PODMAN_MACHINE_EDIT_DISK_SIZE, false);
 });
 
-test('provider is registered without limited capabilities on (HyperV) Windows', async () => {
+test('provider is registered with limited capabilities on (HyperV) Windows', async () => {
   vi.mocked(extensionApi.env).isWindows = true;
   extension.initExtensionContext({ subscriptions: [] } as unknown as extensionApi.ExtensionContext);
   const spyExecPromise = vi.spyOn(extensionApi.process, 'exec');

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -879,7 +879,7 @@ export async function registerProviderFor(
       });
     },
   };
-  //support edit only on MacOS as Podman WSL is nop and generates errors
+  //support edit only on MacOS and HyperV machines as Podman WSL is nop and generates errors
   if (isEditMemorySupported || isEditCPUSupported || isEditDiskSizeSupported) {
     lifecycle.edit = async (context, params, logger, _token): Promise<void> => {
       let effective = false;

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -857,9 +857,9 @@ export async function registerProviderFor(
   machineInfo: MachineInfo,
   socketPath: string,
 ): Promise<void> {
-  const hyperVEnabled = await isHyperVEnabled();
-  const isEditMemorySupported = extensionApi.env.isMac || hyperVEnabled;
-  const isEditCPUSupported = extensionApi.env.isMac || hyperVEnabled;
+  const isHyperVMachine = extensionApi.env.isWindows && machineInfo.vmType === VMTYPE.HYPERV;
+  const isEditMemorySupported = extensionApi.env.isMac || isHyperVMachine;
+  const isEditCPUSupported = extensionApi.env.isMac || isHyperVMachine;
   const isEditDiskSizeSupported = extensionApi.env.isMac;
 
   extensionApi.context.setValue(PODMAN_MACHINE_EDIT_MEMORY, isEditMemorySupported);

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -857,8 +857,9 @@ export async function registerProviderFor(
   machineInfo: MachineInfo,
   socketPath: string,
 ): Promise<void> {
-  const isEditMemorySupported = extensionApi.env.isMac || (extensionApi.env.isWindows && (await isHyperVEnabled()));
-  const isEditCPUSupported = extensionApi.env.isMac || (extensionApi.env.isWindows && (await isHyperVEnabled()));
+  const hyperVEnabled = await isHyperVEnabled();
+  const isEditMemorySupported = extensionApi.env.isMac || hyperVEnabled;
+  const isEditCPUSupported = extensionApi.env.isMac || hyperVEnabled;
   const isEditDiskSizeSupported = extensionApi.env.isMac;
 
   extensionApi.context.setValue(PODMAN_MACHINE_EDIT_MEMORY, isEditMemorySupported);
@@ -879,7 +880,7 @@ export async function registerProviderFor(
     },
   };
   //support edit only on MacOS as Podman WSL is nop and generates errors
-  if (extensionApi.env.isMac || (extensionApi.env.isWindows && (await isHyperVEnabled()))) {
+  if (extensionApi.env.isMac || hyperVEnabled) {
     lifecycle.edit = async (context, params, logger, _token): Promise<void> => {
       let effective = false;
       const args = ['machine', 'set', machineInfo.name];

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -885,13 +885,13 @@ export async function registerProviderFor(
       let effective = false;
       const args = ['machine', 'set', machineInfo.name];
       for (const key of Object.keys(params)) {
-        if (key === 'podman.machine.cpus') {
+        if (isEditCPUSupported && key === 'podman.machine.cpus') {
           args.push('--cpus', params[key]);
           effective = true;
-        } else if (key === 'podman.machine.memory') {
+        } else if (isEditMemorySupported && key === 'podman.machine.memory') {
           args.push('--memory', Math.floor(params[key] / (1024 * 1024)).toString());
           effective = true;
-        } else if (extensionApi.env.isMac && key === 'podman.machine.diskSize') {
+        } else if (isEditDiskSizeSupported && key === 'podman.machine.diskSize') {
           args.push('--disk-size', Math.floor(params[key] / (1024 * 1024 * 1024)).toString());
           effective = true;
         }

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -880,7 +880,7 @@ export async function registerProviderFor(
     },
   };
   //support edit only on MacOS as Podman WSL is nop and generates errors
-  if (extensionApi.env.isMac || hyperVEnabled) {
+  if (isEditMemorySupported || isEditCPUSupported || isEditDiskSizeSupported) {
     lifecycle.edit = async (context, params, logger, _token): Promise<void> => {
       let effective = false;
       const args = ['machine', 'set', machineInfo.name];


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Right now, editing a podman machine is only possible on macOS. However, as part of https://github.com/podman-desktop/podman-desktop/pull/12781, the rootful status is also editable on both macOS and Windows, so we need to indicate which properties are editable only on macOS.
On HyperV, CPU and memory should be editable, and on macOS, all 3 properties are editable

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/pull/12781
Closes https://github.com/podman-desktop/podman-desktop/issues/12943

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
