### PR TITLE
feat: update notification style on dashboard

### DIFF
--- a/packages/renderer/src/lib/dashboard/NotificationCardItem.spec.ts
+++ b/packages/renderer/src/lib/dashboard/NotificationCardItem.spec.ts
@@ -17,6 +17,7 @@
  ***********************************************************************/
 import '@testing-library/jest-dom/vitest';
 
+import { faCircleExclamation, faCircleInfo, faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { beforeAll, expect, test, vi } from 'vitest';
 
@@ -55,4 +56,70 @@ test('Expect notification card to show notification title, description and close
   await fireEvent.click(deleteButton);
 
   expect(removeNotificationMock).toBeCalled();
+});
+
+test('Test info notification style and icon', () => {
+  const notification: NotificationCard = {
+    id: 1,
+    extensionId: 'extension',
+    title: 'Info notification title',
+    body: 'Info notification description',
+    type: 'info',
+  };
+  const { getAllByRole } = render(NotificationCardItem, {
+    notification,
+  });
+  const icon = getAllByRole('img', { hidden: true })[0];
+  // check icon shape
+  const pdIconPath = icon.querySelector('path')?.getAttribute('d');
+  const faIconPath = faCircleInfo.icon[4]; // index 4 is the actual path as per FA IconDefinition
+  expect(pdIconPath).toBe(faIconPath);
+  // check icon color
+  expect(icon).toHaveClass('text-[var(--pd-state-info)]');
+  // check region top border
+  expect(screen.getByRole('region', { name: 'id: 1' })).toHaveClass('border-[var(--pd-state-info)]');
+});
+
+test('Test warning notification style and icon', () => {
+  const notification: NotificationCard = {
+    id: 1,
+    extensionId: 'extension',
+    title: 'Warning notification title',
+    body: 'Warning notification description',
+    type: 'warn',
+  };
+  const { getAllByRole } = render(NotificationCardItem, {
+    notification,
+  });
+  const icon = getAllByRole('img', { hidden: true })[0];
+  // check icon shape
+  const pdIconPath = icon.querySelector('path')?.getAttribute('d');
+  const faIconPath = faExclamationTriangle.icon[4]; // index 4 is the actual path as per FA IconDefinition
+  expect(pdIconPath).toBe(faIconPath);
+  // check icon color
+  expect(icon).toHaveClass('text-[var(--pd-state-warning)]');
+  // check region top border
+  expect(screen.getByRole('region', { name: 'id: 1' })).toHaveClass('border-[var(--pd-state-warning)]');
+});
+
+test('Test error notification style and icon', () => {
+  const notification: NotificationCard = {
+    id: 1,
+    extensionId: 'extension',
+    title: 'Error notification title',
+    body: 'Error notification description',
+    type: 'error',
+  };
+  const { getAllByRole } = render(NotificationCardItem, {
+    notification,
+  });
+  const icon = getAllByRole('img', { hidden: true })[0];
+  // check icon shape
+  const pdIconPath = icon.querySelector('path')?.getAttribute('d');
+  const faIconPath = faCircleExclamation.icon[4]; // index 4 is the actual path as per FA IconDefinition
+  expect(pdIconPath).toBe(faIconPath);
+  // check icon color
+  expect(icon).toHaveClass('text-[var(--pd-state-error)]');
+  // check region top border
+  expect(screen.getByRole('region', { name: 'id: 1' })).toHaveClass('border-[var(--pd-state-error)]');
 });

--- a/packages/renderer/src/lib/dashboard/NotificationCardItem.svelte
+++ b/packages/renderer/src/lib/dashboard/NotificationCardItem.svelte
@@ -8,10 +8,6 @@ import Markdown from '../markdown/Markdown.svelte';
 
 export let notification: NotificationCard;
 
