### PR TITLE
chore: wrap extensions in navigation bar into scrollable section

### DIFF
--- a/packages/renderer/src/App.spec.ts
+++ b/packages/renderer/src/App.spec.ts
@@ -83,6 +83,15 @@ vi.mock('/@/stores/kubernetes-no-current-context');
 const dispatchEventMock = vi.fn();
 const messages = new Map<string, (args: unknown) => void>();
 
+class ResizeObserverMock {
+  private _cb: ResizeObserverCallback;
+  constructor(cb: ResizeObserverCallback) {
+    this._cb = cb;
+  }
+  observe(): void {}
+  disconnect(): void {}
+}
+
 beforeEach(() => {
   vi.resetAllMocks();
   router.goto('/');
@@ -94,6 +103,7 @@ beforeEach(() => {
   Object.defineProperty(window, 'dispatchEvent', { value: dispatchEventMock });
   (window.getConfigurationValue as unknown) = vi.fn();
   vi.mocked(kubernetesNoCurrentContext).kubernetesNoCurrentContext = writable(false);
+  global.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
 });
 
 test('test /image/run/* route', async () => {

--- a/packages/renderer/src/AppNavigation.spec.ts
+++ b/packages/renderer/src/AppNavigation.spec.ts
@@ -40,6 +40,15 @@ const eventsMock = vi.fn();
 
 const callbacks = new Map<string, (arg: unknown) => void>();
 
+class ResizeObserverMock {
+  private _cb: ResizeObserverCallback;
+  constructor(cb: ResizeObserverCallback) {
+    this._cb = cb;
+  }
+  observe(): void {}
+  disconnect(): void {}
+}
+
 vi.mock('/@/stores/kubernetes-contexts-state', async () => {
   return {};
 });
@@ -52,6 +61,7 @@ beforeAll(() => {
   onDidChangeConfiguration.addEventListener = vi.fn().mockImplementation((message: string, callback: () => void) => {
     callbacks.set(message, callback);
   });
+  global.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
 });
 
 test('Test rendering of the navigation bar with empty items', async (_arg: unknown) => {


### PR DESCRIPTION
### What does this PR do?

Based on the comments from https://github.com/podman-desktop/podman-desktop/issues/6774#issuecomment-2984024027:

> I am not sure scrolling would help. From top of my head, there are two options we have:
> 
> either we collapse icons to be vertically smaller when there's no space,
> or bundle icons together in groups (similarly to what Discord does in the sidebar).
> I am afraid scrolling won't help much, as it would always make some icons offscreen. Well, that's what would happen with 2. as well.
> 
> Collapsing (making the icons smaller) won't help on the long run either, we'd just delay the problem again, we'd just buy some time (by buying space).

there’s a proposal to introduce an <ins>interim solution</ins> that relies on showing a scrollable section while we discuss the best way to display multiple extensions in the navigation area. On the next step, the navigation bar will be refactored with the upcoming requirements to display more extensions that it can fit.

Be sure that PR: https://github.com/podman-desktop/podman-desktop/pull/13009 is merged before this PR.

### Screenshot / video of UI

![scrollable_navbar](https://github.com/user-attachments/assets/6fda5b24-7603-458c-b4cf-e3d7ac78aba8)

### What issues does this PR fix or reference?

#12234 

### How to test this PR?

Combine the changes from the current PR with the changes from this PR: [link to PR]. Install more than three extensions, then reduce the window height and verify that the Accounts and Settings buttons remain fixed in place while the list of installed extensions becomes vertically scrollable.

- [ ] Tests are covering the bug fix or the new feature
