### PR TITLE
fix: add better checks to detect Podman Desktop extension in dev mode

### DIFF
--- a/packages/main/src/plugin/extension/extension-development-folders.spec.ts
+++ b/packages/main/src/plugin/extension/extension-development-folders.spec.ts
@@ -238,8 +238,28 @@ describe('addDevelopmentFolder', () => {
     await expect(extensionDevelopmentFolders.addDevelopmentFolder('foo')).rejects.toThrow('foo analyze extension');
   });
 
+  test('check missing main file when analyzing the extension', async () => {
+    vi.mocked(extensionAnalyzer.analyzeExtension).mockResolvedValue({
+      manifest: { main: 'unknown/file.js', engines: { 'podman-desktop': '>=1.18.0' } },
+      error: 'foo analyze extension',
+    } as AnalyzedExtension);
+
+    await expect(extensionDevelopmentFolders.addDevelopmentFolder('foo')).rejects.toThrow('foo analyze extension');
+  });
+
+  test('check missing engine when analyzing the extension', async () => {
+    vi.mocked(extensionAnalyzer.analyzeExtension).mockResolvedValue({} as AnalyzedExtension);
+
+    await expect(extensionDevelopmentFolders.addDevelopmentFolder('foo')).rejects.toThrow(
+      `is not compatible with Podman Desktop. It requires 'podman-desktop' engine.`,
+    );
+  });
+
   test('check working extension', async () => {
-    const analyzedExtension = { path: 'foo' } as AnalyzedExtension;
+    const analyzedExtension = {
+      path: 'foo',
+      manifest: { engines: { 'podman-desktop': '>=1.18.0' } },
+    } as AnalyzedExtension;
     vi.mocked(extensionAnalyzer.analyzeExtension).mockResolvedValue(analyzedExtension);
 
     // mock saveToConfiguration method


### PR DESCRIPTION
### What does this PR do?
add a couple of extra checks to accept a folder as being an extension

1. check for the engine (should be podman-desktop)
2. check if the file is there in case of a main entry

related to https://github.com/podman-desktop/podman-desktop/issues/8616


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
