### PR TITLE
chore: use noResolveAliases on mac for Electron showOpenDialog

### DIFF
--- a/packages/main/src/plugin/dialog-registry.spec.ts
+++ b/packages/main/src/plugin/dialog-registry.spec.ts
@@ -22,6 +22,9 @@ import path from 'node:path';
 import { type BrowserWindow, dialog } from 'electron';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
+import { Deferred } from '/@/plugin/util/deferred.js';
+
+import { isMac } from '../util.js';
 import { DialogRegistry } from './dialog-registry.js';
 import { Uri } from './types/uri.js';
 
@@ -79,10 +82,17 @@ const tmpMyPath = path.resolve(tmpdir(), 'my/path');
 
 describe('showOpenDialog', () => {
   beforeEach(() => {
+    vi.resetAllMocks();
     vi.mocked(dialog.showOpenDialog).mockResolvedValue({
       filePaths: [tmpMyPath],
       canceled: false,
     });
+  });
+
+  vi.mock('../util.js', () => {
+    return {
+      isMac: vi.fn().mockReturnValue(false),
+    };
   });
 
   // check opendialog is failing without browserwindow
@@ -149,6 +159,15 @@ describe('showOpenDialog', () => {
 
     // no result sent to browserWindow
     expect(fakeBrowserWindow.webContents.send).not.toHaveBeenCalled();
+  });
+
+  test('use noResolveAliases property on mac', async () => {
+    vi.mocked(isMac).mockReturnValue(true);
+    await dialogRegistry.openDialog();
+    expect(dialog.showOpenDialog).toHaveBeenCalledWith(
+      fakeBrowserWindow,
+      expect.objectContaining({ properties: ['openFile', 'noResolveAliases'] }),
+    );
   });
 });
 

--- a/packages/main/src/plugin/dialog-registry.spec.ts
+++ b/packages/main/src/plugin/dialog-registry.spec.ts
@@ -22,9 +22,8 @@ import path from 'node:path';
 import { type BrowserWindow, dialog } from 'electron';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { Deferred } from '/@/plugin/util/deferred.js';
+import { isMac } from '/@/util.js';
 
-import { isMac } from '../util.js';
 import { DialogRegistry } from './dialog-registry.js';
 import { Uri } from './types/uri.js';
 
@@ -89,7 +88,7 @@ describe('showOpenDialog', () => {
     });
   });
 
-  vi.mock('../util.js', () => {
+  vi.mock(import('/@/util.js'), () => {
     return {
       isMac: vi.fn().mockReturnValue(false),
     };

--- a/packages/main/src/plugin/dialog-registry.ts
+++ b/packages/main/src/plugin/dialog-registry.ts
@@ -21,7 +21,8 @@ import type { BrowserWindow } from 'electron';
 import { dialog } from 'electron';
 import { inject, injectable } from 'inversify';
 
-import { isMac } from '../util.js';
+import { isMac } from '/@/util.js';
+
 import { Uri } from './types/uri.js';
 
 /**

--- a/packages/main/src/plugin/dialog-registry.ts
+++ b/packages/main/src/plugin/dialog-registry.ts
@@ -21,6 +21,7 @@ import type { BrowserWindow } from 'electron';
 import { dialog } from 'electron';
 import { inject, injectable } from 'inversify';
 
+import { isMac } from '../util.js';
 import { Uri } from './types/uri.js';
 
 /**
@@ -70,7 +71,7 @@ export class DialogRegistry {
     // convert options into electron dialog options
     const electronOpenDialogOptions: Electron.OpenDialogOptions = {
       filters: options?.filters,
-      properties: selectors,
+      properties: isMac() ? [...selectors, 'noResolveAliases'] : selectors,
       defaultPath,
       title: options?.title,
       message: options?.title,


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Adds the option of noResolveAliases on mac when using Electron's showOpenDialog to prevent automatic symlink path resolution

### Screenshot / video of UI

https://github.com/user-attachments/assets/477154de-de23-4785-8f98-71135677d3a6



<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Fixes https://github.com/podman-desktop/podman-desktop/issues/12890

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
