### PR TITLE
test: speed up some vitest tests 

### DIFF
--- a/packages/renderer/src/lib/appearance/Appearance.spec.ts
+++ b/packages/renderer/src/lib/appearance/Appearance.spec.ts
@@ -62,7 +62,7 @@ function getRootElementClassesValue(container: HTMLElement): string | undefined 
   return getRootElement(container).classList.value;
 }
 
-async function awaitRender(): Promise<RenderResult<Component<ComponentProps<Appearance>>>> {
+function renderComponent(): RenderResult<Component<ComponentProps<Appearance>>> {
   const result = render<Component<ComponentProps<Appearance>>>(Appearance);
   return result;
 }
@@ -77,7 +77,7 @@ test('Expect light mode using system when OS is set to light', async () => {
   getConfigurationValueMock.mockResolvedValue(AppearanceSettings.SystemEnumValue);
   configurationProperties.set([]);
 
-  const { baseElement } = await awaitRender();
+  const { baseElement } = renderComponent();
   // expect to have no (dark) class as OS is using light
   await vi.waitFor(() => expect(getRootElementClassesValue(baseElement)).toBe(''));
 });
@@ -92,7 +92,7 @@ test('Expect dark mode using system when OS is set to dark', async () => {
   getConfigurationValueMock.mockResolvedValue(AppearanceSettings.SystemEnumValue);
   configurationProperties.set([]);
 
-  const { baseElement } = await awaitRender();
+  const { baseElement } = renderComponent();
   // expect to have class being "dark" as OS is using dark
   await vi.waitFor(() => expect(getRootElementClassesValue(baseElement)).toBe('dark'));
 });
@@ -101,7 +101,7 @@ test('Expect light mode using light configuration', async () => {
   getConfigurationValueMock.mockResolvedValue(AppearanceSettings.LightEnumValue);
   configurationProperties.set([]);
 
-  const { baseElement } = await awaitRender();
+  const { baseElement } = renderComponent();
 
   // expect to have class being ""  as we should be in light mode
   expect(getRootElementClassesValue(baseElement)).toBe('');
@@ -114,7 +114,7 @@ test('Expect dark mode using dark configuration', async () => {
   getConfigurationValueMock.mockResolvedValue(AppearanceSettings.DarkEnumValue);
   configurationProperties.set([]);
 
-  const { baseElement } = await awaitRender();
+  const { baseElement } = renderComponent();
 
   // expect to have class being "dark" as we should be in dark mode
   expect(getRootElementClassesValue(baseElement)).toBe('dark');
@@ -133,7 +133,7 @@ test('Expect event being changed when changing the default appearance on the ope
     }
   });
 
-  await awaitRender();
+  renderComponent();
 
   // check no dispatched event for now
   expect(spyDispatchEvent).not.toHaveBeenCalled();

--- a/packages/renderer/src/lib/appearance/Appearance.spec.ts
+++ b/packages/renderer/src/lib/appearance/Appearance.spec.ts
@@ -64,10 +64,6 @@ function getRootElementClassesValue(container: HTMLElement): string | undefined 
 
 async function awaitRender(): Promise<RenderResult<Component<ComponentProps<Appearance>>>> {
   const result = render<Component<ComponentProps<Appearance>>>(Appearance);
-  // wait end of asynchrounous onMount
-  // wait 200ms
-  await new Promise(resolve => setTimeout(resolve, 200));
-
   return result;
 }
 

--- a/packages/renderer/src/lib/appearance/IconImage.spec.ts
+++ b/packages/renderer/src/lib/appearance/IconImage.spec.ts
@@ -57,7 +57,7 @@ test('Expect valid source and alt text with dark mode', async () => {
 
   const image = render(IconImage, { image: { light: 'light.png', dark: 'dark.png' }, alt: 'this is alt text' });
 
-  await waitFor(async () => {
+  await waitFor(() => {
     // grab image element
     const imageElement = image.getByRole('img');
 

--- a/packages/renderer/src/lib/appearance/IconImage.spec.ts
+++ b/packages/renderer/src/lib/appearance/IconImage.spec.ts
@@ -19,7 +19,7 @@
 /* eslint-disable no-null/no-null */
 import '@testing-library/jest-dom/vitest';
 
-import { render } from '@testing-library/svelte';
+import { render, waitFor } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
@@ -57,15 +57,13 @@ test('Expect valid source and alt text with dark mode', async () => {
 
   const image = render(IconImage, { image: { light: 'light.png', dark: 'dark.png' }, alt: 'this is alt text' });
 
-  // wait for image to be loaded
-  await new Promise(resolve => setTimeout(resolve, 200));
+  await waitFor(async () => {
+    // grab image element
+    const imageElement = image.getByRole('img');
 
-  // grab image element
-  const imageElement = image.getByRole('img');
-
-  // expect to have valid source
-  await vi.waitFor(async () => expect(imageElement).toHaveAttribute('src', 'dark.png'));
-  expect(imageElement).toHaveAttribute('alt', 'this is alt text');
+    expect(imageElement).toHaveAttribute('src', 'dark.png');
+    expect(imageElement).toHaveAttribute('alt', 'this is alt text');
+  });
 
   vi.clearAllMocks();
   await image.rerender({ image: { light: 'light2.png', dark: 'dark2.png' }, alt: 'this is another alt text' });

--- a/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.spec.ts
@@ -235,7 +235,7 @@ test('Expects images.icon option to be used when no themes are present', async (
   const icon = await waitFor(() => {
     return screen.getByRole('img', { name: `${testProvidersInfoWithSessionRequests[0].displayName}` });
   });
-    
+
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveAttribute('src', './icon.png');
 });
@@ -261,9 +261,9 @@ test('Expects images.icon.dark option to be used when theme is dark', async () =
   configMock.mockReturnValue('dark');
   render(PreferencesAuthenticationProvidersRendering, {});
 
-  await waitFor(() => {
-    const icon = screen.getByRole('img', { name: `${testProvidersInfoWithSessionRequests[0].displayName}` });
-    expect(icon).toBeInTheDocument();
-    expect(icon).toHaveAttribute('src', './icon-dark.png');
+  const icon = await waitFor(() => {
+    return screen.getByRole('img', { name: `${testProvidersInfoWithSessionRequests[0].displayName}` });
   });
+  expect(icon).toBeInTheDocument();
+  expect(icon).toHaveAttribute('src', './icon-dark.png');
 });

--- a/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.spec.ts
@@ -232,11 +232,12 @@ test('Expects images.icon option to be used when no themes are present', async (
   authenticationProviders.set(providerWithImageIcon);
   render(PreferencesAuthenticationProvidersRendering, {});
 
-  await waitFor(() => {
-    const icon = screen.getByRole('img', { name: `${testProvidersInfoWithSessionRequests[0].displayName}` });
-    expect(icon).toBeInTheDocument();
-    expect(icon).toHaveAttribute('src', './icon.png');
+  const icon = await waitFor(() => {
+    return screen.getByRole('img', { name: `${testProvidersInfoWithSessionRequests[0].displayName}` });
   });
+    
+  expect(icon).toBeInTheDocument();
+  expect(icon).toHaveAttribute('src', './icon.png');
 });
 
 test('Expects images.icon.dark option to be used when theme is dark', async () => {

--- a/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.spec.ts
@@ -21,7 +21,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { fireEvent, render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { afterEach, beforeAll, expect, test, vi } from 'vitest';
 
 import { authenticationProviders } from '../../stores/authenticationProviders';
@@ -232,12 +232,11 @@ test('Expects images.icon option to be used when no themes are present', async (
   authenticationProviders.set(providerWithImageIcon);
   render(PreferencesAuthenticationProvidersRendering, {});
 
-  // wait for image to be loaded
-  await new Promise(resolve => setTimeout(resolve, 200));
-
-  const icon = screen.getByRole('img', { name: `${testProvidersInfoWithSessionRequests[0].displayName}` });
-  expect(icon).toBeInTheDocument();
-  expect(icon).toHaveAttribute('src', './icon.png');
+  await waitFor(() => {
+    const icon = screen.getByRole('img', { name: `${testProvidersInfoWithSessionRequests[0].displayName}` });
+    expect(icon).toBeInTheDocument();
+    expect(icon).toHaveAttribute('src', './icon.png');
+  });
 });
 
 test('Expects images.icon.dark option to be used when theme is dark', async () => {
@@ -261,10 +260,9 @@ test('Expects images.icon.dark option to be used when theme is dark', async () =
   configMock.mockReturnValue('dark');
   render(PreferencesAuthenticationProvidersRendering, {});
 
-  // wait for image to be loaded
-  await new Promise(resolve => setTimeout(resolve, 200));
-
-  const icon = screen.getByRole('img', { name: `${testProvidersInfoWithSessionRequests[0].displayName}` });
-  expect(icon).toBeInTheDocument();
-  expect(icon).toHaveAttribute('src', './icon-dark.png');
+  await waitFor(() => {
+    const icon = screen.getByRole('img', { name: `${testProvidersInfoWithSessionRequests[0].displayName}` });
+    expect(icon).toBeInTheDocument();
+    expect(icon).toHaveAttribute('src', './icon-dark.png');
+  });
 });

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.spec.ts
@@ -322,15 +322,9 @@ test('Expect startContainerProvider to only be called once when restarting', asy
   providerInfo.containerConnections[0].status = 'stopped';
   providerInfos.set([providerInfo]);
 
-  // wait a bit
-  await new Promise(resolve => setTimeout(resolve, 1000));
-
   // update provider connection status - simulate it is started again
   providerInfo.containerConnections[0].status = 'started';
   providerInfos.set([providerInfo]);
-
-  // wait a bit
-  await new Promise(resolve => setTimeout(resolve, 1000));
 
   expect(startConnectionMock).toBeCalledTimes(1);
 });

--- a/packages/renderer/src/lib/preferences/item-formats/EditableItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/EditableItem.spec.ts
@@ -167,9 +167,6 @@ test('Expect onSave function called if save button is clicked', async () => {
   await userEvent.clear(input);
   await userEvent.keyboard('20');
 
-  // wait setTimeout in NumberItem expires and push call
-  await new Promise(resolve => setTimeout(resolve, 600));
-
   const buttonCancel = await screen.findByRole('button', { name: 'Cancel' });
   expect(buttonCancel).toBeInTheDocument();
 

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingRepairCleanup.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingRepairCleanup.spec.ts
@@ -20,7 +20,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { fireEvent, render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { beforeAll, expect, test, vi } from 'vitest';
 
 import TroubleshootingRepairCleanup from './TroubleshootingRepairCleanup.svelte';
@@ -50,20 +50,19 @@ test('Check cleanupProviders is called and button is in progress', async () => {
   expect(cleanupButton).toBeEnabled();
   await fireEvent.click(cleanupButton);
 
-  // wait next tick
-  await new Promise(resolve => setTimeout(resolve, 5));
+  await waitFor(() => {
+    // button should be in progress
+    expect(cleanupButton).toBeDisabled();
+  });
 
-  // button should be in progress
-  expect(cleanupButton).toBeDisabled();
   // svg should be inside the button
   const svg = cleanupButton.querySelector('svg');
   expect(svg).toBeInTheDocument();
 
-  // wait 10ms for the cleanup to finish
-  await new Promise(resolve => setTimeout(resolve, 10));
-
-  // button should not be in progress anymore
-  expect(cleanupButton).toBeEnabled();
+  await waitFor(() => {
+    // button should not be in progress anymore
+    expect(cleanupButton).toBeEnabled();
+  });
 
   // check that we asked for confirmation
   expect(showMessageBoxMock).toBeCalledWith({

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingRepairCleanup.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingRepairCleanup.spec.ts
@@ -91,9 +91,6 @@ test('Check errors are displayed with clipboard button', async () => {
   expect(cleanupButton).toBeEnabled();
   await fireEvent.click(cleanupButton);
 
-  // wait next tick
-  await new Promise(resolve => setTimeout(resolve, 100));
-
   // check that we asked for confirmation
   expect(showMessageBoxMock).toBeCalledWith({
     buttons: ['Yes', 'Cancel'],

--- a/packages/renderer/src/lib/ui/Badge.spec.ts
+++ b/packages/renderer/src/lib/ui/Badge.spec.ts
@@ -18,7 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { render, screen } from '@testing-library/svelte';
+import { render, screen, waitFor } from '@testing-library/svelte';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import Badge from './Badge.svelte';
@@ -48,11 +48,10 @@ test('Should display badge', async () => {
   const label = screen.getByText('customLabel');
   expect(label).toBeInTheDocument();
 
-  // check color being the default one
-  await new Promise(r => setTimeout(r, 100));
-
-  // check color being there in the style
-  expect(label).toHaveClass('bg-gray-500');
+  await waitFor(() => {
+    // check color being there in the style
+    expect(label).toHaveClass('bg-gray-500');
+  });
 });
 
 test('Should display badge with rgb color', async () => {
@@ -63,11 +62,10 @@ test('Should display badge with rgb color', async () => {
   const label = screen.getByText('customLabel');
   expect(label).toBeInTheDocument();
 
-  // wait for some time
-  await new Promise(r => setTimeout(r, 100));
-
-  // check color being there in the style
-  expect(label).toHaveStyle('background-color: rgb(255, 0, 0)');
+  await waitFor(() => {
+    // check color being there in the style
+    expect(label).toHaveStyle('background-color: rgb(255, 0, 0)');
+  });
 });
 
 test('Should display badge with light color', async () => {
@@ -78,11 +76,10 @@ test('Should display badge with light color', async () => {
   const label = screen.getByText('customLabel');
   expect(label).toBeInTheDocument();
 
-  // wait for some time
-  await new Promise(r => setTimeout(r, 100));
-
-  // check color being there in the style
-  expect(label).toHaveStyle('background-color: rgb(255, 0, 0)');
+  await waitFor(() => {
+    // check color being there in the style
+    expect(label).toHaveStyle('background-color: rgb(255, 0, 0)');
+  });
 });
 
 test('Should display badge with dark color', async () => {
@@ -93,11 +90,10 @@ test('Should display badge with dark color', async () => {
   const label = screen.getByText('customLabel');
   expect(label).toBeInTheDocument();
 
-  // wait for some time
-  await new Promise(r => setTimeout(r, 100));
-
-  // check color being there in the style
-  expect(label).toHaveStyle('background-color: rgb(0, 255, 0)');
+  await waitFor(() => {
+    // check color being there in the style
+    expect(label).toHaveStyle('background-color: rgb(0, 255, 0)');
+  });
 });
 
 test('Should display badge with custom class', async () => {

--- a/packages/renderer/src/lib/volume/VolumesList.spec.ts
+++ b/packages/renderer/src/lib/volume/VolumesList.spec.ts
@@ -20,7 +20,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { fireEvent, render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 /* eslint-disable import/no-duplicates */
 import { tick } from 'svelte';
@@ -138,13 +138,11 @@ test('Expect volumes being displayed once extensions are started (without size d
   // first call is with listing without details
   expect(listVolumesMock).toHaveBeenNthCalledWith(1, false);
 
-  // wait store are populated
-  while (get(volumeListInfos).length === 0) {
-    await new Promise(resolve => setTimeout(resolve, 500));
-  }
-  while (get(providerInfos).length === 0) {
-    await new Promise(resolve => setTimeout(resolve, 500));
-  }
+  await waitFor(() => {
+    // wait store are populated
+    expect(get(volumeListInfos)).not.toHaveLength(0);
+    expect(get(providerInfos)).not.toHaveLength(0);
+  });
 
   await waitRender({});
 
@@ -202,13 +200,11 @@ test('Expect volumes being displayed once extensions are started (with size data
   // first call is with listing with details
   expect(listVolumesMock).toHaveBeenNthCalledWith(1, true);
 
-  // wait store are populated
-  while (get(volumeListInfos).length === 0) {
-    await new Promise(resolve => setTimeout(resolve, 500));
-  }
-  while (get(providerInfos).length === 0) {
-    await new Promise(resolve => setTimeout(resolve, 500));
-  }
+  await waitFor(() => {
+    // wait store are populated
+    expect(get(volumeListInfos)).not.toHaveLength(0);
+    expect(get(providerInfos)).not.toHaveLength(0);
+  });
 
   await waitRender({});
 
@@ -310,13 +306,11 @@ test('Expect filter empty screen', async () => {
   // first call is with listing without details
   expect(listVolumesMock).toHaveBeenNthCalledWith(1, false);
 
-  // wait store are populated
-  while (get(volumeListInfos).length === 0) {
-    await new Promise(resolve => setTimeout(resolve, 500));
-  }
-  while (get(providerInfos).length === 0) {
-    await new Promise(resolve => setTimeout(resolve, 500));
-  }
+  await waitFor(() => {
+    // wait store are populated
+    expect(get(volumeListInfos)).not.toHaveLength(0);
+    expect(get(providerInfos)).not.toHaveLength(0);
+  });
 
   await waitRender({ searchTerm: 'No match' });
 
@@ -369,13 +363,11 @@ test('Expect user confirmation to pop up when preferences require', async () => 
   // first call is with listing without details
   expect(listVolumesMock).toHaveBeenNthCalledWith(1, false);
 
-  // wait store are populated
-  while (get(volumeListInfos).length === 0) {
-    await new Promise(resolve => setTimeout(resolve, 500));
-  }
-  while (get(providerInfos).length === 0) {
-    await new Promise(resolve => setTimeout(resolve, 500));
-  }
+  await waitFor(() => {
+    // wait store are populated
+    expect(get(volumeListInfos)).not.toHaveLength(0);
+    expect(get(providerInfos)).not.toHaveLength(0);
+  });
 
   await waitRender({});
 


### PR DESCRIPTION
### What does this PR do?

In the vitest tests, I am trying to remove the setTimeout that are not needed or replace them with a `waitFor` to speed up their execution in the CI.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
