### PR TITLE
fix: pod name not working in k8s

### DIFF
--- a/packages/renderer/src/lib/pod/PodEmptyScreen.spec.ts
+++ b/packages/renderer/src/lib/pod/PodEmptyScreen.spec.ts
@@ -79,7 +79,7 @@ const imageInfo = {
   RepoTags: [helloImage],
 } as ImageInfo;
 const podInfo = { engineId: imageInfo.engineId, Id: 'Id' };
-const podCreateCommand = `podman run -dt --pod new:myFirstPod ${helloImage}`;
+const podCreateCommand = `podman run -dt --pod new:my-first-pod ${helloImage}`;
 
 function testComponent(name: string, fn: () => Promise<unknown>): void {
   test(name, () => {
@@ -96,10 +96,10 @@ testComponent('renders button to run first pod', async () => {
 testComponent('button click creates and starts a pod', async () => {
   vi.spyOn(window, 'createPod').mockResolvedValue(podInfo);
   await fireEvent.click(getButton());
-  expect(window.createPod).toBeCalledWith({ name: 'myFirstPod' });
+  expect(window.createPod).toBeCalledWith({ name: 'my-first-pod' });
   expect(window.createAndStartContainer).toBeCalledWith(podInfo.engineId, {
     Image: helloImage,
-    pod: 'myFirstPod',
+    pod: 'my-first-pod',
   });
 });
 

--- a/packages/renderer/src/lib/pod/PodEmptyScreen.svelte
+++ b/packages/renderer/src/lib/pod/PodEmptyScreen.svelte
@@ -5,7 +5,7 @@ import { providerInfos } from '/@/stores/providers';
 
 import PodIcon from '../images/PodIcon.svelte';
 
-const myFirstPod = 'myFirstPod';
+const myFirstPod = 'my-first-pod';
 const helloImage = 'quay.io/podman/hello:latest';
 const commandLine = `podman run -dt --pod new:${myFirstPod} ${helloImage}`;
 


### PR DESCRIPTION
### What does this PR do?

Rename the demonstration pod created with "Start your first pod" to make it able to deploy to Kubernetes. The uppercase letters were unsupported.

### Screenshot / video of UI

<img width="1162" alt="Screenshot 2025-07-03 at 17 25 45" src="https://github.com/user-attachments/assets/db152e51-3e3b-43b0-948e-d24d2c7fee7c" />


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes #13065

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
