### PR TITLE
fix: temp addressed mac popup error on comand+q quit

### DIFF
--- a/packages/main/src/main.spec.ts
+++ b/packages/main/src/main.spec.ts
@@ -44,6 +44,7 @@ const ELECTRON_APP_MOCK: ElectronApp = {
   requestSingleInstanceLock: vi.fn(),
   setAppUserModelId: vi.fn(),
   quit: vi.fn(),
+  exit: vi.fn(),
   on: vi.fn(),
   whenReady: vi.fn(),
   setAsDefaultProtocolClient: vi.fn(),

--- a/packages/main/src/main.ts
+++ b/packages/main/src/main.ts
@@ -150,6 +150,11 @@ export class Main implements IDisposable {
    */
   protected onBeforeQuit(): void {
     this.dispose();
+    // Override Command+Q macOS to call app.exit()
+    // Temp fix for https://github.com/electron/electron/issues/47420
+    if (isMac()) {
+      this.app.exit();
+    }
   }
 
   dispose(): void {


### PR DESCRIPTION
### What does this PR do?

Attempts to fix the issue where on command+q mac will have a popup error either having https://github.com/podman-desktop/podman-desktop/issues/12409 or https://github.com/podman-desktop/podman-desktop/issues/12889

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes: https://github.com/podman-desktop/podman-desktop/issues/12889

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

Run podman desktop using "pnpm watch"
Quickly do command+q right after the main window launches
It shouldnt show any warning/error logs that are related to a stack trace involving v8 or apple thread 

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
