### PR TITLE
chore: update toast notification style

### DIFF
--- a/packages/renderer/src/lib/toast/ToastCustomUi.spec.ts
+++ b/packages/renderer/src/lib/toast/ToastCustomUi.spec.ts
@@ -18,13 +18,22 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import { Spinner } from '@podman-desktop/ui-svelte';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { toast } from '@zerodevx/svelte-toast';
-import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
 
 import type { TaskInfo } from '/@api/taskInfo';
 
 import ToastCustomUi from './ToastCustomUi.svelte';
+
+vi.mock(import('@podman-desktop/ui-svelte'), async importOriginal => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    Spinner: vi.fn(),
+  };
+});
 
 const started = new Date().getTime();
 const onpop = vi.fn();
@@ -60,11 +69,15 @@ const FAILURE_TASK: TaskInfo = {
   cancellable: false,
 };
 
-beforeAll(() => {
-  Object.defineProperty(window, 'executeTask', {
-    value: vi.fn(),
-  });
-});
+const CANCELED_TASK: TaskInfo = {
+  id: '1',
+  name: 'Canceled Task 1',
+  state: 'completed',
+  status: 'canceled',
+  started,
+  action: 'canceled action',
+  cancellable: true,
+};
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -80,21 +93,15 @@ test('Check with in-progress', async () => {
     toastId,
     onpop,
   });
+
   // expect the in-progress is used
   const status = screen.getByRole('status', { name: 'in-progress' });
   expect(status).toBeInTheDocument();
+  expect(Spinner).toHaveBeenCalled();
 
   // expect name is there
-  const name = screen.getAllByText(IN_PROGRESS_TASK.name);
-  expect(name).lengthOf(2);
-
-  // should have an action and can click on it
-  const action = screen.getByRole('link', { name: 'Task action' });
-  expect(action).toBeInTheDocument();
-  await fireEvent.click(action);
-
-  // expect we have been calling the method
-  expect(window.executeTask).toHaveBeenCalledWith(IN_PROGRESS_TASK.id);
+  const name = screen.getByText(IN_PROGRESS_TASK.name);
+  expect(name).toBeInTheDocument();
 
   // expect we can close the toast
   const close = screen.getByRole('button', { name: 'Close' });
@@ -115,21 +122,14 @@ test('Check with success', async () => {
     toastId,
     onpop,
   });
-  // expect the in-progress is used
+  // expect the success status is used
   const status = screen.getByRole('status', { name: 'success' });
   expect(status).toBeInTheDocument();
+  expect(status.children[0]).toHaveClass('text-[var(--pd-state-success)]');
 
   // expect name is there
-  const name = screen.getAllByText(SUCCESS_TASK.name);
-  expect(name).lengthOf(2);
-
-  // should have an action and can click on it
-  const action = screen.getByRole('link', { name: 'Success action' });
-  expect(action).toBeInTheDocument();
-  await fireEvent.click(action);
-
-  // expect we have been calling the method
-  expect(window.executeTask).toHaveBeenCalledWith(SUCCESS_TASK.id);
+  const name = screen.getByText(SUCCESS_TASK.name);
+  expect(name).toBeInTheDocument();
 
   // expect we can close the toast
   const close = screen.getByRole('button', { name: 'Close' });
@@ -150,25 +150,46 @@ test('Check with failure', async () => {
     toastId,
     onpop,
   });
-  // expect the in-progress is used
+  // expect the failure status is used
   const status = screen.getByRole('status', { name: 'failure' });
   expect(status).toBeInTheDocument();
+  expect(status.children[0]).toHaveClass('text-[var(--pd-state-warning)]');
 
   // expect name is there
-  const name = screen.getByText(FAILURE_TASK.name);
+  const name = screen.getByText(`Error ${FAILURE_TASK.name}`);
   expect(name).toBeInTheDocument();
 
   // expect error to be displayed
   const error = screen.getByText(failureTaskError);
   expect(error).toBeInTheDocument();
 
