### PR TITLE
fix(main): invalid electron-builder cache directory

### DIFF
--- a/packages/main/src/plugin/updater.spec.ts
+++ b/packages/main/src/plugin/updater.spec.ts
@@ -45,6 +45,7 @@ vi.mock('electron', () => ({
   app: {
     getVersion: vi.fn(),
     getPath: vi.fn(),
+    name: 'potatoes',
   },
   shell: {
     openExternal: vi.fn(),
@@ -988,7 +989,7 @@ describe('expect electron-updater cache folder is removed on update-not-availabl
   }
 
   test('on windows', () => {
-    const windowsCacheFolderPath = path.join('Users', 'user1', 'AppData', 'Local', 'podman-desktop-updater');
+    const windowsCacheFolderPath = path.join('Users', 'user1', 'AppData', 'Local');
     vi.spyOn(appAdapter, 'getAppCacheDir').mockReturnValue(windowsCacheFolderPath);
     mockPlatform('win32');
     const rmMock = vi.spyOn(fs, 'rm').mockResolvedValue(undefined);
@@ -998,14 +999,14 @@ describe('expect electron-updater cache folder is removed on update-not-availabl
 
     listener?.();
 
-    expect(rmMock).toBeCalledWith(windowsCacheFolderPath, {
+    expect(rmMock).toBeCalledWith(path.join(windowsCacheFolderPath, app.name), {
       recursive: true,
       force: true,
     });
   });
 
   test('on macOS', () => {
-    const macosCacheFolderPath = path.join('Users', 'user1', 'Library', 'Caches', 'podman-desktop-updater');
+    const macosCacheFolderPath = path.join('Users', 'user1', 'Library', 'Caches');
     vi.spyOn(appAdapter, 'getAppCacheDir').mockReturnValue(macosCacheFolderPath);
     mockPlatform('darwin');
     const rmMock = vi.spyOn(fs, 'rm').mockResolvedValue(undefined);
@@ -1015,7 +1016,7 @@ describe('expect electron-updater cache folder is removed on update-not-availabl
 
     listener?.();
 
-    expect(rmMock).toBeCalledWith(macosCacheFolderPath, {
+    expect(rmMock).toBeCalledWith(path.join(macosCacheFolderPath, app.name), {
       recursive: true,
       force: true,
     });

--- a/packages/main/src/plugin/updater.ts
+++ b/packages/main/src/plugin/updater.ts
@@ -365,6 +365,7 @@ export class Updater {
     // Remove the Electron updater cache folder
     if (isWindows() || isMac()) {
       const cacheDir = join(getAppCacheDir(), app.name);
+      console.warn('Deleting electron-updater cache folder: ', cacheDir);
       fs.rm(cacheDir, { recursive: true, force: true })
         .then(() => console.info(`Electron updater cache folder deleted: ${cacheDir}`))
         .catch((error: unknown) => console.error(`Error deleting Electron updater cache folder ${cacheDir}: ${error}`));

--- a/packages/main/src/plugin/updater.ts
+++ b/packages/main/src/plugin/updater.ts
@@ -18,6 +18,7 @@
 
 import * as fs from 'node:fs/promises';
 import * as https from 'node:https';
+import { join } from 'node:path';
 
 import { app, shell } from 'electron';
 import {
@@ -363,7 +364,7 @@ export class Updater {
 
     // Remove the Electron updater cache folder
     if (isWindows() || isMac()) {
-      const cacheDir = getAppCacheDir();
+      const cacheDir = join(getAppCacheDir(), app.name);
       fs.rm(cacheDir, { recursive: true, force: true })
         .then(() => console.info(`Electron updater cache folder deleted: ${cacheDir}`))
         .catch((error: unknown) => console.error(`Error deleting Electron updater cache folder ${cacheDir}: ${error}`));


### PR DESCRIPTION
### What does this PR do?

In https://github.com/podman-desktop/podman-desktop/pull/12870/ has been introduced the abilities to delete electron-update cache folder. However, the folder used was the wrong one.

We use `getAppCacheDir` from `electron-updater/out/AppAdapter.js`, but this function **does not** return the real cache dir, but return the parent of the cache dir, we need to concat with the app name.

We can see in [electron-userland/electron-builder#packages/electron-updater/src/AppUpdater.ts#L699](https://github.com/electron-userland/electron-builder/blob/6cc5d2ee45250aae4a05872ae5b800a9e5cca939/packages/electron-updater/src/AppUpdater.ts#L699) how `getAppCacheDir` is used.

I added a console.warn as recommended by @odockal in https://github.com/podman-desktop/podman-desktop/issues/13150#issuecomment-3057853364

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/13150

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
