### PR TITLE
chore(test): fix notification-box identifier

### DIFF
--- a/packages/renderer/src/lib/dashboard/NotificationsBox.spec.ts
+++ b/packages/renderer/src/lib/dashboard/NotificationsBox.spec.ts
@@ -29,7 +29,7 @@ test('Expect notifications box to be hidden if there are no notifications in the
   notificationQueue.set([]);
   render(NotificationsBox);
 
-  const noNotificationsDiv = screen.queryByLabelText('Notifications');
+  const noNotificationsDiv = screen.queryByLabelText('Notifications Box');
   expect(noNotificationsDiv).not.toBeInTheDocument();
 });
 


### PR DESCRIPTION
The test would never fail as the it checks for non-existing element. This fixes it.