### PR TITLE
fix: docker-compose warning messages mention kubectl

### DIFF
--- a/extensions/compose/src/detect.ts
+++ b/extensions/compose/src/detect.ts
@@ -98,7 +98,7 @@ export class Detect {
         const { stdout: fullPath } = await extensionApi.process.exec('which', [executable]);
         return fullPath;
       } catch (err) {
-        console.warn('Error getting kubectl full path', err);
+        console.warn('Error getting docker-compose full path', err);
       }
     } else if (extensionApi.env.isWindows) {
       // grab full path for Windows
@@ -107,7 +107,7 @@ export class Detect {
         // remove all line break/carriage return characters from full path
         return fullPath.replace(/(\r\n|\n|\r)/gm, '');
       } catch (err) {
-        console.warn('Error getting kubectl full path', err);
+        console.warn('Error getting docker-compose full path', err);
       }
     }
 

--- a/extensions/compose/src/detect.ts
+++ b/extensions/compose/src/detect.ts
@@ -98,7 +98,7 @@ export class Detect {
         const { stdout: fullPath } = await extensionApi.process.exec('which', [executable]);
         return fullPath;
       } catch (err) {
-        console.warn('Error getting docker-compose full path', err);
+        console.warn(`Error getting ${executable} full path`, err);
       }
     } else if (extensionApi.env.isWindows) {
       // grab full path for Windows
@@ -107,7 +107,7 @@ export class Detect {
         // remove all line break/carriage return characters from full path
         return fullPath.replace(/(\r\n|\n|\r)/gm, '');
       } catch (err) {
-        console.warn('Error getting docker-compose full path', err);
+        console.warn(`Error getting ${executable} full path`, err);
       }
     }
 


### PR DESCRIPTION
### What does this PR do?

Replaces do kubectl to docker-compose in compose extension concole
warning messages

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
