### PR TITLE
chore(test): navigation takes longer on cicd

### DIFF
--- a/tests/playwright/src/specs/image-push-to-registry-smoke.spec.ts
+++ b/tests/playwright/src/specs/image-push-to-registry-smoke.spec.ts
@@ -75,7 +75,7 @@ test.describe.serial('Push image to container registry', { tag: '@smoke' }, () =
     await playExpect(imagesPage.heading).toBeVisible();
 
     await playExpect
-      .poll(async () => await imagesPage.waitForRowToExists(helloContainer, 15_000), { timeout: 0 })
+      .poll(async () => imagesPage.waitForRowToExists(helloContainer, 30_000), { timeout: 0 })
       .toBeTruthy();
   });
 
@@ -89,7 +89,7 @@ test.describe.serial('Push image to container registry', { tag: '@smoke' }, () =
     await playExpect(imagesPage.heading).toBeVisible();
 
     await playExpect
-      .poll(async () => await imagesPage.waitForRowToExists(fullName, 30_000), {
+      .poll(async () => imagesPage.waitForRowToExists(fullName, 30_000), {
         timeout: 0,
       })
       .toBeTruthy();
@@ -110,7 +110,7 @@ test.describe.serial('Push image to container registry', { tag: '@smoke' }, () =
     await playExpect(imagesPage.heading).toBeVisible();
 
     await playExpect
-      .poll(async () => await imagesPage.waitForRowToExists(fullName, 15_000), {
+      .poll(async () => imagesPage.waitForRowToExists(fullName, 30_000), {
         timeout: 0,
       })
       .toBeTruthy();
@@ -119,7 +119,7 @@ test.describe.serial('Push image to container registry', { tag: '@smoke' }, () =
     await playExpect(imageDetailPage.heading).toBeVisible();
 
     imagesPage = await imageDetailPage.deleteImage();
-    await playExpect(imagesPage.heading).toBeVisible();
+    await playExpect(imagesPage.heading).toBeVisible({ timeout: 30_000 });
 
     await playExpect
       .poll(async () => await imagesPage.waitForRowToBeDelete(fullName, 60_000), { timeout: 0 })

--- a/tests/playwright/src/specs/podman-machine-tests.spec.ts
+++ b/tests/playwright/src/specs/podman-machine-tests.spec.ts
@@ -71,6 +71,8 @@ test.afterAll(async ({ runner, page }) => {
 
 test.describe
   .serial(`Podman machine switching validation `, () => {
+    test.describe.configure({ timeout: 120_000 });
+
     test('Check data for available Podman Machine and stop machine', async ({ page, navigationBar }) => {
       await test.step('Open resources page', async () => {
         const settingsBar = await navigationBar.openSettings();


### PR DESCRIPTION
### What does this PR do?
In the overnight test runs some tests failed due to default timeout expiring while test was executing. This PR increases some timesouts to allow for a slower cicd environment.

### What issues does this PR fix or reference?
