### PR TITLE
chore: use aggregating way to report activateExtension event

### DIFF
--- a/packages/main/src/plugin/extension/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension/extension-loader.spec.ts
@@ -203,7 +203,7 @@ const onboardingRegistry: OnboardingRegistry = {
 } as unknown as OnboardingRegistry;
 
 const telemetryTrackMock = vi.fn();
-const telemetry: Telemetry = { track: telemetryTrackMock } as unknown as Telemetry;
+const telemetry: Telemetry = { aggregateTrack: vi.fn(), track: telemetryTrackMock } as unknown as Telemetry;
 
 const viewRegistry: ViewRegistry = {} as unknown as ViewRegistry;
 
@@ -2239,7 +2239,7 @@ describe('extensionContext', async () => {
 
     expect(extensionContext).toBeDefined();
     expect(extensionContext?.secrets).toBeDefined();
-    expect(telemetry.track).toBeCalledWith('activateExtension', {
+    expect(telemetry.aggregateTrack).toBeCalledWith('activateExtensions', {
       extensionId: 'fooPublisher.fooName',
       extensionVersion: '1.0',
       duration: expect.any(Number),

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -1717,7 +1717,7 @@ export class ExtensionLoader {
       // Storing error in the telemetry options
       telemetryOptions['error'] = err;
     } finally {
-      this.telemetry.track('activateExtension', telemetryOptions);
+      this.telemetry.aggregateTrack('activateExtensions', telemetryOptions);
     }
   }
 


### PR DESCRIPTION
### What does this PR do?

instead of sending like 12 events in a row, send only one event from time to time that has aggregated the previous values

PR will be rebased when the dependent PR has been merged (separate commit)

depends on :
 - [x] https://github.com/podman-desktop/podman-desktop/pull/13063

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes #12633 

### How to test this PR?

you can monitor/debug the event being sent

- [x] Tests are covering the bug fix or the new feature