-async function removeNotification(id: number): Promise<void> {
-  await window.removeNotification(id);
-}
-
 const notificationStyleMap = {
   info: {
     borderColor: 'border-[var(--pd-state-info)]',
@@ -61,7 +57,7 @@ const notificationStyle = notificationStyleMap[notification.type];
     <div class="text-[var(--pd-content-card-carousel-card-header-text)]">
       <button
         class="p-1 hover:bg-[var(--pd-button-close-hover-bg)] hover:bg-opacity-10 transition-all rounded-[4px]"
-        on:click={(): Promise<void> => removeNotification(notification.id)}
+        on:click={(): Promise<void> => window.removeNotification(notification.id)}
         aria-label={`Delete notification ${notification.id}`}>
         <Icon icon={faXmark} />
       </button>

--- a/packages/renderer/src/lib/dashboard/NotificationCardItem.svelte
+++ b/packages/renderer/src/lib/dashboard/NotificationCardItem.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-import { faCircleInfo, faXmark } from '@fortawesome/free-solid-svg-icons';
-import Fa from 'svelte-fa';
+import { faCircleExclamation, faCircleInfo, faExclamationTriangle, faXmark } from '@fortawesome/free-solid-svg-icons';
+import { Icon } from '@podman-desktop/ui-svelte/icons';
 
 import type { NotificationCard } from '/@api/notification';
 
@@ -11,35 +11,60 @@ export let notification: NotificationCard;
 async function removeNotification(id: number): Promise<void> {
   await window.removeNotification(id);
 }
+
+const notificationStyleMap = {
+  info: {
+    borderColor: 'border-[var(--pd-state-info)]',
+    iconColor: 'text-[var(--pd-state-info)]',
+    icon: faCircleInfo,
+  },
+  warn: {
+    borderColor: 'border-[var(--pd-state-warning)]',
+    iconColor: 'text-[var(--pd-state-warning)]',
+    icon: faExclamationTriangle,
+  },
+  error: {
+    borderColor: 'border-[var(--pd-state-error)]',
+    iconColor: 'text-[var(--pd-state-error)]',
+    icon: faCircleExclamation,
+  },
+};
+
+const notificationStyle = notificationStyleMap[notification.type];
 </script>
 
 <div
-  class="relative bg-[var(--pd-content-card-carousel-card-bg)] w-full py-4 px-5 rounded-md"
+  class="bg-[var(--pd-content-card-bg)] text-[var(--pd-content-card-text)] p-4 w-full {notificationStyle.borderColor} border-t-[3px]"
   role="region"
   aria-label="id: {notification.id}">
-  <div class="flex flex-row">
-    <div class="mr-3">
-      {#if notification.type === 'info'}
-        <Fa size="1.5x" class="text-[var(--pd-notification-dot)]" icon={faCircleInfo} />
+  <div class="flex flex-row space-x-3">
+    <div class="flex">
+        <Icon size="1.5x" icon={notificationStyle.icon} class={notificationStyle.iconColor} />
+    </div>
+    <div class="flex flex-col space-y-2 flex-1">
+      <div class="flex flex-row items-center justify-between">
+        <span class="font-medium" aria-label="Notification title">
+          {notification.title}
+        </span>
+      </div>
+      {#if notification.body}
+        <span aria-label="Notification description">
+          <Markdown markdown={notification.body} />
+        </span>
       {/if}
     </div>
-    <div class="flex flex-col space-y-2">
-      <div class="text-[var(--pd-content-card-carousel-card-header-text)] font-bold" aria-label="Notification title">
-        {notification.title}
+    {#if notification.markdownActions}
+      <div class="flex mt-2 self-center">
+        <Markdown markdown={notification.markdownActions} />
       </div>
-      <div class="text-[var(--pd-content-card-carousel-card-text)]" aria-label="Notification description">
-        <Markdown markdown={notification.body ?? ''} />
-      </div>
+    {/if}
+    <div class="text-[var(--pd-content-card-carousel-card-header-text)]">
+      <button
+        class="p-1 hover:bg-[var(--pd-button-close-hover-bg)] hover:bg-opacity-10 transition-all rounded-[4px]"
+        on:click={(): Promise<void> => removeNotification(notification.id)}
+        aria-label={`Delete notification ${notification.id}`}>
+        <Icon icon={faXmark} />
+      </button>
     </div>
-  </div>
-  {#if notification.markdownActions}
-    <div class="w-full flex justify-center mt-2">
-      <Markdown markdown={notification.markdownActions} />
-    </div>
-  {/if}
-  <div class="absolute top-2 right-2 text-[var(--pd-content-card-carousel-card-header-text)]">
-    <button on:click={(): Promise<void> => removeNotification(notification.id)} aria-label={`Delete notification ${notification.id}`}>
-      <Fa size="1x" icon={faXmark} />
-    </button>
   </div>
 </div>

--- a/packages/renderer/src/lib/dashboard/NotificationsBox.svelte
+++ b/packages/renderer/src/lib/dashboard/NotificationsBox.svelte
@@ -25,12 +25,12 @@ onDestroy(() => {
 </script>
 
 {#if notifications.length > 0}
-  <div class="bg-[var(--pd-content-card-bg)] m-5 px-5 py-4 rounded-lg">
-    <div class="flex flex-col items-center justify-content space-y-3" role="region" aria-label="Notifications Box">
-      <span class="text-[var(--pd-content-card-header-text)] text-lg font-semibold self-start mb-1">Notifications</span>
-      {#each notifications as notification (notification.id)}
-        <NotificationCardItem notification={notification} />
-      {/each}
-    </div>
+  <div
+    class="flex flex-col items-center justify-content space-y-3 my-5 px-5"
+    role="region"
+    aria-label="Notifications Box">
+    {#each notifications as notification (notification.id)}
+      <NotificationCardItem {notification} />
+    {/each}
   </div>
 {/if}

--- a/packages/renderer/src/lib/markdown/Markdown.spec.ts
+++ b/packages/renderer/src/lib/markdown/Markdown.spec.ts
@@ -53,7 +53,7 @@ describe('Custom button', () => {
     const markdownContent = screen.getByRole('region', { name: 'markdown-content' });
     expect(markdownContent).toBeInTheDocument();
     expect(markdownContent).toContainHTML(
-      '<a class="px-4 py-[6px] rounded-[4px] text-white! text-[13px] whitespace-nowrap bg-purple-600 hover:bg-purple-500 no-underline!">Name of the button</a>',
+      '<a class="px-4 py-[6px] rounded-[4px] text-white! text-[13px] whitespace-nowrap bg-purple-600 hover:bg-purple-500! no-underline!">Name of the button</a>',
     );
   });
 

--- a/packages/renderer/src/lib/markdown/micromark-button-directive.ts
+++ b/packages/renderer/src/lib/markdown/micromark-button-directive.ts
@@ -72,7 +72,7 @@ export function button(d: Directive): void {
   } else {
     // If href is passed in, make this an anchor tag but make it look like a button
     this.tag(
-      '<a class="px-4 py-[6px] rounded-[4px] text-white! text-[13px] whitespace-nowrap bg-purple-600 hover:bg-purple-500 no-underline!"',
+      '<a class="px-4 py-[6px] rounded-[4px] text-white! text-[13px] whitespace-nowrap bg-purple-600 hover:bg-purple-500! no-underline!"',
     );
 
     // Href & title


### PR DESCRIPTION
### What does this PR do?
Implements new design of notifications on dashboard for consistency reasons.
Implements notification variant of info, warn and error.

Before:
<img width="1435" height="363" alt="image" src="https://github.com/user-attachments/assets/8cad6b96-dade-416c-a3cb-1b6f52e4f28e" />
After:
<img width="1433" height="269" alt="image" src="https://github.com/user-attachments/assets/2fc09328-a0f8-48df-b188-938eb18a2470" />

### How to test this PR?
To test all notification types, I'd recommend crafting custom 

Info, warn and error look like following:
<img width="2057" height="822" alt="image" src="https://github.com/user-attachments/assets/35dc72dc-d7e9-494b-9d84-4a0f20733d9e" />

- [x] Tests are covering the bug fix or the new feature


Closes https://github.com/podman-desktop/podman-desktop/issues/13106
