### PR TITLE
chore: update notice for azure code signing

### DIFF
--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -148,14 +148,10 @@ const config = {
       },
     ],
     /**
-     * TODO: replace with {@link import('electron-builder').Configuration#win#azureSignOptions}
-     * references:
-     * - https://www.electron.build/code-signing-win#using-azure-trusted-signing-beta
-     * - https://github.com/electron-userland/electron-builder/releases/tag/v26.0.0
-     * - https://github.com/electron-userland/electron-builder/pull/8582
+     * Use Azure Keyvault to sign the Windows binaries (using Digicert timestamp server and not Azure Trusted Signing).
      */
     signtoolOptions: {
-      sign: configuration => azureCodeSign(configuration.path),
+      sign: configuration => azureKeyvaultSign(configuration.path),
     },
   },
   flatpak: {
@@ -255,11 +251,11 @@ if (process.env.AIRGAP_DOWNLOAD) {
 }
 
 /**
- * @deprecated use {@link import('electron-builder').Configuration#win#azureSignOptions}
+ * Use a keyvault instance that has a certificate to sign the Windows binaries.
  * @param filePath
  * @return {Promise<void>}
  */
-const azureCodeSign = filePath => {
+const azureKeyvaultSign = filePath => {
   if (!process.env.AZURE_KEY_VAULT_URL) {
     console.log('Skipping code signing, no environment variables set for that.');
     return Promise.resolve();


### PR DESCRIPTION
### What does this PR do?
there is no plan to move away from Digicerts so method should not be deprecated

and keyvault != Trusted Signing so we can't use new electron builder methods


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/issues/12701

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
