### PR TITLE
fix: use correct regexp to set ELECTRON_CACHE env variable

### DIFF
--- a/.github/workflows/publish-flathub.yaml
+++ b/.github/workflows/publish-flathub.yaml
@@ -124,7 +124,7 @@ jobs:
           yq -i '(.modules[].sources[] | select(.url == "*podman-desktop*refs*tags*")) += {"url":strenv(PODMAN_DESKTOP_SOURCE_URL), "sha256":strenv(PODMAN_DESKTOP_SOURCE_SHASUM)}' io.podman_desktop.PodmanDesktop.yml
 
           # update the version of the cache for the env variable
-          sed -i -E "s|^(- export ELECTRON_CACHE=\").*(\")|\1\$(pwd)/${ELECTRON_CACHE_DIRECTORY}\2|" io.podman_desktop.PodmanDesktop.yml
+          sed -i -E 's|^( *- export ELECTRON_CACHE="\$\(\s*pwd\s*\)/)[^"]+|\1'"$ELECTRON_CACHE_DIRECTORY"'|' io.podman_desktop.PodmanDesktop.yml
 
         env:
           GITHUB_TOKEN: ${{ secrets.PODMAN_DESKTOP_BOT_TOKEN }}

--- a/.github/workflows/publish-flathub.yaml
+++ b/.github/workflows/publish-flathub.yaml
@@ -124,7 +124,7 @@ jobs:
           yq -i '(.modules[].sources[] | select(.url == "*podman-desktop*refs*tags*")) += {"url":strenv(PODMAN_DESKTOP_SOURCE_URL), "sha256":strenv(PODMAN_DESKTOP_SOURCE_SHASUM)}' io.podman_desktop.PodmanDesktop.yml
 
           # update the version of the cache for the env variable
-          sed -i -E 's|^( *- export ELECTRON_CACHE="\$\(\s*pwd\s*\)/)[^"]+|\1'"$ELECTRON_CACHE_DIRECTORY"'|' io.podman_desktop.PodmanDesktop.yml
+          sed -i -E 's|^( *- export ELECTRON_CACHE="\$\(\s*pwd\s*\)/)[^"]+(".*)|\1'"$ELECTRON_CACHE_DIRECTORY"'\2|' io.podman_desktop.PodmanDesktop.yml
 
         env:
           GITHUB_TOKEN: ${{ secrets.PODMAN_DESKTOP_BOT_TOKEN }}


### PR DESCRIPTION
### What does this PR do?

Update regexp pattern to correctly set ELECTRON_CACHE environment variable.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

fixes correct build of flathub packaging

### How to test this PR?

Make sure that in `io.podman_desktop.PodmanDesktop.yml` line:
```
- export ELECTRON_CACHE="$(pwd)/electron-cache/3823f8325b6228c0ad28ae147ee67c92fe61e3948351d195d7f8b92a19bbe1dd"
```

replaced with:
```
- export ELECTRON_CACHE="$(pwd)/electron-cache/28d2068055e57c7ab8dc09f3990794733bb7b675c612114cf4402d1e508431b8"
```

- [ ] Tests are covering the bug fix or the new feature
