### PR TITLE
fix: display an error to the user using uppercase in image name

### DIFF
--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
@@ -593,11 +593,11 @@ test('Expect error to be displayed if uppercase character in image name', async 
   setup();
   const { getByRole, getByLabelText, getByText } = render(BuildImageFromContainerfile, {});
 
-  const containerFilePath = screen.getByRole('textbox', { name: 'Containerfile path' });
+  const containerFilePath = getByRole('textbox', { name: 'Containerfile path' });
   expect(containerFilePath).toBeInTheDocument();
   await userEvent.type(containerFilePath, '/somepath/containerfile');
 
-  const buildFolder = screen.getByRole('textbox', { name: 'Build context directory' });
+  const buildFolder = getByRole('textbox', { name: 'Build context directory' });
   expect(buildFolder).toBeInTheDocument();
   await userEvent.type(buildFolder, '/somepath');
 

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
@@ -588,3 +588,31 @@ test('Expect build page to load a state for a build requested by taskId', async 
   expect(buildFolder).toHaveValue('/somepath');
   expect(containerImageName).toHaveValue('foobar');
 });
+
+test('Expect error to be displayed if uppercase character in image name', async () => {
+  setup();
+  const { getByRole, getByLabelText, getByText } = render(BuildImageFromContainerfile, {});
+
+  const containerFilePath = screen.getByRole('textbox', { name: 'Containerfile path' });
+  expect(containerFilePath).toBeInTheDocument();
+  await userEvent.type(containerFilePath, '/somepath/containerfile');
+
+  const buildFolder = screen.getByRole('textbox', { name: 'Build context directory' });
+  expect(buildFolder).toBeInTheDocument();
+  await userEvent.type(buildFolder, '/somepath');
+
+  // Get the input field by its associated label text
+  const imageNameInput = getByLabelText('Image name');
+
+  // Simulate user typing an image name with an uppercase character
+  await userEvent.type(imageNameInput, 'gpuTest');
+
+  // Check that the specific error message is now visible
+  const errorMessage = getByText('Image name should be lowercase');
+  expect(errorMessage).toBeInTheDocument();
+
+  // Verify the build button is still disabled
+  const buildButton = getByRole('button', { name: 'Build' });
+  expect(buildButton).toBeInTheDocument();
+  expect(buildButton).toBeDisabled();
+});

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
@@ -335,7 +335,7 @@ let hasInvalidFields = $derived(
     !buildImageInfo.containerBuildContextDirectory ||
     (platforms.length > 1 && !buildImageInfo.containerImageName) ||
     platforms.length === 0 ||
-    !errorContainerImageName ||
+    !!errorContainerImageName ||
     !selectedProvider,
 );
 </script>

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
@@ -324,19 +324,20 @@ $effect(() => {
   buildImageInfo.selectedProvider = selectedProvider;
 });
 
-let isImageNameLowercase = $derived(
-  buildImageInfo.containerImageName === buildImageInfo.containerImageName.toLowerCase(),
+let errorContainerImageName = $derived(
+  buildImageInfo.containerImageName === buildImageInfo.containerImageName.toLowerCase()
+    ? undefined
+    : 'Image name should be lowercase',
 );
+
 let hasInvalidFields = $derived(
   !buildImageInfo.containerFilePath ||
     !buildImageInfo.containerBuildContextDirectory ||
     (platforms.length > 1 && !buildImageInfo.containerImageName) ||
     platforms.length === 0 ||
-    !isImageNameLowercase ||
+    !errorContainerImageName ||
     !selectedProvider,
 );
-
-let errorContainerImageName = $derived(isImageNameLowercase ? undefined : 'Image name should be lowercase');
 </script>
 
 <EngineFormPage

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
@@ -379,7 +379,7 @@ let hasInvalidFields = $derived(
           name="containerImageName"
           id="containerImageName"
           placeholder="Image name (e.g. quay.io/namespace/my-custom-image)"
-          error={isImageNameLowercase ? void 0 : 'Image name should be lowercase'}
+          error={isImageNameLowercase ? undefined : 'Image name should be lowercase'}
           class="w-full" />
       </div>
 

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
@@ -335,6 +335,8 @@ let hasInvalidFields = $derived(
     !isImageNameLowercase ||
     !selectedProvider,
 );
+
+let errorContainerImageName = $derived(isImageNameLowercase ? undefined : 'Image name should be lowercase');
 </script>
 
 <EngineFormPage
@@ -379,7 +381,7 @@ let hasInvalidFields = $derived(
           name="containerImageName"
           id="containerImageName"
           placeholder="Image name (e.g. quay.io/namespace/my-custom-image)"
-          error={isImageNameLowercase ? undefined : 'Image name should be lowercase'}
+          error={errorContainerImageName}
           class="w-full" />
       </div>
 

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
@@ -323,11 +323,16 @@ $effect(() => {
   }
   buildImageInfo.selectedProvider = selectedProvider;
 });
+
+let isImageNameLowercase = $derived(
+  buildImageInfo.containerImageName === buildImageInfo.containerImageName.toLowerCase(),
+);
 let hasInvalidFields = $derived(
   !buildImageInfo.containerFilePath ||
     !buildImageInfo.containerBuildContextDirectory ||
     (platforms.length > 1 && !buildImageInfo.containerImageName) ||
     platforms.length === 0 ||
+    !isImageNameLowercase ||
     !selectedProvider,
 );
 </script>
@@ -374,6 +379,7 @@ let hasInvalidFields = $derived(
           name="containerImageName"
           id="containerImageName"
           placeholder="Image name (e.g. quay.io/namespace/my-custom-image)"
+          error={isImageNameLowercase ? void 0 : 'Image name should be lowercase'}
           class="w-full" />
       </div>
 


### PR DESCRIPTION

### What does this PR do?

Displays an error to the user using uppercase in image name

### Screenshot / video of UI

<img width="1162" alt="Screenshot 2025-07-08 at 11 17 12" src="https://github.com/user-attachments/assets/213920cf-dff3-4795-a3cc-6b0680618622" />


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes #10077

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
