### PR TITLE
fix: do not search full path executable

### DIFF
--- a/extensions/compose/src/extension.spec.ts
+++ b/extensions/compose/src/extension.spec.ts
@@ -446,7 +446,6 @@ describe('registerCLITool', () => {
 
     await installer?.doUninstall({} as unknown as Logger);
     expect(fs.promises.unlink).toHaveBeenNthCalledWith(1, 'storage-path');
-    expect(extensionApi.process.exec).toHaveBeenCalledWith('which', ['system-wide-path']);
     expect(extensionApi.process.exec).toHaveBeenCalledWith('rm', ['system-wide-path'], { isAdmin: true });
   });
 

--- a/extensions/compose/src/extension.ts
+++ b/extensions/compose/src/extension.ts
@@ -466,28 +466,12 @@ async function deleteFileAsAdmin(filePath: string): Promise<void> {
 
 async function deleteExecutableAsAdmin(filePath: string): Promise<void> {
   const command = extensionApi.env.isWindows ? 'del' : 'rm';
-  const checkCommand = extensionApi.env.isWindows ? 'where.exe' : 'which';
-  let fileExistsPath = '';
-
   try {
-    const { stdout: fullPath } = await extensionApi.process.exec(checkCommand, [filePath]);
-    fileExistsPath = fullPath;
-  } catch (err) {
-    if (err && typeof err === 'object' && 'stderr' in err) {
-      console.log(err.stderr);
-    } else {
-      console.warn(`Error checking Compose ${filePath} path`, err);
-    }
-  }
-
-  if (fileExistsPath) {
-    try {
-      // Use admin privileges
-      await extensionApi.process.exec(command, [filePath], { isAdmin: true });
-    } catch (error) {
-      console.error(`Failed to uninstall '${filePath}': ${error}`);
-      throw error;
-    }
+    // Use admin privileges
+    await extensionApi.process.exec(command, [filePath], { isAdmin: true });
+  } catch (error) {
+    console.error(`Failed to uninstall '${filePath}': ${error}`);
+    throw error;
   }
 }
 

--- a/extensions/kind/src/extension.spec.ts
+++ b/extensions/kind/src/extension.spec.ts
@@ -485,7 +485,6 @@ describe('cli#uninstall', () => {
 
     await cliToolInstaller?.doUninstall({} as unknown as extensionApi.Logger);
     expect(fs.promises.unlink).toHaveBeenCalledWith('storage-path');
-    expect(podmanDesktopApi.process.exec).toHaveBeenCalledWith('which', ['test-storage-path/kind']);
     expect(podmanDesktopApi.process.exec).toHaveBeenCalledWith('rm', ['test-storage-path/kind'], { isAdmin: true });
   });
 

--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -627,28 +627,12 @@ async function deleteFileAsAdmin(filePath: string): Promise<void> {
 
 async function deleteExecutableAsAdmin(filePath: string): Promise<void> {
   const command = extensionApi.env.isWindows ? 'del' : 'rm';
-  const checkCommand = extensionApi.env.isWindows ? 'where.exe' : 'which';
-  let fileExistsPath = '';
-
   try {
-    const { stdout: fullPath } = await extensionApi.process.exec(checkCommand, [filePath]);
-    fileExistsPath = fullPath;
-  } catch (err) {
-    if (err && typeof err === 'object' && 'stderr' in err) {
-      console.log(err.stderr);
-    } else {
-      console.warn(`Error checking Kind ${filePath} path`, err);
-    }
-  }
-
-  if (fileExistsPath) {
-    try {
-      // Use admin privileges
-      await extensionApi.process.exec(command, [filePath], { isAdmin: true });
-    } catch (error) {
-      console.error(`Failed to uninstall '${filePath}': ${error}`);
-      throw error;
-    }
+    // Use admin privileges
+    await extensionApi.process.exec(command, [filePath], { isAdmin: true });
+  } catch (error) {
+    console.error(`Failed to uninstall '${filePath}': ${error}`);
+    throw error;
   }
 }
 

--- a/extensions/kubectl-cli/src/extension.spec.ts
+++ b/extensions/kubectl-cli/src/extension.spec.ts
@@ -626,7 +626,6 @@ describe('postActivate', () => {
     await cliInstaller.doUninstall({} as unknown as Logger);
 
     expect(fs.promises.unlink).toHaveBeenCalledWith(path.join(extensionContext.storagePath, 'bin', 'kubectl'));
-    expect(extensionApi.process.exec).toHaveBeenCalledWith('which', ['system-path']);
     expect(extensionApi.process.exec).toHaveBeenCalledWith('rm', ['system-path'], { isAdmin: true });
   });
 

--- a/extensions/kubectl-cli/src/extension.ts
+++ b/extensions/kubectl-cli/src/extension.ts
@@ -485,27 +485,11 @@ async function deleteFileAsAdmin(filePath: string): Promise<void> {
 
 async function deleteExecutableAsAdmin(filePath: string): Promise<void> {
   const command = extensionApi.env.isWindows ? 'del' : 'rm';
-  const checkCommand = extensionApi.env.isWindows ? 'where.exe' : 'which';
-  let fileExistsPath = '';
-
   try {
-    const { stdout: fullPath } = await extensionApi.process.exec(checkCommand, [filePath]);
-    fileExistsPath = fullPath;
-  } catch (err) {
-    if (err && typeof err === 'object' && 'stderr' in err) {
-      console.log(err.stderr);
-    } else {
-      console.warn(`Error checking kubectl ${filePath} path`, err);
-    }
-  }
-
-  if (fileExistsPath) {
-    try {
-      // Use admin privileges
-      await extensionApi.process.exec(command, [filePath], { isAdmin: true });
-    } catch (error) {
-      console.error(`Failed to uninstall '${filePath}': ${error}`);
-      throw error;
-    }
+    // Use admin privileges
+    await extensionApi.process.exec(command, [filePath], { isAdmin: true });
+  } catch (error) {
+    console.error(`Failed to uninstall '${filePath}': ${error}`);
+    throw error;
   }
 }


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

A `where.exe` / `which` is executed to find the executable to delete, but the path passed to the command is already the full path.

With the `which` command, it is harmless as this command works correctly with a full path, but `where.exe` raises an error `Invalid pattern in specified in "path:pattern"` in this case.

This PR removes the where/which part, and directly deletes the file at the given full path

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #12240 

### How to test this PR?

On Windows, try to uninstall docker-compose / kind / kubectl

- [x] Tests are covering the bug fix or the new feature
