### PR TITLE
refactor: centralized statusbar providers

### DIFF
--- a/packages/main/src/plugin/statusbar/statusbar-providers-init.spec.ts
+++ b/packages/main/src/plugin/statusbar/statusbar-providers-init.spec.ts
@@ -37,8 +37,7 @@ test('should register a configuration', async () => {
   expect(configurationNode?.properties).toBeDefined();
   expect(Object.keys(configurationNode?.properties ?? {}).length).toBe(1);
   expect(configurationNode?.properties?.['statusbarProviders.showProviders']).toBeDefined();
-  expect(configurationNode?.properties?.['statusbarProviders.showProviders']?.type).toBe('boolean');
-  expect(configurationNode?.properties?.['statusbarProviders.showProviders']?.default).toBe(true);
+  expect(configurationNode?.properties?.['statusbarProviders.showProviders']?.type).toBe('object');
   expect(configurationNode?.properties?.['statusbarProviders.showProviders']?.description).toBe(
     'Show providers in the status bar',
   );
@@ -47,7 +46,7 @@ test('should register a configuration', async () => {
   );
 });
 
-test('False should be default if not in dev env', () => {
+test('Undefined should be default if not in dev env', () => {
   vi.resetAllMocks();
   vi.stubEnv('DEV', false);
   const statusbarProvidersInit = new StatusbarProvidersInit(configurationRegistryMock);
@@ -56,5 +55,5 @@ test('False should be default if not in dev env', () => {
   expect(configurationRegistryMock.registerConfigurations).toBeCalled();
   const configurationNode = vi.mocked(configurationRegistryMock.registerConfigurations).mock.calls[0]?.[0][0];
 
-  expect(configurationNode?.properties?.['statusbarProviders.showProviders']?.default).toBe(false);
+  expect(configurationNode?.properties?.['statusbarProviders.showProviders']?.default).toBe(undefined);
 });

--- a/packages/main/src/plugin/statusbar/statusbar-providers-init.ts
+++ b/packages/main/src/plugin/statusbar/statusbar-providers-init.ts
@@ -32,8 +32,8 @@ export class StatusbarProvidersInit {
       properties: {
         [`statusbarProviders.showProviders`]: {
           description: 'Show providers in the status bar',
-          type: 'boolean',
-          default: import.meta.env.DEV ? true : false,
+          type: 'object',
+          default: import.meta.env.DEV ? {} : undefined,
           experimental: {
             githubDiscussionLink: 'https://github.com/podman-desktop/podman-desktop/discussions/10802',
           },


### PR DESCRIPTION
### What does this PR do?
Changes logic from storing boolean value to object/undefined for experimental features, uses new experimental configuration manager https://github.com/podman-desktop/podman-desktop/pull/13316

More info in https://github.com/podman-desktop/podman-desktop/issues/13095

### Screenshot / video of UI


### What issues does this PR fix or reference?
Closes #13203 

THOSE PRs MUST be merged together:
https://github.com/podman-desktop/podman-desktop/pull/13225
https://github.com/podman-desktop/podman-desktop/pull/13224
https://github.com/podman-desktop/podman-desktop/pull/13223
https://github.com/podman-desktop/podman-desktop/pull/13226
https://github.com/podman-desktop/podman-desktop/pull/13227

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
