### PR TITLE
refactor: move message box interfaces to api package

### DIFF
--- a/packages/api/src/dialog.ts
+++ b/packages/api/src/dialog.ts
@@ -1,0 +1,67 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export interface DropdownType {
+  heading: string;
+  buttons: string[];
+}
+
+export type ButtonsType = string | DropdownType;
+
+/**
+ * Options to configure the behavior of the message box UI.
+ */
+export interface MessageBoxOptions {
+  /**
+   * The title of the message box.
+   */
+  title: string;
+  /**
+   * The primary message.
+   */
+  message: string;
+  /**
+   * An additional (optional) detailed message.
+   */
+  detail?: string;
+  /**
+   * Text for buttons.
+   */
+  buttons?: ButtonsType[];
+  /**
+   * The (optional) type, one of 'none' | 'info' | 'error' | 'question' | 'warning'.
+   */
+  type?: string;
+  /**
+   * The (optional) index of the default button.
+   */
+  defaultId?: number;
+  /**
+   * The (optional) index of the button to be used to cancel the dialog.
+   */
+  cancelId?: number;
+  /**
+   * An additional (optional) markdown detailed message aligned to center
+   */
+  footerMarkdownDescription?: string;
+}
+
+export interface MessageBoxReturnValue {
+  response: number | undefined;
+  dropdownIndex?: number;
+}

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -81,6 +81,7 @@ import type {
 import type { ContainerInspectInfo } from '/@api/container-inspect-info.js';
 import type { ContainerStatsInfo } from '/@api/container-stats-info.js';
 import type { ContributionInfo } from '/@api/contribution-info.js';
+import type { MessageBoxOptions, MessageBoxReturnValue } from '/@api/dialog.js';
 import type { DockerSocketMappingStatusInfo } from '/@api/docker-compatibility-info.js';
 import type { ExtensionDevelopmentFolderInfo } from '/@api/extension-development-folders-info.js';
 import type { ExtensionInfo } from '/@api/extension-info.js';
@@ -176,7 +177,6 @@ import { KubernetesClient } from './kubernetes/kubernetes-client.js';
 import { downloadGuideList } from './learning-center/learning-center.js';
 import { LearningCenterInit } from './learning-center-init.js';
 import { LibpodApiInit } from './libpod-api-enable/libpod-api-init.js';
-import type { MessageBoxOptions, MessageBoxReturnValue } from './message-box.js';
 import { MessageBox } from './message-box.js';
 import { NavigationItemsInit } from './navigation-items-init.js';
 import { OnboardingRegistry } from './onboarding-registry.js';

--- a/packages/main/src/plugin/message-box.spec.ts
+++ b/packages/main/src/plugin/message-box.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,9 @@
 
 import { expect, test, vi } from 'vitest';
 
+import type { DropdownType } from '/@api/dialog.js';
+
 import type { ApiSenderType } from './api.js';
-import type { DropdownType } from './message-box.js';
 import { MessageBox } from './message-box.js';
 
 test('Should return first item if button clicked is the first', async () => {

--- a/packages/main/src/plugin/message-box.ts
+++ b/packages/main/src/plugin/message-box.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,60 +15,12 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
+import type { ButtonsType, DropdownType, MessageBoxOptions, MessageBoxReturnValue } from '/@api/dialog.js';
+
 import type { ApiSenderType } from './api.js';
 import { Deferred } from './util/deferred.js';
 
 type DialogType = 'none' | 'info' | 'error' | 'question' | 'warning';
-
-export interface DropdownType {
-  heading: string;
-  buttons: string[];
-}
-
-export type ButtonsType = string | DropdownType;
-
-/**
- * Options to configure the behavior of the message box UI.
- */
-export interface MessageBoxOptions {
-  /**
-   * The title of the message box.
-   */
-  title: string;
-  /**
-   * The primary message.
-   */
-  message: string;
-  /**
-   * An additional (optional) detailed message.
-   */
-  detail?: string;
-  /**
-   * Text for buttons.
-   */
-  buttons?: ButtonsType[];
-  /**
-   * The (optional) type, one of 'none' | 'info' | 'error' | 'question' | 'warning'.
-   */
-  type?: string;
-  /**
-   * The (optional) index of the default button.
-   */
-  defaultId?: number;
-  /**
-   * The (optional) index of the button to be used to cancel the dialog.
-   */
-  cancelId?: number;
-  /**
-   * An additional (optional) markdown detailed message aligned to center
-   */
-  footerMarkdownDescription?: string;
-}
-
-export interface MessageBoxReturnValue {
-  response: number | undefined;
-  dropdownIndex?: number;
-}
 
 export class MessageBox {
   private callbackId = 0;

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -60,6 +60,7 @@ import type {
 import type { ContainerInspectInfo } from '/@api/container-inspect-info';
 import type { ContainerStatsInfo } from '/@api/container-stats-info';
 import type { ContributionInfo } from '/@api/contribution-info';
+import type { MessageBoxOptions, MessageBoxReturnValue } from '/@api/dialog';
 import type { DockerSocketMappingStatusInfo } from '/@api/docker-compatibility-info';
 import type { ExtensionDevelopmentFolderInfo } from '/@api/extension-development-folders-info';
 import type { ExtensionInfo } from '/@api/extension-info';
@@ -120,7 +121,6 @@ import type {
   KubernetesGeneratorSelector,
 } from '../../main/src/plugin/kubernetes/kube-generator-registry';
 import type { Guide } from '../../main/src/plugin/learning-center/learning-center-api';
-import type { MessageBoxOptions, MessageBoxReturnValue } from '../../main/src/plugin/message-box';
 import type { ExtensionBanner, RecommendedRegistry } from '../../main/src/plugin/recommendations/recommendations-api';
 import type { IDisposable } from '../../main/src/plugin/types/disposable';
 import { Deferred } from './util/deferred';

--- a/packages/renderer/src/lib/recommendation/ExtensionBanner.svelte
+++ b/packages/renderer/src/lib/recommendation/ExtensionBanner.svelte
@@ -2,8 +2,8 @@
 import { CloseButton } from '@podman-desktop/ui-svelte';
 
 import FeaturedExtension from '/@/lib/featured/FeaturedExtension.svelte';
+import type { MessageBoxReturnValue } from '/@api/dialog';
 
-import type { MessageBoxReturnValue } from '../../../../main/src/plugin/message-box';
 import { type ExtensionBanner } from '../../../../main/src/plugin/recommendations/recommendations-api';
 
 // Pass in the theme appearance colour of PD to the banner, we do it here so we don't have to do multiple isDark checks when rendering multiple banners.


### PR DESCRIPTION
### What does this PR do?
move message box interfaces to api package

depends on:
 - [x] https://github.com/podman-desktop/podman-desktop/pull/13005
 - [x] https://github.com/podman-desktop/podman-desktop/pull/13006

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
