### PR TITLE
test(packages/renderer): make test run faster

### DIFF
--- a/packages/renderer/src/lib/kube/pods/terminal/KubernetesTerminal.spec.ts
+++ b/packages/renderer/src/lib/kube/pods/terminal/KubernetesTerminal.spec.ts
@@ -82,9 +82,9 @@ test('Test should render the terminal and being able to reconnect', async () => 
 
   render(KubernetesTerminal, { podName: 'podName', containerName: 'containerName' });
 
-  await new Promise(resolve => setTimeout(resolve, 1000));
-
-  // Called twice because we now create the terminal each session when we reconnect in order
-  // to ensure that we have a fresh terminal with the previous history shown.
-  expect(kubernetesExecMock).toHaveBeenCalledTimes(2);
+  await waitFor(() => {
+    // Called twice because we now create the terminal each session when we reconnect in order
+    // to ensure that we have a fresh terminal with the previous history shown.
+    expect(kubernetesExecMock).toHaveBeenCalledTimes(2);
+  });
 });


### PR DESCRIPTION
### What does this PR do?

I changed the  value in this test to make it pass in 79ms (on my Mac) instead of 2 200ms.
This is to make the CI faster.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
