### PR TITLE
fix: avoid jitter between 9-11%

### DIFF
--- a/packages/renderer/src/lib/task-manager/ProgressBar.svelte
+++ b/packages/renderer/src/lib/task-manager/ProgressBar.svelte
@@ -53,6 +53,6 @@ let { progress, width = 'w-36', height = 'h-4', class: className, ...restProps }
     {/if}
   </div>
   {#if progress !== undefined}
-    <div class="ml-2 text-xs">{Math.round(progress)}%</div>
+    <div class="ml-2 text-xs min-w-5">{Math.round(progress)}%</div>
   {/if}
 </div>


### PR DESCRIPTION
fix: avoid jitter between 9-11%

### What does this PR do?

### Screenshot / video of UI

The status bar was jittering between 9 and 11% before: 
<img width="838" alt="Screenshot 2025-07-09 at 17 34 50" src="https://github.com/user-attachments/assets/d8c8b42a-2f16-4a7f-9499-b92892165712" />

After:

<img width="869" alt="Screenshot 2025-07-09 at 18 30 20" src="https://github.com/user-attachments/assets/ba4eb73d-1fce-4e72-b8cf-3198d8ad1adc" />



<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes #11203 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

Change updater.ts to set a progress value manually and see the result. You also need to simulate a update available in the same file.

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
