### PR TITLE
chore: set oneClick false and perMachine false in nsis

### DIFF
--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -134,6 +134,7 @@ const config = {
   },
   nsis: {
     artifactName: `podman-desktop${artifactNameSuffix}-\${version}-setup-\${arch}.\${ext}`,
+    oneClick: false,
   },
   win: {
     target: [


### PR DESCRIPTION
chore: set oneClick false and perMachine false in nsis

### What does this PR do?

This PR updates the NSIS installer settings to:

* oneClick: false
* perMachine: false

The result is that clicking on the .exe to install there is no change
(we do not have an "interactive" installation anyways, so onClick
despite it being set to true by default doe snot apply).

However, you can now use `/ALLUSERS` on the command line to successfully
install to all users.

**Why this is required:**

Electron-Builder’s NSIS logic combines the two flags as shown below.

| oneClick | perMachine | Interactive UI scope          | Silent /S scope        | /ALLUSERS respected? |
|----------|------------|-------------------------------|------------------------|----------------------|
| true     | false      | Always per-user (silent)      | Per-user               | No                   |
| true     | true       | Always per-machine (silent)   | Per-machine            | No (forced machine)  |
| false    | true       | Wizard, forces admin install  | Per-machine            | Yes, but no per-user |
| false    | false      | Wizard, defaults per-user     | Per-user or per-machine (when /ALLUSERS) | Yes |

We now set it to both false, allowing us to have both combinations
(single user install, and CLI install to all users).

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Closes https://github.com/podman-desktop/podman-desktop/issues/12734

### How to test this PR?

**Confirming that it installs for all users:**

1. Run `pnpm build` and `pnpm compile` on a WINDOWS MACHINE.

2. Run the following using the installer:

```sh
cd dist/
./podman-desktop-installer.exe /S /ALLUSERS
```

3. Confirm that it is installed SYSTEM WIDE in `C:/Program Files/Podman
   Desktop`

**Confirming it installs regularly:**

1. Run `pnpm build` and `pnpm compile` on a WINDOWS MACHINE.

2. Run the installer (dist/podman-desktop-installer.exe) as normal

3. See it installs to `%AppData%` correctly.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
