### PR TITLE
refactor: move interfaces of configuration to the api package

### DIFF
--- a/packages/api/src/configuration/models.ts
+++ b/packages/api/src/configuration/models.ts
@@ -16,7 +16,100 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type {
+  Configuration,
+  ConfigurationChangeEvent,
+  ConfigurationScope as PodmanDesktopApiConfigurationScope,
+} from '@podman-desktop/api';
+
+import type { IDisposable } from '../disposable.js';
+import type { Event } from '../event.js';
+
 export interface IExperimentalConfiguration {
   // href to the discussion
   githubDiscussionLink?: string;
+}
+
+export type IConfigurationPropertySchemaType =
+  | 'markdown'
+  | 'string'
+  | 'number'
+  | 'integer'
+  | 'boolean'
+  | 'null'
+  | 'array'
+  | 'object';
+
+export interface IConfigurationChangeEvent {
+  key: string;
+  value: unknown;
+  scope: PodmanDesktopApiConfigurationScope;
+}
+
+export interface IConfigurationPropertyRecordedSchema extends IConfigurationPropertySchema {
+  title: string;
+  parentId: string;
+  extension?: IConfigurationExtensionInfo;
+}
+
+export interface IConfigurationPropertySchema {
+  id?: string;
+  type?: IConfigurationPropertySchemaType | IConfigurationPropertySchemaType[];
+  default?: unknown;
+  group?: string;
+  description?: string;
+  placeholder?: string;
+  markdownDescription?: string;
+  minimum?: number;
+  maximum?: number | string;
+  format?: string;
+  step?: number;
+  scope?: ConfigurationScope | ConfigurationScope[];
+  readonly?: boolean;
+  // if hidden is true, the property is not shown in the preferences page. It may still appear in other locations if it uses other scope (like onboarding)
+  hidden?: boolean;
+  enum?: string[];
+  when?: string;
+  experimental?: IExperimentalConfiguration;
+}
+
+export type ConfigurationScope =
+  | 'DEFAULT'
+  | 'ContainerConnection'
+  | 'KubernetesConnection'
+  | 'VmConnection'
+  | 'ContainerProviderConnectionFactory'
+  | 'KubernetesProviderConnectionFactory'
+  | 'VmProviderConnectionFactory'
+  | 'DockerCompatibility'
+  | 'Onboarding';
+
+export interface IConfigurationExtensionInfo {
+  id: string;
+}
+
+export interface IConfigurationNode {
+  id: string;
+  type?: string | string[];
+  title: string;
+  description?: string;
+  properties?: Record<string, IConfigurationPropertySchema>;
+  scope?: ConfigurationScope;
+  extension?: IConfigurationExtensionInfo;
+}
+
+export interface IConfigurationRegistry {
+  registerConfigurations(configurations: IConfigurationNode[]): IDisposable;
+  deregisterConfigurations(configurations: IConfigurationNode[]): void;
+  updateConfigurations(configurations: { add: IConfigurationNode[]; remove: IConfigurationNode[] }): void;
+  readonly onDidUpdateConfiguration: Event<{ properties: string[] }>;
+  readonly onDidChangeConfiguration: Event<IConfigurationChangeEvent>;
+  readonly onDidChangeConfigurationAPI: Event<ConfigurationChangeEvent>;
+  getConfigurationProperties(): Record<string, IConfigurationPropertyRecordedSchema>;
+  getConfiguration(section?: string, scope?: PodmanDesktopApiConfigurationScope): Configuration;
+  updateConfigurationValue(
+    key: string,
+    value: unknown,
+    scope?: PodmanDesktopApiConfigurationScope | PodmanDesktopApiConfigurationScope[],
+  ): Promise<void>;
 }

--- a/packages/main/src/index.spec.ts
+++ b/packages/main/src/index.spec.ts
@@ -21,8 +21,9 @@ import { app, BrowserWindow, Menu, Tray } from 'electron';
 import { aboutMenuItem } from 'electron-util/main';
 import { afterEach, assert, beforeEach, expect, test, vi } from 'vitest';
 
+import type { IConfigurationChangeEvent, IConfigurationRegistry } from '/@api/configuration/models.js';
+
 import { mainWindowDeferred } from './index.js';
-import type { ConfigurationRegistry, IConfigurationChangeEvent } from './plugin/configuration-registry.js';
 import { Emitter } from './plugin/events/emitter.js';
 import { PluginSystem } from './plugin/index.js';
 import { Deferred } from './plugin/util/deferred.js';
