### PR TITLE
test(packages/renderer): make test run faster

### DIFF
--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingRepairCleanup.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingRepairCleanup.spec.ts
@@ -43,15 +43,15 @@ test('Check cleanupProviders is called and button is in progress', async () => {
   const cleanupButton = screen.getByRole('button', { name: 'Cleanup' });
   expect(cleanupButton).toBeInTheDocument();
 
-  // mock the cleanup as waiting for 2 seconds
-  cleanupProvidersMock.mockResolvedValue(new Promise(resolve => setTimeout(resolve, 2000)));
+  // mock the cleanup as waiting for 10ms
+  cleanupProvidersMock.mockResolvedValue(new Promise(resolve => setTimeout(resolve, 10)));
 
   // click on the cleanup button
   expect(cleanupButton).toBeEnabled();
   await fireEvent.click(cleanupButton);
 
   // wait next tick
-  await new Promise(resolve => setTimeout(resolve, 100));
+  await new Promise(resolve => setTimeout(resolve, 5));
 
   // button should be in progress
   expect(cleanupButton).toBeDisabled();
@@ -59,8 +59,8 @@ test('Check cleanupProviders is called and button is in progress', async () => {
   const svg = cleanupButton.querySelector('svg');
   expect(svg).toBeInTheDocument();
 
-  // wait 2s for the cleanup to finish
-  await new Promise(resolve => setTimeout(resolve, 2000));
+  // wait 10ms for the cleanup to finish
+  await new Promise(resolve => setTimeout(resolve, 10));
 
   // button should not be in progress anymore
   expect(cleanupButton).toBeEnabled();


### PR DESCRIPTION
### What does this PR do?

I changed the timers value in this test to make it pass in 79ms (on my Mac) instead of 2 200ms.
This is to make the CI faster.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
