### PR TITLE
fix: change podman machine stream close function context

### DIFF
--- a/extensions/podman/packages/extension/src/utils/podman-machine-stream.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-machine-stream.spec.ts
@@ -161,3 +161,10 @@ describe('Test SSH Stream', () => {
     expect(providerConnectionShellAccess.onEndEmit.fire).toHaveBeenCalled();
   });
 });
+
+test('Returned functions should run without errors', () => {
+  const shellAccess = providerConnectionShellAccess.open();
+  expect(() => shellAccess.close()).not.toThrow();
+  expect(() => shellAccess.write('test')).not.toThrow();
+  expect(() => shellAccess.resize({ rows: 1, cols: 2 })).not.toThrow();
+});

--- a/extensions/podman/packages/extension/src/utils/podman-machine-stream.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-machine-stream.ts
@@ -129,7 +129,7 @@ export class ProviderConnectionShellAccessImpl implements ProviderConnectionShel
       onEnd: this.onEnd,
       write: this.write.bind(this),
       resize: this.resize.bind(this),
-      close: this.close,
+      close: this.close.bind(this),
     };
   }
 }


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR bind the context of the returned `close` function to the original class. Without binding the `close` function to `this`, any calling for `close` with output an error saying that `this.closeStream()`(L#82) is not a function due to the different calling context of `close`

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Related to https://github.com/redhat-developer/podman-desktop-rhel-ext/issues/81 and https://github.com/podman-desktop/podman-desktop/pull/12981

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