-  // should have an action and can click on it
-  const action = screen.getByRole('link', { name: 'failure action' });
-  expect(action).toBeInTheDocument();
-  await fireEvent.click(action);
+  // expect we can close the toast
+  const close = screen.getByRole('button', { name: 'Close' });
+  expect(close).toBeInTheDocument();
+  await fireEvent.click(close);
+  expect(onpop).toHaveBeenCalled();
 
-  // expect we have been calling the method
-  expect(window.executeTask).toHaveBeenCalledWith(FAILURE_TASK.id);
+  expect(toastPopSpy).toHaveBeenCalledWith(toastId);
+});
+
+test('Check with cancel', async () => {
+  // spy pop method on toast
+  const toastPopSpy = vi.spyOn(toast, 'pop');
+  const toastId = 1234;
+
+  render(ToastCustomUi, {
+    taskInfo: CANCELED_TASK,
+    toastId,
+    onpop,
+  });
+  // expect the failure status is used
+  const status = screen.getByRole('status', { name: 'canceled' });
+  expect(status).toBeInTheDocument();
+  expect(status.children[0]).toHaveClass('text-[var(--pd-state-error)]');
+
+  // expect name is there
+  const name = screen.getByText(`Canceled ${CANCELED_TASK.name}`);
+  expect(name).toBeInTheDocument();
 
   // expect we can close the toast
   const close = screen.getByRole('button', { name: 'Close' });

--- a/packages/renderer/src/lib/toast/ToastCustomUi.spec.ts
+++ b/packages/renderer/src/lib/toast/ToastCustomUi.spec.ts
@@ -153,7 +153,7 @@ test('Check with failure', async () => {
   // expect the failure status is used
   const status = screen.getByRole('status', { name: 'failure' });
   expect(status).toBeInTheDocument();
-  expect(status.children[0]).toHaveClass('text-[var(--pd-state-warning)]');
+  expect(status.children[0]).toHaveClass('text-[var(--pd-state-error)]');
 
   // expect name is there
   const name = screen.getByText(`Error ${FAILURE_TASK.name}`);
@@ -185,7 +185,7 @@ test('Check with cancel', async () => {
   // expect the failure status is used
   const status = screen.getByRole('status', { name: 'canceled' });
   expect(status).toBeInTheDocument();
-  expect(status.children[0]).toHaveClass('text-[var(--pd-state-error)]');
+  expect(status.children[0]).toHaveClass('text-[var(--pd-state-warning)]');
 
   // expect name is there
   const name = screen.getByText(`Canceled ${CANCELED_TASK.name}`);

--- a/packages/renderer/src/lib/toast/ToastCustomUi.svelte
+++ b/packages/renderer/src/lib/toast/ToastCustomUi.svelte
@@ -16,7 +16,7 @@ let { toastId, taskInfo, onpop = (): void => {} }: Props = $props();
 
 const taskStatus: { [taskInfo.status]: string } = {
   failure: 'Error',
-  canceled: 'Cancelled',
+  canceled: 'Canceled',
 };
 
 function hideToast(): void {
@@ -35,7 +35,7 @@ const closeAction = (): void => {
 >
   <div class="flex flex-row gap-1">
     <div
-      class="mr-1 text-[var(--pd-state-info)] w-fit h-fit self-center w-[2em]"
+      class="mr-1 text-[var(--pd-state-info)] w-fit h-fit self-center"
       role="status"
       aria-label={taskInfo.status}
     >
@@ -46,13 +46,16 @@ const closeAction = (): void => {
       {:else if taskInfo.status === 'canceled'}
         <Fa icon={faCircleXmark} class="text-[var(--pd-state-error)] fa-xl"/>
       {:else if taskInfo.status === 'failure'}
-        <Fa icon={faTriangleExclamation } class=" fa fa-exclamation-triangle text-[var(--pd-state-warning)] fa-xl" />
+        <Fa icon={faTriangleExclamation } class="text-[var(--pd-state-warning)] fa-xl" />
       {/if}
     </div>
 
-    <p class="text-base text-ellipsis text-[var(--pd-modal-text)] line-clamp-3 h-full overflow-hidden break-all">
+    <div class="text-base text-ellipsis text-[var(--pd-card-text)] line-clamp-3 h-full overflow-hidden break-all">
       {taskStatus[taskInfo.status] ?? ''} {taskInfo.name}
-    </p>
+      {#if taskInfo.error}
+        <p class="text-[var(--pd-content-text)]">{taskInfo.error}</p>
+      {/if}
+    </div>
   </div>
 
   <div class="flex flex-none whitespace-nowrap flex-col self-start w-fit">

--- a/packages/renderer/src/lib/toast/ToastCustomUi.svelte
+++ b/packages/renderer/src/lib/toast/ToastCustomUi.svelte
@@ -33,14 +33,14 @@ const closeAction = (): void => {
   class="flex flex-nowrap min-h-10 cursor-default max-h-30 max-w-[var(--toastWidth)] flex-row p-2 border-[var(--pd-content-divider)] border rounded-md bg-[var(--pd-modal-bg)] gap-2 justify-between text-base"
   title={taskInfo.name}
 >
-  <div class="flex flex-row gap-1">
+  <div class="flex flex-row gap-1 items-center">
     <div
       class="mr-1 text-[var(--pd-state-info)] w-fit h-fit self-center"
       role="status"
       aria-label={taskInfo.status}
     >
       {#if taskInfo.status === 'in-progress'}
-        <Spinner size="2em"/>
+        <Spinner size="1.5em"/>
       {:else if taskInfo.status === 'success'}
         <Fa icon={faCheckCircle} class="text-[var(--pd-state-success)] fa-xl"/>
       {:else if taskInfo.status === 'canceled'}
@@ -50,7 +50,7 @@ const closeAction = (): void => {
       {/if}
     </div>
 
-    <div class="text-base text-ellipsis text-[var(--pd-card-text)] line-clamp-3 h-full overflow-hidden break-all">
+    <div class="text-base text-ellipsis text-[var(--pd-card-text)] line-clamp-3 h-fit overflow-hidden break-all">
       {taskStatus[taskInfo.status] ?? ''} {taskInfo.name}
       {#if taskInfo.error}
         <p class="text-[var(--pd-content-text)]">{taskInfo.error}</p>

--- a/packages/renderer/src/lib/toast/ToastCustomUi.svelte
+++ b/packages/renderer/src/lib/toast/ToastCustomUi.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-import { faCheckCircle, faCircleXmark } from '@fortawesome/free-regular-svg-icons';
-import { faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
-import { CloseButton, Link, Spinner } from '@podman-desktop/ui-svelte';
+import { faCheckCircle, faCircleXmark, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
+import { CloseButton, Spinner } from '@podman-desktop/ui-svelte';
 import { toast } from '@zerodevx/svelte-toast';
 import Fa from 'svelte-fa';
 
@@ -28,46 +27,36 @@ const closeAction = (): void => {
   hideToast();
   onpop();
 };
-
-const executeAction = async (): Promise<void> => {
-  hideToast();
-  await window.executeTask(taskInfo.id);
-};
 </script>
 
 <div
-  class="flex flex-nowrap min-h-10 cursor-default max-h-30 max-w-[var(--toastWidth)] flex-row p-2 border-[var(--pd-content-divider)] border rounded-md bg-[var(--pd-modal-bg)] gap-2"
+  class="flex flex-nowrap min-h-10 cursor-default max-h-30 max-w-[var(--toastWidth)] flex-row p-2 border-[var(--pd-content-divider)] border rounded-md bg-[var(--pd-modal-bg)] gap-2 justify-between text-base"
   title={taskInfo.name}
 >
-  <div
-    class="mr-1 text-[var(--pd-state-info)] w-fit h-fit self-center"
-    role="status"
-    aria-label={taskInfo.status}
-  >
-    {#if taskInfo.status === 'in-progress'}
-      <Spinner size="2em"/>
-    {:else if taskInfo.status === 'success'}
-      <Fa icon={faCheckCircle} class="text-[var(--pd-state-success)] fa-xl"/>
-    {:else if taskInfo.status === 'canceled'}
-      <Fa icon={faCircleXmark} class="text-[var(--pd-state-error)] fa-xl"/>
-    {:else if taskInfo.status === 'failure'}
-      <Fa icon={faTriangleExclamation } class=" fa fa-exclamation-triangle text-[var(--pd-state-warning)] fa-xl" />
-    {/if}
+  <div class="flex flex-row gap-1">
+    <div
+      class="mr-1 text-[var(--pd-state-info)] w-fit h-fit self-center w-[2em]"
+      role="status"
+      aria-label={taskInfo.status}
+    >
+      {#if taskInfo.status === 'in-progress'}
+        <Spinner size="2em"/>
+      {:else if taskInfo.status === 'success'}
+        <Fa icon={faCheckCircle} class="text-[var(--pd-state-success)] fa-xl"/>
+      {:else if taskInfo.status === 'canceled'}
+        <Fa icon={faCircleXmark} class="text-[var(--pd-state-error)] fa-xl"/>
+      {:else if taskInfo.status === 'failure'}
+        <Fa icon={faTriangleExclamation } class=" fa fa-exclamation-triangle text-[var(--pd-state-warning)] fa-xl" />
+      {/if}
+    </div>
+
+    <p class="text-base text-ellipsis text-[var(--pd-modal-text)] line-clamp-3 h-full overflow-hidden break-all">
+      {taskStatus[taskInfo.status] ?? ''} {taskInfo.name}
+    </p>
   </div>
 
-  <div class="flex flex-col h-full max-w-[85%]">
-    <div class="mb-1 flex flex-row h-full gap-1">
-        <p class="flex flex-wrap text-base text-ellipsis overflow-hidden text-[var(--pd-modal-text)]">
-          {taskStatus[taskInfo.status] ?? ''} {taskInfo.name}
-        </p>
-      <div class="flex flex-none whitespace-nowrap flex-col self-start w-fit">
-        <CloseButton class="text-[var(--pd-modal-text)]" onclick={closeAction} />
-      </div>
-    </div>
-    {#if taskInfo.action}
-      <div class="text-right text-xs text-[var(--pd-content-text)]">
-        <Link onclick={executeAction}>{taskInfo.action}</Link>
-      </div>
-    {/if}
+  <div class="flex flex-none whitespace-nowrap flex-col self-start w-fit">
+    <CloseButton class="text-[var(--pd-modal-text)]" onclick={closeAction} />
   </div>
+
 </div>

--- a/packages/renderer/src/lib/toast/ToastCustomUi.svelte
+++ b/packages/renderer/src/lib/toast/ToastCustomUi.svelte
@@ -30,12 +30,12 @@ const closeAction = (): void => {
 </script>
 
 <div
-  class="flex flex-nowrap min-h-10 cursor-default max-h-30 max-w-[var(--toastWidth)] flex-row p-2 border-[var(--pd-content-divider)] border rounded-md bg-[var(--pd-modal-bg)] gap-2 justify-between text-base"
+  class="flex flex-nowrap min-h-10 cursor-default max-h-50 max-w-[var(--toastWidth)] flex-row p-2 border-[var(--pd-content-divider)] border rounded-md bg-[var(--pd-modal-bg)] gap-2 justify-between text-base"
   title={taskInfo.name}
 >
-  <div class="flex flex-row gap-1 items-center">
+  <div class="flex flex-row gap-1 items-start">
     <div
-      class="mr-1 text-[var(--pd-state-info)] w-fit h-fit self-center"
+      class="mr-1 text-[var(--pd-state-info)] w-fit h-fit"
       role="status"
       aria-label={taskInfo.status}
     >
@@ -50,7 +50,7 @@ const closeAction = (): void => {
       {/if}
     </div>
 
-    <div class="text-base text-ellipsis text-[var(--pd-card-text)] line-clamp-3 h-fit overflow-hidden break-all">
+    <div class="text-base text-balance text-ellipsis text-[var(--pd-card-text)] h-fit wrap-break-word max-w-46">
       {taskStatus[taskInfo.status] ?? ''} {taskInfo.name}
       {#if taskInfo.error}
         <p class="text-[var(--pd-content-text)]">{taskInfo.error}</p>

--- a/packages/renderer/src/lib/toast/ToastCustomUi.svelte
+++ b/packages/renderer/src/lib/toast/ToastCustomUi.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faCheckCircle, faCircleXmark, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
+import { faCheckCircle, faCircleExclamation, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
 import { CloseButton, Spinner } from '@podman-desktop/ui-svelte';
 import { toast } from '@zerodevx/svelte-toast';
 import Fa from 'svelte-fa';
@@ -30,7 +30,7 @@ const closeAction = (): void => {
 </script>
 
 <div
-  class="flex flex-nowrap min-h-10 cursor-default max-h-50 max-w-[var(--toastWidth)] flex-row p-2 border-[var(--pd-content-divider)] border rounded-md bg-[var(--pd-modal-bg)] gap-2 justify-between text-base"
+  class="flex flex-nowrap min-h-10 select-none pointer-events-auto cursor-default max-h-50 max-w-[var(--toastWidth)] flex-row p-2 border-[var(--pd-content-divider)] border rounded-md bg-[var(--pd-modal-bg)] gap-2 justify-between text-base"
   title={taskInfo.name}
 >
   <div class="flex flex-row gap-1 items-start">
@@ -43,9 +43,9 @@ const closeAction = (): void => {
         <Spinner size="1.5em"/>
       {:else if taskInfo.status === 'success'}
         <Fa icon={faCheckCircle} class="text-[var(--pd-state-success)] fa-xl"/>
-      {:else if taskInfo.status === 'canceled'}
-        <Fa icon={faCircleXmark} class="text-[var(--pd-state-error)] fa-xl"/>
       {:else if taskInfo.status === 'failure'}
+        <Fa icon={faCircleExclamation} class="text-[var(--pd-state-error)] fa-xl"/>
+      {:else if taskInfo.status === 'canceled'}
         <Fa icon={faTriangleExclamation } class="text-[var(--pd-state-warning)] fa-xl" />
       {/if}
     </div>

--- a/packages/renderer/src/lib/toast/ToastCustomUi.svelte
+++ b/packages/renderer/src/lib/toast/ToastCustomUi.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-import { faCheckCircle, faCircleExclamation } from '@fortawesome/free-solid-svg-icons';
+import { faCheckCircle, faCircleXmark } from '@fortawesome/free-regular-svg-icons';
+import { faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
 import { CloseButton, Link, Spinner } from '@podman-desktop/ui-svelte';
 import { toast } from '@zerodevx/svelte-toast';
 import Fa from 'svelte-fa';
@@ -13,6 +14,11 @@ interface Props {
 }
 
 let { toastId, taskInfo, onpop = (): void => {} }: Props = $props();
+
+const taskStatus: { [taskInfo.status]: string } = {
+  failure: 'Error',
+  canceled: 'Cancelled',
+};
 
 function hideToast(): void {
   toast.pop(toastId);
@@ -30,50 +36,38 @@ const executeAction = async (): Promise<void> => {
 </script>
 
 <div
-  class="flex min-h-10 cursor-default max-h-30 max-w-[var(--toastWidth)] flex-col p-2 border-[var(--pd-button-tab-border-selected)] border rounded-md bg-[var(--pd-modal-bg)]"
+  class="flex flex-nowrap min-h-10 cursor-default max-h-30 max-w-[var(--toastWidth)] flex-row p-2 border-[var(--pd-content-divider)] border rounded-md bg-[var(--pd-modal-bg)] gap-2"
   title={taskInfo.name}
 >
-  <div class="mb-1 flex flex-row items-center">
-    <div
-      class="mr-1 text-[var(--pd-state-info)]"
-      role="status"
-      aria-label={taskInfo.status}
-    >
-      {#if taskInfo.status === 'in-progress'}
-        <Spinner size="1em"/>
-      {:else if taskInfo.status === 'success'}
-        <Fa icon={faCheckCircle} />
-      {:else if taskInfo.status === 'failure'}
-        <Fa icon={faCircleExclamation} class="text-[var(--pd-state-error)]" />
-      {/if}
-    </div>
-
-    <div class="font-bold text-ellipsis line-clamp-1 overflow-hidden text-[var(--pd-modal-text)]">
-      {taskInfo.name}
-    </div>
-
-    {#if taskInfo.progress && taskInfo.status === 'in-progress'}
-      <span class="ml-1">{taskInfo.progress}%</span>
-    {/if}
-
-    <div class="flex grow flex-col items-end">
-      <CloseButton class="text-[var(--pd-modal-text)]" onclick={closeAction} />
-    </div>
-  </div>
-  <div class="flex flex-row items-center italic line-clamp-4">
-    {#if taskInfo.error}
-      <p class="flex-1 text-sm line-clamp-4 text-[var(--pd-state-error)]">
-        {taskInfo.error}
-      </p>
-    {:else}
-    <p class="flex-1 text-sm text-ellipsis overflow-hidden text-[var(--pd-modal-text)]">
-      {taskInfo.name}
-    </p>
+  <div
+    class="mr-1 text-[var(--pd-state-info)] w-fit h-fit self-center"
+    role="status"
+    aria-label={taskInfo.status}
+  >
+    {#if taskInfo.status === 'in-progress'}
+      <Spinner size="2em"/>
+    {:else if taskInfo.status === 'success'}
+      <Fa icon={faCheckCircle} class="text-[var(--pd-state-success)] fa-xl"/>
+    {:else if taskInfo.status === 'canceled'}
+      <Fa icon={faCircleXmark} class="text-[var(--pd-state-error)] fa-xl"/>
+    {:else if taskInfo.status === 'failure'}
+      <Fa icon={faTriangleExclamation } class=" fa fa-exclamation-triangle text-[var(--pd-state-warning)] fa-xl" />
     {/if}
   </div>
-  {#if taskInfo.action}
-    <div class="text-right text-xs text-[var(--pd-content-text)]">
-      <Link onclick={executeAction}>{taskInfo.action}</Link>
+
+  <div class="flex flex-col h-full max-w-[85%]">
+    <div class="mb-1 flex flex-row h-full gap-1">
+        <p class="flex flex-wrap text-base text-ellipsis overflow-hidden text-[var(--pd-modal-text)]">
+          {taskStatus[taskInfo.status] ?? ''} {taskInfo.name}
+        </p>
+      <div class="flex flex-none whitespace-nowrap flex-col self-start w-fit">
+        <CloseButton class="text-[var(--pd-modal-text)]" onclick={closeAction} />
+      </div>
     </div>
-  {/if}
+    {#if taskInfo.action}
+      <div class="text-right text-xs text-[var(--pd-content-text)]">
+        <Link onclick={executeAction}>{taskInfo.action}</Link>
+      </div>
+    {/if}
+  </div>
 </div>

--- a/packages/renderer/src/lib/toast/ToastHandler.svelte
+++ b/packages/renderer/src/lib/toast/ToastHandler.svelte
@@ -11,6 +11,7 @@
   --toastContainerBottom: 1rem;
   --toastContainerLeft: auto;
   --toastBackground: var(--pd-modal-bg);
+  --toastBarHeight: 3px;
 }
 </style>
 


### PR DESCRIPTION
### What does this PR do?
Update the style of the task notification toast based on https://github.com/podman-desktop/podman-desktop/issues/9579#issuecomment-2604550568:

### Screenshot / video of UI
<img width="268" height="279" alt="Screenshot 2025-08-01 at 10 02 00 AM" src="https://github.com/user-attachments/assets/bd10b31c-d647-43b7-b27f-73b70b64918c" />



<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/podman-desktop/issues/11151

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
