### PR TITLE
refactor(extensions/podman): move the mac podman notification

### DIFF
--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -3332,26 +3332,6 @@ describe('podman-mac-helper tests', () => {
     );
   });
 
-  test('set do not show configuration setting to true, make sure notification is NOT shown', async () => {
-    // Set configuration to always be true
-    // mimicking the 'doNotShow' setting being true
-    const spyGetConfiguration = vi.spyOn(config, 'get');
-    spyGetConfiguration.mockReturnValue(true);
-
-    // Activate
-    const api = await extension.activate(contextMock);
-    expect(api).toBeDefined();
-
-    // Make sure showNotification is not shown at all.
-    expect(extensionApi.window.showNotification).not.toBeCalledWith(
-      expect.objectContaining({
-        body: expect.stringContaining(
-          'The Podman Mac Helper is not set up, some features might not function optimally.',
-        ),
-      }),
-    );
-  });
-
   test('mock that the provider is "stopped" and make sure that the notification is NOT shown', async () => {
     // Mock the provider to be "stopped"
     vi.spyOn(apiProvider, 'createProvider').mockReturnValue(

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -1365,25 +1365,8 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   // Compatibility mode status bar item
   // only available for macOS
   if (extensionApi.env.isMac) {
-    // Get if we should never show the podman-mac-helper notification ever again
-    extensionNotifications.doNotShowMacHelperSetup = extensionNotifications.getDoNotShowMacHelperSetting();
-
     // Register the command for disabling the do not show mac helper setting permanently
-    extensionContext.subscriptions.push(
-      extensionApi.commands.registerCommand('podman.doNotShowMacHelperNotification', async () => {
-        // Set the configuration setting to true, so on reload of Podman Desktop it
-        // is consistent / will not show the notification again
-        await extensionApi.configuration
-          .getConfiguration('podman')
-          .update(ExtensionNotifications.configurationCompatibilityModeMacSetupNotificationDoNotShow, true);
-
-        //  Set the global variable to true
-        extensionNotifications.doNotShowMacHelperSetup = true;
-
-        // Dismiss the notification
-        extensionNotifications.podmanMacHelperNotificationDisposable?.dispose();
-      }),
-    );
+    extensionContext.subscriptions.push(extensionNotifications.setupNotificationMacPodman());
 
     // register two commands to enable and disable compatibility mode
     extensionContext.subscriptions.push(

--- a/extensions/podman/packages/extension/src/utils/notifications.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/notifications.spec.ts
@@ -255,4 +255,26 @@ describe('podman-mac-helper tests', () => {
       );
     });
   });
+
+  test('set do not show configuration setting to true, make sure notification is NOT shown', async () => {
+    const extensionNotifications = new ExtensionNotifications();
+
+    // Set configuration to always be true
+    // mimicking the 'doNotShow' setting being true
+    const spyGetConfiguration = vi.spyOn(config, 'get');
+    spyGetConfiguration.mockReturnValue(true);
+
+    extensionNotifications.setupNotificationMacPodman();
+
+    await extensionNotifications.checkMacSocket();
+
+    // Make sure showNotification is not shown at all.
+    expect(extensionApi.window.showNotification).not.toBeCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining(
+          'The Podman Mac Helper is not set up, some features might not function optimally.',
+        ),
+      }),
+    );
+  });
 });


### PR DESCRIPTION
### What does this PR do?

For the refactoring of the podman extension, I have introduced a class for the notifications. This PR moves the mac setup of notification and its tests to the newly created class.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Closes https://github.com/podman-desktop/podman-desktop/issues/13250

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
