### PR TITLE
feat: add badge for in-development extensions

### DIFF
--- a/packages/renderer/src/lib/extensions/ExtensionBadge.spec.ts
+++ b/packages/renderer/src/lib/extensions/ExtensionBadge.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,12 +23,15 @@ import { beforeEach, expect, test } from 'vitest';
 
 import ExtensionBadge from './ExtensionBadge.svelte';
 
+type ExtensionType = { type: 'dd' | 'pd'; removable: boolean; devMode: boolean };
+
 beforeEach(() => {});
 
 test('Expect to have badge for dd Extension', async () => {
-  const extension: { type: 'dd' | 'pd'; removable: boolean } = {
+  const extension: ExtensionType = {
     type: 'dd',
     removable: true,
+    devMode: false,
   };
   render(ExtensionBadge, { extension });
   // expect 'Docker Desktop extension' badge
@@ -41,9 +44,10 @@ test('Expect to have badge for dd Extension', async () => {
 });
 
 test('Expect to have badge for pd  built-in Extension', async () => {
-  const extension: { type: 'dd' | 'pd'; removable: boolean } = {
+  const extension: ExtensionType = {
     type: 'pd',
     removable: false,
+    devMode: false,
   };
   render(ExtensionBadge, { extension });
   // expect 'built-in' badge
@@ -53,4 +57,19 @@ test('Expect to have badge for pd  built-in Extension', async () => {
   expect(labels).toHaveLength(2);
   expect(labels[0]).toBeInTheDocument();
   expect(labels[1]).toBeInTheDocument();
+});
+
+test('Expect to have badge for devMode Extension', async () => {
+  const extension: ExtensionType = {
+    type: 'pd',
+    removable: false,
+    devMode: true,
+  };
+  render(ExtensionBadge, { extension });
+  // expect 'devMode' badge
+  const labels = screen.getAllByText('In Development Mode Extension');
+
+  // 2 items
+  expect(labels).toHaveLength(1);
+  expect(labels[0]).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/extensions/ExtensionBadge.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionBadge.svelte
@@ -3,13 +3,17 @@ import { Tooltip } from '@podman-desktop/ui-svelte';
 
 import Badge from '/@/lib/ui/Badge.svelte';
 
-export let extension: { type: 'dd' | 'pd'; removable: boolean };
+export let extension: { type: 'dd' | 'pd'; removable: boolean; devMode: boolean };
 </script>
 
 <div class="flex flex-row gap-1 items-center {$$props.class}" role="region" aria-label="Extension Badge">
   {#if extension.type === 'dd'}
     <Tooltip right tip="Docker Desktop extension">
       <Badge class="text-[8px] text-[var(--pd-badge-dd-extension-text)]" color="bg-[var(--pd-badge-dd-extension-bg)]" label="Docker Desktop extension" />
+    </Tooltip>
+  {:else if extension.devMode}
+    <Tooltip right tip="In Development Mode Extension">
+      <Badge class="text-[8px] text-[var(--pd-badge-text)]" color="bg-[var(--pd-badge-devmode-extension-bg)]" label="devMode Extension" />
     </Tooltip>
   {:else if !extension.removable}
     <Tooltip right tip="built-in Extension">


### PR DESCRIPTION
### What does this PR do?
add a badge in extension view for extensions that are in development

- [x] depends on https://github.com/podman-desktop/podman-desktop/pull/12940

### Screenshot / video of UI

![image](https://github.com/user-attachments/assets/7665845c-3388-41d7-a10b-65a3dfd568b2)

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/pull/12942 and https://github.com/podman-desktop/podman-desktop/issues/8616

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature