### PR TITLE
fix(extensions/podman): avoid infinite loop when deactivating extension

### DIFF
--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -2712,15 +2712,7 @@ test('activate function returns an api implementation', async () => {
   vi.spyOn(PodmanInstall.prototype, 'checkForUpdate').mockResolvedValue({
     hasUpdate: false,
   } as unknown as UpdateCheck);
-  const contextMock = {
-    subscriptions: [],
-    secrets: {
-      delete: vi.fn(),
-      get: vi.fn(),
-      onDidChange: vi.fn(),
-      store: vi.fn(),
-    },
-  } as unknown as extensionApi.ExtensionContext;
+  const contextMock = getContextMock();
   const api = await extension.activate(contextMock);
   expect(api).toBeDefined();
   expect(typeof api.exec).toBe('function');
@@ -2730,15 +2722,7 @@ function mockExtensionForAuditTests() {
   vi.spyOn(PodmanInstall.prototype, 'checkForUpdate').mockResolvedValue({
     hasUpdate: false,
   } as unknown as UpdateCheck);
-  const contextMock = {
-    subscriptions: [],
-    secrets: {
-      delete: vi.fn(),
-      get: vi.fn(),
-      onDidChange: vi.fn(),
-      store: vi.fn(),
-    },
-  } as unknown as extensionApi.ExtensionContext;
+  const contextMock = getContextMock();
   vi.spyOn(provider, 'setContainerProviderConnectionFactory');
   return contextMock;
 }
@@ -2775,16 +2759,7 @@ test('activate on mac register commands for setting compatibility moide ', async
   vi.spyOn(PodmanInstall.prototype, 'checkForUpdate').mockResolvedValue({
     hasUpdate: false,
   } as unknown as UpdateCheck);
-  const contextMock = {
-    subscriptions: [],
-    secrets: {
-      delete: vi.fn(),
-      get: vi.fn(),
-      onDidChange: vi.fn(),
-      store: vi.fn(),
-    },
-  } as unknown as extensionApi.ExtensionContext;
-
+  const contextMock = getContextMock();
   // mock getSocketCompatibility
   const disableMock = vi.fn();
   const enableMock = vi.fn();
@@ -3239,15 +3214,7 @@ test('activate and autostart should not duplicate machines ', async () => {
   vi.spyOn(PodmanInstall.prototype, 'checkForUpdate').mockResolvedValue({
     hasUpdate: false,
   } as unknown as UpdateCheck);
-  const contextMock = {
-    subscriptions: [],
-    secrets: {
-      delete: vi.fn(),
-      get: vi.fn(),
-      onDidChange: vi.fn(),
-      store: vi.fn(),
-    },
-  } as unknown as extensionApi.ExtensionContext;
+  const contextMock = getContextMock();
 
   // mock getSocketCompatibility
   const disableMock = vi.fn();
@@ -3320,15 +3287,7 @@ describe('macOS: tests for notifying if disguised podman socket fails / passes',
   let contextMock: extensionApi.ExtensionContext;
 
   beforeEach(() => {
-    contextMock = {
-      subscriptions: [],
-      secrets: {
-        delete: vi.fn(),
-        get: vi.fn(),
-        onDidChange: vi.fn(),
-        store: vi.fn(),
-      },
-    } as unknown as extensionApi.ExtensionContext;
+    contextMock = getContextMock();
 
     // Mock the get compatibility functionality.
     // we will always assuming it's "disabled" for the tests
@@ -3459,15 +3418,7 @@ describe('podman-mac-helper tests', () => {
     vi.mocked(extensionApi.env).isLinux = false;
 
     // Mock the context
-    contextMock = {
-      subscriptions: [],
-      secrets: {
-        delete: vi.fn(),
-        get: vi.fn(),
-        onDidChange: vi.fn(),
-        store: vi.fn(),
-      },
-    } as unknown as extensionApi.ExtensionContext;
+    contextMock = getContextMock();
 
     // Mock the get compatibility functionality.
     // we just assume that it's false / not enabled by default to test the functionality.

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -3555,6 +3555,7 @@ describe('Check notify podman setup', () => {
 
 describe('monitorProvider', () => {
   test('should run the monitoring loop once and then stop correctly', async () => {
+    vi.resetAllMocks();
     vi.useFakeTimers();
 
     const contextMock = getContextMock();

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -3304,16 +3304,15 @@ test('activate and autostart should not duplicate machines ', async () => {
   vi.useFakeTimers();
 
   const promises = Array.from({ length: 100 }).map(() => extension.monitorMachines(provider, podmanConfiguration));
+  vi.useFakeTimers();
+
+  const promises = Array.from({ length: 100 }).map(() => extension.monitorMachines(provider, podmanConfiguration));
 
   await promiseAutoStart;
 
   // should be only 1 but we allow some more calls (if there is not a check to check during the autostart it would be 100+ calls)
   expect(podmanMachineListCalls).toBeLessThan(5);
   expect(promiseAutoStart).toBeDefined();
-
-  await vi.advanceTimersByTimeAsync(5000);
-
-  await Promise.allSettled(promises);
 });
 
 describe('macOS: tests for notifying if disguised podman socket fails / passes', () => {

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -3555,8 +3555,8 @@ describe('Check notify podman setup', () => {
 
 describe('monitorProvider', () => {
   test('should run the monitoring loop once and then stop correctly', async () => {
-    vi.resetAllMocks();
-    await extension.deactivate();
+    const mockDoMonitorProvider = vi.fn().mockResolvedValue(undefined);
+
     vi.useFakeTimers();
 
     const contextMock = getContextMock();
@@ -3564,16 +3564,21 @@ describe('monitorProvider', () => {
 
     // Start the monitor. DO NOT await it, since it's a "never-ending" loop.
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    extension.monitorProvider(provider);
+    extension.monitorProvider(provider, mockDoMonitorProvider);
 
-    expect(extensionApi.process.exec).toHaveBeenCalledTimes(3);
+    expect(mockDoMonitorProvider).toHaveBeenCalledTimes(1);
 
     await vi.advanceTimersByTimeAsync(8000);
+
+    expect(mockDoMonitorProvider).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(8000);
+    expect(mockDoMonitorProvider).toHaveBeenCalledTimes(3);
 
     await extension.deactivate();
 
     await vi.runAllTimersAsync();
-    expect(extensionApi.process.exec).toHaveBeenCalledTimes(4);
+    expect(mockDoMonitorProvider).toHaveBeenCalledTimes(3);
   });
 });
 

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -3556,6 +3556,7 @@ describe('Check notify podman setup', () => {
 describe('monitorProvider', () => {
   test('should run the monitoring loop once and then stop correctly', async () => {
     vi.resetAllMocks();
+    await extension.deactivate();
     vi.useFakeTimers();
 
     const contextMock = getContextMock();

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -196,6 +196,7 @@ beforeEach(() => {
       VMType: 'wsl',
     },
   };
+  vi.resetAllMocks();
   extension.resetShouldNotifySetup();
   (extensionApi.env.createTelemetryLogger as Mock).mockReturnValue(telemetryLogger);
   vi.mocked(fs).readFile.mockImplementation(
@@ -384,7 +385,6 @@ afterEach(async () => {
   console.error = originalConsoleError;
   await extension.deactivate();
   vi.useRealTimers();
-  vi.resetAllMocks();
 });
 
 describe.each([

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -3304,15 +3304,16 @@ test('activate and autostart should not duplicate machines ', async () => {
   vi.useFakeTimers();
 
   const promises = Array.from({ length: 100 }).map(() => extension.monitorMachines(provider, podmanConfiguration));
-  vi.useFakeTimers();
-
-  const promises = Array.from({ length: 100 }).map(() => extension.monitorMachines(provider, podmanConfiguration));
 
   await promiseAutoStart;
 
   // should be only 1 but we allow some more calls (if there is not a check to check during the autostart it would be 100+ calls)
   expect(podmanMachineListCalls).toBeLessThan(5);
   expect(promiseAutoStart).toBeDefined();
+
+  await vi.advanceTimersByTimeAsync(5000);
+
+  await Promise.allSettled(promises);
 });
 
 describe('macOS: tests for notifying if disguised podman socket fails / passes', () => {

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -705,11 +705,11 @@ async function monitorProvider(provider: extensionApi.Provider): Promise<void> {
   // call us again
   if (!stopLoop) {
     await doMonitorProvider(provider);
+    await timeout(8000);
+    monitorProvider(provider).catch((error: unknown) => {
+      console.error('Error monitoring podman provider', error);
+    });
   }
-  await timeout(8000);
-  monitorProvider(provider).catch((error: unknown) => {
-    console.error('Error monitoring podman provider', error);
-  });
 }
 
 export async function doMonitorProvider(provider: extensionApi.Provider): Promise<void> {

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -701,7 +701,7 @@ function shouldNotifyQemuMachinesWithV5(installedPodman: InstalledPodman): boole
   return false;
 }
 
-async function monitorProvider(provider: extensionApi.Provider): Promise<void> {
+export async function monitorProvider(provider: extensionApi.Provider): Promise<void> {
   // call us again
   if (!stopLoop) {
     await doMonitorProvider(provider);

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -701,12 +701,15 @@ function shouldNotifyQemuMachinesWithV5(installedPodman: InstalledPodman): boole
   return false;
 }
 
-export async function monitorProvider(provider: extensionApi.Provider): Promise<void> {
+export async function monitorProvider(
+  provider: extensionApi.Provider,
+  monitorAction: (provider: extensionApi.Provider) => Promise<void>,
+): Promise<void> {
   // call us again
   if (!stopLoop) {
-    await doMonitorProvider(provider);
+    await monitorAction(provider);
     await timeout(8000);
-    monitorProvider(provider).catch((error: unknown) => {
+    monitorProvider(provider, monitorAction).catch((error: unknown) => {
       console.error('Error monitoring podman provider', error);
     });
   }
@@ -1642,7 +1645,7 @@ export async function start(
 
   // monitor provider
   // like version, checks, warnings
-  monitorProvider(provider).catch((error: unknown) => {
+  monitorProvider(provider, doMonitorProvider).catch((error: unknown) => {
     console.error('Error while monitoring provider', error);
   });
 


### PR DESCRIPTION
### What does this PR do?

It breaks the loop when deactivating the podman extension to avoid infinite loop. 

Like in docker extension:

<img width="836" height="587" alt="Screenshot 2025-07-10 at 17 46 26" src="https://github.com/user-attachments/assets/0da9ab98-b012-418e-a99e-ca03132bef3a" />


### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/13149

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

I added a test and check that it was in error with the infinite loop if reverting the code of this PR.
- [ ] Tests are covering the bug fix or the new feature
