### PR TITLE
fix: don't show table when there are no running container engines

### DIFF
--- a/packages/renderer/src/lib/image/ImagesList.spec.ts
+++ b/packages/renderer/src/lib/image/ImagesList.spec.ts
@@ -659,3 +659,45 @@ test('Expect user confirmation to pop up when preferences require', async () => 
   expect(window.showMessageBox).toHaveBeenCalledTimes(2);
   await vi.waitFor(() => expect(window.deleteImage).toHaveBeenCalled());
 });
+
+test('Expect to see empty page and no table when no container engine is running', async () => {
+  vi.mocked(window.getProviderInfos).mockResolvedValue([
+    {
+      name: 'podman',
+      status: 'started',
+      internalId: 'podman-internal-id',
+      containerConnections: [
+        {
+          name: 'podman-machine-default',
+          status: 'stoppped',
+        } as unknown as ProviderContainerConnectionInfo,
+      ],
+    } as unknown as ProviderInfo,
+  ]);
+  vi.mocked(window.listImages).mockResolvedValue([
+    {
+      Id: 'sha256:1234567890',
+      RepoTags: ['mockimage:latest'],
+      Created: 1644009612,
+      Size: 123,
+      Status: 'Running',
+      engineId: 'podman',
+      engineName: 'podman',
+    },
+  ] as unknown as ImageInfo[]);
+
+  window.dispatchEvent(new CustomEvent('extensions-already-started'));
+  window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
+  window.dispatchEvent(new CustomEvent('image-build'));
+
+  // wait imageInfo store is populated
+  await vi.waitFor(() => get(imagesInfos).length > 0);
+
+  await waitRender({});
+
+  const table = screen.queryByRole('table');
+  expect(table).toBeNull();
+
+  const noContainerEngine = screen.getByText('No Container Engine');
+  expect(noContainerEngine).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/image/ImagesList.spec.ts
+++ b/packages/renderer/src/lib/image/ImagesList.spec.ts
@@ -669,7 +669,7 @@ test('Expect to see empty page and no table when no container engine is running'
       containerConnections: [
         {
           name: 'podman-machine-default',
-          status: 'stoppped',
+          status: 'stopped',
         } as unknown as ProviderContainerConnectionInfo,
       ],
     } as unknown as ProviderInfo,

--- a/packages/renderer/src/lib/image/ImagesList.svelte
+++ b/packages/renderer/src/lib/image/ImagesList.svelte
@@ -314,15 +314,6 @@ const row = new TableRow<ImageInfoUI>({
 
   {#snippet content()}
   <div class="flex min-w-full h-full">
-    <Table
-      kind="image"
-      bind:selectedItemsNumber={selectedItemsNumber}
-      data={images}
-      columns={columns}
-      row={row}
-      defaultSortColumn="Age"
-      on:update={(): ImageInfoUI[] => (images = images)}>
-    </Table>
 
     {#if providerConnections.length === 0}
       <NoContainerEngineEmptyScreen />
@@ -332,6 +323,16 @@ const row = new TableRow<ImageInfoUI>({
       {:else}
         <ImageEmptyScreen />
       {/if}
+    {:else}
+      <Table
+        kind="image"
+        bind:selectedItemsNumber={selectedItemsNumber}
+        data={images}
+        columns={columns}
+        row={row}
+        defaultSortColumn="Age"
+        on:update={(): ImageInfoUI[] => (images = images)}>
+      </Table>
     {/if}
   </div>
   {/snippet}

--- a/packages/renderer/src/lib/pod/PodsList.spec.ts
+++ b/packages/renderer/src/lib/pod/PodsList.spec.ts
@@ -583,7 +583,7 @@ test('Expect to see empty page and no table when no container engine is running'
       containerConnections: [
         {
           name: 'podman-machine-default',
-          status: 'stoppped',
+          status: 'stopped',
         } as unknown as ProviderContainerConnectionInfo,
       ],
     } as unknown as ProviderInfo,

--- a/packages/renderer/src/lib/pod/PodsList.spec.ts
+++ b/packages/renderer/src/lib/pod/PodsList.spec.ts
@@ -33,7 +33,7 @@ import PodsList from '/@/lib/pod/PodsList.svelte';
 import { filtered, podsInfos } from '/@/stores/pods';
 import { providerInfos } from '/@/stores/providers';
 import type { ContextGeneralState } from '/@api/kubernetes-contexts-states';
-import type { ProviderInfo } from '/@api/provider-info';
+import type { ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provider-info';
 
 import type { PodInfo } from '../../../../main/src/plugin/api/pod-info';
 
@@ -572,4 +572,35 @@ test('Expect user confirmation to pop up when preferences require', async () => 
   await fireEvent.click(deleteButton);
   expect(window.showMessageBox).toHaveBeenCalledTimes(2);
   await vi.waitFor(() => expect(window.removePod).toHaveBeenCalled());
+});
+
+test('Expect to see empty page and no table when no container engine is running', async () => {
+  getProvidersInfoMock.mockResolvedValue([
+    {
+      name: 'podman',
+      status: 'started',
+      internalId: 'podman-internal-id',
+      containerConnections: [
+        {
+          name: 'podman-machine-default',
+          status: 'stoppped',
+        } as unknown as ProviderContainerConnectionInfo,
+      ],
+    } as unknown as ProviderInfo,
+  ]);
+  listPodsMock.mockResolvedValue([pod1]);
+
+  window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
+  window.dispatchEvent(new CustomEvent('extensions-already-started'));
+
+  // wait imageInfo store is populated
+  await vi.waitFor(() => get(podsInfos).length > 0);
+
+  await waitRender({});
+
+  const table = screen.queryByRole('table');
+  expect(table).toBeNull();
+
+  const noContainerEngine = screen.getByText('No Container Engine');
+  expect(noContainerEngine).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -224,17 +224,8 @@ const row = new TableRow<PodInfoUI>({ selectable: (_pod): boolean => true });
 
   {#snippet content()}
   <div class="flex min-w-full h-full">
-    <Table
-      kind="pod"
-      bind:selectedItemsNumber={selectedItemsNumber}
-      data={pods}
-      columns={columns}
-      row={row}
-      defaultSortColumn="Name"
-      on:update={(): PodInfoUI[] => (pods = pods)}>
-    </Table>
 
-    {#if $filtered.length === 0 && providerConnections.length === 0}
+    {#if providerConnections.length === 0}
       <NoContainerEngineEmptyScreen />
     {:else if $filtered.length === 0}
       {#if searchTerm}
@@ -249,6 +240,16 @@ const row = new TableRow<PodInfoUI>({ selectable: (_pod): boolean => true });
       {:else}
         <PodEmptyScreen />
       {/if}
+    {:else}
+      <Table
+        kind="pod"
+        bind:selectedItemsNumber={selectedItemsNumber}
+        data={pods}
+        columns={columns}
+        row={row}
+        defaultSortColumn="Name"
+        on:update={(): PodInfoUI[] => (pods = pods)}>
+      </Table>
     {/if}
   </div>
   {/snippet}

--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -210,15 +210,6 @@ const row = new TableRow<VolumeInfoUI>({
 
   {#snippet content()}
   <div class="flex min-w-full h-full">
-    <Table
-      kind="volume"
-      bind:selectedItemsNumber={selectedItemsNumber}
-      data={volumes}
-      columns={columns}
-      row={row}
-      defaultSortColumn="Name"
-      on:update={(): VolumeInfoUI[] => (volumes = volumes)}>
-    </Table>
 
     {#if providerConnections.length === 0}
       <NoContainerEngineEmptyScreen />
@@ -228,6 +219,16 @@ const row = new TableRow<VolumeInfoUI>({
       {:else}
         <VolumeEmptyScreen />
       {/if}
+    {:else}
+      <Table
+        kind="volume"
+        bind:selectedItemsNumber={selectedItemsNumber}
+        data={volumes}
+        columns={columns}
+        row={row}
+        defaultSortColumn="Name"
+        on:update={(): VolumeInfoUI[] => (volumes = volumes)}>
+      </Table>
     {/if}
   </div>
   {/snippet}


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR updates the image, pods, and volumes pages to make sure that the tables are not visible when there are not running container engines (as seen in https://github.com/podman-desktop/podman-desktop/issues/12782)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Fixes https://github.com/podman-desktop/podman-desktop/issues/12782

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->
1. Open the images page and make sure that the table is visible with at least one row in it
2. From the CLI, stop the running podman machine
3. Assert that when the no container engine screen shows up, the old table is not visible (without this fix it could happen for a few seconds until all the data is updated)

- [X] Tests are covering the bug fix or the new feature
