### PR TITLE
feat(cli-tools): install latest version without asking to select one

### DIFF
--- a/extensions/compose/src/extension.spec.ts
+++ b/extensions/compose/src/extension.spec.ts
@@ -383,12 +383,9 @@ describe('registerCLITool', () => {
     );
   });
 
-  test('after selecting the version to be installed it should download compose', async () => {
+  test('doInstall should download and install latest version', async () => {
     vi.mocked(detectMock.checkSystemWideDockerCompose).mockResolvedValue(false);
     vi.mocked(detectMock.getStoragePath).mockResolvedValue('');
-    vi.mocked(composeDownloadMock.promptUserForVersion).mockResolvedValue({
-      tag: 'v1.0.0',
-    } as unknown as ComposeGithubReleaseArtifactMetadata);
 
     let installer: extensionApi.CliToolInstaller | undefined;
     vi.mocked(cliToolMock.registerInstaller).mockImplementation(mInstaller => {
@@ -402,7 +399,11 @@ describe('registerCLITool', () => {
       expect(installer).toBeDefined();
     });
 
-    await installer?.selectVersion();
+    vi.mocked(composeDownloadMock.getLatestVersionAsset).mockResolvedValue({
+      tag: 'v1.0.0',
+    } as unknown as ComposeGithubReleaseArtifactMetadata);
+
+    await installer?.selectVersion(true);
 
     await installer?.doInstall({} as unknown as Logger);
     expect(composeDownloadMock.download).toHaveBeenCalledWith({

--- a/extensions/compose/src/extension.ts
+++ b/extensions/compose/src/extension.ts
@@ -371,8 +371,13 @@ async function registerCLITool(
   );
 
   composeCliToolInstallerDisposable = composeCliTool.registerInstaller({
-    selectVersion: async () => {
-      const selected = await composeDownload.promptUserForVersion();
+    selectVersion: async (latest?: boolean) => {
+      let selected: ComposeGithubReleaseArtifactMetadata;
+      if (latest) {
+        selected = latestVersionAsset ?? (await composeDownload.getLatestVersionAsset());
+      } else {
+        selected = await composeDownload.promptUserForVersion();
+      }
       releaseToInstall = selected;
       releaseVersionToInstall = removeVersionPrefix(selected.tag);
       return releaseVersionToInstall;

--- a/extensions/kind/src/extension.spec.ts
+++ b/extensions/kind/src/extension.spec.ts
@@ -418,24 +418,30 @@ describe('cli#install', () => {
     );
   });
 
-  test('after selecting the version to be installed it should download kind', async () => {
+  test('should install latest version', async () => {
+    const latest = {
+      label: 'kind v1.0.2',
+      tag: 'v1.0.2',
+      id: 1,
+    };
     vi.mocked(util.installBinaryToSystem).mockResolvedValue('path');
     // mock prompt result
-    vi.mocked(KindInstaller.prototype.promptUserForVersion).mockResolvedValue(mockV1Release);
 
     const cliToolInstaller: extensionApi.CliToolInstaller = await getCliToolInstaller();
 
+    vi.mocked(KindInstaller.prototype.getLatestVersionAsset).mockResolvedValue(latest);
     // mock workflow (user select version then we install it)
-    await cliToolInstaller?.selectVersion();
+    vi.mocked(util.removeVersionPrefix).mockReturnValue('1.0.2');
+    expect(await cliToolInstaller?.selectVersion(true)).equals('1.0.2');
     await cliToolInstaller?.doInstall({} as unknown as extensionApi.Logger);
 
-    expect(KindInstaller.prototype.download).toHaveBeenCalledWith(mockV1Release);
+    expect(KindInstaller.prototype.download).toHaveBeenCalledWith(latest);
     expect(KindInstaller.prototype.getKindCliStoragePath).toHaveBeenCalled();
     expect(util.installBinaryToSystem).toHaveBeenCalledWith('storage-path', 'kind');
     expect(CLI_TOOL_MOCK.updateVersion).toHaveBeenCalledWith({
       installationSource: 'extension',
       path: 'path',
-      version: '1.0.0',
+      version: '1.0.2',
     });
   });
 

--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -524,8 +524,13 @@ async function registerCliTool(
   }
 
   kindCli.registerInstaller({
-    selectVersion: async () => {
-      const selected = await installer.promptUserForVersion();
+    selectVersion: async (latest?: boolean) => {
+      let selected: KindGithubReleaseArtifactMetadata;
+      if (latest) {
+        selected = latestAsset ?? (await installer.getLatestVersionAsset());
+      } else {
+        selected = await installer.promptUserForVersion();
+      }
       releaseToInstall = selected;
       releaseVersionToInstall = removeVersionPrefix(selected.tag);
       return releaseVersionToInstall;

--- a/extensions/kubectl-cli/src/extension.ts
+++ b/extensions/kubectl-cli/src/extension.ts
@@ -388,8 +388,13 @@ async function postActivate(
   };
 
   kubectlCliToolUpdaterDisposable = kubectlCliTool.registerInstaller({
-    selectVersion: async () => {
-      const selected = await kubectlDownload.promptUserForVersion();
+    selectVersion: async (latest?: boolean) => {
+      let selected: KubectlGithubReleaseArtifactMetadata;
+      if (latest) {
+        selected = latestAsset ?? (await kubectlDownload.getLatestVersionAsset());
+      } else {
+        selected = await kubectlDownload.promptUserForVersion();
+      }
       releaseToInstall = selected;
       releaseVersionToInstall = selected.tag.slice(1);
       return releaseVersionToInstall;
@@ -409,6 +414,11 @@ async function postActivate(
         installationSource: 'extension',
       });
       vpState.version = releaseVersionToInstall;
+      if (releaseToInstall === latestAsset) {
+        delete update.version;
+      } else {
+        update.version = latestAsset?.tag.slice(1);
+      }
       releaseVersionToInstall = undefined;
       releaseToInstall = undefined;
     },

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -4752,7 +4752,7 @@ declare module '@podman-desktop/api' {
   }
 
   export interface CliToolInstaller {
-    selectVersion: () => Promise<string>;
+    selectVersion: (latest?: boolean) => Promise<string>;
     doInstall: (logger: Logger) => Promise<void>;
     doUninstall: (logger: Logger) => Promise<void>;
   }

--- a/packages/main/src/plugin/cli-tool-registry.ts
+++ b/packages/main/src/plugin/cli-tool-registry.ts
@@ -107,12 +107,12 @@ export class CliToolRegistry {
     return cliToolUpdater.selectVersion();
   }
 
-  async selectCliToolVersionToInstall(id: string): Promise<string> {
+  async selectCliToolVersionToInstall(id: string, latest = true): Promise<string> {
     const cliToolInstaller = this.cliToolsInstaller.get(id);
     if (!cliToolInstaller) {
       throw new Error(`No installer registered for ${id}`);
     }
-    return cliToolInstaller.selectVersion();
+    return cliToolInstaller.selectVersion(latest);
   }
 
   isUpdaterToPredefinedVersion(update: CliToolUpdate | CliToolSelectUpdate): update is CliToolUpdate {

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1607,8 +1607,8 @@ export class PluginSystem {
 
     this.ipcHandle(
       'cli-tool-registry:selectCliToolVersionToInstall',
-      async (_listener, id: string): Promise<string> => {
-        return cliToolRegistry.selectCliToolVersionToInstall(id);
+      async (_listener, id: string, latest = true): Promise<string> => {
+        return cliToolRegistry.selectCliToolVersionToInstall(id, latest);
       },
     );
 
@@ -1621,7 +1621,7 @@ export class PluginSystem {
 
         // create task
         const task = taskManager.createTask({
-          title: `Installing ${tool.name} to v${versionToInstall}`,
+          title: `Installing ${tool.name} ${versionToInstall ? 'v' + versionToInstall : 'latest'}`,
           action: {
             name: 'goto task >',
             execute: (): void => {

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1326,9 +1326,12 @@ export function initExposure(): void {
     },
   );
 
-  contextBridge.exposeInMainWorld('selectCliToolVersionToInstall', async (id: string): Promise<string> => {
-    return ipcInvoke('cli-tool-registry:selectCliToolVersionToInstall', id);
-  });
+  contextBridge.exposeInMainWorld(
+    'selectCliToolVersionToInstall',
+    async (id: string, latest = true): Promise<string> => {
+      return ipcInvoke('cli-tool-registry:selectCliToolVersionToInstall', id, latest);
+    },
+  );
 
   contextBridge.exposeInMainWorld(
     'installCliTool',

--- a/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
@@ -257,7 +257,7 @@ function getLoggerHandler(_cliToolId: string): ConnectionCallback {
                     await update(cliTool);
                   }
                 }}
-                title={`${cliTool.displayName} will be updated`}
+                title={`${cliTool.displayName} will be updated${cliTool.newVersion ? ' to ' + cliTool.newVersion : ''} `}
                 disabled={!cliTool.canUpdate}
                 aria-label="Update available">
                 {`${cliTool.newVersion ? 'Update available' : 'Upgrade/Downgrade'}`}


### PR DESCRIPTION
### What does this PR do?

This PR adds support for cli tool installer to install latest version without asking user to chose one.

### Screenshot / video of UI


https://github.com/user-attachments/assets/9d6063aa-0456-4a8b-8f71-29d4cf92a768


### What issues does this PR fix or reference?

Fix #9222.

### How to test this PR?

Uninstall any of available tools and try to install again, latest version should be installed without asking to select version to install. Then there is a way to downgrade to previous one. Follow up issue should be opened for any usability issues after merging this PR.

- [x] Tests are covering the bug fix or the new feature
