### PR TITLE
chore(test): clean hanging podman machine in e2e test

### DIFF
--- a/tests/playwright/src/specs/podman-machine-tests.spec.ts
+++ b/tests/playwright/src/specs/podman-machine-tests.spec.ts
@@ -26,8 +26,8 @@ import { expect as playExpect, test } from '../utility/fixtures';
 import {
   createPodmanMachineFromCLI,
   deletePodmanMachine,
-  deletePodmanMachineFromCLI,
   handleConfirmationDialog,
+  resetPodmanMachinesFromCLI,
 } from '../utility/operations';
 import { isLinux } from '../utility/platform';
 import { waitForPodmanMachineStartup } from '../utility/wait';
@@ -55,7 +55,7 @@ test.afterAll(async ({ runner, page }) => {
   test.setTimeout(120_000);
 
   if (test.info().status === 'failed') {
-    await deletePodmanMachineFromCLI(ROOTLESS_PODMAN_MACHINE_VISIBLE);
+    await resetPodmanMachinesFromCLI();
     await createPodmanMachineFromCLI();
   }
 

--- a/tests/playwright/src/utility/operations.ts
+++ b/tests/playwright/src/utility/operations.ts
@@ -358,6 +358,12 @@ export async function deletePodmanMachineFromCLI(podmanMachineName: string): Pro
   });
 }
 
+export async function resetPodmanMachinesFromCLI(): Promise<void> {
+  return test.step('Reset Podman machine from CLI', () => {
+    execSync(`podman machine reset -f`);
+  });
+}
+
 export async function fillTextbox(textbox: Locator, text: string): Promise<void> {
   return test.step(`Fill textbox with ${text}`, async () => {
     await playExpect(textbox).toBeVisible({ timeout: 15_000 });


### PR DESCRIPTION
### What does this PR do?
One of the podman machine e2e tests causes a cascade failure of several test suites when it fails in a specific way because it leaves the podman machine hanging in a bad state.

### What issues does this PR fix or reference?
