### PR TITLE
feat: display local port and copy on click

### DIFF
--- a/packages/renderer/src/lib/kube/details/KubePort.spec.ts
+++ b/packages/renderer/src/lib/kube/details/KubePort.spec.ts
@@ -250,4 +250,33 @@ describe('port forwarding', () => {
       expect(error).toBeNull();
     });
   });
+
+  test('existing forward should display localhost port and copy', async () => {
+    const clipboardWriteTextMock = vi.fn().mockImplementation(() => {});
+    Object.defineProperty(window, 'clipboardWriteText', { value: clipboardWriteTextMock });
+    const { getByTitle, getByRole } = render(KubePort, {
+      namespace: 'dummy-ns',
+      port: {
+        displayValue: '80/TCP',
+        value: 80,
+        protocol: 'TCP',
+      },
+      forwardConfig: DUMMY_FORWARD_CONFIG,
+      resourceName: 'dummy-pod-name',
+      kind: WorkloadKind.POD,
+    });
+
+    const expected = 'http://localhost:55076';
+    const copySpan = getByTitle(expected);
+    expect(copySpan).toBeDefined();
+
+    const button = getByRole('button', { name: 'Copy To Clipboard' });
+
+    expect(button).toBeInTheDocument();
+    expect(button).toBeEnabled();
+
+    await fireEvent.click(button);
+
+    expect(clipboardWriteTextMock).toBeCalledWith(expected);
+  });
 });

--- a/packages/renderer/src/lib/kube/details/KubePort.svelte
+++ b/packages/renderer/src/lib/kube/details/KubePort.svelte
@@ -3,6 +3,7 @@ import { faQuestionCircle, faSquareUpRight, faTrash } from '@fortawesome/free-so
 import { Button, ErrorMessage, Tooltip } from '@podman-desktop/ui-svelte';
 import Fa from 'svelte-fa';
 
+import CopyToClipboard from '/@/lib/ui/CopyToClipboard.svelte';
 import type { ForwardConfig, PortMapping, WorkloadKind } from '/@api/kubernetes-port-forward-model';
 
 import type { KubePortInfo } from './kube-port';
@@ -50,9 +51,11 @@ async function onForwardRequest(port: KubePortInfo): Promise<void> {
   }
 }
 
+let localhostAddress = $derived(mapping ? `http://localhost:${mapping.localPort}` : undefined);
+
 async function openExternal(): Promise<void> {
-  if (!mapping) return;
-  return window.openExternal(`http://localhost:${mapping.localPort}`);
+  if (!localhostAddress) return;
+  return window.openExternal(localhostAddress);
 }
 
 async function removePortForward(): Promise<void> {
@@ -75,6 +78,19 @@ async function removePortForward(): Promise<void> {
 <span aria-label="port {port.value}" class="flex gap-x-2 items-center">
   {port.displayValue}
   {#if mapping}
+
+
+  {#if localhostAddress}
+
+  <CopyToClipboard
+  clipboardData={localhostAddress}
+  title={localhostAddress}
+  />
+  
+  {/if}
+ 
+    
+
     <Button
       title="Open in browser"
       disabled={loading}

--- a/packages/renderer/src/lib/kube/details/KubePort.svelte
+++ b/packages/renderer/src/lib/kube/details/KubePort.svelte
@@ -78,19 +78,9 @@ async function removePortForward(): Promise<void> {
 <span aria-label="port {port.value}" class="flex gap-x-2 items-center">
   {port.displayValue}
   {#if mapping}
-
-
-  {#if localhostAddress}
-
-  <CopyToClipboard
-  clipboardData={localhostAddress}
-  title={localhostAddress}
-  />
-  
-  {/if}
- 
-    
-
+    {#if localhostAddress}
+      <CopyToClipboard clipboardData={localhostAddress} title={localhostAddress} />
+    {/if}
     <Button
       title="Open in browser"
       disabled={loading}


### PR DESCRIPTION
### What does this PR do?

Displaying the localhost address with port, and make it copyable by clicking or pressing enter.

### Screenshot / video of UI

Port not forwarded:
<img width="1424" alt="Screenshot 2025-07-08 at 18 34 09" src="https://github.com/user-attachments/assets/ae9b6836-2a83-4d06-bcfc-561e0b0d00a5" />

Port forwarded now displays localhost address with a message on hover:
<img width="1459" alt="Screenshot 2025-07-08 at 18 58 06" src="https://github.com/user-attachments/assets/1de10723-6df7-4bfb-af0d-b101ab2e3f15" />

It copies the entire address : "http://localhost:PORT"


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes #10923 

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

You can apply for instance a k8s file like this https://gist.githubusercontent.com/sdenel/1bd2c8b5975393ababbcff9b57784e82/raw/f1b885349ba17cb2a81ca3899acc86c6ad150eb1/nginx-hello-world-deployment.yaml

with Kubernetes -> Apply YAML button.

Then open created Nginx pod. Under ports, click "Forward" for port 80.

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
