### PR TITLE
chore: refactor tooltip component to avoid render component inside container viewport

### DIFF
--- a/packages/ui/src/lib/tooltip/TestTooltipSlotWrapper.svelte
+++ b/packages/ui/src/lib/tooltip/TestTooltipSlotWrapper.svelte
@@ -1,0 +1,8 @@
+<script>
+import Tooltip from './Tooltip.svelte';
+</script>
+
+<Tooltip>
+  <span slot="tip">slot-tip-content</span>
+  <button data-testid="trigger">trigger</button>
+</Tooltip>

--- a/packages/ui/src/lib/tooltip/Tooltip.spec.ts
+++ b/packages/ui/src/lib/tooltip/Tooltip.spec.ts
@@ -56,9 +56,7 @@ async function computePos(directionProps: Record<string, boolean>): Promise<{ to
   const outer = screen.getByText('pos').parentElement as HTMLElement;
 
   // Complain because we overwrite readonly method – this is intentional for the unit test.
-  // @ts-expect-error overriding for test stub
   wrapper.getBoundingClientRect = (): DOMRect => WRAPPER_RECT;
-  // @ts-expect-error overriding for test stub
   outer.getBoundingClientRect = (): DOMRect => TIP_RECT;
 
   await fireEvent.mouseEnter(wrapper);

--- a/packages/ui/src/lib/tooltip/Tooltip.spec.ts
+++ b/packages/ui/src/lib/tooltip/Tooltip.spec.ts
@@ -263,7 +263,7 @@ test('adds extra classes from `class` prop', () => {
     },
   });
 
-  const outer = screen.getByText('my tooltip').parentElement as HTMLElement;
+  const outer = screen.getByText('my tooltip') as HTMLElement;
 
   expect(outer).toHaveClass('bg-red-500');
   expect(outer).toHaveClass('shadow-lg');

--- a/packages/ui/src/lib/tooltip/Tooltip.spec.ts
+++ b/packages/ui/src/lib/tooltip/Tooltip.spec.ts
@@ -18,12 +18,59 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen } from '@testing-library/svelte';
 import { tick } from 'svelte';
-import { expect, test } from 'vitest';
+import { afterEach, expect, test } from 'vitest';
 
+import SlotWrapper from './TestTooltipSlotWrapper.svelte';
 import Tooltip from './Tooltip.svelte';
 import { tooltipHidden } from './tooltip-store';
