### PR TITLE
fix: remove not needed timeout around registerCLITool in compose extension activation

### DIFF
--- a/extensions/compose/src/extension.ts
+++ b/extensions/compose/src/extension.ts
@@ -234,11 +234,9 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
 
   // Push the CLI tool as well (but it will do it postActivation so it does not block the activate() function)
   // Post activation
-  setTimeout(() => {
-    registerCLITool(composeDownload, detect, extensionContext).catch((error: unknown) => {
-      console.error('Error activating extension', error);
-    });
-  }, 0);
+  registerCLITool(composeDownload, detect, extensionContext).catch((error: unknown) => {
+    console.error('Error activating extension', error);
+  });
 }
 
 // Activate the CLI tool (check version, etc) and register the CLi so it does not block activation.


### PR DESCRIPTION
### What does this PR do?

PR removes setTimeout call that triggers async function registerCLITool call. setTimeout is not required because async function call without wait does not hold exit from extension's activation function.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
