### PR TITLE
fix(extension/podman): ensure loop of monitoring can be started at activation of extension

### DIFF
--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -3300,16 +3300,21 @@ test('activate and autostart should not duplicate machines ', async () => {
   // call the autostart method
   const promiseAutoStart = autoStartMethod?.start();
 
-  // call 100 times monitorMachines
-  for (let i = 0; i < 100; i++) {
-    extension.monitorMachines(provider, podmanConfiguration).catch(() => {});
-  }
+  vi.useFakeTimers();
+
+  const promises = Array.from({ length: 100 }).map(() => extension.monitorMachines(provider, podmanConfiguration));
 
   await promiseAutoStart;
 
   // should be only 1 but we allow some more calls (if there is not a check to check during the autostart it would be 100+ calls)
   expect(podmanMachineListCalls).toBeLessThan(5);
   expect(promiseAutoStart).toBeDefined();
+
+  await vi.advanceTimersByTimeAsync(5000);
+
+  await Promise.allSettled(promises);
+
+  vi.useRealTimers();
 });
 
 describe('macOS: tests for notifying if disguised podman socket fails / passes', () => {

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -384,6 +384,7 @@ beforeEach(() => {
 afterEach(async () => {
   console.error = originalConsoleError;
   await extension.deactivate();
+  vi.useRealTimers();
 });
 
 describe.each([
@@ -3313,8 +3314,6 @@ test('activate and autostart should not duplicate machines ', async () => {
   await vi.advanceTimersByTimeAsync(5000);
 
   await Promise.allSettled(promises);
-
-  vi.useRealTimers();
 });
 
 describe('macOS: tests for notifying if disguised podman socket fails / passes', () => {

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -1304,6 +1304,8 @@ async function exec(args: string[], options?: PodmanRunOptions): Promise<extensi
 }
 
 export async function activate(extensionContext: extensionApi.ExtensionContext): Promise<PodmanExtensionApi> {
+  stopLoop = false;
+
   initExtensionContext(extensionContext);
 
   initTelemetryLogger();


### PR DESCRIPTION


### What does this PR do?

This PR is made to prepare another PR where the monitoring loop is tested. The stop loop is activated in the deactivate method, but it is not desactivated in the activate method. So the test cannot be run as the global stop loop can be modified from another test.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

https://github.com/podman-desktop/podman-desktop/pull/13153/files/ec5af1256af8c61821c3b277af26f5c553cba34d#r2215571950

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
