### PR TITLE
fix(ui): make overflow hidden to fix fitAddon when search bar

### DIFF
--- a/packages/renderer/src/lib/ui/TerminalWindow.svelte
+++ b/packages/renderer/src/lib/ui/TerminalWindow.svelte
@@ -86,6 +86,7 @@ onDestroy(() => {
 </script>
 
 {#if search && terminal}
-  <TerminalSearchControls terminal={terminal} />
+  <TerminalSearchControls {terminal} />
 {/if}
-<div class="{className} p-[5px] pr-0 bg-[var(--pd-terminal-background)]" role="term" bind:this={logsXtermDiv}></div>
+
+<div class="{className} overflow-hidden p-[5px] pr-0 bg-[var(--pd-terminal-background)]" role="term" bind:this={logsXtermDiv}></div>


### PR DESCRIPTION
### What does this PR do?

Fixes the logs display when there is a search bar.
When resizing the window, there was an issue where the height of the search controls was not taken into account overflowing to the status bar and making logs not visible.

### Screenshot / video of UI



https://github.com/user-attachments/assets/801a77a4-2447-43b0-b5df-976f177ae639


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/13231

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
