### PR TITLE
refactor: centralized tasks statusbar

### DIFF
--- a/packages/main/src/plugin/tasks/task-manager.spec.ts
+++ b/packages/main/src/plugin/tasks/task-manager.spec.ts
@@ -90,9 +90,8 @@ test('task manager init should register a configuration option', async () => {
       expect.objectContaining({
         properties: expect.objectContaining({
           'tasks.StatusBar': {
-            type: 'boolean',
+            type: 'object',
             description: 'Show running tasks in the status bar',
-            default: false,
             experimental: {
               githubDiscussionLink: expect.stringContaining('github.com/podman-desktop/podman-desktop/discussions'),
             },

--- a/packages/main/src/plugin/tasks/task-manager.ts
+++ b/packages/main/src/plugin/tasks/task-manager.ts
@@ -72,8 +72,7 @@ export class TaskManager {
         properties: {
           [`${ExperimentalTasksSettings.SectionName}.${ExperimentalTasksSettings.StatusBar}`]: {
             description: 'Show running tasks in the status bar',
-            type: 'boolean',
-            default: false,
+            type: 'object',
             experimental: {
               githubDiscussionLink: 'https://github.com/podman-desktop/podman-desktop/discussions/10777',
             },

--- a/packages/renderer/src/lib/statusbar/StatusBar.svelte
+++ b/packages/renderer/src/lib/statusbar/StatusBar.svelte
@@ -65,10 +65,9 @@ onMount(async () => {
       });
   });
 
-  experimentalTaskStatusBar =
-    (await window.getConfigurationValue<boolean>(
-      `${ExperimentalTasksSettings.SectionName}.${ExperimentalTasksSettings.StatusBar}`,
-    )) ?? false;
+  experimentalTaskStatusBar = await window.isExperimentalConfigurationEnabled(
+    `${ExperimentalTasksSettings.SectionName}.${ExperimentalTasksSettings.StatusBar}`,
+  );
 
   experimentalProvidersStatusBar =
     (await window.getConfigurationValue<boolean>('statusbarProviders.showProviders')) ?? false;


### PR DESCRIPTION
### What does this PR do?
Changes logic from storing boolean value to object/undefined for experimental features, uses new experimental configuration manager https://github.com/podman-desktop/podman-desktop/pull/13316

More info in https://github.com/podman-desktop/podman-desktop/issues/13095

### Screenshot / video of UI


### What issues does this PR fix or reference?
Closes #13202


THOSE PRs MUST be merged together:
https://github.com/podman-desktop/podman-desktop/pull/13225
https://github.com/podman-desktop/podman-desktop/pull/13224
https://github.com/podman-desktop/podman-desktop/pull/13223
https://github.com/podman-desktop/podman-desktop/pull/13226
https://github.com/podman-desktop/podman-desktop/pull/13227

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
