### PR TITLE
fix(extensions/kind): dispose update version on uninstall

### DIFF
--- a/extensions/kind/src/extension.spec.ts
+++ b/extensions/kind/src/extension.spec.ts
@@ -356,6 +356,14 @@ describe('cli#update', () => {
 
     expect(disposeMock).toHaveBeenCalled();
   });
+
+  test('uninstall updatable version should dispose update', async () => {
+    vi.mocked(KindInstaller.prototype.getLatestVersionAsset).mockResolvedValue(mockV1Release);
+
+    await (await getCliToolInstaller()).doUninstall({} as unknown as extensionApi.Logger);
+
+    expect(disposeMock).toHaveBeenCalled();
+  });
 });
 
 /**

--- a/extensions/kind/src/extension.spec.ts
+++ b/extensions/kind/src/extension.spec.ts
@@ -297,6 +297,10 @@ test('Ensuring a progress task is created when calling kind.image.move command',
   expect(contextSetValueMock).toHaveBeenNthCalledWith(2, 'imagesPushInProgressToKind', []);
 });
 
+const mockV1Release = {
+  tag: 'v1.0.0',
+} as unknown as KindGithubReleaseArtifactMetadata;
+
 describe('cli#update', () => {
   /**
    * Utility method to get the {@link extensionApi.CliToolSelectUpdate} object registered by kind
@@ -334,19 +338,13 @@ describe('cli#update', () => {
     vi.mocked(util.installBinaryToSystem).mockResolvedValue('path');
 
     vi.mocked(KindInstaller.prototype.getKindCliStoragePath).mockReturnValue('storage-path');
-    vi.mocked(KindInstaller.prototype.promptUserForVersion).mockResolvedValue({
-      tag: 'v1.0.0',
-    } as unknown as KindGithubReleaseArtifactMetadata);
-    vi.mocked(KindInstaller.prototype.getLatestVersionAsset).mockResolvedValue({
-      tag: 'v1.0.0',
-    } as unknown as KindGithubReleaseArtifactMetadata);
+    vi.mocked(KindInstaller.prototype.promptUserForVersion).mockResolvedValue(mockV1Release);
+    vi.mocked(KindInstaller.prototype.getLatestVersionAsset).mockResolvedValue(mockV1Release);
     const update: extensionApi.CliToolSelectUpdate = await getCliToolUpdate();
     await update?.selectVersion();
     await update.doUpdate({} as unknown as extensionApi.Logger);
 
-    expect(KindInstaller.prototype.download).toHaveBeenCalledWith({
-      tag: 'v1.0.0',
-    });
+    expect(KindInstaller.prototype.download).toHaveBeenCalledWith(mockV1Release);
     expect(KindInstaller.prototype.getKindCliStoragePath).toHaveBeenCalled();
 
     expect(util.installBinaryToSystem).toHaveBeenCalledWith('storage-path', 'kind');
@@ -415,9 +413,7 @@ describe('cli#install', () => {
   test('after selecting the version to be installed it should download kind', async () => {
     vi.mocked(util.installBinaryToSystem).mockResolvedValue('path');
     // mock prompt result
-    vi.mocked(KindInstaller.prototype.promptUserForVersion).mockResolvedValue({
-      tag: 'v1.0.0',
-    } as unknown as KindGithubReleaseArtifactMetadata);
+    vi.mocked(KindInstaller.prototype.promptUserForVersion).mockResolvedValue(mockV1Release);
 
     const cliToolInstaller: extensionApi.CliToolInstaller = await getCliToolInstaller();
 
@@ -425,9 +421,7 @@ describe('cli#install', () => {
     await cliToolInstaller?.selectVersion();
     await cliToolInstaller?.doInstall({} as unknown as extensionApi.Logger);
 
-    expect(KindInstaller.prototype.download).toHaveBeenCalledWith({
-      tag: 'v1.0.0',
-    });
+    expect(KindInstaller.prototype.download).toHaveBeenCalledWith(mockV1Release);
     expect(KindInstaller.prototype.getKindCliStoragePath).toHaveBeenCalled();
     expect(util.installBinaryToSystem).toHaveBeenCalledWith('storage-path', 'kind');
     expect(CLI_TOOL_MOCK.updateVersion).toHaveBeenCalledWith({
@@ -441,9 +435,7 @@ describe('cli#install', () => {
     // mock error when trying to install system wide
     vi.mocked(util.installBinaryToSystem).mockRejectedValue('error');
     // mock user select v1.0.0
-    vi.mocked(KindInstaller.prototype.promptUserForVersion).mockResolvedValue({
-      tag: 'v1.0.0',
-    } as unknown as KindGithubReleaseArtifactMetadata);
+    vi.mocked(KindInstaller.prototype.promptUserForVersion).mockResolvedValue(mockV1Release);
 
     const cliToolInstaller: extensionApi.CliToolInstaller = await getCliToolInstaller();
 
@@ -452,9 +444,7 @@ describe('cli#install', () => {
     await cliToolInstaller?.doInstall({} as unknown as extensionApi.Logger);
 
     // ensure the download has been called
-    expect(KindInstaller.prototype.download).toHaveBeenCalledWith({
-      tag: 'v1.0.0',
-    });
+    expect(KindInstaller.prototype.download).toHaveBeenCalledWith(mockV1Release);
     expect(KindInstaller.prototype.getKindCliStoragePath).toHaveBeenCalled();
     expect(util.installBinaryToSystem).toHaveBeenCalledWith('storage-path', 'kind');
     expect(CLI_TOOL_MOCK.updateVersion).toHaveBeenCalledWith({

--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -579,6 +579,8 @@ async function registerCliTool(
 
       // update the version and path to undefined
       kindPath = undefined;
+
+      currentUpdateDisposable?.dispose();
     },
   });
 }


### PR DESCRIPTION
### What does this PR do?

This PR cleans the update data for the kind extension when it is uninstalled, to avoid showing a ghost "update" button.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes #13128 

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
See issue #13128 

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
