### PR TITLE
fix(ContainerList): same named container group should have individual groups

### DIFF
--- a/packages/renderer/src/lib/container/ContainerList.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerList.spec.ts
@@ -1001,6 +1001,18 @@ test('Ensuring the table and empty screen are not visible at the same time', asy
 });
 
 test('pods with same name on different engines should have separate group', async () => {
+  window.dispatchEvent(new CustomEvent('extensions-already-started'));
+  window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
+  window.dispatchEvent(new CustomEvent('tray:update-provider'));
+
+  // wait until the store is populated
+  await vi.waitUntil(
+    async () => {
+      return get(containersInfos).length === 0;
+    },
+    { interval: 250, timeout: 5000 },
+  );
+
   const CONTAINERS_MOCK: Array<ContainerInfo> = Array.from({ length: 3 }).map((_, index) => ({
     Id: `sha256:${index}`,
     Image: 'sha256:234',

--- a/packages/renderer/src/lib/container/ContainerList.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerList.spec.ts
@@ -999,3 +999,50 @@ test('Ensuring the table and empty screen are not visible at the same time', asy
   const table = queryByRole('table');
   expect(table).toBeNull();
 });
+
+test('pods with same name on different engines should have separate group', async () => {
+  const CONTAINERS_MOCK: Array<ContainerInfo> = Array.from({ length: 3 }).map((_, index) => ({
+    Id: `sha256:${index}`,
+    Image: 'sha256:234',
+    Names: ['foo-bar-pod'], // have the same name for all
+    RepoTags: ['veryold:image'],
+    Status: 'Running',
+    pod: {
+      name: 'my-pod',
+      id: `podman-engine-${index}`, // unique pod id (only pod-id is unique accross all engines)
+      status: 'Running',
+      engineId: `podman-${index}`,
+    },
+    engineId: `podman-${index}`,
+    engineName: 'podman',
+    ImageID: 'dummy-image-id',
+    engineType: 'podman',
+    StartedAt: '0',
+    ImageBase64RepoTag: '',
+    Created: 0,
+    Ports: [],
+    Labels: {},
+    State: '',
+  }));
+
+  vi.mocked(window.listContainers).mockResolvedValue(CONTAINERS_MOCK);
+
+  window.dispatchEvent(new CustomEvent('extensions-already-started'));
+  window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
+  window.dispatchEvent(new CustomEvent('tray:update-provider'));
+
+  // wait until the store is populated
+  await vi.waitUntil(
+    async () => {
+      return get(containersInfos).length > 0;
+    },
+    { interval: 250, timeout: 5000 },
+  );
+
+  const { getAllByRole } = await waitRender({});
+
+  await vi.waitFor(() => {
+    const expandButtons = getAllByRole('button', { name: 'Collapse Row' });
+    expect(expandButtons).toHaveLength(CONTAINERS_MOCK.length);
+  });
+});

--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -444,6 +444,10 @@ let containersAndGroups: (ContainerGroupInfoUI | ContainerInfoUI)[];
 $: containersAndGroups = containerGroups.map(group =>
   group?.type === ContainerGroupInfoTypeUI.STANDALONE ? group.containers[0] : group,
 );
+
+function key(item: ContainerGroupInfoUI | ContainerInfoUI): string {
+  return item.id;
+}
 </script>
 
 <NavPage bind:searchTerm={searchTerm} title="containers">
@@ -524,6 +528,7 @@ $: containersAndGroups = containerGroups.map(group =>
           columns={columns}
           row={row}
           defaultSortColumn="Name"
+          key={key}
           on:update={(): ContainerGroupInfoUI[] => (containerGroups = [...containerGroups])}>
         </Table>
       {/if}


### PR DESCRIPTION
### What does this PR do?

Following https://github.com/podman-desktop/podman-desktop/pull/12915 and https://github.com/podman-desktop/podman-desktop/pull/12994.

Making use of the `Table#key` prop, allowing us to properly define which key will be used to define the collapsed state. By default it  uses the `object#name` but this is not unique, only ids are in our context.

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/13001

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
