### PR TITLE
fix(website): preload css to avoid flashing big icons on load

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -393,6 +393,8 @@ const config = {
     ],
   ],
 
+  clientModules: [require.resolve('./src/scripts/fontAwesomeIcons.ts')],
+
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({

--- a/website/src/scripts/fontAwesomeIcons.ts
+++ b/website/src/scripts/fontAwesomeIcons.ts
@@ -1,0 +1,5 @@
+import '@fortawesome/fontawesome-svg-core/styles.css';
+
+import { config } from '@fortawesome/fontawesome-svg-core';
+
+config.autoAddCss = false;


### PR DESCRIPTION
### What does this PR do?

Use the fort awesome style in a base component to load in at build time. So the webpages are rendered with the icons of the correct size, and not changed dynamically on client side making it flash from big to small.

### Screenshot / video of UI




<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes #13333

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
