### PR TITLE
refactor: centralized kubernetes experimental

### DIFF
--- a/packages/main/src/plugin/kubernetes/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.ts
@@ -238,8 +238,7 @@ export class KubernetesClient {
         },
         ['kubernetes.statesExperimental']: {
           description: 'Use new version of Kubernetes contexts monitoring (needs restart)',
-          type: 'boolean',
-          default: false,
+          type: 'object',
           experimental: {
             githubDiscussionLink: 'https://github.com/podman-desktop/podman-desktop/discussions/11424',
           },

--- a/packages/renderer/src/lib/kube/NamespaceDropdown.svelte
+++ b/packages/renderer/src/lib/kube/NamespaceDropdown.svelte
@@ -9,7 +9,7 @@ let isExperimental: boolean = $state(false);
 
 onMount(async () => {
   try {
-    isExperimental = (await window.getConfigurationValue<boolean>('kubernetes.statesExperimental')) ?? false;
+    isExperimental = await window.isExperimentalConfigurationEnabled('kubernetes.statesExperimental');
   } catch {
     // keep default value
   }

--- a/packages/renderer/src/lib/kube/active-resources-count-listen.spec.ts
+++ b/packages/renderer/src/lib/kube/active-resources-count-listen.spec.ts
@@ -55,7 +55,7 @@ test('listenActiveResourcesCount is undefined in non experimental mode (setting 
 
 describe('experimental mode is set', () => {
   beforeEach(() => {
-    vi.mocked(window.getConfigurationValue<boolean>).mockResolvedValue(true);
+    vi.mocked(window.isExperimentalConfigurationEnabled).mockResolvedValue(true);
   });
 
   test('get initial and updated values', async () => {

--- a/packages/renderer/src/lib/kube/active-resources-count-listen.ts
+++ b/packages/renderer/src/lib/kube/active-resources-count-listen.ts
@@ -53,7 +53,7 @@ function collectAndSendCount(callback: (activeResourcesCount: ResourceCount[]) =
 
 export async function isKubernetesExperimentalMode(): Promise<boolean> {
   try {
-    return (await window.getConfigurationValue<boolean>('kubernetes.statesExperimental')) ?? false;
+    return await window.isExperimentalConfigurationEnabled('kubernetes.statesExperimental');
   } catch {
     return false;
   }

--- a/packages/renderer/src/lib/kube/resource-permission.spec.ts
+++ b/packages/renderer/src/lib/kube/resource-permission.spec.ts
@@ -52,7 +52,7 @@ beforeEach(() => {
 describe('listenResourcePermitted', () => {
   test('resource shoudl be permitted', async () => {
     const callbackMock = vi.fn();
-    vi.mocked(window.getConfigurationValue<boolean>).mockResolvedValue(true);
+    vi.mocked(window.isExperimentalConfigurationEnabled).mockResolvedValue(true);
 
     kubernetesContexts.set([mockContext1, mockContext2]);
     kubernetesContextsPermissions.set([{ contextName: 'context-name2', resourceName: 'deployments', permitted: true }]);
@@ -63,7 +63,7 @@ describe('listenResourcePermitted', () => {
 
   test('resource shoudl be not permitted', async () => {
     const callbackMock = vi.fn();
-    vi.mocked(window.getConfigurationValue<boolean>).mockResolvedValue(true);
+    vi.mocked(window.isExperimentalConfigurationEnabled).mockResolvedValue(true);
 
     kubernetesContexts.set([mockContext1, mockContext2]);
     kubernetesContextsPermissions.set([
@@ -76,7 +76,7 @@ describe('listenResourcePermitted', () => {
 
   test('shopuld be permitted if kubernetes experimental is not enabled', async () => {
     const callbackMock = vi.fn();
-    vi.mocked(window.getConfigurationValue<boolean>).mockResolvedValue(false);
+    vi.mocked(window.isExperimentalConfigurationEnabled).mockResolvedValue(false);
 
     kubernetesContexts.set([mockContext1, mockContext2]);
     kubernetesContextsPermissions.set([

--- a/packages/renderer/src/lib/kube/resource-permission.ts
+++ b/packages/renderer/src/lib/kube/resource-permission.ts
@@ -25,7 +25,8 @@ export async function listenResourcePermitted(
   resourceName: string,
   callback: (permitted: boolean) => void,
 ): Promise<IDisposable> {
-  const experimental = (await window.getConfigurationValue<boolean>('kubernetes.statesExperimental')) ?? false;
+  const experimental = await window.isExperimentalConfigurationEnabled('kubernetes.statesExperimental');
+
   let contextName = '';
   let permissions: ContextPermission[] = [];
 

--- a/packages/renderer/src/lib/kube/resources-listen.spec.ts
+++ b/packages/renderer/src/lib/kube/resources-listen.spec.ts
@@ -49,19 +49,19 @@ beforeAll(() => {
 });
 
 test('listenResources is undefined in non experimental mode', async () => {
-  vi.mocked(window.getConfigurationValue<boolean>).mockResolvedValue(false);
+  vi.mocked(window.isExperimentalConfigurationEnabled).mockResolvedValue(false);
   const result = await listenResources('resource1', {}, (): void => {});
   expect(result).toBeUndefined();
 });
 
 test('listenResources is undefined in non experimental mode (getConfigurationValue fails)', async () => {
-  vi.mocked(window.getConfigurationValue<boolean>).mockRejectedValue(undefined);
+  vi.mocked(window.isExperimentalConfigurationEnabled).mockRejectedValue(undefined);
   const result = await listenResources('resource1', {}, (): void => {});
   expect(result).toBeUndefined();
 });
 
 test('non filtered resources', async () => {
-  vi.mocked(window.getConfigurationValue<boolean>).mockResolvedValue(true);
+  vi.mocked(window.isExperimentalConfigurationEnabled).mockResolvedValue(true);
   vi.mocked(contexts).kubernetesContexts = writable([
     {
       currentContext: true,
@@ -94,7 +94,7 @@ test('non filtered resources', async () => {
 });
 
 test('updated resources without filter', async () => {
-  vi.mocked(window.getConfigurationValue<boolean>).mockResolvedValue(true);
+  vi.mocked(window.isExperimentalConfigurationEnabled).mockResolvedValue(true);
   vi.mocked(contexts).kubernetesContexts = writable([
     {
       currentContext: true,
@@ -142,7 +142,7 @@ test('updated resources without filter', async () => {
 
 test('filtered resources', async () => {
   const searchTermStore = writable<string>('');
-  vi.mocked(window.getConfigurationValue<boolean>).mockResolvedValue(true);
+  vi.mocked(window.isExperimentalConfigurationEnabled).mockResolvedValue(true);
   vi.mocked(contexts).kubernetesContexts = writable([
     {
       currentContext: true,
@@ -201,7 +201,7 @@ test('filtered resources', async () => {
 
 test('updated resources with filter', async () => {
   const searchTermStore = writable<string>('');
-  vi.mocked(window.getConfigurationValue<boolean>).mockResolvedValue(true);
+  vi.mocked(window.isExperimentalConfigurationEnabled).mockResolvedValue(true);
   vi.mocked(contexts).kubernetesContexts = writable([
     {
       currentContext: true,

--- a/packages/renderer/src/lib/kube/resources-listen.ts
+++ b/packages/renderer/src/lib/kube/resources-listen.ts
@@ -115,7 +115,7 @@ function filter(resources: KubernetesObject[], searchTerm: string): KubernetesOb
 
 export async function isKubernetesExperimentalMode(): Promise<boolean> {
   try {
-    return (await window.getConfigurationValue<boolean>('kubernetes.statesExperimental')) ?? false;
+    return await window.isExperimentalConfigurationEnabled('kubernetes.statesExperimental');
   } catch {
     return false;
   }

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
@@ -222,7 +222,7 @@ describe.each([
     initMocks: (): void => {
       Object.defineProperty(global, 'window', {
         value: {
-          getConfigurationValue: vi.fn(),
+          isExperimentalConfigurationEnabled: vi.fn(),
           telemetryTrack: vi.fn(),
           kubernetesRefreshContextState: vi.fn(),
         },
@@ -239,7 +239,7 @@ describe.each([
           count: 2,
         },
       ]);
-      vi.mocked(window.getConfigurationValue<boolean>).mockResolvedValue(true);
+      vi.mocked(window.isExperimentalConfigurationEnabled).mockResolvedValue(true);
       kubernetesContextsHealths.set([
         {
           contextName: 'context-name',

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -74,7 +74,7 @@ onMount(async () => {
   }
 
   try {
-    experimentalStates = (await window.getConfigurationValue<boolean>('kubernetes.statesExperimental')) ?? false;
+    experimentalStates = await window.isExperimentalConfigurationEnabled('kubernetes.statesExperimental');
   } catch {
     // keep default value
   }

--- a/packages/renderer/src/stores/kubernetes-context-health-experimental.spec.ts
+++ b/packages/renderer/src/stores/kubernetes-context-health-experimental.spec.ts
@@ -32,7 +32,7 @@ beforeAll(() => {
   Object.defineProperty(global, 'window', {
     value: {
       kubernetesGetContextsHealths: vi.fn(),
-      getConfigurationValue: vi.fn(),
+      isExperimentalConfigurationEnabled: vi.fn(),
       addEventListener: eventEmitter.receive,
       events: {
         receive: eventEmitter.receive,
@@ -42,7 +42,7 @@ beforeAll(() => {
 });
 
 test('kubernetesContextsHealths in experimental states mode', async () => {
-  vi.mocked(window.getConfigurationValue).mockResolvedValue(true);
+  vi.mocked(window.isExperimentalConfigurationEnabled).mockResolvedValue(true);
   const initialValues = [
     {
       contextName: 'context1',

--- a/packages/renderer/src/stores/kubernetes-context-health-non-experimental.spec.ts
+++ b/packages/renderer/src/stores/kubernetes-context-health-non-experimental.spec.ts
@@ -36,7 +36,7 @@ beforeAll(() => {
   Object.defineProperty(global, 'window', {
     value: {
       kubernetesGetContextsHealths: vi.fn(),
-      getConfigurationValue: vi.fn(),
+      isExperimentalConfigurationEnabled: vi.fn(),
       addEventListener: eventEmitter.receive,
       events: {
         receive: eventEmitter.receive,
@@ -46,7 +46,7 @@ beforeAll(() => {
 });
 
 test('kubernetesContextsHealths not in experimental states mode', async () => {
-  vi.mocked(window.getConfigurationValue).mockResolvedValue(false);
+  vi.mocked(window.isExperimentalConfigurationEnabled).mockResolvedValue(false);
   const initialValues = [
     {
       contextName: 'context1',

--- a/packages/renderer/src/stores/kubernetes-context-health.ts
+++ b/packages/renderer/src/stores/kubernetes-context-health.ts
@@ -25,13 +25,12 @@ import { EventStore } from './event-store';
 const windowEvents = ['kubernetes-contexts-healths', 'extension-stopped', 'extensions-started'];
 const windowListeners = ['extensions-already-started'];
 
-let experimentalStates: boolean | undefined = undefined;
 let readyToUpdate = false;
 
 export async function checkForUpdate(eventName: string): Promise<boolean> {
   // check for update only in experimental states mode
-  experimentalStates ??= (await window.getConfigurationValue<boolean>('kubernetes.statesExperimental')) ?? false;
-  if (experimentalStates === false) {
+  const enabled = await window.isExperimentalConfigurationEnabled('kubernetes.statesExperimental');
+  if (!enabled) {
     return false;
   }
 

--- a/packages/renderer/src/stores/kubernetes-context-permission-experimental.spec.ts
+++ b/packages/renderer/src/stores/kubernetes-context-permission-experimental.spec.ts
@@ -34,7 +34,7 @@ beforeAll(() => {
   Object.defineProperty(global, 'window', {
     value: {
       kubernetesGetContextsPermissions: vi.fn(),
-      getConfigurationValue: vi.fn(),
+      isExperimentalConfigurationEnabled: vi.fn(),
       addEventListener: eventEmitter.receive,
       events: {
         receive: eventEmitter.receive,
@@ -44,7 +44,7 @@ beforeAll(() => {
 });
 
 test('kubernetesContextsPermissions in experimental states mode', async () => {
-  vi.mocked(window.getConfigurationValue).mockResolvedValue(true);
+  vi.mocked(window.isExperimentalConfigurationEnabled).mockResolvedValue(true);
 
   const initialValues: ContextPermission[] = [];
   const nextValues: ContextPermission[] = [

--- a/packages/renderer/src/stores/kubernetes-context-permission-non-experimental.spec.ts
+++ b/packages/renderer/src/stores/kubernetes-context-permission-non-experimental.spec.ts
@@ -34,7 +34,7 @@ beforeAll(() => {
   Object.defineProperty(global, 'window', {
     value: {
       kubernetesGetContextsPermissions: vi.fn(),
-      getConfigurationValue: vi.fn(),
+      isExperimentalConfigurationEnabled: vi.fn(),
       addEventListener: eventEmitter.receive,
       events: {
         receive: eventEmitter.receive,
@@ -44,7 +44,7 @@ beforeAll(() => {
 });
 
 test('kubernetesContextsPermissions in experimental states mode', async () => {
-  vi.mocked(window.getConfigurationValue).mockResolvedValue(false);
+  vi.mocked(window.isExperimentalConfigurationEnabled).mockResolvedValue(false);
 
   const initialValues: ContextPermission[] = [
     {

--- a/packages/renderer/src/stores/kubernetes-context-permission.ts
+++ b/packages/renderer/src/stores/kubernetes-context-permission.ts
@@ -25,13 +25,12 @@ import { EventStore } from './event-store';
 const windowEvents = ['kubernetes-contexts-permissions', 'extension-stopped', 'extensions-started'];
 const windowListeners = ['extensions-already-started'];
 
-let experimentalStates: boolean | undefined = undefined;
 let readyToUpdate = false;
 
 export async function checkForUpdate(eventName: string): Promise<boolean> {
   // check for update only in experimental states mode
-  experimentalStates ??= (await window.getConfigurationValue<boolean>('kubernetes.statesExperimental')) ?? false;
-  if (experimentalStates === false) {
+  const enabled = await window.isExperimentalConfigurationEnabled('kubernetes.statesExperimental');
+  if (!enabled) {
     return false;
   }
 

--- a/packages/renderer/src/stores/kubernetes-experimental.spec.ts
+++ b/packages/renderer/src/stores/kubernetes-experimental.spec.ts
@@ -23,7 +23,7 @@ import { configurationProperties } from './configurationProperties';
 import { isKubernetesExperimentalModeStore } from './kubernetes-experimental';
 
 test('experimental mode is set', async () => {
-  vi.mocked(window.getConfigurationValue).mockImplementation(async () => {
+  vi.mocked(window.isExperimentalConfigurationEnabled).mockImplementation(async () => {
     return true;
   });
   configurationProperties.set([]);
@@ -33,8 +33,8 @@ test('experimental mode is set', async () => {
   });
 });
 
-test('experimental mode is set to false', async () => {
-  vi.mocked(window.getConfigurationValue).mockImplementation(async () => {
+test('experimental mode is not set', async () => {
+  vi.mocked(window.isExperimentalConfigurationEnabled).mockImplementation(async () => {
     return false;
   });
   configurationProperties.set([]);

--- a/packages/renderer/src/stores/kubernetes-experimental.ts
+++ b/packages/renderer/src/stores/kubernetes-experimental.ts
@@ -23,9 +23,9 @@ import { configurationProperties } from './configurationProperties';
 export const isKubernetesExperimentalModeStore: Writable<boolean | undefined> = writable();
 
 configurationProperties.subscribe(() => {
-  if (window?.getConfigurationValue) {
+  if (window?.isExperimentalConfigurationEnabled) {
     window
-      ?.getConfigurationValue<boolean>('kubernetes.statesExperimental')
+      ?.isExperimentalConfigurationEnabled('kubernetes.statesExperimental')
       ?.then(value => isKubernetesExperimentalModeStore.set(value ?? false))
       ?.catch((err: unknown) =>
         console.error(`Error getting configuration value 'kubernetes.statesExperimental'}`, err),

--- a/packages/renderer/src/stores/kubernetes-resources-count-experimental.spec.ts
+++ b/packages/renderer/src/stores/kubernetes-resources-count-experimental.spec.ts
@@ -34,7 +34,7 @@ beforeAll(() => {
   Object.defineProperty(global, 'window', {
     value: {
       kubernetesGetResourcesCount: vi.fn(),
-      getConfigurationValue: vi.fn(),
+      isExperimentalConfigurationEnabled: vi.fn(),
       addEventListener: eventEmitter.receive,
       events: {
         receive: eventEmitter.receive,
@@ -44,7 +44,7 @@ beforeAll(() => {
 });
 
 test('kubernetesResourcesCount in experimental states mode', async () => {
-  vi.mocked(window.getConfigurationValue).mockResolvedValue(true);
+  vi.mocked(window.isExperimentalConfigurationEnabled).mockResolvedValue(true);
 
   const initialValues: ResourceCount[] = [];
   const nextValues: ResourceCount[] = [

--- a/packages/renderer/src/stores/kubernetes-resources-count-non-experimental.spec.ts
+++ b/packages/renderer/src/stores/kubernetes-resources-count-non-experimental.spec.ts
@@ -34,7 +34,7 @@ beforeAll(() => {
   Object.defineProperty(global, 'window', {
     value: {
       kubernetesGetResourcesCount: vi.fn(),
-      getConfigurationValue: vi.fn(),
+      isExperimentalConfigurationEnabled: vi.fn(),
       addEventListener: eventEmitter.receive,
       events: {
         receive: eventEmitter.receive,
@@ -44,7 +44,7 @@ beforeAll(() => {
 });
 
 test('kubernetesResourcesCount in non experimental states mode', async () => {
-  vi.mocked(window.getConfigurationValue).mockResolvedValue(false);
+  vi.mocked(window.isExperimentalConfigurationEnabled).mockResolvedValue(false);
 
   const initialValues: ResourceCount[] = [
     {

--- a/packages/renderer/src/stores/kubernetes-resources-count.ts
+++ b/packages/renderer/src/stores/kubernetes-resources-count.ts
@@ -25,13 +25,12 @@ import { EventStore } from './event-store';
 const windowEvents = ['kubernetes-resources-count', 'extension-stopped', 'extensions-started'];
 const windowListeners = ['extensions-already-started'];
 
-let experimentalStates: boolean | undefined = undefined;
 let readyToUpdate = false;
 
 export async function checkForUpdate(eventName: string): Promise<boolean> {
   // check for update only in experimental states mode
-  experimentalStates ??= (await window.getConfigurationValue<boolean>('kubernetes.statesExperimental')) ?? false;
-  if (experimentalStates === false) {
+  const enabled = await window.isExperimentalConfigurationEnabled('kubernetes.statesExperimental');
+  if (!enabled) {
     return false;
   }
 


### PR DESCRIPTION
### What does this PR do?
Changes logic from storing boolean value to object/undefined  for experimental features, uses new experimental configuration manager https://github.com/podman-desktop/podman-desktop/pull/13316
More info in https://github.com/podman-desktop/podman-desktop/issues/13095

### Screenshot / video of UI


### What issues does this PR fix or reference?
Closes #13200

THOSE PRs MUST be merged together:
https://github.com/podman-desktop/podman-desktop/pull/13225
https://github.com/podman-desktop/podman-desktop/pull/13224
https://github.com/podman-desktop/podman-desktop/pull/13223
https://github.com/podman-desktop/podman-desktop/pull/13226
https://github.com/podman-desktop/podman-desktop/pull/13227

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
