### PR TITLE
fix: reduce github rate limit errors for compose install

### DIFF
--- a/extensions/compose/package.json
+++ b/extensions/compose/package.json
@@ -169,7 +169,8 @@
   "dependencies": {
     "@octokit/rest": "^22.0.0",
     "mustache": "^4.2.0",
-    "shell-path": "^3.0.0"
+    "shell-path": "^3.0.0",
+    "typescript-memoize": "^1.1.1"
   },
   "devDependencies": {
     "@podman-desktop/api": "workspace:*",

--- a/extensions/compose/src/download.ts
+++ b/extensions/compose/src/download.ts
@@ -21,6 +21,7 @@ import { arch, platform } from 'node:os';
 import * as path from 'node:path';
 
 import * as extensionApi from '@podman-desktop/api';
+import { Memoize } from 'typescript-memoize';
 
 import type { ComposeGithubReleaseArtifactMetadata, ComposeGitHubReleases } from './compose-github-releases';
 import type { OS } from './os';
@@ -42,6 +43,7 @@ export class ComposeDownload {
 
   // Get the latest versions of Compose from GitHub Releases
   // and return the artifacts metadata
+  @Memoize({ expiring: 1000 * 60 * 60 })
   async getLatestReleases(): Promise<ComposeGithubReleaseArtifactMetadata[]> {
     return this.composeGitHubReleases.grabLatestsReleasesMetadata();
   }
@@ -49,7 +51,7 @@ export class ComposeDownload {
   // Create a "quickpick" prompt to ask the user which version of Compose they want to download
   async promptUserForVersion(currentComposeTag?: string): Promise<ComposeGithubReleaseArtifactMetadata> {
     // Get the latest releases
-    let lastReleasesMetadata = await this.composeGitHubReleases.grabLatestsReleasesMetadata();
+    let lastReleasesMetadata = await this.getLatestReleases();
     // if the user already has an installed version, we remove it from the list
     if (currentComposeTag) {
       lastReleasesMetadata = lastReleasesMetadata.filter(release => release.tag.slice(1) !== currentComposeTag);

--- a/extensions/compose/tsconfig.json
+++ b/extensions/compose/tsconfig.json
@@ -10,7 +10,8 @@
     "rootDir": "src",
     "outDir": "dist",
     "skipLibCheck": true,
-    "types": ["node"]
+    "types": ["node"],
+    "experimentalDecorators": true
   },
 
   "include": ["src", "types/*.d.ts", "../../types/**/*.d.ts"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -307,6 +307,9 @@ importers:
       shell-path:
         specifier: ^3.0.0
         version: 3.0.0
+      typescript-memoize:
+        specifier: ^1.1.1
+        version: 1.1.1
     devDependencies:
       '@podman-desktop/api':
         specifier: workspace:*
@@ -11436,6 +11439,9 @@ packages:
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.9.0'
+
+  typescript-memoize@1.1.1:
+    resolution: {integrity: sha512-GQ90TcKpIH4XxYTI2F98yEQYZgjNMOGPpOgdjIBhaLaWji5HPWlRnZ4AeA1hfBxtY7bCGDJsqDDHk/KaHOl5bA==}
 
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
@@ -25025,6 +25031,8 @@ snapshots:
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
+
+  typescript-memoize@1.1.1: {}
 
   typescript@5.8.3: {}
 


### PR DESCRIPTION
### What does this PR do?

The fix using @memoize decorator to cache github responses eliminating most of rate limit related errors.
The only drawback of this approach is when check for update is implemented one would see new release with a delay.

### Screenshot / video of UI

https://github.com/user-attachments/assets/e425633c-5511-4ecf-a4ac-c9ce2134ee17

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

1. Pull the branch and run it with `pnpm watch`. 
2. Go to CLI Tools settings and try request docker-compose install
3. After seeing the quick picks of compose versions cancel it and repeat step 2

With branch there should be no rate limit errors, because result is cached for an hour (could have define in preference settings and could be shorter of course). 

- [ ] Tests are covering the bug fix or the new feature
