### PR TITLE
refactor(main): create AppPlugin for window creation

### DIFF
--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 import { app, ipcMain, Menu, Tray } from 'electron';
 
-import { createNewWindow, restoreWindow } from '/@/mainWindow.js';
+import { restoreWindow } from '/@/mainWindow.js';
 import type { ExtensionLoader } from '/@/plugin/extension/extension-loader.js';
 import type { Event } from '/@api/event.js';
 
@@ -87,38 +87,6 @@ app.on('will-finish-launching', () => {
 
 app.whenReady().then(
   async () => {
-    // We must create the window first before initialization so that we can load the
-    // configuration as well as plugins
-    // The window is hiddenly created and shown when ready
-
-    // Platforms: Linux, macOS, Windows
-    // Create the main window
-    createNewWindow()
-      .then(w => podmanDesktopMain.mainWindowDeferred.resolve(w))
-      .catch((error: unknown) => {
-        console.error('Error creating window', error);
-      });
-
-    // Platforms: macOS
-    // Required for macOS to start the app correctly (this is will be shown in the dock)
-    // We use 'activate' within whenReady in order to gracefully start on macOS, see this link:
-    // https://www.electronjs.org/docs/latest/tutorial/quick-start#open-a-window-if-none-are-open-macos
-    app.on('activate', (_event, hasVisibleWindows) => {
-      createNewWindow()
-        .then(w => podmanDesktopMain.mainWindowDeferred.resolve(w))
-        .catch((error: unknown) => {
-          console.log('Error creating window', error);
-        });
-
-      // try to restore the window if it's not visible
-      // for example user click on the dock icon
-      if (isMac() && !hasVisibleWindows) {
-        restoreWindow().catch((error: unknown) => {
-          console.error('Error restoring window', error);
-        });
-      }
-    });
-
     // Setup the default tray icon + menu items
     const animatedTray = new AnimatedTray();
     tray = new Tray(animatedTray.getDefaultImage());

--- a/packages/main/src/main.spec.ts
+++ b/packages/main/src/main.spec.ts
@@ -20,6 +20,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { AppPlugin } from '/@/plugin/app-ready/app-plugin.js';
 import { DefaultProtocolClient } from '/@/plugin/app-ready/default-protocol-client.js';
+import { WindowPlugin } from '/@/plugin/app-ready/window-plugin.js';
 import { SecurityRestrictions } from '/@/security-restrictions.js';
 import { isLinux, isMac, isWindows } from '/@/util.js';
 
@@ -29,9 +30,13 @@ import { Main } from './main.js';
 vi.mock('electron');
 vi.mock('/@/util.js');
 vi.mock('/@/security-restrictions.js');
+vi.mock(import('electron-context-menu'), () => ({
+  default: vi.fn(),
+}));
 
 // App Plugin
 vi.mock(import('/@/plugin/app-ready/default-protocol-client.js'));
+vi.mock(import('/@/plugin/app-ready/window-plugin.js'));
 
 const ELECTRON_APP_MOCK: ElectronApp = {
   name: 'dummy-electron-mock',
@@ -182,7 +187,7 @@ describe('ElectronApp#on window-all-closed', () => {
 });
 
 describe('AppPlugin', () => {
-  const plugins: Array<AppPlugin> = [DefaultProtocolClient.prototype];
+  const plugins: Array<AppPlugin> = [DefaultProtocolClient.prototype, WindowPlugin.prototype];
 
   let promiseWithResolvers: PromiseWithResolvers<void>;
 

--- a/packages/main/src/main.ts
+++ b/packages/main/src/main.ts
@@ -19,6 +19,7 @@ import type { App as ElectronApp, BrowserWindow } from 'electron';
 
 import type { AppPlugin } from '/@/plugin/app-ready/app-plugin.js';
 import { DefaultProtocolClient } from '/@/plugin/app-ready/default-protocol-client.js';
+import { WindowPlugin } from '/@/plugin/app-ready/window-plugin.js';
 import { SecurityRestrictions } from '/@/security-restrictions.js';
 import { isLinux, isMac, isWindows } from '/@/util.js';
 import type { IDisposable } from '/@api/disposable.js';
@@ -56,7 +57,7 @@ export class Main implements IDisposable {
     this.app = app;
     this.mainWindowDeferred = new Deferred<BrowserWindow>();
     this.protocolLauncher = new ProtocolLauncher(this.mainWindowDeferred);
-    this.#plugins = [new DefaultProtocolClient(this.app)];
+    this.#plugins = [new DefaultProtocolClient(this.app), new WindowPlugin(this.app, this.mainWindowDeferred.resolve)];
   }
 
   main(args: string[]): void {

--- a/packages/main/src/plugin/app-ready/window-plugin.spec.ts
+++ b/packages/main/src/plugin/app-ready/window-plugin.spec.ts
@@ -1,0 +1,123 @@
+/*********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************/
+
+import type { App as ElectronApp, BrowserWindow, Event as ElectronEvent } from 'electron';
+import { assert, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { createNewWindow, restoreWindow } from '/@/mainWindow.js';
+import { WindowPlugin } from '/@/plugin/app-ready/window-plugin.js';
+import { isMac } from '/@/util.js';
+
+// mock createNewWindow & restoreWindow
+vi.mock(import('/@/mainWindow.js'));
+vi.mock(import('electron-context-menu'), () => ({
+  default: vi.fn(),
+}));
+// mock isMac
+vi.mock(import('/@/util.js'));
+
+const ELECTRON_APP_MOCK: ElectronApp = {
+  on: vi.fn(),
+} as unknown as ElectronApp;
+
+const BROWSER_WINDOW_MOCK: BrowserWindow = {
+  id: 42,
+} as unknown as BrowserWindow;
+
+const CREATE_WINDOW_PROMISE_WITH_RESOLVERS: PromiseWithResolvers<BrowserWindow> = Promise.withResolvers();
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  vi.mocked(createNewWindow).mockReturnValue(CREATE_WINDOW_PROMISE_WITH_RESOLVERS.promise);
+  vi.mocked(restoreWindow).mockResolvedValue(undefined);
+
+  // default to false
+  vi.mocked(isMac).mockReturnValue(false);
+});
+
+test('no window operation should be triggered on constructor', async () => {
+  const plugin = new WindowPlugin(ELECTRON_APP_MOCK, vi.fn());
+  expect(plugin).toBeDefined();
+
+  expect(ELECTRON_APP_MOCK.on).not.toHaveBeenCalled();
+  expect(createNewWindow).not.toHaveBeenCalled();
+  expect(restoreWindow).not.toHaveBeenCalled();
+});
+
+test('onReady should createWindow & register on activate listener', async () => {
+  const plugin = new WindowPlugin(ELECTRON_APP_MOCK, vi.fn());
+  await plugin.onReady();
+
+  expect(createNewWindow).toHaveBeenCalledOnce();
+  expect(ELECTRON_APP_MOCK.on).toHaveBeenCalledOnce();
+  expect(ELECTRON_APP_MOCK.on).toHaveBeenCalledWith('activate', expect.any(Function));
+});
+
+test('createNewWindow results should be passed to constructor callback', async () => {
+  const resolveMock = vi.fn();
+
+  const plugin = new WindowPlugin(ELECTRON_APP_MOCK, resolveMock);
+  await plugin.onReady();
+
+  expect(resolveMock).not.toHaveBeenCalled();
+  CREATE_WINDOW_PROMISE_WITH_RESOLVERS.resolve(BROWSER_WINDOW_MOCK);
+
+  await vi.waitFor(() => {
+    expect(resolveMock).toHaveBeenCalledOnce();
+    expect(resolveMock).toHaveBeenCalledWith(BROWSER_WINDOW_MOCK);
+  });
+});
+
+const DUMMY_ELECTRON_EVENT: ElectronEvent = {} as unknown as ElectronEvent;
+
+describe('activate', () => {
+  let listener: (event: ElectronEvent, hasVisibleWindows: boolean) => void;
+
+  beforeEach(async () => {
+    const plugin = new WindowPlugin(ELECTRON_APP_MOCK, vi.fn());
+    await plugin.onReady();
+
+    expect(ELECTRON_APP_MOCK.on).toHaveBeenCalledOnce();
+
+    const mListener = vi.mocked(ELECTRON_APP_MOCK.on).mock.calls[0]?.[1];
+    assert(mListener);
+
+    listener = mListener;
+
+    vi.mocked(createNewWindow).mockClear();
+    vi.mocked(restoreWindow).mockClear();
+  });
+
+  test('activate listener should call createNewWindow', async () => {
+    expect(createNewWindow).not.toHaveBeenCalled();
+
+    listener(DUMMY_ELECTRON_EVENT, false);
+
+    expect(createNewWindow).toHaveBeenCalledOnce();
+  });
+
+  test('activate listener on MacOS should call restoreWindow', async () => {
+    vi.mocked(isMac).mockReturnValue(true);
+    expect(restoreWindow).not.toHaveBeenCalled();
+
+    listener(DUMMY_ELECTRON_EVENT, false);
+
+    expect(restoreWindow).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/main/src/plugin/app-ready/window-plugin.ts
+++ b/packages/main/src/plugin/app-ready/window-plugin.ts
@@ -1,0 +1,65 @@
+/*********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************/
+import type { App as ElectronApp, BrowserWindow } from 'electron';
+
+import { createNewWindow, restoreWindow } from '/@/mainWindow.js';
+import type { AppPlugin } from '/@/plugin/app-ready/app-plugin.js';
+import { isMac } from '/@/util.js';
+
+export class WindowPlugin implements AppPlugin {
+  constructor(
+    private readonly app: ElectronApp,
+    private readonly resolve: (window: BrowserWindow) => void,
+  ) {}
+
+  dispose(): void {}
+
+  async onReady(): Promise<void> {
+    // We must create the window first before initialization so that we can load the
+    // configuration as well as plugins
+    // The window is hiddenly created and shown when ready
+
+    // Platforms: Linux, macOS, Windows
+    // Create the main window
+    createNewWindow()
+      .then(this.resolve)
+      .catch((error: unknown) => {
+        console.error('Error creating window', error);
+      });
+
+    // Platforms: macOS
+    // Required for macOS to start the app correctly (this is will be shown in the dock)
+    // We use 'activate' within whenReady in order to gracefully start on macOS, see this link:
+    // https://www.electronjs.org/docs/latest/tutorial/quick-start#open-a-window-if-none-are-open-macos
+    this.app.on('activate', (_event, hasVisibleWindows) => {
+      createNewWindow()
+        .then(this.resolve)
+        .catch((error: unknown) => {
+          console.log('Error creating window', error);
+        });
+
+      // try to restore the window if it's not visible
+      // for example user click on the dock icon
+      if (isMac() && !hasVisibleWindows) {
+        restoreWindow().catch((error: unknown) => {
+          console.error('Error restoring window', error);
+        });
+      }
+    });
+  }
+}


### PR DESCRIPTION
### What does this PR do?

When the electron app is ready we call `createWindow`, and register an `activate` listener for MacOS. Following the work on https://github.com/podman-desktop/podman-desktop/pull/12905, creating a `WindowCreation` `AppPlugin` to handle this logic in a separate file.

I added tests for completeness.

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/13082

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