+
+async function hoverReveals(trigger: HTMLElement, outer: HTMLElement): Promise<boolean> {
+  await fireEvent.mouseEnter(trigger);
+  await tick();
+  const visible = !outer.classList.contains('opacity-0');
+  await fireEvent.mouseLeave(trigger);
+  await tick();
+  return visible;
+}
+
+function mockRect({ top, left, width, height }: { top: number; left: number; width: number; height: number }): DOMRect {
+  return {
+    top,
+    left,
+    right: left + width,
+    bottom: top + height,
+    width,
+    height,
+  } as DOMRect;
+}
+
+const WRAPPER_RECT = mockRect({ top: 100, left: 100, width: 50, height: 50 });
+const TIP_RECT = mockRect({ top: 0, left: 0, width: 80, height: 40 });
+
+async function computePos(directionProps: Record<string, boolean>): Promise<{ top: number; left: number }> {
+  const { container } = render(Tooltip, { props: { tip: 'pos', ...directionProps } });
+
+  const wrapper = container.firstElementChild as HTMLElement;
+  const outer = screen.getByText('pos').parentElement as HTMLElement;
+
+  // Complain because we overwrite readonly method – this is intentional for the unit test.
+  // @ts-expect-error overriding for test stub
+  wrapper.getBoundingClientRect = (): DOMRect => WRAPPER_RECT;
+  // @ts-expect-error overriding for test stub
+  outer.getBoundingClientRect = (): DOMRect => TIP_RECT;
+
+  await fireEvent.mouseEnter(wrapper);
+  await tick();
+
+  return {
+    top: parseFloat(outer.style.top),
+    left: parseFloat(outer.style.left),
+  };
+}
+
+afterEach(() => tooltipHidden.set(false));
 
 test('tooltip is not empty string when tooltipHidden value false', async () => {
   tooltipHidden.set(false);
@@ -46,4 +93,180 @@ test('tooltip z order', async () => {
   // get the tooltip
   const tooltip = screen.getByText('my tooltip');
   expect(tooltip.parentElement).toHaveClass('z-60');
+});
+
+test('hover shows and hides tooltip', async () => {
+  const { container } = render(Tooltip, { props: { tip: 'my tooltip' } });
+
+  const trigger = container.firstElementChild as HTMLElement;
+  const outer = screen.getByText('my tooltip').parentElement as HTMLElement;
+
+  expect(outer).toHaveClass('opacity-0');
+
+  await fireEvent.mouseEnter(trigger);
+  await tick();
+  expect(outer).not.toHaveClass('opacity-0');
+
+  await fireEvent.mouseLeave(trigger);
+  await tick();
+  expect(outer).toHaveClass('opacity-0');
+});
+
+test('renders content from named slot', () => {
+  render(SlotWrapper);
+  expect(screen.getByText('slot-tip-content')).toBeInTheDocument();
+});
+
+test('updates tooltip text when `tip` prop changes', async () => {
+  const { rerender } = render(Tooltip, { props: { tip: 'my tooltip' } });
+
+  expect(screen.getByText('my tooltip')).toBeInTheDocument();
+
+  await rerender({ tip: 'updated' });
+  await tick();
+
+  expect(screen.queryByText('my tooltip')).not.toBeInTheDocument();
+  expect(screen.getByText('updated')).toBeInTheDocument();
+});
+
+test('should test contentAvailable: non-empty tip prop', async () => {
+  const { container } = render(Tooltip, { props: { tip: 'my tooltip' } });
+
+  const trigger = container.firstElementChild as HTMLElement;
+  const outer = screen.getByText('my tooltip').parentElement as HTMLElement;
+
+  expect(await hoverReveals(trigger, outer)).toBe(true);
+});
+
+test('should test contentAvailable: slot content present', async () => {
+  render(SlotWrapper);
+
+  const trigger = screen.getByTestId('trigger');
+  const outer = screen.getByText('slot-tip-content').parentElement as HTMLElement;
+
+  expect(await hoverReveals(trigger, outer)).toBe(true);
+});
+
+test('should test contentAvailable: no tip and no slot', async () => {
+  const { container } = render(Tooltip, { props: { tip: '' } });
+
+  const trigger = container.firstElementChild as HTMLElement;
+  const outer = document.body.querySelector('.tooltip') as HTMLElement;
+
+  expect(await hoverReveals(trigger, outer)).toBe(false);
+});
+
+test('should test calculatePosition: top', async () => {
+  const pos = await computePos({ top: true });
+
+  // tp = 100 - 40 - 8 = 52
+  // lp = 100 + 25 - 40 = 85
+  expect(pos).toEqual({ top: 52, left: 85 });
+});
+
+test('should test calculatePosition: bottom', async () => {
+  const pos = await computePos({ bottom: true });
+
+  // tp = 150 + 8 = 158
+  // lp = 100 + 25 - 40 = 85
+  expect(pos).toEqual({ top: 158, left: 85 });
+});
+
+test('should test calculatePosition: left', async () => {
+  const pos = await computePos({ left: true });
+
+  // tp = 100 + 25 - 20 = 105
+  // lp = 100 - 80 - 8  = 12
+  expect(pos).toEqual({ top: 105, left: 12 });
+});
+
+test('should test calculatePosition: right', async () => {
+  const pos = await computePos({ right: true });
+
+  // tp = 100 + 25 - 20 - 10 = 95
+  // lp = 150 + 8 = 158
+  expect(pos).toEqual({ top: 95, left: 158 });
+});
+
+test('should test calculatePosition: topLeft', async () => {
+  const pos = await computePos({ topLeft: true });
+
+  // tp = 100 - 40 - 8 = 52
+  // lp = 100 - 80 * 0.8 = 36
+  expect(pos).toEqual({ top: 52, left: 36 });
+});
+
+test('should test calculatePosition: topRight', async () => {
+  const pos = await computePos({ topRight: true });
+
+  // tp = 52
+  // lp = 100
+  expect(pos).toEqual({ top: 52, left: 100 });
+});
+
+test('should test calculatePosition: bottomLeft', async () => {
+  const pos = await computePos({ bottomLeft: true });
+
+  // tp = 150 + 8 = 158
+  // lp = 36
+  expect(pos).toEqual({ top: 158, left: 36 });
+});
+
+test('should test calculatePosition: bottomRight', async () => {
+  const pos = await computePos({ bottomRight: true });
+
+  // tp = 158
+  // lp = 100
+  expect(pos).toEqual({ top: 158, left: 100 });
+});
+
+test('tooltipHidden subscribe detaches and re-attaches tooltipOuter', async () => {
+  render(Tooltip, { props: { tip: 'my tooltip' } });
+
+  const outer = screen.getByText('my tooltip').parentElement as HTMLElement;
+  expect(document.body.contains(outer)).toBe(true);
+
+  tooltipHidden.set(true);
+  await tick();
+  expect(document.body.contains(outer)).toBe(false);
+
+  tooltipHidden.set(false);
+  await tick();
+  expect(document.body.contains(outer)).toBe(true);
+  expect(outer).toHaveClass('opacity-0');
+});
+
+test('click hides tooltip and listeners removed on destroy', async () => {
+  const utils = render(Tooltip, { props: { tip: 'my tooltip' } });
+
+  const trigger = utils.container.firstElementChild as HTMLElement;
+  const outer = screen.getByText('my tooltip').parentElement as HTMLElement;
+
+  await fireEvent.mouseEnter(trigger);
+  await tick();
+  expect(outer).not.toHaveClass('opacity-0');
+
+  await fireEvent.click(trigger);
+  await tick();
+  expect(outer).toHaveClass('opacity-0');
+
+  utils.unmount();
+  await fireEvent.mouseEnter(trigger);
+  await tick();
+
+  expect(document.body.contains(outer)).toBe(false);
+});
+
+test('adds extra classes from `class` prop', () => {
+  render(Tooltip, {
+    props: {
+      tip: 'my tooltip',
+      class: '  bg-red-500  shadow-lg  ',
+    },
+  });
+
+  const outer = screen.getByText('my tooltip').parentElement as HTMLElement;
+
+  expect(outer).toHaveClass('bg-red-500');
+  expect(outer).toHaveClass('shadow-lg');
 });

--- a/packages/ui/src/lib/tooltip/Tooltip.svelte
+++ b/packages/ui/src/lib/tooltip/Tooltip.svelte
@@ -25,24 +25,24 @@ interface Position {
   lp: number;
 }
 
-const props = $props() as TooltipProps;
+const propsData = $props() as TooltipProps;
 
 // Forward all unknown attributes to the wrapper element (class handled separately)
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const { class: _classIgnored, ...restProps } = props;
+const { class: _classIgnored, ...restProps } = propsData;
 
 let hasSlotContent = false;
 
 const EDGE = 8;
 const SHIFT_RIGHT_VERT = 10;
 
-let wrapperEl;
-let slotContainer;
-let tooltipOuter;
-let tooltipInner;
+let wrapperEl: HTMLElement | null = null;
+let slotContainer: HTMLElement | null = null;
+let tooltipOuter: HTMLDivElement | null = null;
+let tooltipInner: HTMLDivElement | null = null;
 
 $effect(() => {
-  const { tip } = props;
+  const { tip } = propsData;
   if (tooltipInner) {
     tooltipInner.textContent = tip ?? '';
     if (tip !== undefined) {
@@ -54,13 +54,13 @@ $effect(() => {
 });
 
 function contentAvailable(): boolean {
-  if (props.tip?.trim().length) return true;
+  if (propsData.tip?.trim().length) return true;
   if (hasSlotContent) return true;
   return !!tooltipInner?.textContent?.trim().length;
 }
 
 function calculatePosition(rect: DOMRect, tipRect: DOMRect): Position {
-  const { top, bottom, left, right, topLeft, topRight, bottomLeft, bottomRight } = props;
+  const { top, bottom, left, right, topLeft, topRight, bottomLeft, bottomRight } = propsData;
 
   let tp = 0;
   let lp = 0;
@@ -96,7 +96,7 @@ function showTooltip(): void {
   if (!contentAvailable()) return;
   if (!wrapperEl || !tooltipOuter || !tooltipInner) return;
 
-  if (props.tip) tooltipInner.textContent = props.tip;
+  if (propsData.tip) tooltipInner.textContent = propsData.tip;
 
   const rect = wrapperEl.getBoundingClientRect();
   const tipRect = tooltipOuter.getBoundingClientRect();
@@ -132,14 +132,14 @@ onMount(() => {
   tooltipOuter.className =
     'whitespace-nowrap absolute tooltip opacity-0 inline-block transition-opacity duration-150 ease-in-out pointer-events-none text-sm z-60';
 
-  const extra = props.class?.trim();
+  const extra = propsData.class?.trim();
   if (extra) tooltipOuter.classList.add(...extra.split(/\s+/));
 
   tooltipInner.className =
     'inline-block py-2 px-4 rounded-md bg-[var(--pd-tooltip-bg)] text-[var(--pd-tooltip-text)] border border-[var(--pd-tooltip-border)]';
 
-  if (props.tip?.trim().length) {
-    tooltipInner.textContent = props.tip;
+  if (propsData.tip?.trim().length) {
+    tooltipInner.textContent = propsData.tip;
   } else if (slotContainer) {
     while (slotContainer.firstChild) {
       const node = slotContainer.firstChild;

--- a/packages/ui/src/lib/tooltip/Tooltip.svelte
+++ b/packages/ui/src/lib/tooltip/Tooltip.svelte
@@ -43,13 +43,14 @@ let tooltipInner: HTMLDivElement | null = null;
 
 $effect(() => {
   const { tip } = propsData;
-  if (tooltipInner) {
-    tooltipInner.textContent = tip ?? '';
-    if (tip !== undefined) {
-      tooltipInner.setAttribute('aria-label', tip);
-    } else {
-      tooltipInner.removeAttribute('aria-label');
-    }
+
+  if (!tooltipInner) return;
+
+  while (tooltipInner.firstChild) tooltipInner.removeChild(tooltipInner.firstChild);
+
+  if (tip?.trim().length) {
+    tooltipInner.append(document.createTextNode(tip));
+    hasSlotContent = false;
   }
 });
 
@@ -132,14 +133,26 @@ onMount(() => {
   tooltipOuter.className =
     'whitespace-nowrap absolute tooltip opacity-0 inline-block transition-opacity duration-150 ease-in-out pointer-events-none text-sm z-60';
 
+  if (propsData.left) tooltipOuter.classList.add('left');
+  if (propsData.right) tooltipOuter.classList.add('right');
+  if (propsData.top) tooltipOuter.classList.add('top');
+  if (propsData.bottom) tooltipOuter.classList.add('bottom');
+  if (propsData.topLeft) tooltipOuter.classList.add('top-left');
+  if (propsData.topRight) tooltipOuter.classList.add('top-right');
+  if (propsData.bottomLeft) tooltipOuter.classList.add('bottom-left');
+  if (propsData.bottomRight) tooltipOuter.classList.add('bottom-right');
+
+  const { tip } = propsData;
+
   const extra = propsData.class?.trim();
-  if (extra) tooltipOuter.classList.add(...extra.split(/\s+/));
 
   tooltipInner.className =
-    'inline-block py-2 px-4 rounded-md bg-[var(--pd-tooltip-bg)] text-[var(--pd-tooltip-text)] border border-[var(--pd-tooltip-border)]';
+    'inline-block py-2 px-4 rounded-md bg-[var(--pd-tooltip-bg)] text-[var(--pd-tooltip-text)] border-[1px] border-[var(--pd-tooltip-border)]';
 
-  if (propsData.tip?.trim().length) {
-    tooltipInner.textContent = propsData.tip;
+  if (extra) tooltipInner.classList.add(...extra.split(/\s+/));
+
+  if (tip?.trim().length) {
+    tooltipInner.append(document.createTextNode(tip));
   } else if (slotContainer) {
     while (slotContainer.firstChild) {
       const node = slotContainer.firstChild;
@@ -148,6 +161,10 @@ onMount(() => {
       tooltipInner.appendChild(node);
       if (isMeaningful) hasSlotContent = true;
     }
+  }
+
+  if (contentAvailable()) {
+    tooltipInner.setAttribute('aria-label', 'tooltip');
   }
 
   tooltipOuter.appendChild(tooltipInner);

--- a/packages/ui/src/lib/tooltip/Tooltip.svelte
+++ b/packages/ui/src/lib/tooltip/Tooltip.svelte
@@ -1,95 +1,181 @@
-<style>
-.tooltip.top {
-  left: 50%;
-  transform: translate(-50%, -100%);
-  margin-top: -8px;
-}
-.tooltip.bottom {
-  left: 50%;
-  bottom: 0;
-  transform: translate(-50%, 100%);
-  margin-bottom: -8px;
-}
-.tooltip.left {
-  left: 0;
-  transform: translateX(-100%);
-  margin-left: -8px;
-}
-.tooltip.right {
-  right: 0;
-  transform: translate(100%, -50%);
-  margin-top: -10px;
-  margin-right: -8px;
-}
-.tooltip.top-left {
-  left: 0;
-  transform: translate(-80%, -100%);
-  margin-top: -8px;
-}
-.tooltip.bottom-left {
-  left: 0;
-  bottom: 0;
-  transform: translate(-80%, 100%);
-  margin-top: -8px;
-}
-.tooltip.bottom-right {
-  left: 0;
-  bottom: 0;
-  transform: translate(0%, 100%);
-  margin-top: -8px;
-}
-.tooltip.top-right {
-  left: 0;
-  transform: translate(0%, -100%);
-  margin-top: -8px;
-}
-.tooltip-slot:hover + .tooltip {
-  opacity: 1;
-  visibility: initial;
-}
-</style>
-
 <script lang="ts">
+import { onDestroy, onMount } from 'svelte';
+import { get } from 'svelte/store';
+
 import { tooltipHidden } from './tooltip-store';
 
-export let tip: string | undefined = undefined;
-export let top = false;
-export let topLeft = false;
-export let topRight = false;
-export let right = false;
-export let bottom = false;
-export let bottomLeft = false;
-export let bottomRight = false;
-export let left = false;
+interface TooltipProps {
+  tip?: string;
+  class?: string;
+  /** positional flags */
+  top?: boolean;
+  topLeft?: boolean;
+  topRight?: boolean;
+  bottom?: boolean;
+  bottomLeft?: boolean;
+  bottomRight?: boolean;
+  left?: boolean;
+  right?: boolean;
+  /** forwarded HTML attributes */
+  [key: string]: unknown;
+}
+
+interface Position {
+  tp: number;
+  lp: number;
+}
+
+const props = $props() as TooltipProps;
+
+// Forward all unknown attributes to the wrapper element (class handled separately)
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const { class: _classIgnored, ...restProps } = props;
+
+let hasSlotContent = false;
+
+const EDGE = 8;
+const SHIFT_RIGHT_VERT = 10;
+
+let wrapperEl;
+let slotContainer;
+let tooltipOuter;
+let tooltipInner;
+
+$effect(() => {
+  const { tip } = props;
+  if (tooltipInner) {
+    tooltipInner.textContent = tip ?? '';
+    if (tip !== undefined) {
+      tooltipInner.setAttribute('aria-label', tip);
+    } else {
+      tooltipInner.removeAttribute('aria-label');
+    }
+  }
+});
+
+function contentAvailable(): boolean {
+  if (props.tip?.trim().length) return true;
+  if (hasSlotContent) return true;
+  return !!tooltipInner?.textContent?.trim().length;
+}
+
+function calculatePosition(rect: DOMRect, tipRect: DOMRect): Position {
+  const { top, bottom, left, right, topLeft, topRight, bottomLeft, bottomRight } = props;
+
+  let tp = 0;
+  let lp = 0;
+
+  // vertical position
+  if (top || topLeft || topRight) {
+    tp = rect.top + window.scrollY - tipRect.height - EDGE;
+  } else if (bottom || bottomLeft || bottomRight) {
+    tp = rect.bottom + window.scrollY + EDGE;
+  } else {
+    tp = rect.top + window.scrollY + rect.height / 2 - tipRect.height / 2;
+    if (right) tp -= SHIFT_RIGHT_VERT;
+  }
+
+  // horizontal position
+  if (left) {
+    lp = rect.left + window.scrollX - tipRect.width - EDGE;
+  } else if (right) {
+    lp = rect.right + window.scrollX + EDGE;
+  } else if (topLeft || bottomLeft) {
+    lp = rect.left + window.scrollX - tipRect.width * 0.8;
+  } else if (topRight || bottomRight) {
+    lp = rect.left + window.scrollX; // 0% shift
+  } else {
+    lp = rect.left + window.scrollX + rect.width / 2 - tipRect.width / 2;
+  }
+
+  return { tp, lp };
+}
+
+function showTooltip(): void {
+  if (get(tooltipHidden)) return;
+  if (!contentAvailable()) return;
+  if (!wrapperEl || !tooltipOuter || !tooltipInner) return;
+
+  if (props.tip) tooltipInner.textContent = props.tip;
+
+  const rect = wrapperEl.getBoundingClientRect();
+  const tipRect = tooltipOuter.getBoundingClientRect();
+  const { tp, lp } = calculatePosition(rect, tipRect);
+  tooltipOuter.style.top = `${tp}px`;
+  tooltipOuter.style.left = `${lp}px`;
+  tooltipOuter.classList.remove('opacity-0');
+}
+
+const hideTooltip = (): void => {
+  tooltipOuter?.classList.add('opacity-0');
+};
+
+function attachTooltip(): void {
+  if (tooltipOuter && !document.body.contains(tooltipOuter)) {
+    document.body.appendChild(tooltipOuter);
+  }
+  hideTooltip();
+}
+
+function detachTooltip(): void {
+  tooltipOuter?.parentNode?.removeChild(tooltipOuter);
+}
+
+const updateTooltipVisibility = (): void => {
+  get(tooltipHidden) ? detachTooltip() : attachTooltip();
+};
+
+onMount(() => {
+  tooltipOuter = document.createElement('div');
+  tooltipInner = document.createElement('div');
+
+  tooltipOuter.className =
+    'whitespace-nowrap absolute tooltip opacity-0 inline-block transition-opacity duration-150 ease-in-out pointer-events-none text-sm z-60';
+
+  const extra = props.class?.trim();
+  if (extra) tooltipOuter.classList.add(...extra.split(/\s+/));
+
+  tooltipInner.className =
+    'inline-block py-2 px-4 rounded-md bg-[var(--pd-tooltip-bg)] text-[var(--pd-tooltip-text)] border border-[var(--pd-tooltip-border)]';
+
+  if (props.tip?.trim().length) {
+    tooltipInner.textContent = props.tip;
+  } else if (slotContainer) {
+    while (slotContainer.firstChild) {
+      const node = slotContainer.firstChild;
+      const isMeaningful =
+        node.nodeType === Node.ELEMENT_NODE || (node.nodeType === Node.TEXT_NODE && node.textContent!.trim().length);
+      tooltipInner.appendChild(node);
+      if (isMeaningful) hasSlotContent = true;
+    }
+  }
+
+  tooltipOuter.appendChild(tooltipInner);
+  document.body.appendChild(tooltipOuter);
+
+  wrapperEl?.addEventListener('mouseenter', showTooltip);
+  wrapperEl?.addEventListener('mouseleave', hideTooltip);
+  wrapperEl?.addEventListener('click', hideTooltip);
+
+  const unsub = tooltipHidden.subscribe((): void => updateTooltipVisibility());
+
+  onDestroy(unsub);
+});
+
+onDestroy(() => {
+  wrapperEl?.removeEventListener('mouseenter', showTooltip);
+  wrapperEl?.removeEventListener('mouseleave', hideTooltip);
+  wrapperEl?.removeEventListener('click', hideTooltip);
+  tooltipOuter?.remove();
+});
 </script>
 
-<div class="relative inline-block">
-  <span class="group tooltip-slot {$$props.class}">
+<div class="relative inline-block" bind:this={wrapperEl} {...restProps}>
+  <span class="group tooltip-slot flex flex-col items-center">
     <slot />
   </span>
-  <div
-    class="whitespace-nowrap absolute tooltip opacity-0 inline-block transition-opacity duration-150 ease-in-out pointer-events-none text-sm z-60"
-    class:left={left}
-    class:right={right}
-    class:bottom={bottom}
-    class:top={top}
-    class:top-left={topLeft}
-    class:top-right={topRight}
-    class:bottom-left={bottomLeft}
-    class:bottom-right={bottomRight}>
-    {#if tip && !$tooltipHidden}
-      <div
-        class="inline-block py-2 px-4 rounded-md bg-[var(--pd-tooltip-bg)] text-[var(--pd-tooltip-text)] border-[1px] border-[var(--pd-tooltip-border)] {$$props.class}"
-        aria-label="tooltip">
-        {tip}
-      </div>
-    {/if}
-    {#if $$slots.tip && !tip && !$tooltipHidden}
-      <div
-        class="inline-block rounded-md bg-[var(--pd-tooltip-bg)] text-[var(--pd-tooltip-text)] border-[1px] border-[var(--pd-tooltip-border)] {$$props.class}"
-        aria-label="tooltip">
-        <slot name="tip" />
-      </div>
-    {/if}
+  <!-- Hidden container to capture named tip slot content (if provided) -->
+  <div style="display: none;" bind:this={slotContainer}>
+    <slot name="tip" />
   </div>
 </div>

--- a/packages/ui/src/lib/tooltip/TooltipSpec.spec.ts
+++ b/packages/ui/src/lib/tooltip/TooltipSpec.spec.ts
@@ -50,7 +50,7 @@ test('Expect basic prop styling', async () => {
 });
 
 test('Expect class styling to apply to tip slot div', async () => {
-  render(TooltipSpec, { classStyle: 'my-[5px] mx-[10px]' });
+  render(TooltipSpec, { tipProp: tip, classStyle: 'my-[5px] mx-[10px]' });
 
   const slotElement = screen.getByLabelText('tooltip');
   expect(slotElement).toHaveClass('my-[5px] mx-[10px]');


### PR DESCRIPTION
### What does this PR do?

Side PR  needed for https://github.com/podman-desktop/podman-desktop/pull/13008
The current PR need to be merged before https://github.com/podman-desktop/podman-desktop/pull/13008

A situation may arise where the component that needs a tooltip is inside a scrollable area or an element with overflow settings. In this case, the tooltip would be hidden from the user. To prevent this, we should render the tooltip as a separate component at the root of the HTML document and display it above all other elements using absolute positioning.

Our current behavior for displaying the tooltip:
<img width="125" src="https://github.com/user-attachments/assets/da19fb8c-925e-44c8-ba2f-efdea2dc4e43" />

With the new changes, the tooltip should appear above all UI elements.

### Screenshot / video of UI

<img width="170" src="https://github.com/user-attachments/assets/66c5eac2-cc89-44a7-8813-a8d50a071ea7" />

### What issues does this PR fix or reference?

Part of #12234 

### How to test this PR?

Ensure that behaviour of rendering tooltips is not changed on the UI.

- [x] Tests are covering the bug fix or the new feature
