### PR TITLE
refactor(extensions/podman): handle notifications in specific class

### DIFF
--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -3520,6 +3520,31 @@ describe('Check notify podman setup', () => {
 
     expect(extensionApi.window.showNotification).not.toHaveBeenCalled();
   });
+
+  test('reset the notification flag so if podman is uninstalled in future we can show the notification again', async () => {
+    vi.mocked(extensionApi.env).isLinux = true;
+
+    // No podman install
+
+    await extension.doMonitorProvider(provider);
+    expect(extensionApi.window.showNotification).toHaveBeenCalledExactlyOnceWith(notifySetupPodmanExpectedContent);
+
+    // Podman has been installed
+
+    vi.mocked(extensionApi.process.exec).mockResolvedValueOnce({
+      stdout: 'podman version 5.0.0',
+    } as unknown as extensionApi.RunResult);
+
+    await extension.doMonitorProvider(provider);
+
+    expect(extensionApi.window.showNotification).toHaveBeenCalledExactlyOnceWith(notifySetupPodmanExpectedContent);
+
+    // Podman has been uninstalled -> Show the notification a second time
+
+    await extension.doMonitorProvider(provider);
+    expect(extensionApi.window.showNotification).toHaveBeenCalledTimes(2);
+    expect(extensionApi.window.showNotification).toHaveBeenLastCalledWith(notifySetupPodmanExpectedContent);
+  });
 });
 
 describe('monitorProvider', () => {

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -709,7 +709,7 @@ export async function doMonitorProvider(provider: extensionApi.Provider): Promis
       // if podman is not installed and the OS is linux we show the podman onboarding notification (if it has not been shown earlier)
       // this should be limited to Linux as in other OSes the onboarding workflow is enabled based on the podman machine existance
       // and the notification is handled by checking the machine
-      if (extensionApi.env.isLinux && extensionNotifications.shouldNotifySetup) {
+      if (extensionApi.env.isLinux) {
         // push setup notification
         extensionNotifications.notifySetupPodman();
       }

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -219,8 +219,7 @@ async function doUpdateMachines(
   // podman is correctly setup so if there is an old notification asking the user to take action
   // we dispose it as not needed anymore
   if (!shouldCleanMachine && machines.length > 0 && !extensionApi.env.isLinux) {
-    extensionNotifications.notificationDisposable?.dispose();
-    extensionNotifications.shouldNotifySetup = true;
+    extensionNotifications.disposeNotification();
   }
 
   // update status of existing machines
@@ -724,9 +723,8 @@ export async function doMonitorProvider(provider: extensionApi.Provider): Promis
       extensionApi.context.setValue('podmanIsNotInstalled', false, 'onboarding');
       // if podman has been installed, we reset the notification flag so if podman is uninstalled in future we can show the notification again
       if (extensionApi.env.isLinux) {
-        extensionNotifications.shouldNotifySetup = true;
         // notification is no more required
-        extensionNotifications.notificationDisposable?.dispose();
+        extensionNotifications.disposeNotification();
       }
     }
   } catch (error) {
@@ -1256,9 +1254,7 @@ export function registerOnboardingRemoveUnsupportedMachinesCommand(): extensionA
         }
       }
 
-      extensionNotifications.shouldNotifySetup = true;
-      // notification is no more required
-      extensionNotifications.notificationDisposable?.dispose();
+      extensionNotifications.disposeNotification();
     }
 
     if (errors.length > 0) {
@@ -2258,9 +2254,7 @@ export async function createMachine(
     sendTelemetryRecords('podman.machine.init', telemetryRecords, false);
   }
   extensionApi.context.setValue('podmanMachineExists', true, 'onboarding');
-  extensionNotifications.shouldNotifySetup = true;
-  // notification is no more required
-  extensionNotifications.notificationDisposable?.dispose();
+  extensionNotifications.disposeNotification();
 }
 
 export function resetShouldNotifySetup(): void {

--- a/extensions/podman/packages/extension/src/utils/notifications.ts
+++ b/extensions/podman/packages/extension/src/utils/notifications.ts
@@ -38,10 +38,6 @@ export class ExtensionNotifications {
 
   private _notificationDisposable?: extensionApi.Disposable;
 
-  public get notificationDisposable(): extensionApi.Disposable | undefined {
-    return this._notificationDisposable;
-  }
-
   private _disguisedPodmanNotificationDisposable?: extensionApi.Disposable;
 
   public get disguisedPodmanNotificationDisposable(): extensionApi.Disposable | undefined {
@@ -184,5 +180,11 @@ export class ExtensionNotifications {
       // push setup notification
       this.notifySetupPodman();
     }
+  }
+
+  public disposeNotification(): void {
+    // notification is no more required
+    this._notificationDisposable?.dispose();
+    this.shouldNotifySetup = true;
   }
 }

--- a/extensions/podman/packages/extension/src/utils/notifications.ts
+++ b/extensions/podman/packages/extension/src/utils/notifications.ts
@@ -71,16 +71,18 @@ export class ExtensionNotifications {
   // to avoid having multiple notification of the same nature in the notifications list
   // we first dispose the old one and then push the same again
   public notifySetupPodman(): void {
-    // Alert for setting up
-    this._notificationDisposable ??= extensionApi.window.showNotification({
-      title: 'Podman needs to be set up',
-      body: 'The Podman extension is installed, yet requires configuration. Some features might not function optimally.',
-      type: 'info',
-      markdownActions: ':button[Set up]{href=/preferences/onboarding/podman-desktop.podman title="Set up Podman"}',
-      highlight: true,
-      silent: true,
-    });
-    this.shouldNotifySetup = false;
+    if (this.shouldNotifySetup) {
+      // Alert for setting up
+      this._notificationDisposable ??= extensionApi.window.showNotification({
+        title: 'Podman needs to be set up',
+        body: 'The Podman extension is installed, yet requires configuration. Some features might not function optimally.',
+        type: 'info',
+        markdownActions: ':button[Set up]{href=/preferences/onboarding/podman-desktop.podman title="Set up Podman"}',
+        highlight: true,
+        silent: true,
+      });
+      this.shouldNotifySetup = false;
+    }
   }
 
   private notifyDisguisedPodmanSocket(): void {
@@ -176,7 +178,7 @@ export class ExtensionNotifications {
   public notifySetupPodmanNotLinux(): void {
     // Only show the notification on macOS and Windows
     // as Podman is already installed on Linux and machine is OPTIONAL.
-    if (this.shouldNotifySetup && !extensionApi.env.isLinux) {
+    if (!extensionApi.env.isLinux) {
       // push setup notification
       this.notifySetupPodman();
     }


### PR DESCRIPTION
### What does this PR do?

This PR moves code specific to notification management in podman extension to the newly created class. This is too help keeping the extension file code short.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Partial fixes of #13250 

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
