### PR TITLE
fix: reconnect logger handler only once

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
@@ -729,16 +729,6 @@ test('Expect reconnectUI to be called only once', async () => {
     };
   });
 
-  vi.mock('@xterm/xterm', () => {
-    const writeMock = vi.fn();
-    return {
-      writeMock,
-      Terminal: vi
-        .fn()
-        .mockReturnValue({ loadAddon: vi.fn(), open: vi.fn(), write: writeMock, clear: vi.fn(), dispose: vi.fn() }),
-    };
-  });
-
   let providedKeyLogger: ((key: symbol, eventName: LoggerEventName, args: string[]) => void) | undefined;
   const callback = mockCallback(async keyLogger => {
     providedKeyLogger = keyLogger;

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
@@ -100,9 +100,10 @@ $effect(() => {
   if (!reconnectedUI && logsTerminal && loggerHandlerKey) {
     try {
       reconnectUI(loggerHandlerKey, getLoggerHandler());
-      reconnectedUI = true;
     } catch (error) {
       console.error('error while reconnecting', error);
+    } finally {
+      reconnectedUI = true;
     }
   }
 });

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
@@ -93,12 +93,14 @@ let contextsUnsubscribe: Unsubscriber;
 const buttonLabel = connectionInfo ? 'Update' : 'Create';
 const operationLabel = connectionInfo ? 'Update' : 'Creation';
 let loggerHandlerKey: symbol | undefined = undefined;
+let reconnectedUI: boolean = false;
 
 // reconnect the logger handler
 $effect(() => {
-  if (logsTerminal && loggerHandlerKey) {
+  if (!reconnectedUI && logsTerminal && loggerHandlerKey) {
     try {
       reconnectUI(loggerHandlerKey, getLoggerHandler());
+      reconnectedUI = true;
     } catch (error) {
       console.error('error while reconnecting', error);
     }


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR ensures that the reconnectUI function is called only once.
By using the `terminalLogs` value inside the effect block, any time some text is added to the terminal (especially from the reconnectUI function), the `terminalLogs` logs object is considered changed, and the effect block is executed, leading to unending logs.
Even using a derived value such as `let logsTerminalExists: boolean = $derived(logsTerminal !== undefined)` inside the effect (`if (logsTerminalExists && loggerHandlerKey)`), still leads to more and more logs as it depends on `logsTerminal`

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Fixes https://github.com/podman-desktop/podman-desktop/issues/12430

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

1. Create a RHEL VM or a Kind cluster and cancel the action before it's done
2. Exit the creation form page
3. Go back to the creation form page from the task manager by clicking on go to task >
4. Assert that there is only one copy of the logs and that nothing more is added

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
