### PR TITLE
feat(ExtensionLoader): implements AsyncDisposable

### DIFF
--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -22,7 +22,7 @@ import * as path from 'node:path';
 import type * as containerDesktopAPI from '@podman-desktop/api';
 import AdmZip from 'adm-zip';
 import { app, clipboard as electronClipboard } from 'electron';
-import { inject, injectable } from 'inversify';
+import { inject, injectable, preDestroy } from 'inversify';
 
 import { ColorRegistry } from '/@/plugin/color-registry.js';
 import {
@@ -115,7 +115,7 @@ export interface AnalyzedExtensionWithApi extends AnalyzedExtension {
  * Handle the loading of an extension
  */
 @injectable()
-export class ExtensionLoader {
+export class ExtensionLoader implements AsyncDisposable {
   private moduleLoader: ModuleLoader;
 
   protected activatedExtensions = new Map<string, ActivatedExtension>();
@@ -219,6 +219,21 @@ export class ExtensionLoader {
     this.extensionsStorageDirectory = directories.getExtensionsStorageDirectory();
     this.moduleLoader = new ModuleLoader(require('node:module'), this.analyzedExtensions);
     this.extensionDevelopmentFolder.onNeedToLoadExension(extension => this.loadExtension(extension));
+  }
+
+  @preDestroy()
+  async [Symbol.asyncDispose](): Promise<void> {
+    await this.stopAllExtensions();
+
+    // clear maps
+    this.activatedExtensions.clear();
+    this.analyzedExtensions.clear();
+    this.reloadInProgressExtensions.clear();
+    this.extensionState.clear();
+    this.extensionStateErrors.clear();
+
+    // clear emitter
+    this._onDidChange.dispose();
   }
 
   mapError(err: unknown): ExtensionError | undefined {


### PR DESCRIPTION
### What does this PR do?

Split of https://github.com/podman-desktop/podman-desktop/pull/13236 - Making the ExtensionLoader AsyncDisposable, to stop all extensions when called.

Adding the `@preDestroy` inversify annotation to tell inversify to call this method when unbinding this object. In the follow-up PR, updating the `src/plugin/index.spec` to unbind all singleton after each test.


### What issues does this PR fix or reference?

Related to https://github.com/podman-desktop/podman-desktop/issues/13166
Part of https://github.com/podman-desktop/podman-desktop/issues/13257

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
