### PR TITLE
feat(table): adding accessibility labels to collapse button

### DIFF
--- a/packages/ui/src/lib/table/Table.spec.ts
+++ b/packages/ui/src/lib/table/Table.spec.ts
@@ -445,11 +445,11 @@ describe('Table#collapsed', () => {
     });
 
     const fooRow = getByRole('row', { name: 'foo' });
-    const fooExpandBtn = within(fooRow).getByRole('button', { name: 'Expand' });
+    const fooExpandBtn = within(fooRow).getByRole('button', { name: 'Expand Row' });
     expect(fooExpandBtn).toHaveAttribute('aria-expanded', 'false');
 
     const barRow = getByRole('row', { name: 'bar' });
-    const barCollapseBtn = within(barRow).getByRole('button', { name: 'Collapse' });
+    const barCollapseBtn = within(barRow).getByRole('button', { name: 'Collapse Row' });
     expect(barCollapseBtn).toHaveAttribute('aria-expanded', 'true');
   });
 });

--- a/packages/ui/src/lib/table/Table.spec.ts
+++ b/packages/ui/src/lib/table/Table.spec.ts
@@ -409,9 +409,9 @@ test('Expect table is scoped for css manipulation', async () => {
 });
 
 describe('Table#collapsed', () => {
-  type Item = {
-    name: string;
-  };
+  interface Item {
+    name?: string;
+  }
 
   const ROW = new Row<Item>({
     selectable: (): boolean => true,
@@ -424,12 +424,12 @@ describe('Table#collapsed', () => {
 
   const SIMPLE_COLUMN = new Column<Item, string>('Name', {
     width: '3fr',
-    renderMapping: (obj): string => obj.name,
+    renderMapping: (obj): string => obj.name ?? 'unknown',
     renderer: SimpleColumn,
   });
 
   test('Table#collapsed prop should be used for collapsed', async () => {
-    const { getByRole } = render(Table<Item>, {
+    const { getByRole } = render(Table, {
       kind: 'demo',
       data: [
         {

--- a/packages/ui/src/lib/table/Table.spec.ts
+++ b/packages/ui/src/lib/table/Table.spec.ts
@@ -20,7 +20,11 @@ import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen, within } from '@testing-library/svelte';
 import { tick } from 'svelte';
-import { expect, test, vi } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
+
+import { Table } from '/@/lib';
+import SimpleColumn from '/@/lib/table/SimpleColumn.svelte';
+import { Column, Row } from '/@/lib/table/table';
 
 import TestTable from './TestTable.svelte';
 
@@ -402,4 +406,50 @@ test('Expect table is scoped for css manipulation', async () => {
 
   // and there should be no style applied to this group as it's not part of the table
   expect(dummyComponent.style.gridTemplateColumns).toBe('');
+});
+
+describe('Table#collapsed', () => {
+  type Item = {
+    name: string;
+  };
+
+  const ROW = new Row<Item>({
+    selectable: (): boolean => true,
+    children: (person): Array<Item> => [
+      {
+        name: `${person.name} child`,
+      },
+    ],
+  });
+
+  const SIMPLE_COLUMN = new Column<Item, string>('Name', {
+    width: '3fr',
+    renderMapping: (obj): string => obj.name,
+    renderer: SimpleColumn,
+  });
+
+  test('Table#collapsed prop should be used for collapsed', async () => {
+    const { getByRole } = render(Table<Item>, {
+      kind: 'demo',
+      data: [
+        {
+          name: 'foo',
+        },
+        {
+          name: 'bar',
+        },
+      ],
+      columns: [SIMPLE_COLUMN],
+      row: ROW,
+      collapsed: ['foo'],
+    });
+
+    const fooRow = getByRole('row', { name: 'foo' });
+    const fooExpandBtn = within(fooRow).getByRole('button', { name: 'Expand' });
+    expect(fooExpandBtn).toHaveAttribute('aria-expanded', 'false');
+
+    const barRow = getByRole('row', { name: 'bar' });
+    const barCollapseBtn = within(barRow).getByRole('button', { name: 'Collapse' });
+    expect(barCollapseBtn).toHaveAttribute('aria-expanded', 'true');
+  });
 });

--- a/packages/ui/src/lib/table/Table.svelte
+++ b/packages/ui/src/lib/table/Table.svelte
@@ -252,8 +252,12 @@ function toggleChildren(name: string | undefined): void {
           role="row"
           aria-label={object.name}>
           <div class="whitespace-nowrap place-self-center" role="cell">
-            {#if children.length > 0}
-              <button on:click={toggleChildren.bind(undefined, object.name)}>
+            {#if object.name && children.length > 0}
+              <button
+                title={collapsed.includes(object.name) ? 'Expand' : 'Collapse'}
+                aria-expanded={!collapsed.includes(object.name)}
+                on:click={toggleChildren.bind(undefined, object.name)}
+              >
                 <Fa
                   size="0.8x"
                   class="text-[var(--pd-table-body-text)] cursor-pointer"

--- a/packages/ui/src/lib/table/Table.svelte
+++ b/packages/ui/src/lib/table/Table.svelte
@@ -254,7 +254,7 @@ function toggleChildren(name: string | undefined): void {
           <div class="whitespace-nowrap place-self-center" role="cell">
             {#if object.name && children.length > 0}
               <button
-                title={collapsed.includes(object.name) ? 'Expand' : 'Collapse'}
+                title={collapsed.includes(object.name) ? 'Expand Row' : 'Collapse Row'}
                 aria-expanded={!collapsed.includes(object.name)}
                 on:click={toggleChildren.bind(undefined, object.name)}
               >


### PR DESCRIPTION
### What does this PR do?

To be able to migrate the Table component to Svelte v5 I wanted to properly cover all the table feature to ensure no regression. The collapse action does not seems to be covered by tests.

To be able to easily test it, I need to add some recommended attributes, to properly test it. Such as [aria-expanded](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-expanded).

### Screenshot / video of UI

![image](https://github.com/user-attachments/assets/d297e37b-5e62-452a-a6e9-0ac743a4e36a)
![image](https://github.com/user-attachments/assets/c8e7bfee-6164-4ade-a733-f8879384e6cc)

### What issues does this PR fix or reference?

Required for
- https://github.com/podman-desktop/podman-desktop/pull/12921

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
