### PR TITLE
feat: expose repository info parser for usage in extensions

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -4954,4 +4954,27 @@ declare module '@podman-desktop/api' {
      */
     onDidChange: Event<SecretStorageChangeEvent>;
   }
+
+  /**
+   * Parses a repository URL to extract owner and repository information.
+   * It currently only supports GitHub repositories.
+   */
+  export class RepositoryInfoParser {
+    /**
+     * The owner of the GitHub repository (e.g., 'microsoft').
+     */
+    public readonly owner: string;
+    /**
+     * The name of the GitHub repository (e.g., 'vscode').
+     */
+    public readonly repository: string;
+
+    /**
+     * Creates an instance of RepositoryInfoParser.
+     * @param url The URL of the repository to parse.
+     * @throws {Error} If the URL cannot be parsed.
+     * @throws {Error} If the repository is not hosted on GitHub.
+     */
+    constructor(url: string);
+  }
 }

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -37,6 +37,7 @@ import type { Event } from '/@api/event.js';
 import type { ExtensionError, ExtensionInfo, ExtensionUpdateInfo } from '/@api/extension-info.js';
 import { DEFAULT_TIMEOUT, ExtensionLoaderSettings } from '/@api/extension-loader-settings.js';
 import type { ImageInspectInfo } from '/@api/image-inspect-info.js';
+import { RepositoryInfoParser } from '/@api/repository-info-parser.js';
 
 import { securityRestrictionCurrentHandler } from '../../security-restrictions-handler.js';
 import { getBase64Image, isLinux, isMac, isWindows } from '../../util.js';
@@ -1562,6 +1563,7 @@ export class ExtensionLoader {
       cli,
       imageChecker,
       navigation,
+      RepositoryInfoParser,
     };
   }
 


### PR DESCRIPTION
### What does this PR do?

This PR exposes the repository info parser to the extensions, so that it can be reused. The goal is to use it in extensions to replace occurrences of the repository owner and name in the code.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?


<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
