### PR TITLE
test(renderer): fix async components tests for Svelte 5.36

### DIFF
--- a/packages/renderer/src/lib/dashboard/ReleaseNotesBox.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ReleaseNotesBox.spec.ts
@@ -167,6 +167,7 @@ test('show release notes on configuration change to non-current version value', 
   const showReleaseNotes = 'releaseNotesBanner.show';
   render(ReleaseNotesBox);
   await tick();
+  await waitFor(() => expect(podmanDesktopGetReleaseNotesMock).toBeCalled());
 
   expect(screen.queryByText(responseJSON.title)).not.toBeInTheDocument();
   expect(screen.queryByText(responseJSON.summary)).not.toBeInTheDocument();

--- a/packages/renderer/src/lib/dashboard/ReleaseNotesBox.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ReleaseNotesBox.spec.ts
@@ -166,7 +166,6 @@ test('show release notes on configuration change to non-current version value', 
   getConfigurationValueMock.mockResolvedValueOnce('1.1.0');
   const showReleaseNotes = 'releaseNotesBanner.show';
   render(ReleaseNotesBox);
-  await tick();
   await waitFor(() => expect(podmanDesktopGetReleaseNotesMock).toBeCalled());
 
   expect(screen.queryByText(responseJSON.title)).not.toBeInTheDocument();

--- a/packages/renderer/src/lib/learning-center/LearningCenter.spec.ts
+++ b/packages/renderer/src/lib/learning-center/LearningCenter.spec.ts
@@ -102,11 +102,11 @@ test('Toggling expansion sets configuration', async () => {
 
   const button = screen.getByRole('button', { name: 'Learning Center' });
   expect(button).toBeInTheDocument();
-  expect(button).toHaveAttribute('aria-expanded', 'true');
+  await waitFor(() => expect(button).toHaveAttribute('aria-expanded', 'true'));
 
   await fireEvent.click(button);
   expect(updateConfigurationValueMock).toHaveBeenCalledWith('learningCenter.expanded', false);
-  expect(button).toHaveAttribute('aria-expanded', 'false');
+  await waitFor(() => expect(button).toHaveAttribute('aria-expanded', 'false'));
 
   await fireEvent.click(button);
   expect(updateConfigurationValueMock).toHaveBeenCalledWith('learningCenter.expanded', true);

--- a/packages/renderer/src/lib/learning-center/LearningCenter.spec.ts
+++ b/packages/renderer/src/lib/learning-center/LearningCenter.spec.ts
@@ -19,7 +19,6 @@
 import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
-import { tick } from 'svelte';
 import { afterEach, beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
 import learningCenter from '../../../../main/src/plugin/learning-center/guides.json';
@@ -94,9 +93,6 @@ test('Clicking on LearningCenter title hides carousel with guides', async () => 
 
 test('Toggling expansion sets configuration', async () => {
   render(LearningCenter);
-
-  // wait for onMount
-  await tick();
 
   expect(updateConfigurationValueMock).not.toHaveBeenCalled();
 

--- a/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
@@ -220,16 +220,16 @@ test('Expect to create routes with OpenShift and open Link', async () => {
   await fireEvent.click(createButton);
 
   // wait that openshiftCreateRouteMock is called
-  while (openshiftCreateRouteMock.mock.calls.length === 0) {
-    await new Promise(resolve => setTimeout(resolve, 100));
-  }
+  await vi.waitFor(() => expect(openshiftCreateRouteMock.mock.calls).not.toHaveLength(0));
 
-  expect(telemetryTrackMock).toBeCalledWith('deployToKube', {
-    useRoutes: true,
-    useServices: true,
-    isOpenshift: true,
-    createIngress: false,
-  });
+  await vi.waitFor(() =>
+    expect(telemetryTrackMock).toBeCalledWith('deployToKube', {
+      useRoutes: true,
+      useServices: true,
+      isOpenshift: true,
+      createIngress: false,
+    }),
+  );
 
   // check tls option is used
   expect(openshiftCreateRouteMock).toBeCalledWith('default', {

--- a/packages/renderer/src/lib/pod/PodEmptyScreen.spec.ts
+++ b/packages/renderer/src/lib/pod/PodEmptyScreen.spec.ts
@@ -97,16 +97,18 @@ testComponent('button click creates and starts a pod', async () => {
   vi.spyOn(window, 'createPod').mockResolvedValue(podInfo);
   await fireEvent.click(getButton());
   expect(window.createPod).toBeCalledWith({ name: 'my-first-pod' });
-  expect(window.createAndStartContainer).toBeCalledWith(podInfo.engineId, {
-    Image: helloImage,
-    pod: 'my-first-pod',
-  });
+  await vi.waitFor(() =>
+    expect(window.createAndStartContainer).toBeCalledWith(podInfo.engineId, {
+      Image: helloImage,
+      pod: 'my-first-pod',
+    }),
+  );
 });
 
 testComponent('button click shows error message if creating pod fails', async () => {
   vi.spyOn(window, 'createPod').mockRejectedValue(error);
   await fireEvent.click(getButton());
-  expect(window.showMessageBox).toBeCalledWith(errorMessage);
+  await vi.waitFor(() => expect(window.showMessageBox).toBeCalledWith(errorMessage));
 });
 
 testComponent('button click shows error message if starting pod fails', async () => {

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsLogs.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsLogs.spec.ts
@@ -22,9 +22,8 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { render, screen } from '@testing-library/svelte';
+import { render, screen, waitFor } from '@testing-library/svelte';
 import { Terminal } from '@xterm/xterm';
-import { tick } from 'svelte';
 import type { Mock } from 'vitest';
 import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
@@ -90,11 +89,7 @@ test('Should call startReceiveLogs with empty colour codes', async () => {
     noLog: false,
   });
 
-  await tick();
-  // second tick need to process all await statements in onMount method
-  await tick();
-
-  expect(window.startReceiveLogs).toHaveBeenCalledTimes(1);
+  await waitFor(() => expect(window.startReceiveLogs).toHaveBeenCalledTimes(1));
 
   const args = (window.startReceiveLogs as Mock).mock.calls[0];
   const [id, cb1, cb2, cb3] = args;

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsTerminal.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsTerminal.spec.ts
@@ -231,7 +231,7 @@ test('terminal active/ restarts connection after stopping and starting a provide
     () => {
       expect(shellInProviderConnectionMock).toHaveBeenCalledTimes(3);
       expect(shellInProviderConnectionCloseMock).toHaveBeenCalledTimes(2);
-      expect(shellInProviderConnectionResizeMock).toHaveBeenCalledTimes(2);
+      expect(shellInProviderConnectionResizeMock).toHaveBeenCalledTimes(3);
     },
     { timeout: 2000 },
   );

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRenderingEditModal.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRenderingEditModal.spec.ts
@@ -20,9 +20,8 @@ import '@testing-library/jest-dom/vitest';
 
 import type { Cluster, User } from '@kubernetes/client-node';
 import { Dropdown } from '@podman-desktop/ui-svelte';
-import { render, screen } from '@testing-library/svelte';
+import { render, screen, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
-import { tick } from 'svelte';
 import { assert, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { KubeContext } from '/@api/kubernetes-context';
@@ -191,18 +190,17 @@ describe('UpdateContext', () => {
       closeCallback: closeCallback,
     });
 
-    // wait until is the component rendered
-    await tick();
-
-    expect(Dropdown).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        options: [mockUser1, mockUser2].map(user => ({
-          value: user.name,
-          label: user.name,
-        })),
-      }),
-    );
+    await waitFor(() => {
+      expect(Dropdown).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          options: [mockUser1, mockUser2].map(user => ({
+            value: user.name,
+            label: user.name,
+          })),
+        }),
+      );
+    });
   });
 
   test('dropdown value should match window#kubernetesGetClusters', async () => {
@@ -212,18 +210,17 @@ describe('UpdateContext', () => {
       closeCallback: closeCallback,
     });
 
-    // wait until is the component rendered
-    await tick();
-
-    expect(Dropdown).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        options: [mockCluster1, mockCluster2].map(cluster => ({
-          value: cluster.name,
-          label: cluster.name,
-        })),
-      }),
-    );
+    await waitFor(() => {
+      expect(Dropdown).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          options: [mockCluster1, mockCluster2].map(cluster => ({
+            value: cluster.name,
+            label: cluster.name,
+          })),
+        }),
+      );
+    });
   });
 
   test('dropdown#onUserStateChange should update value', async () => {

--- a/packages/renderer/src/lib/statusbar/StatusBar.spec.ts
+++ b/packages/renderer/src/lib/statusbar/StatusBar.spec.ts
@@ -111,7 +111,8 @@ describe('providers', () => {
   test('providers should show up when configuration changes from false to true', async () => {
     vi.mocked(window.getConfigurationValue).mockResolvedValue(false);
     render(StatusBar);
-    await tick();
+
+    await vi.waitFor(() => expect(window.getConfigurationValue).toBeCalledTimes(2));
 
     expect(Providers).not.toHaveBeenCalled();
 
@@ -119,11 +120,7 @@ describe('providers', () => {
       detail: { key: `statusbarProviders.showProviders`, value: true },
     });
 
-    await tick();
-
-    await vi.waitFor(() => {
-      expect(Providers).toHaveBeenCalled();
-    });
+    await vi.waitFor(() => expect(Providers).toHaveBeenCalled());
   });
 
   test('providers are hidden when configuration changes from true to false', async () => {


### PR DESCRIPTION
### What does this PR do?


For update to Svelte 5.36, some UT must be updated because the async logic has changed a bit in Svelte. This PR proposes change to make the tests pass after Svelte 5.36 update.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes #13374
The update of Svelte in https://github.com/podman-desktop/podman-desktop/pull/13359 is stuck because some UT are not passing.
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
