### PR TITLE
fix(ci): improve test file memory usage

### DIFF
--- a/packages/main/src/plugin/index.spec.ts
+++ b/packages/main/src/plugin/index.spec.ts
@@ -112,12 +112,12 @@ beforeAll(async () => {
       } as unknown as BrowserWindow,
     ];
   });
-  // to avoid port conflict when tests are running on windows host
-  vi.spyOn(HttpServer.prototype, 'start').mockImplementation(vi.fn());
   vi.mocked(app.getVersion).mockReturnValue('100.0.0');
   vi.spyOn(Updater.prototype, 'init').mockReturnValue(new Disposable(vi.fn()));
   vi.spyOn(ExtensionLoader.prototype, 'readDevelopmentFolders').mockResolvedValue([]);
   await pluginSystem.initExtensions(new Emitter<ConfigurationRegistry>());
+  // to avoid port conflict when tests are running on windows host
+  vi.spyOn(HttpServer.prototype, 'start').mockImplementation(vi.fn());
 });
 
 beforeEach(() => {

--- a/packages/main/src/plugin/index.spec.ts
+++ b/packages/main/src/plugin/index.spec.ts
@@ -172,6 +172,7 @@ test('Check SecurityRestrictions on Links and user accept', async () => {
 
 test('Check SecurityRestrictions on Links and user copy link', async () => {
   const showMessageBoxMock = vi.fn();
+
   const messageBox = {
     showMessageBox: showMessageBoxMock,
   } as unknown as MessageBox;


### PR DESCRIPTION
### What does this PR do?

This PR tries to improve memory usage of a serie of tests to avoid CI random errors and heap dump. To do so, I put in beforeAll some of the calls to initExtensions which is expensive in memory.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Tries to mitigate https://github.com/podman-desktop/podman-desktop/issues/13166 by putting in common some calls to memory expensive method initExtensions.

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
