### PR TITLE
chore: allow to remove extension in dev mode without error

### DIFF
--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -1773,7 +1773,7 @@ export class ExtensionLoader {
       // delete the path
       if (extension.removable) {
         await fs.promises.rm(extension.path, { recursive: true, force: true });
-      } else {
+      } else if (!extension.devMode) {
         throw new Error(`Extension ${extensionId} is not removable`);
       }
       this.analyzedExtensions.delete(extensionId);


### PR DESCRIPTION
### What does this PR do?
in development mode we can remove the extension but we don't remove the folder

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/issues/8616

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
