### PR TITLE
feat(table): adding key props

### DIFF
--- a/packages/ui/src/lib/table/Table.spec.ts
+++ b/packages/ui/src/lib/table/Table.spec.ts
@@ -410,6 +410,7 @@ test('Expect table is scoped for css manipulation', async () => {
 
 describe('Table#collapsed', () => {
   interface Item {
+    id: string;
     name?: string;
   }
 
@@ -417,6 +418,7 @@ describe('Table#collapsed', () => {
     selectable: (): boolean => true,
     children: (person): Array<Item> => [
       {
+        id: `${person.id}-child`,
         name: `${person.name} child`,
       },
     ],
@@ -429,13 +431,15 @@ describe('Table#collapsed', () => {
   });
 
   test('Table#collapsed prop should be used for collapsed', async () => {
-    const { getByRole } = render(Table, {
+    const { getByRole } = render<Table<Item>>(Table, {
       kind: 'demo',
       data: [
         {
+          id: 'foo',
           name: 'foo',
         },
         {
+          id: 'bar',
           name: 'bar',
         },
       ],
@@ -451,5 +455,33 @@ describe('Table#collapsed', () => {
     const barRow = getByRole('row', { name: 'bar' });
     const barCollapseBtn = within(barRow).getByRole('button', { name: 'Collapse Row' });
     expect(barCollapseBtn).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  test('item with same name can be distinct using Table#key prop', async () => {
+    const { getAllByRole } = render<Table<Item>>(Table, {
+      kind: 'demo',
+      data: [
+        {
+          id: '1',
+          name: 'foo',
+        },
+        {
+          id: '2',
+          name: 'foo',
+        },
+      ],
+      columns: [SIMPLE_COLUMN],
+      row: ROW,
+      collapsed: ['1'],
+      key: ({ id }: Item): string => id,
+    });
+
+    const [foo1, foo2] = getAllByRole('row', { name: 'foo' });
+
+    const foo1ExpandBtn = within(foo1).getByRole('button', { name: 'Expand Row' });
+    expect(foo1ExpandBtn).toHaveAttribute('aria-expanded', 'false');
+
+    const foo2ExpandBtn = within(foo2).getByRole('button', { name: 'Collapse Row' });
+    expect(foo2ExpandBtn).toHaveAttribute('aria-expanded', 'true');
   });
 });

--- a/packages/ui/src/lib/table/Table.spec.ts
+++ b/packages/ui/src/lib/table/Table.spec.ts
@@ -431,7 +431,7 @@ describe('Table#collapsed', () => {
   });
 
   test('Table#collapsed prop should be used for collapsed', async () => {
-    const { getByRole } = render<Table<Item>>(Table, {
+    const { getByRole } = render(Table, {
       kind: 'demo',
       data: [
         {
@@ -458,7 +458,7 @@ describe('Table#collapsed', () => {
   });
 
   test('item with same name can be distinct using Table#key prop', async () => {
-    const { getAllByRole } = render<Table<Item>>(Table, {
+    const { getAllByRole } = render(Table, {
       kind: 'demo',
       data: [
         {

--- a/packages/ui/src/lib/table/Table.svelte
+++ b/packages/ui/src/lib/table/Table.svelte
@@ -22,6 +22,12 @@ export let row: Row<T>;
 export let data: T[];
 export let defaultSortColumn: string | undefined = undefined;
 export let collapsed: string[] = [];
+/**
+ * To better distinct individual row, you can provide a dedicated key method
+ *
+ * By default, it will use the object name property
+ */
+export let key: (object: T) => string = item => item.name ?? String(item);
 
 let tableHtmlDivElement: HTMLDivElement | undefined = undefined;
 
@@ -240,28 +246,27 @@ function toggleChildren(name: string | undefined): void {
   <div role="rowgroup">
     {#each data as object (object)}
       {@const children = row.info.children?.(object) ?? []}
+      {@const itemKey = key(object)}
       <div class="min-h-[48px] h-fit bg-[var(--pd-content-card-bg)] rounded-lg mb-2 border border-[var(--pd-content-table-border)]">
         <div
           class="grid grid-table gap-x-0.5 min-h-[48px] hover:bg-[var(--pd-content-card-hover-bg)]"
-          class:rounded-t-lg={object.name &&
-            !collapsed.includes(object.name) &&
+          class:rounded-t-lg={!collapsed.includes(itemKey) &&
             children.length > 0}
-          class:rounded-lg={!object.name ||
-            collapsed.includes(object.name) ||
+          class:rounded-lg={collapsed.includes(itemKey) ||
             children.length === 0}
           role="row"
           aria-label={object.name}>
           <div class="whitespace-nowrap place-self-center" role="cell">
-            {#if object.name && children.length > 0}
+            {#if children.length > 0}
               <button
-                title={collapsed.includes(object.name) ? 'Expand Row' : 'Collapse Row'}
-                aria-expanded={!collapsed.includes(object.name)}
-                on:click={toggleChildren.bind(undefined, object.name)}
+                title={collapsed.includes(itemKey) ? 'Expand Row' : 'Collapse Row'}
+                aria-expanded={!collapsed.includes(itemKey)}
+                on:click={toggleChildren.bind(undefined, itemKey)}
               >
                 <Fa
                   size="0.8x"
                   class="text-[var(--pd-table-body-text)] cursor-pointer"
-                  icon={object.name && !collapsed.includes(object.name) ? faChevronDown : faChevronRight} />
+                  icon={!collapsed.includes(itemKey) ? faChevronDown : faChevronRight} />
               </button>
             {/if}
           </div>
@@ -295,7 +300,7 @@ function toggleChildren(name: string | undefined): void {
         </div>
 
         <!-- Child objects -->
-        {#if object.name && !collapsed.includes(object.name) && children.length > 0}
+        {#if !collapsed.includes(itemKey) && children.length > 0}
           {#each children as child, i (child)}
             <div
               class="grid grid-table gap-x-0.5 hover:bg-[var(--pd-content-card-hover-bg)]"


### PR DESCRIPTION
### What does this PR do?

Today to determine if a given group of containers (compose, pods) we use the `object.name` property as a key. But this has some issue, for example as explained in https://github.com/podman-desktop/podman-desktop/pull/12915#issuecomment-2988601245 the name can be shared (we can have a pod on one podman machine named the same as another pod in another podman machine.)

Therefore, we should be able to provide a custom `key` function, taking the object and returning a unique string, that will be used as unique key, to determine if something should be collapsed or not.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Required for https://github.com/podman-desktop/podman-desktop/issues/12842

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
