### PR TITLE
refactor(ui/table): replace filter#map#flat chain by reduce

### DIFF
--- a/packages/ui/src/lib/table/Table.svelte
+++ b/packages/ui/src/lib/table/Table.svelte
@@ -43,9 +43,16 @@ let selectedAllCheckboxes = false;
 $: selectedAllCheckboxes = row.info.selectable
   ? data.filter(object => row.info.selectable?.(object)).every(object => object.selected) &&
     data
-      .filter(object => row.info.children?.(object))
-      .map(object => row.info.children?.(object))
-      .flat()
+      .reduce(
+        (accumulator, current) => {
+          const children = row.info.children?.(current);
+          if (children) {
+            accumulator.push(...children);
+          }
+          return accumulator;
+        },
+        [] as Array<{ selected?: boolean }>,
+      )
       .filter(child => row.info.selectable?.(child))
       .every(child => child.selected) &&
     data.filter(object => row.info.selectable?.(object)).length > 0


### PR DESCRIPTION
### What does this PR do?

Replace the `filter.map.flat` chain with a reduce, this is required for https://github.com/podman-desktop/podman-desktop/pull/12933 as currently this is all interpreted as `any` by typescript.

Changing to a reduce, allow me to define nicely the type, for this PR, it can be reduce to just `{ selected?: boolean }`.

> Bonus: reduce is more performant than `filter.map.flat`

### What issues does this PR fix or reference?

Required for 
- https://github.com/podman-desktop/podman-desktop/pull/12933

### How to test this PR?

- [x] Existing tests ensure no regression