@@ -64,7 +65,7 @@ const configurationRegistryMock = {
   getConfiguration: vi.fn().mockReturnValue({
     get: vi.fn(),
   }),
-} as unknown as ConfigurationRegistry;
+} as unknown as IConfigurationRegistry;
 
 const fakeWindow = {
   isDestroyed: vi.fn(),
@@ -242,7 +243,7 @@ test('app-ready event with activate event', async () => {
   expect(_onDidConfigurationRegistry).toBeDefined();
 
   // cast as Emitter
-  const onDidConfigurationRegistry = _onDidConfigurationRegistry as Emitter<ConfigurationRegistry>;
+  const onDidConfigurationRegistry = _onDidConfigurationRegistry as Emitter<IConfigurationRegistry>;
 
   // create a Menu
   vi.mocked(Menu.getApplicationMenu).mockReturnValue({

--- a/packages/main/src/plugin/appearance-init.spec.ts
+++ b/packages/main/src/plugin/appearance-init.spec.ts
@@ -19,10 +19,11 @@
 import { nativeTheme } from 'electron';
 import { beforeAll, expect, test, vi } from 'vitest';
 
+import type { IConfigurationChangeEvent } from '/@api/configuration/models.js';
+
 import type { ApiSenderType } from './api.js';
 import { AppearanceInit } from './appearance-init.js';
 import { AppearanceSettings } from './appearance-settings.js';
-import type { IConfigurationChangeEvent } from './configuration-registry.js';
 import { ConfigurationRegistry } from './configuration-registry.js';
 import type { Directories } from './directories.js';
 

--- a/packages/main/src/plugin/appearance-init.ts
+++ b/packages/main/src/plugin/appearance-init.ts
@@ -18,8 +18,9 @@
 
 import { nativeTheme } from 'electron';
 
+import type { IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
+
 import { AppearanceSettings } from './appearance-settings.js';
-import type { IConfigurationNode, IConfigurationRegistry } from './configuration-registry.js';
 
 const APPEARANCE_FULL_KEY = `${AppearanceSettings.SectionName}.${AppearanceSettings.Appearance}`;
 

--- a/packages/main/src/plugin/autostart-engine.spec.ts
+++ b/packages/main/src/plugin/autostart-engine.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,9 +21,9 @@ import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
 import type { ApiSenderType } from '/@/plugin/api.js';
 import { CONFIGURATION_DEFAULT_SCOPE, CONFIGURATION_ONBOARDING_SCOPE } from '/@api/configuration/constants.js';
+import type { IConfigurationNode } from '/@api/configuration/models.js';
 
 import { AutostartEngine } from './autostart-engine.js';
-import type { IConfigurationNode } from './configuration-registry.js';
 import { ConfigurationRegistry } from './configuration-registry.js';
 import type { Directories } from './directories.js';
 import type { ProviderRegistry } from './provider-registry.js';

--- a/packages/main/src/plugin/autostart-engine.ts
+++ b/packages/main/src/plugin/autostart-engine.ts
@@ -17,8 +17,8 @@
  ***********************************************************************/
 
 import { CONFIGURATION_DEFAULT_SCOPE, CONFIGURATION_ONBOARDING_SCOPE } from '/@api/configuration/constants.js';
+import type { IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
 
-import type { ConfigurationRegistry, IConfigurationNode } from './configuration-registry.js';
 import type { ProviderRegistry } from './provider-registry.js';
 import { Disposable } from './types/disposable.js';
 
@@ -26,7 +26,7 @@ export class AutostartEngine {
   private providerExtension = new Map<string, string>();
 
   constructor(
-    private configurationRegistry: ConfigurationRegistry,
+    private configurationRegistry: IConfigurationRegistry,
     private providerRegistry: ProviderRegistry,
   ) {}
 

--- a/packages/main/src/plugin/close-behavior.ts
+++ b/packages/main/src/plugin/close-behavior.ts
@@ -16,11 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
+
 import { isUnixLike } from '../util.js';
-import type { ConfigurationRegistry, IConfigurationNode } from './configuration-registry.js';
 
 export class CloseBehavior {
-  constructor(private configurationRegistry: ConfigurationRegistry) {}
+  constructor(private configurationRegistry: IConfigurationRegistry) {}
 
   async init(): Promise<void> {
     // add configuration

--- a/packages/main/src/plugin/color-registry.spec.ts
+++ b/packages/main/src/plugin/color-registry.spec.ts
@@ -21,16 +21,17 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { ApiSenderType } from '/@/plugin/api.js';
 import { AppearanceSettings } from '/@/plugin/appearance-settings.js';
-import type { ConfigurationRegistry, IConfigurationChangeEvent } from '/@/plugin/configuration-registry.js';
 import { Emitter } from '/@/plugin/events/emitter.js';
 import type { AnalyzedExtension } from '/@/plugin/extension/extension-analyzer.js';
 import { Disposable } from '/@/plugin/types/disposable.js';
 import type { ColorDefinition } from '/@api/color-info.js';
+import type { IConfigurationChangeEvent } from '/@api/configuration/models.js';
 import type { RawThemeContribution } from '/@api/theme-info.js';
 
 import colorPalette from '../../../../tailwind-color-palette.json' with { type: 'json' };
 import * as util from '../util.js';
 import { ColorRegistry } from './color-registry.js';
+import type { ConfigurationRegistry } from './configuration-registry.js';
 
 class TestColorRegistry extends ColorRegistry {
   override notifyUpdate(): void {

--- a/packages/main/src/plugin/configuration-impl.ts
+++ b/packages/main/src/plugin/configuration-impl.ts
@@ -19,9 +19,9 @@
 import type * as containerDesktopAPI from '@podman-desktop/api';
 
 import { CONFIGURATION_DEFAULT_SCOPE } from '/@api/configuration/constants.js';
+import type { IConfigurationChangeEvent } from '/@api/configuration/models.js';
 
 import type { ApiSenderType } from './api.js';
-import type { IConfigurationChangeEvent } from './configuration-registry.js';
 
 /**
  * Local view of the configuration values for a given scope

--- a/packages/main/src/plugin/configuration-registry.spec.ts
+++ b/packages/main/src/plugin/configuration-registry.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2024 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,12 +21,12 @@ import * as fs from 'node:fs';
 import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { ApiSenderType } from '/@/plugin/api.js';
+import type { IConfigurationNode } from '/@api/configuration/models.js';
+import type { IDisposable } from '/@api/disposable.js';
 
-import type { IConfigurationNode } from './configuration-registry.js';
 import { ConfigurationRegistry } from './configuration-registry.js';
 import type { Directories } from './directories.js';
 import type { NotificationRegistry } from './tasks/notification-registry.js';
-import type { Disposable } from './types/disposable.js';
 
 let configurationRegistry: ConfigurationRegistry;
 
@@ -46,7 +46,7 @@ const notificationRegistry = {
   addNotification: vi.fn(),
 } as unknown as NotificationRegistry;
 
-let registerConfigurationsDisposable: Disposable;
+let registerConfigurationsDisposable: IDisposable;
 
 beforeAll(() => {
   // mock the fs module

--- a/packages/main/src/plugin/confirmation-init.ts
+++ b/packages/main/src/plugin/confirmation-init.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { IConfigurationNode, IConfigurationRegistry } from './configuration-registry.js';
+import type { IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
 
 export class ConfirmationInit {
   constructor(private configurationRegistry: IConfigurationRegistry) {}

--- a/packages/main/src/plugin/docker/docker-compatibility.ts
+++ b/packages/main/src/plugin/docker/docker-compatibility.ts
@@ -21,10 +21,10 @@ import { promises } from 'node:fs';
 import Dockerode from 'dockerode';
 
 import { isMac, isWindows } from '/@/util.js';
+import type { IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
 import type { DockerSocketMappingStatusInfo, DockerSocketServerInfoType } from '/@api/docker-compatibility-info.js';
 import { DockerCompatibilitySettings } from '/@api/docker-compatibility-info.js';
 
-import type { ConfigurationRegistry, IConfigurationNode } from '../configuration-registry.js';
 import type { LibPod } from '../dockerode/libpod-dockerode.js';
 import type { ProviderRegistry } from '../provider-registry.js';
 
@@ -35,11 +35,11 @@ export class DockerCompatibility {
   static readonly ENABLED_FULL_KEY =
     `${DockerCompatibilitySettings.SectionName}.${DockerCompatibilitySettings.Enabled}`;
 
-  #configurationRegistry: ConfigurationRegistry;
+  #configurationRegistry: IConfigurationRegistry;
 
   #providerRegistry: ProviderRegistry;
 
-  constructor(configurationRegistry: ConfigurationRegistry, providerRegistry: ProviderRegistry) {
+  constructor(configurationRegistry: IConfigurationRegistry, providerRegistry: ProviderRegistry) {
     this.#configurationRegistry = configurationRegistry;
     this.#providerRegistry = providerRegistry;
   }

--- a/packages/main/src/plugin/editor-init.ts
+++ b/packages/main/src/plugin/editor-init.ts
@@ -16,7 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { IConfigurationNode, IConfigurationRegistry } from './configuration-registry.js';
+import type { IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
+
 import { EditorSettings } from './editor-settings.js';
 
 export class EditorInit {

--- a/packages/main/src/plugin/extension/catalog/extensions-catalog.ts
+++ b/packages/main/src/plugin/extension/catalog/extensions-catalog.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2024 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,12 +22,12 @@ import { HttpProxyAgent, HttpsProxyAgent } from 'hpagent';
 
 import type { ApiSenderType } from '/@/plugin/api.js';
 import type { Certificates } from '/@/plugin/certificates.js';
-import type { ConfigurationRegistry, IConfigurationNode } from '/@/plugin/configuration-registry.js';
 import type {
   CatalogExtension,
   CatalogFetchableExtension,
 } from '/@/plugin/extension/catalog/extensions-catalog-api.js';
 import type { Proxy } from '/@/plugin/proxy.js';
+import type { IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
 
 import { ExtensionsCatalogSettings } from './extensions-catalog-settings.js';
 
@@ -44,7 +44,7 @@ export class ExtensionsCatalog {
   constructor(
     private certificates: Certificates,
     private proxy: Proxy,
-    private configurationRegistry: ConfigurationRegistry,
+    private configurationRegistry: IConfigurationRegistry,
     private apiSender: ApiSenderType,
   ) {}
 

--- a/packages/main/src/plugin/extension/extension-development-folders.ts
+++ b/packages/main/src/plugin/extension/extension-development-folders.ts
@@ -19,8 +19,8 @@
 import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 
-import type { ConfigurationRegistry, IConfigurationNode } from '/@/plugin/configuration-registry.js';
 import { Emitter } from '/@/plugin/events/emitter.js';
+import type { IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
 import type { ExtensionDevelopmentFolderInfo } from '/@api/extension-development-folders-info.js';
 import { ExtensionDevelopmentFolderInfoSettings } from '/@api/extension-development-folders-info.js';
 
@@ -29,7 +29,7 @@ import type { AnalyzedExtension, ExtensionAnalyzer } from './extension-analyzer.
 
 // Handle the registration / track of all development folders used when developing extensions
 export class ExtensionDevelopmentFolders {
-  #configurationRegistry: ConfigurationRegistry;
+  #configurationRegistry: IConfigurationRegistry;
 
   #apiSender: ApiSenderType;
 
@@ -52,7 +52,7 @@ export class ExtensionDevelopmentFolders {
   onNeedToLoadExension = this.#onRequestLoadExension.event;
 
   constructor(
-    configurationRegistry: ConfigurationRegistry,
+    configurationRegistry: IConfigurationRegistry,
     extensionAnalyzer: ExtensionAnalyzer,
     apiSender: ApiSenderType,
   ) {

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -31,6 +31,7 @@ import type {
 import type { MenuRegistry } from '/@/plugin/menu-registry.js';
 import type { NavigationManager } from '/@/plugin/navigation/navigation-manager.js';
 import type { WebviewRegistry } from '/@/plugin/webview/webview-registry.js';
+import type { IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
 import type { Event } from '/@api/event.js';
 import type { ExtensionError, ExtensionInfo, ExtensionUpdateInfo } from '/@api/extension-info.js';
 import { DEFAULT_TIMEOUT, ExtensionLoaderSettings } from '/@api/extension-loader-settings.js';
@@ -45,7 +46,6 @@ import { CancellationTokenSource } from '../cancellation-token.js';
 import type { Certificates } from '../certificates.js';
 import type { CliToolRegistry } from '../cli-tool-registry.js';
 import type { CommandRegistry } from '../command-registry.js';
-import type { ConfigurationRegistry, IConfigurationNode } from '../configuration-registry.js';
 import type { ContainerProviderRegistry } from '../container-registry.js';
 import type { Context } from '../context/context.js';
 import type { CustomPickRegistry } from '../custompick/custompick-registry.js';
@@ -136,7 +136,7 @@ export class ExtensionLoader {
     private commandRegistry: CommandRegistry,
     private menuRegistry: MenuRegistry,
     private providerRegistry: ProviderRegistry,
-    private configurationRegistry: ConfigurationRegistry,
+    private configurationRegistry: IConfigurationRegistry,
     private imageRegistry: ImageRegistry,
     private apiSender: ApiSenderType,
     private trayMenuRegistry: TrayMenuRegistry,
@@ -1783,7 +1783,7 @@ export class ExtensionLoader {
     }
   }
 
-  getConfigurationRegistry(): ConfigurationRegistry {
+  getConfigurationRegistry(): IConfigurationRegistry {
     return this.configurationRegistry;
   }
 

--- a/packages/main/src/plugin/extension/updater/extensions-updater.ts
+++ b/packages/main/src/plugin/extension/updater/extensions-updater.ts
@@ -20,12 +20,12 @@ import { compareVersions } from 'compare-versions';
 import { app } from 'electron';
 import { coerce, satisfies } from 'semver';
 
-import type { ConfigurationRegistry, IConfigurationNode } from '/@/plugin/configuration-registry.js';
 import type { ExtensionsCatalog } from '/@/plugin/extension/catalog/extensions-catalog.js';
 import type { ExtensionLoader } from '/@/plugin/extension/extension-loader.js';
 import { ExtensionsUpdaterSettings } from '/@/plugin/extension/updater/extensions-updater-settings.js';
 import type { ExtensionInstaller } from '/@/plugin/install/extension-installer.js';
 import type { Telemetry } from '/@/plugin/telemetry/telemetry.js';
+import type { IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
 import type { ExtensionUpdateInfo } from '/@api/extension-info.js';
 
 export class ExtensionsUpdater {
@@ -36,7 +36,7 @@ export class ExtensionsUpdater {
   constructor(
     private extensionCatalog: ExtensionsCatalog,
     private extensionLoader: ExtensionLoader,
-    private configurationRegistry: ConfigurationRegistry,
+    private configurationRegistry: IConfigurationRegistry,
     private extensionInstaller: ExtensionInstaller,
     private telemetry: Telemetry,
   ) {}

--- a/packages/main/src/plugin/image-files-registry.ts
+++ b/packages/main/src/plugin/image-files-registry.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,11 +24,11 @@ import type {
   ImageInfo,
 } from '@podman-desktop/api';
 
+import type { IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
 import type { ImageFilesExtensionInfo, ImageFilesInfo } from '/@api/image-files-info.js';
 import type { ImageFilesystemLayersUI } from '/@api/image-filesystem-layers.js';
 
 import type { ApiSenderType } from './api.js';
-import type { IConfigurationNode, IConfigurationRegistry } from './configuration-registry.js';
 import type { Context } from './context/context.js';
 import { toImageFilesystemLayerUIs } from './image-details-files.js';
 import { ImageFilesImpl } from './image-files-impl.js';

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -67,6 +67,7 @@ import { Updater } from '/@/plugin/updater.js';
 import type { CliToolInfo } from '/@api/cli-tool-info.js';
 import type { ColorInfo } from '/@api/color-info.js';
 import type { CommandInfo } from '/@api/command-info.js';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
 import type {
   ContainerCreateOptions,
   ContainerExportOptions,
@@ -138,7 +139,6 @@ import { CloseBehavior } from './close-behavior.js';
 import { ColorRegistry } from './color-registry.js';
 import { CommandRegistry } from './command-registry.js';
 import { CommandsInit } from './commands-init.js';
-import type { IConfigurationPropertyRecordedSchema } from './configuration-registry.js';
 import { ConfigurationRegistry } from './configuration-registry.js';
 import { ConfirmationInit } from './confirmation-init.js';
 import { ContainerProviderRegistry } from './container-registry.js';

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
@@ -48,11 +48,11 @@ import { beforeAll, beforeEach, describe, expect, type Mock, test, vi } from 'vi
 
 import type { KubernetesPortForwardService } from '/@/plugin/kubernetes/kubernetes-port-forward-service.js';
 import { KubernetesPortForwardServiceProvider } from '/@/plugin/kubernetes/kubernetes-port-forward-service.js';
+import type { IConfigurationChangeEvent, IConfigurationRegistry } from '/@api/configuration/models.js';
 import { type ForwardConfig, type ForwardOptions, WorkloadKind } from '/@api/kubernetes-port-forward-model.js';
 import type { V1Route } from '/@api/openshift-types.js';
 
 import type { ApiSenderType } from '../api.js';
-import type { ConfigurationRegistry, IConfigurationChangeEvent } from '../configuration-registry.js';
 import { Emitter } from '../events/emitter.js';
 import { FilesystemMonitoring } from '../filesystem-monitoring.js';
 import type { Telemetry } from '../telemetry/telemetry.js';
@@ -64,13 +64,13 @@ import { ResizableTerminalWriter } from './kubernetes-exec-transmitter.js';
 vi.mock(import('node:fs'));
 
 const _onDidChangeConfiguration = new Emitter<IConfigurationChangeEvent>();
-const configurationRegistry: ConfigurationRegistry = {
+const configurationRegistry: IConfigurationRegistry = {
   onDidChangeConfiguration: _onDidChangeConfiguration.event,
   registerConfigurations: vi.fn(),
   getConfiguration: vi.fn().mockReturnValue({
     get: vi.fn().mockReturnValue(''),
   }),
-} as unknown as ConfigurationRegistry;
+} as unknown as IConfigurationRegistry;
 
 const fileSystemMonitoring: FilesystemMonitoring = new FilesystemMonitoring();
 const telemetry: Telemetry = {

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.ts
@@ -73,6 +73,7 @@ import { parseAllDocuments } from 'yaml';
 
 import type { KubernetesPortForwardService } from '/@/plugin/kubernetes/kubernetes-port-forward-service.js';
 import { KubernetesPortForwardServiceProvider } from '/@/plugin/kubernetes/kubernetes-port-forward-service.js';
+import type { IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
 import type { KubeContext } from '/@api/kubernetes-context.js';
 import type { ContextHealth } from '/@api/kubernetes-contexts-healths.js';
 import type { ContextPermission } from '/@api/kubernetes-contexts-permissions.js';
@@ -84,7 +85,6 @@ import type { KubernetesTroubleshootingInformation } from '/@api/kubernetes-trou
 import type { V1Route } from '/@api/openshift-types.js';
 
 import type { ApiSenderType } from '../api.js';
-import type { ConfigurationRegistry, IConfigurationNode } from '../configuration-registry.js';
 import { Emitter } from '../events/emitter.js';
 import type { FilesystemMonitoring } from '../filesystem-monitoring.js';
 import type { Telemetry } from '../telemetry/telemetry.js';
@@ -205,7 +205,7 @@ export class KubernetesClient {
 
   constructor(
     private readonly apiSender: ApiSenderType,
-    private readonly configurationRegistry: ConfigurationRegistry,
+    private readonly configurationRegistry: IConfigurationRegistry,
     private readonly fileSystemMonitoring: FilesystemMonitoring,
     private readonly telemetry: Telemetry,
   ) {

--- a/packages/main/src/plugin/learning-center-init.ts
+++ b/packages/main/src/plugin/learning-center-init.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { IConfigurationNode, IConfigurationRegistry } from './configuration-registry.js';
+import type { IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
 
 export class LearningCenterInit {
   constructor(private configurationRegistry: IConfigurationRegistry) {}

--- a/packages/main/src/plugin/libpod-api-enable/libpod-api-init.ts
+++ b/packages/main/src/plugin/libpod-api-enable/libpod-api-init.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { IConfigurationNode, IConfigurationRegistry } from '../configuration-registry.js';
+import type { IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
+
 import { LibpodApiSettings } from './libpod-api-settings.js';
 
 export class LibpodApiInit {

--- a/packages/main/src/plugin/navigation-items-init.ts
+++ b/packages/main/src/plugin/navigation-items-init.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { IConfigurationNode, IConfigurationRegistry } from './configuration-registry.js';
+import type { IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
 
 export class NavigationItemsInit {
   constructor(private configurationRegistry: IConfigurationRegistry) {}

--- a/packages/main/src/plugin/open-devtools-init.ts
+++ b/packages/main/src/plugin/open-devtools-init.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ConfigurationRegistry, IConfigurationNode } from './configuration-registry.js';
+import type { IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
 
 export class OpenDevToolsInit {
-  constructor(private configurationRegistry: ConfigurationRegistry) {}
+  constructor(private configurationRegistry: IConfigurationRegistry) {}
 
   init(): void {
     // add configuration

--- a/packages/main/src/plugin/proxy.ts
+++ b/packages/main/src/plugin/proxy.ts
@@ -20,9 +20,9 @@ import type { Event, ProxySettings } from '@podman-desktop/api';
 import { ProxyAgent } from 'undici';
 
 import type { Certificates } from '/@/plugin/certificates.js';
+import type { IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
 import { ProxyState } from '/@api/proxy.js';
 
-import type { ConfigurationRegistry, IConfigurationNode } from './configuration-registry.js';
 import { Emitter } from './events/emitter.js';
 import { getProxyUrl } from './proxy-resolver.js';
 import { getProxySettingsFromSystem } from './proxy-system.js';
@@ -65,7 +65,7 @@ export class Proxy {
   public readonly onDidStateChange: Event<boolean> = this._onDidStateChange.event;
 
   constructor(
-    private configurationRegistry: ConfigurationRegistry,
+    private configurationRegistry: IConfigurationRegistry,
     private certificates: Certificates,
   ) {}
 

--- a/packages/main/src/plugin/recommendations/recommendations-registry.ts
+++ b/packages/main/src/plugin/recommendations/recommendations-registry.ts
@@ -16,23 +16,23 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ConfigurationRegistry, IConfigurationNode } from '/@/plugin/configuration-registry.js';
 import type { ExtensionsCatalog } from '/@/plugin/extension/catalog/extensions-catalog.js';
 import type { ExtensionLoader } from '/@/plugin/extension/extension-loader.js';
 import type { Featured } from '/@/plugin/featured/featured.js';
 import type { FeaturedExtension } from '/@/plugin/featured/featured-api.js';
-import {
-  type ExtensionBanner,
-  type RecommendedRegistry,
-  type RecommendedRegistryExtensionDetails,
+import type {
+  ExtensionBanner,
+  RecommendedRegistry,
+  RecommendedRegistryExtensionDetails,
 } from '/@/plugin/recommendations/recommendations-api.js';
+import type { IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
 
 import recommendations from '../../../../../recommendations.json' with { type: 'json' };
 import { RecommendationsSettings } from './recommendations-settings.js';
 
 export class RecommendationsRegistry {
   constructor(
-    private configurationRegistry: ConfigurationRegistry,
+    private configurationRegistry: IConfigurationRegistry,
     private featured: Featured,
     private extensionLoader: ExtensionLoader,
     private extensionsCatalog: ExtensionsCatalog,

--- a/packages/main/src/plugin/release-notes-banner-init.ts
+++ b/packages/main/src/plugin/release-notes-banner-init.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { IConfigurationNode, IConfigurationRegistry } from './configuration-registry.js';
+import type { IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
 
 export class ReleaseNotesBannerInit {
   constructor(private configurationRegistry: IConfigurationRegistry) {}

--- a/packages/main/src/plugin/statusbar/statusbar-providers-init.ts
+++ b/packages/main/src/plugin/statusbar/statusbar-providers-init.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { IConfigurationNode, IConfigurationRegistry } from '../configuration-registry.js';
+import type { IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
 
 export class StatusbarProvidersInit {
   constructor(private configurationRegistry: IConfigurationRegistry) {}

--- a/packages/main/src/plugin/telemetry/telemetry.ts
+++ b/packages/main/src/plugin/telemetry/telemetry.ts
@@ -32,12 +32,12 @@ import type { LinuxOs } from 'getos';
 import getos from 'getos';
 import * as osLocale from 'os-locale';
 
+import type { IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
 import type { Event } from '/@api/event.js';
 import type { FeedbackProperties } from '/@api/feedback.js';
 
 import telemetry from '../../../../../telemetry.json' with { type: 'json' };
 import { stoppedExtensions } from '../../util.js';
-import type { ConfigurationRegistry, IConfigurationNode } from '../configuration-registry.js';
 import { Emitter } from '../events/emitter.js';
 import { TelemetryTrustedValue as TypeTelemetryTrustedValue } from '../types/telemetry.js';
 import { Identity } from './identity.js';
@@ -86,7 +86,7 @@ export class Telemetry {
   private readonly _onDidChangeTelemetryEnabled = new Emitter<boolean>();
   readonly onDidChangeTelemetryEnabled: Event<boolean> = this._onDidChangeTelemetryEnabled.event;
 
-  constructor(private configurationRegistry: ConfigurationRegistry) {
+  constructor(private configurationRegistry: IConfigurationRegistry) {
     this.identity = new Identity();
     this.lastTimeEvents = new Map();
   }

--- a/packages/main/src/plugin/terminal-init.ts
+++ b/packages/main/src/plugin/terminal-init.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022 Red Hat, Inc.
+ * Copyright (C) 2022-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { IConfigurationNode, IConfigurationRegistry } from './configuration-registry.js';
+import type { IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
+
 import { TerminalSettings } from './terminal-settings.js';
 
 export class TerminalInit {

--- a/packages/main/src/plugin/tray-icon-color.ts
+++ b/packages/main/src/plugin/tray-icon-color.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ConfigurationRegistry, IConfigurationNode } from './configuration-registry.js';
+import type { IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
 
 export class TrayIconColor {
-  constructor(private configurationRegistry: ConfigurationRegistry) {}
+  constructor(private configurationRegistry: IConfigurationRegistry) {}
 
   async init(): Promise<void> {
     // add configuration

--- a/packages/main/src/plugin/welcome/welcome-init.ts
+++ b/packages/main/src/plugin/welcome/welcome-init.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { IConfigurationNode, IConfigurationRegistry } from '../configuration-registry.js';
+import type { IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
+
 import { WelcomeSettings } from './welcome-settings.js';
 
 export class WelcomeInit {

--- a/packages/main/src/plugin/zoom-level-handler.spec.ts
+++ b/packages/main/src/plugin/zoom-level-handler.spec.ts
@@ -20,12 +20,13 @@ import type { Configuration } from '@podman-desktop/api';
 import type { BrowserWindow } from 'electron';
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
-import { AppearanceSettings } from './appearance-settings.js';
 import type {
-  ConfigurationRegistry,
   IConfigurationChangeEvent,
   IConfigurationPropertyRecordedSchema,
-} from './configuration-registry.js';
+  IConfigurationRegistry,
+} from '/@api/configuration/models.js';
+
+import { AppearanceSettings } from './appearance-settings.js';
 import { Emitter } from './events/emitter.js';
 import { ZoomLevelHandler } from './zoom-level-handler.js';
 
@@ -51,7 +52,7 @@ Object.defineProperty(browserWindowMock.webContents, 'zoomLevel', {
   set: setZoomLevelMock,
 });
 
-let configurationRegistryMock: ConfigurationRegistry;
+let configurationRegistryMock: IConfigurationRegistry;
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -64,7 +65,7 @@ beforeEach(() => {
     getConfiguration: vi.fn().mockReturnValue({
       get: vi.fn(),
     }),
-  } as unknown as ConfigurationRegistry;
+  } as unknown as IConfigurationRegistry;
   zoomLevelHandler = new TestZoomLevelHandler(browserWindowMock, configurationRegistryMock);
 });
 

--- a/packages/main/src/plugin/zoom-level-handler.ts
+++ b/packages/main/src/plugin/zoom-level-handler.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,19 +18,20 @@
 
 import type { BrowserWindow } from 'electron';
 
+import type { IConfigurationRegistry } from '/@api/configuration/models.js';
+
 import { AppearanceSettings } from './appearance-settings.js';
-import type { ConfigurationRegistry } from './configuration-registry.js';
 import type { IDisposable } from './types/disposable.js';
 
 export class ZoomLevelHandler {
   #browserWindow: BrowserWindow;
-  #configurationRegistry: ConfigurationRegistry;
+  #configurationRegistry: IConfigurationRegistry;
   #disposable: IDisposable | undefined;
   #stepValue = 0.5;
   #maximumZoomLevel = 3;
   #minimumZoomLevel = -3;
 
-  constructor(browserWindow: BrowserWindow, configurationRegistry: ConfigurationRegistry) {
+  constructor(browserWindow: BrowserWindow, configurationRegistry: IConfigurationRegistry) {
     this.#browserWindow = browserWindow;
     this.#configurationRegistry = configurationRegistry;
   }

--- a/packages/main/src/system/macos-startup.ts
+++ b/packages/main/src/system/macos-startup.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022-2024 Red Hat, Inc.
+ * Copyright (C) 2022-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import path from 'node:path';
 
 import { app } from 'electron';
 
-import type { ConfigurationRegistry } from '../plugin/configuration-registry.js';
+import type { IConfigurationRegistry } from '/@api/configuration/models.js';
 
 /**
  * On macOS, startup on login is done via a plist file
@@ -32,9 +32,9 @@ import type { ConfigurationRegistry } from '../plugin/configuration-registry.js'
 export class MacosStartup {
   private podmanDesktopBinaryPath;
   private plistFile;
-  private configurationRegistry: ConfigurationRegistry;
+  private configurationRegistry: IConfigurationRegistry;
 
-  constructor(configurationRegistry: ConfigurationRegistry) {
+  constructor(configurationRegistry: IConfigurationRegistry) {
     this.configurationRegistry = configurationRegistry;
 
     // grab current path of the binary

--- a/packages/main/src/system/startup-install.ts
+++ b/packages/main/src/system/startup-install.ts
@@ -18,14 +18,15 @@
 
 import * as os from 'node:os';
 
-import type { ConfigurationRegistry, IConfigurationNode } from '../plugin/configuration-registry.js';
+import type { IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
+
 import { MacosStartup } from './macos-startup.js';
 import { WindowsStartup } from './windows-startup.js';
 
 export class StartupInstall {
   private osStartup: MacosStartup | WindowsStartup | undefined;
 
-  constructor(private configurationRegistry: ConfigurationRegistry) {
+  constructor(private configurationRegistry: IConfigurationRegistry) {
     // macos ?
     if (os.platform() === 'darwin') {
       this.osStartup = new MacosStartup(configurationRegistry);

--- a/packages/main/src/system/window/window-handler.ts
+++ b/packages/main/src/system/window/window-handler.ts
@@ -18,7 +18,7 @@
 
 import { type BrowserWindow, type Rectangle, screen } from 'electron';
 
-import type { ConfigurationRegistry, IConfigurationNode } from '/@/plugin/configuration-registry.js';
+import type { IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
 
 import { WindowSettings } from './window-settings.js';
 
@@ -27,11 +27,11 @@ import { WindowSettings } from './window-settings.js';
  */
 export class WindowHandler {
   readonly #browserWindow: BrowserWindow;
-  readonly #configurationRegistry: ConfigurationRegistry;
+  readonly #configurationRegistry: IConfigurationRegistry;
 
   #debounceSaveTimeout: NodeJS.Timeout | undefined;
 
-  constructor(configurationRegistry: ConfigurationRegistry, browserWindow: BrowserWindow) {
+  constructor(configurationRegistry: IConfigurationRegistry, browserWindow: BrowserWindow) {
     this.#browserWindow = browserWindow;
     this.#configurationRegistry = configurationRegistry;
   }

--- a/packages/main/src/system/windows-startup.ts
+++ b/packages/main/src/system/windows-startup.ts
@@ -21,7 +21,7 @@ import path from 'node:path';
 
 import { app } from 'electron';
 
-import type { ConfigurationRegistry } from '../plugin/configuration-registry.js';
+import type { IConfigurationRegistry } from '/@api/configuration/models.js';
 
 /**
  * On Windows, launching program automatically on startup is done via %APPDATA%\Roaming\Microsoft\Windows\Start Menu\Programs\Startup folder
@@ -34,9 +34,9 @@ export class WindowsStartup {
   private startupFile;
   private windowsStartupFoler;
   private exeDirectory;
-  private configurationRegistry: ConfigurationRegistry;
+  private configurationRegistry: IConfigurationRegistry;
 
-  constructor(configurationRegistry: ConfigurationRegistry) {
+  constructor(configurationRegistry: IConfigurationRegistry) {
     // configuration settings
     this.configurationRegistry = configurationRegistry;
 

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -46,6 +46,7 @@ import { contextBridge, ipcRenderer } from 'electron';
 import type { CliToolInfo } from '/@api/cli-tool-info';
 import type { ColorInfo } from '/@api/color-info';
 import type { CommandInfo } from '/@api/command-info';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
 import type {
   ContainerCreateOptions,
   ContainerExportOptions,
@@ -105,7 +106,6 @@ import type { ContextInfo } from '../../main/src/plugin/api/context-info';
 import type { KubernetesGeneratorInfo } from '../../main/src/plugin/api/KubernetesGeneratorInfo';
 import type { PodCreateOptions, PodInfo, PodInspectInfo } from '../../main/src/plugin/api/pod-info';
 import type { AuthenticationProviderInfo } from '../../main/src/plugin/authentication';
-import type { IConfigurationPropertyRecordedSchema } from '../../main/src/plugin/configuration-registry';
 import type {
   ContainerCreateOptions as PodmanContainerCreateOptions,
   PlayKubeInfo,

--- a/packages/renderer/src/PreferencesNavigation.spec.ts
+++ b/packages/renderer/src/PreferencesNavigation.spec.ts
@@ -23,7 +23,8 @@ import { tick } from 'svelte';
 import type { TinroRouteMeta } from 'tinro';
 import { beforeEach, expect, test, vi } from 'vitest';
 
-import type { IConfigurationPropertyRecordedSchema } from '../../main/src/plugin/configuration-registry';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
+
 import PreferencesNavigation from './PreferencesNavigation.svelte';
 import { configurationProperties } from './stores/configurationProperties';
 

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftOnboardingAndProperties.spec.ts
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftOnboardingAndProperties.spec.ts
@@ -25,9 +25,9 @@ import { beforeEach, expect, test, vi } from 'vitest';
 import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
 import { configurationProperties } from '/@/stores/configurationProperties';
 import { onboardingList } from '/@/stores/onboarding';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
 import type { OnboardingInfo } from '/@api/onboarding';
 
-import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import InstalledExtensionCardLeftOnboardingAndProperties from './InstalledExtensionCardLeftOnboardingAndProperties.svelte';
 
 // mock the router

--- a/packages/renderer/src/lib/onboarding/OnboardingComponent.svelte
+++ b/packages/renderer/src/lib/onboarding/OnboardingComponent.svelte
@@ -5,10 +5,10 @@ import Fa from 'svelte-fa';
 
 import { configurationProperties } from '/@/stores/configurationProperties';
 import { providerInfos } from '/@/stores/providers';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
 import type { OnboardingEmbeddedComponentType } from '/@api/onboarding';
 import type { ProviderInfo } from '/@api/provider-info';
 
-import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import PreferencesConnectionCreationOrEditRendering from '../preferences/PreferencesConnectionCreationOrEditRendering.svelte';
 
 export let component: OnboardingEmbeddedComponentType;

--- a/packages/renderer/src/lib/onboarding/OnboardingItem.svelte
+++ b/packages/renderer/src/lib/onboarding/OnboardingItem.svelte
@@ -5,9 +5,9 @@ import type { Unsubscriber } from 'svelte/store';
 import { configurationProperties } from '/@/stores/configurationProperties';
 import { context } from '/@/stores/context';
 import { CONFIGURATION_ONBOARDING_SCOPE } from '/@api/configuration/constants.js';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
 import type { OnboardingStepItem } from '/@api/onboarding';
 
-import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import type { ContextUI } from '../context/context';
 import Markdown from '../markdown/Markdown.svelte';
 import PreferencesRenderingItem from '../preferences/PreferencesRenderingItem.svelte';

--- a/packages/renderer/src/lib/preferences/ExperimentalPage.spec.ts
+++ b/packages/renderer/src/lib/preferences/ExperimentalPage.spec.ts
@@ -23,8 +23,7 @@ import { beforeEach, expect, test, vi } from 'vitest';
 
 import ExperimentalPage from '/@/lib/preferences/ExperimentalPage.svelte';
 import { CONFIGURATION_DEFAULT_SCOPE } from '/@api/configuration/constants';
-
-import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
 
 beforeEach(() => {
   vi.resetAllMocks();

--- a/packages/renderer/src/lib/preferences/ExperimentalPage.svelte
+++ b/packages/renderer/src/lib/preferences/ExperimentalPage.svelte
@@ -4,8 +4,7 @@ import PreferencesRenderingItem from '/@/lib/preferences/PreferencesRenderingIte
 import SettingsPage from '/@/lib/preferences/SettingsPage.svelte';
 import { getInitialValue } from '/@/lib/preferences/Util';
 import SlideToggle from '/@/lib/ui/SlideToggle.svelte';
-
-import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
 
 interface Props {
   properties: IConfigurationPropertyRecordedSchema[];

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2024 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,9 +30,9 @@ import { beforeAll, beforeEach, describe, expect, type Mock, test, vi } from 'vi
 
 import { eventCollect } from '/@/lib/preferences/preferences-connection-rendering-task';
 import { operationConnectionsInfo } from '/@/stores/operation-connections';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
 import type { ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provider-info';
 
-import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import PreferencesConnectionCreationOrEditRendering from './PreferencesConnectionCreationOrEditRendering.svelte';
 
 type LoggerEventName = 'log' | 'warn' | 'error' | 'finish';

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
@@ -13,13 +13,13 @@ import type { ContextUI } from '/@/lib/context/context';
 import { context } from '/@/stores/context';
 /* eslint-enable import/no-duplicates */
 import { operationConnectionsInfo } from '/@/stores/operation-connections';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
 import type {
   ProviderContainerConnectionInfo,
   ProviderInfo,
   ProviderKubernetesConnectionInfo,
 } from '/@api/provider-info';
 
-import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import Markdown from '../markdown/Markdown.svelte';
 import AuditMessageBox from '../ui/AuditMessageBox.svelte';
 import TerminalWindow from '../ui/TerminalWindow.svelte';

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionDetailsSummary.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionDetailsSummary.svelte
@@ -3,9 +3,9 @@ import type { ContainerProviderConnection } from '@podman-desktop/api';
 import { filesize } from 'filesize';
 
 import Donut from '/@/lib/donut/Donut.svelte';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
 import type { ProviderContainerConnectionInfo } from '/@api/provider-info';
 
-import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import { PeerProperties } from './PeerProperties';
 import type { IProviderConnectionConfigurationPropertyRecorded } from './Util';
 

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionEdit.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionEdit.svelte
@@ -6,13 +6,13 @@ import type { Unsubscriber } from 'svelte/store';
 import PreferencesConnectionCreationRendering from '/@/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte';
 import DetailsPage from '/@/lib/ui/DetailsPage.svelte';
 import WarningMessage from '/@/lib/ui/WarningMessage.svelte';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
 import type {
   ProviderContainerConnectionInfo,
   ProviderInfo,
   ProviderKubernetesConnectionInfo,
 } from '/@api/provider-info';
 
-import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import { providerInfos } from '../../stores/providers';
 import IconImage from '../appearance/IconImage.svelte';
 import { isContainerConnection } from './Util';

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
@@ -6,10 +6,10 @@ import type { Unsubscriber } from 'svelte/store';
 import { router } from 'tinro';
 
 import { handleNavigation } from '/@/navigation';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
 import { NavigationPage } from '/@api/navigation-page';
 import type { ProviderConnectionInfo, ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provider-info';
 
-import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import Route from '../../Route.svelte';
 import { providerInfos } from '../../stores/providers';
 import IconImage from '../appearance/IconImage.svelte';

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionDetailsSummary.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionDetailsSummary.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 import type { KubernetesProviderConnection } from '@podman-desktop/api';
 
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
 import type { ProviderKubernetesConnectionInfo } from '/@api/provider-info';
 
-import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import type { IProviderConnectionConfigurationPropertyRecorded } from './Util';
 
 export let properties: IConfigurationPropertyRecordedSchema[] = [];

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.svelte
@@ -6,10 +6,10 @@ import type { Unsubscriber } from 'svelte/store';
 import { router } from 'tinro';
 
 import { handleNavigation } from '/@/navigation';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
 import { NavigationPage } from '/@api/navigation-page';
 import type { ProviderConnectionInfo, ProviderInfo, ProviderKubernetesConnectionInfo } from '/@api/provider-info';
 
-import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import Route from '../../Route.svelte';
 import { providerInfos } from '../../stores/providers';
 import IconImage from '../appearance/IconImage.svelte';

--- a/packages/renderer/src/lib/preferences/PreferencesPage.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesPage.svelte
@@ -3,8 +3,8 @@ import { onMount } from 'svelte';
 
 import ExperimentalPage from '/@/lib/preferences/ExperimentalPage.svelte';
 import PreferencesContainerConnectionEdit from '/@/lib/preferences/PreferencesContainerConnectionEdit.svelte';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
 
-import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import Route from '../../Route.svelte';
 import { configurationProperties } from '../../stores/configurationProperties';
 import Onboarding from '../onboarding/Onboarding.svelte';

--- a/packages/renderer/src/lib/preferences/PreferencesProviderRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProviderRendering.svelte
@@ -7,9 +7,9 @@ import { router } from 'tinro';
 
 import { operationConnectionsInfo } from '/@/stores/operation-connections';
 import { providerInfos } from '/@/stores/providers';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
 import type { ProviderConnectionInfo, ProviderInfo } from '/@api/provider-info';
 
-import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import Route from '../../Route.svelte';
 import FormPage from '../ui/FormPage.svelte';
 import TerminalWindow from '../ui/TerminalWindow.svelte';

--- a/packages/renderer/src/lib/preferences/PreferencesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRendering.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +28,8 @@ import { beforeAll, expect, test, vi } from 'vitest';
 
 import { context } from '/@/stores/context';
 import { CONFIGURATION_DEFAULT_SCOPE } from '/@api/configuration/constants.js';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
 
-import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import { ContextUI } from '../context/context';
 import PreferencesRendering from './PreferencesRendering.svelte';
 

--- a/packages/renderer/src/lib/preferences/PreferencesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRendering.svelte
@@ -4,8 +4,8 @@ import { onDestroy, onMount } from 'svelte';
 import { type Unsubscriber } from 'svelte/store';
 
 import { context } from '/@/stores/context';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
 
-import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import Route from '../../Route.svelte';
 import type { ContextUI } from '../context/context';
 import PreferencesRenderingItem from './PreferencesRenderingItem.svelte';

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.spec.ts
@@ -22,8 +22,7 @@ import { fireEvent, render } from '@testing-library/svelte';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import PreferencesRenderingItem from '/@/lib/preferences/PreferencesRenderingItem.svelte';
-
-import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
 
 const EXPERIMENTAL_RECORD: IConfigurationPropertyRecordedSchema = {
   id: 'hello.world.fooBar',

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
@@ -6,8 +6,8 @@ import Fa from 'svelte-fa';
 import { getInitialValue } from '/@/lib/preferences/Util';
 import Label from '/@/lib/ui/Label.svelte';
 import RefreshButton from '/@/lib/ui/RefreshButton.svelte';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
 
-import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import Markdown from '../markdown/Markdown.svelte';
 import PreferencesRenderingItemFormat from './PreferencesRenderingItemFormat.svelte';
 

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2024 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,8 +29,8 @@ import { beforeAll, expect, test, vi } from 'vitest';
 
 import { getInitialValue } from '/@/lib/preferences/Util';
 import { onDidChangeConfiguration } from '/@/stores/configurationProperties';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
 
-import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import PreferencesRenderingItemFormat from './PreferencesRenderingItemFormat.svelte';
 
 beforeAll(() => {

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -9,8 +9,8 @@ import NumberItem from '/@/lib/preferences/item-formats/NumberItem.svelte';
 import SliderItem from '/@/lib/preferences/item-formats/SliderItem.svelte';
 import StringItem from '/@/lib/preferences/item-formats/StringItem.svelte';
 import { onDidChangeConfiguration } from '/@/stores/configurationProperties';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
 
-import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import Markdown from '../markdown/Markdown.svelte';
 import { getInitialValue, getNormalizedDefaultNumberValue } from './Util';
 

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -13,9 +13,9 @@ import Donut from '/@/lib/donut/Donut.svelte';
 import ActionsMenu from '/@/lib/image/ActionsMenu.svelte';
 import { context } from '/@/stores/context';
 import { onboardingList } from '/@/stores/onboarding';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
 import type { CheckStatus, ProviderConnectionInfo, ProviderInfo } from '/@api/provider-info';
 
-import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import { type Menu, MenuContext } from '../../../../main/src/plugin/menu-registry';
 import { configurationProperties } from '../../stores/configurationProperties';
 import { providerInfos } from '../../stores/providers';
@@ -458,7 +458,7 @@ function handleError(errorMessage: string): void {
                         ? (provider.containerProviderConnectionCreationDisplayName ?? undefined)
                         : provider.kubernetesProviderConnectionCreation
                           ? provider.kubernetesProviderConnectionCreationDisplayName
-                          : provider.vmProviderConnectionCreation 
+                          : provider.vmProviderConnectionCreation
                             ? provider.vmProviderConnectionCreationDisplayName
                             : undefined) ?? provider.name}
                     {@const buttonTitle =

--- a/packages/renderer/src/lib/preferences/Util.spec.ts
+++ b/packages/renderer/src/lib/preferences/Util.spec.ts
@@ -19,7 +19,8 @@
 import type { Terminal } from '@xterm/xterm';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
-import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
+
 import { ContextUI } from '../context/context';
 import {
   calcHalfCpuCores,

--- a/packages/renderer/src/lib/preferences/Util.ts
+++ b/packages/renderer/src/lib/preferences/Util.ts
@@ -20,6 +20,7 @@ import type { ConfigurationScope } from '@podman-desktop/api';
 import type { Terminal } from '@xterm/xterm';
 
 import { CONFIGURATION_DEFAULT_SCOPE } from '/@api/configuration/constants.js';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
 import type {
   ProviderConnectionInfo,
   ProviderContainerConnectionInfo,
@@ -27,7 +28,6 @@ import type {
   ProviderKubernetesConnectionInfo,
 } from '/@api/provider-info';
 
-import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import type { ContextUI } from '../context/context';
 import { ContextKeyExpr } from '../context/contextKey';
 

--- a/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityContributions.svelte
+++ b/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityContributions.svelte
@@ -8,9 +8,9 @@ import { get, type Unsubscriber, type Writable } from 'svelte/store';
 import { configurationProperties } from '/@/stores/configurationProperties';
 import { context } from '/@/stores/context';
 import { extensionInfos } from '/@/stores/extensions';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
 import type { ExtensionInfo } from '/@api/extension-info';
 
-import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
 import IconImage from '../../appearance/IconImage.svelte';
 import type { ContextUI } from '../../context/context';
 import Markdown from '../../markdown/Markdown.svelte';

--- a/packages/renderer/src/lib/preferences/item-formats/BooleanItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/BooleanItem.spec.ts
@@ -21,7 +21,8 @@ import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/svelte';
 import { beforeAll, expect, test, vi } from 'vitest';
 
-import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
+
 import BooleanItem from './BooleanItem.svelte';
 
 beforeAll(() => {

--- a/packages/renderer/src/lib/preferences/item-formats/BooleanItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/BooleanItem.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
+
 import SlideToggle from '../../ui/SlideToggle.svelte';
 
 export let record: IConfigurationPropertyRecordedSchema;

--- a/packages/renderer/src/lib/preferences/item-formats/EditableConnectionResourceItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/EditableConnectionResourceItem.spec.ts
@@ -22,7 +22,8 @@ import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { expect, test, vi } from 'vitest';
 
-import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
+
 import EditableConnectionResourceItem from './EditableConnectionResourceItem.svelte';
 
 const onSave = vi.fn();

--- a/packages/renderer/src/lib/preferences/item-formats/EditableConnectionResourceItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/EditableConnectionResourceItem.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 import { filesize } from 'filesize';
 
-import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
+
 import { getNormalizedDefaultNumberValue } from '../Util';
 import EditableItem from './EditableItem.svelte';
 

--- a/packages/renderer/src/lib/preferences/item-formats/EditableItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/EditableItem.spec.ts
@@ -22,7 +22,8 @@ import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { expect, test, vi } from 'vitest';
 
-import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
+
 import EditableItem from './EditableItem.svelte';
 
 test('Expect input not being visible if editing is NOT in progress', async () => {

--- a/packages/renderer/src/lib/preferences/item-formats/EditableItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/EditableItem.svelte
@@ -3,7 +3,8 @@ import { faCheck, faPencil, faXmark } from '@fortawesome/free-solid-svg-icons';
 import { Button } from '@podman-desktop/ui-svelte';
 import Fa from 'svelte-fa';
 
-import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
+
 import FloatNumberItem from './FloatNumberItem.svelte';
 
 export let record: IConfigurationPropertyRecordedSchema;

--- a/packages/renderer/src/lib/preferences/item-formats/EnumItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/EnumItem.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2024 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,8 @@ import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/svelte';
 import { beforeAll, expect, test, vi } from 'vitest';
 
-import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
+
 import EnumItem from './EnumItem.svelte';
 
 beforeAll(() => {

--- a/packages/renderer/src/lib/preferences/item-formats/EnumItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/EnumItem.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { Dropdown } from '@podman-desktop/ui-svelte';
 
-import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
 
 export let record: IConfigurationPropertyRecordedSchema;
 export let value: string | undefined;

--- a/packages/renderer/src/lib/preferences/item-formats/FileItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/FileItem.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2024 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,8 @@ import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { beforeAll, expect, test, vi } from 'vitest';
 
-import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
+
 import FileItem from './FileItem.svelte';
 
 const openDialogMock = vi.fn();

--- a/packages/renderer/src/lib/preferences/item-formats/FileItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/FileItem.svelte
@@ -2,8 +2,7 @@
 import type { OpenDialogOptions } from '@podman-desktop/api';
 
 import FileInput from '/@/lib/ui/FileInput.svelte';
-
-import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
 
 export let record: IConfigurationPropertyRecordedSchema;
 export let value: string = '';

--- a/packages/renderer/src/lib/preferences/item-formats/FloatNumberItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/FloatNumberItem.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2024 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,8 @@ import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { expect, test, vi } from 'vitest';
 
-import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
+
 import FloatNumberItem from './FloatNumberItem.svelte';
 
 test('Expect tooltip if value input is NaN', async () => {

--- a/packages/renderer/src/lib/preferences/item-formats/FloatNumberItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/FloatNumberItem.svelte
@@ -2,7 +2,8 @@
 import { Tooltip } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 
-import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
+
 import { uncertainStringToNumber } from '../Util';
 import { checkNumericValueValid } from './NumberItemUtils';
 

--- a/packages/renderer/src/lib/preferences/item-formats/NumberItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/NumberItem.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2024 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,8 @@ import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { afterEach, expect, test, vi } from 'vitest';
 
-import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
+
 import NumberItem from './NumberItem.svelte';
 
 afterEach(() => {

--- a/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { NumberInput, Tooltip } from '@podman-desktop/ui-svelte';
 
-import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
 
 export let record: IConfigurationPropertyRecordedSchema;
 export let value: number | undefined;

--- a/packages/renderer/src/lib/preferences/item-formats/NumberItemUtils.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/NumberItemUtils.spec.ts
@@ -20,7 +20,8 @@ import '@testing-library/jest-dom/vitest';
 
 import { expect, test } from 'vitest';
 
-import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
+
 import { checkNumericValueValid } from './NumberItemUtils';
 
 test('Expect an error message if value input is NaN', async () => {

--- a/packages/renderer/src/lib/preferences/item-formats/NumberItemUtils.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/NumberItemUtils.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
 
 export interface NumericValue {
   valid: boolean;

--- a/packages/renderer/src/lib/preferences/item-formats/SliderItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/SliderItem.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2024 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,8 @@ import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/svelte';
 import { beforeAll, expect, test, vi } from 'vitest';
 
-import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
+
 import SliderItem from './SliderItem.svelte';
 
 beforeAll(() => {

--- a/packages/renderer/src/lib/preferences/item-formats/SliderItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/SliderItem.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
+
 import { uncertainStringToNumber } from '../Util';
 
 export let record: IConfigurationPropertyRecordedSchema;

--- a/packages/renderer/src/lib/preferences/item-formats/StringItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/StringItem.spec.ts
@@ -21,7 +21,8 @@ import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/svelte';
 import { beforeAll, expect, test, vi } from 'vitest';
 
-import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
+
 import StringItem from './StringItem.svelte';
 
 beforeAll(() => {

--- a/packages/renderer/src/lib/preferences/item-formats/StringItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/StringItem.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { Input } from '@podman-desktop/ui-svelte';
 
-import type { IConfigurationPropertyRecordedSchema } from '../../../../../main/src/plugin/configuration-registry';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
 
 export let record: IConfigurationPropertyRecordedSchema;
 export let value: string | undefined;

--- a/packages/renderer/src/stores/configurationProperties.spec.ts
+++ b/packages/renderer/src/stores/configurationProperties.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,8 @@
 
 import { beforeAll, expect, test, vi } from 'vitest';
 
-import type { IConfigurationChangeEvent } from '../../../main/src/plugin/configuration-registry';
+import type { IConfigurationChangeEvent } from '/@api/configuration/models';
+
 import { onDidChangeConfiguration, setupConfigurationChange } from './configurationProperties';
 
 // first, patch window object

--- a/packages/renderer/src/stores/configurationProperties.ts
+++ b/packages/renderer/src/stores/configurationProperties.ts
@@ -18,10 +18,8 @@
 
 import { type Writable, writable } from 'svelte/store';
 
-import type {
-  IConfigurationChangeEvent,
-  IConfigurationPropertyRecordedSchema,
-} from '../../../main/src/plugin/configuration-registry';
+import type { IConfigurationChangeEvent, IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
+
 import { EventStore } from './event-store';
 
 const windowEvents = ['extensions-started', 'extension-started', 'extension-stopped', 'configuration-changed'];

--- a/packages/renderer/src/stores/operation-connections.ts
+++ b/packages/renderer/src/stores/operation-connections.ts
@@ -19,13 +19,12 @@
 import type { Writable } from 'svelte/store';
 import { writable } from 'svelte/store';
 
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
 import type {
   ProviderContainerConnectionInfo,
   ProviderInfo,
   ProviderKubernetesConnectionInfo,
 } from '/@api/provider-info';
-
-import type { IConfigurationPropertyRecordedSchema } from '../../../main/src/plugin/configuration-registry';
 
 interface OperationConnectionInfo {
   operationKey: symbol;


### PR DESCRIPTION
### What does this PR do?
avoid to have renderer part importing main stuff using ../../..

related to https://github.com/podman-desktop/podman-desktop/issues/12640 as it'll remove some "type" imports for annotations like `@inject(Type)`

- [x] depends on https://github.com/podman-desktop/podman-desktop/pull/12996

will rebase once this PR is merged

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

#12640 

### How to test this PR?

noop, everything should be 💚 

- [x] Tests are covering the bug fix or the new feature
