### PR TITLE
chore: add markdown support for parsing HTML entities and podman-desktop:// links

### DIFF
--- a/packages/renderer/src/lib/markdown/Markdown.spec.ts
+++ b/packages/renderer/src/lib/markdown/Markdown.spec.ts
@@ -123,6 +123,13 @@ describe('Custom link', () => {
       '<a data-command="example.onboarding.command.checkRequirements">Name of the link</a>',
     );
   });
+
+  test('expect a tags to be renderer as working links', async () => {
+    await waitRender({ markdown: '- **important info**: some more info. <a href="/some/link">click here to test</a>' });
+    const markdownContent = screen.getByRole('region', { name: 'markdown-content' });
+    expect(markdownContent).toBeInTheDocument();
+    expect(markdownContent).toContainHTML('<a href="/some/link">click here to test</a>');
+  });
 });
 
 describe('Custom warnings', () => {

--- a/packages/renderer/src/lib/markdown/Markdown.svelte
+++ b/packages/renderer/src/lib/markdown/Markdown.svelte
@@ -81,6 +81,12 @@ $: markdown
     }))
   : undefined;
 
+function decode(htmlString: string): string {
+  let textArea = document.createElement('textarea');
+  textArea.innerHTML = htmlString;
+  return textArea.value;
+}
+
 onMount(() => {
   if (markdown) {
     text = markdown;
@@ -95,7 +101,7 @@ onMount(() => {
   // remove href values in each anchor using # for links
   // and set the attribute data-pd-jump-in-page
   const parser = new DOMParser();
-  const doc = parser.parseFromString(html, 'text/html');
+  const doc = parser.parseFromString(decode(html), 'text/html');
   const links = doc.querySelectorAll('a');
   links.forEach(link => {
     const currentHref = link.getAttribute('href');
@@ -112,6 +118,10 @@ onMount(() => {
 
       // add a class for cursor
       link.classList.add('cursor-pointer');
+    } else if (link.getAttribute('href')?.startsWith('podman-desktop://')) {
+      let internalLink = '';
+      internalLink = link.getAttribute('href')?.replace('podman-desktop://', '/') ?? '';
+      link.setAttribute('href', internalLink);
     }
   });
 


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR adds support to correctly decode HTML entities is markdown strings like `<a></a>` and update.`podman-desktop://` links so that they could be used inside the app.
Should be checked and merged after https://github.com/podman-desktop/podman-desktop/pull/12809

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/podman-desktop/issues/11851

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

1. In packages/main/src/plugin/updater.ts, change `${rootPackage.homepage}/release-notes/${urlVersionFormat}.json` to `http://localhost:3000/release-notes/1.20.json` in line 118.
2. Build Podman Desktop locally and make sure that the app build is working
3. In `website/blog/2025-05-22-release-1.20.md`, add in the first bullet point `<a href="podman-desktop://preferences/experimental">click here to test</a>`
4. Run the website locally
6. Clicking on the link in the 1.20 release notes in the website should open the app (once https://github.com/podman-desktop/podman-desktop/pull/12809 is merged, it should direct the user the the experimental features page) and in the release notes banner in the app (with `pnpm watch`) it should open the experimental features page.

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
