### PR TITLE
chore(renderer/dialog): prepare dialog component migration to Svelte 5

### DIFF
--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -539,7 +539,7 @@ function key(item: ContainerGroupInfoUI | ContainerInfoUI): string {
 {#if openChoiceModal}
   <Dialog
     title="Create a new container"
-    on:close={(): void => {
+    onclose={(): void => {
       openChoiceModal = false;
     }}>
     <div slot="content" class="h-full flex flex-col justify-items-center text-[var(--pd-modal-text)]">

--- a/packages/renderer/src/lib/dialogs/Dialog.svelte
+++ b/packages/renderer/src/lib/dialogs/Dialog.svelte
@@ -3,10 +3,10 @@ import { CloseButton, Modal } from '@podman-desktop/ui-svelte';
 
 export let title: string;
 
-export let onclose: () => void;
+export let onclose: (() => void) | undefined = undefined;
 </script>
 
-<Modal name={title} on:close={onclose}>
+<Modal name={title} onclose={onclose}>
   <div class="flex items-center justify-between pl-4 pr-3 py-3 space-x-2 text-[var(--pd-modal-header-text)]">
     <slot name="icon" />
     <h1 class="grow text-lg font-bold capitalize">{title}</h1>

--- a/packages/renderer/src/lib/dialogs/Dialog.svelte
+++ b/packages/renderer/src/lib/dialogs/Dialog.svelte
@@ -1,14 +1,9 @@
 <script lang="ts">
 import { CloseButton, Modal } from '@podman-desktop/ui-svelte';
-import { createEventDispatcher } from 'svelte';
 
 export let title: string;
 
-const dispatch = createEventDispatcher();
-
-export let onclose: () => void = () => {
-  dispatch('close');
-};
+export let onclose: () => void;
 </script>
 
 <Modal name={title} on:close={onclose}>

--- a/packages/renderer/src/lib/dialogs/DialogSpec.svelte
+++ b/packages/renderer/src/lib/dialogs/DialogSpec.svelte
@@ -2,7 +2,7 @@
 import Dialog from './Dialog.svelte';
 </script>
 
-<Dialog title="Test dialog" onclose={(): void => {}}>
+<Dialog title="Test dialog">
   <i slot="icon" aria-label="icon">Icon</i>
 
   <i slot="content" aria-label="content">Content</i>

--- a/packages/renderer/src/lib/dialogs/DialogSpec.svelte
+++ b/packages/renderer/src/lib/dialogs/DialogSpec.svelte
@@ -2,7 +2,7 @@
 import Dialog from './Dialog.svelte';
 </script>
 
-<Dialog title="Test dialog">
+<Dialog title="Test dialog" onclose={(): void => {}}>
   <i slot="icon" aria-label="icon">Icon</i>
 
   <i slot="content" aria-label="content">Content</i>

--- a/packages/renderer/src/lib/dialogs/MessageBox.svelte
+++ b/packages/renderer/src/lib/dialogs/MessageBox.svelte
@@ -116,7 +116,7 @@ function getButtonType(b: boolean): ButtonType {
 </script>
 
 {#if display}
-  <Dialog title={title} on:close={onClose}>
+  <Dialog title={title} onclose={onClose}>
     <svelte:fragment slot="icon">
       {#if type === 'error'}
         <Fa class="h-4 w-4 text-[var(--pd-state-error)]" icon={faCircleExclamation} />

--- a/packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.svelte
+++ b/packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.svelte
@@ -92,7 +92,7 @@ async function handleKeydown(e: KeyboardEvent): Promise<void> {
 
 <Dialog
   title="Install Custom Extension"
-  on:close={closeCallback}>
+  onclose={closeCallback}>
   <div slot="content" class="flex flex-col leading-5 space-y-5">
     <div>
       <label for="imageName" class="block pb-2 text-[var(--pd-modal-text)]">OCI Image:</label>

--- a/packages/renderer/src/lib/image/PushImageModal.svelte
+++ b/packages/renderer/src/lib/image/PushImageModal.svelte
@@ -81,7 +81,7 @@ $: window
 
 <Dialog
   title="Push image"
-  on:close={closeCallback}>
+  onclose={closeCallback}>
   <div slot="content" class="flex flex-col text-sm leading-5 space-y-5">
     <div class="pb-4">
       <label for="modalImageTag" class="block mb-2 text-sm font-medium text-[var(--pd-modal-text)]">Image tag</label>

--- a/packages/renderer/src/lib/image/PushManifestModal.svelte
+++ b/packages/renderer/src/lib/image/PushManifestModal.svelte
@@ -45,7 +45,7 @@ async function pushManifestFinished(): Promise<void> {
 
 <Dialog
   title="Push manifest"
-  on:close={(): void => {
+  onclose={(): void => {
     closeCallback();
     logsPush?.dispose();
   }}>

--- a/packages/renderer/src/lib/image/RenameImageModal.svelte
+++ b/packages/renderer/src/lib/image/RenameImageModal.svelte
@@ -67,7 +67,7 @@ async function renameImage(imageName: string, imageTag: string): Promise<void> {
 
 <Dialog
   title="Edit Image"
-  on:close={closeCallback}>
+  onclose={closeCallback}>
   <div slot="content" class="w-full">
     <label for="imageName" class="block my-2 text-sm font-bold text-[var(--pd-modal-text)]">Image Name</label>
     <Input

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRenderingEditModal.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRenderingEditModal.svelte
@@ -105,7 +105,7 @@ function onUserStateChange(key: unknown): void {
 
 <Dialog
     title="Edit Context"
-    on:close={closeCallback}>
+    onclose={closeCallback}>
     <div slot="content" class="w-full">
     <label for="contextName" class="block my-2 text-sm font-bold text-[var(--pd-modal-text)]">Name</label>
     <Input

--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
@@ -449,7 +449,7 @@ async function removeExistingRegistry(registry: containerDesktopAPI.Registry): P
 {#if showNewRegistryForm}
   <Dialog
     title="Add Registry"
-    on:close={(): void => {
+    onclose={(): void => {
       setNewRegistryFormVisible(false);
     }}>
     <div slot="content" class="flex flex-col text-[var(--pd-modal-text)] space-y-5">

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStoreDetails.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStoreDetails.svelte
@@ -23,7 +23,7 @@ async function fetch(): Promise<void> {
 }
 </script>
 
-<Dialog title="Details of {eventStoreInfo.name}" on:close={closeCallback}>
+<Dialog title="Details of {eventStoreInfo.name}" onclose={closeCallback}>
   <svelte:component this={eventStoreInfo.iconComponent} slot="icon" size="20" />
 
   <div slot="content" class="inline-block w-full overflow-hidden overflow-y-auto text-left transition-all">


### PR DESCRIPTION
### What does this PR do?

Remove legacy createEventDispatcher in Dialog component to prepare for the migration to Svelte 5

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/13381

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
