### PR TITLE
feat(renderer): migrate dialog to Svelte 5, deprecate Svelte 4 version

### DIFF
--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -31,7 +31,7 @@ import { findMatchInLeaves } from '../../stores/search-util';
 import { viewsContributions } from '../../stores/views';
 import { withBulkConfirmation } from '../actions/BulkActions';
 import type { ContextUI } from '../context/context';
-import Dialog from '../dialogs/Dialog.svelte';
+import LegacyDialog from '../dialogs/LegacyDialog.svelte';
 import type { EngineInfoUI } from '../engine/EngineInfoUI';
 import Prune from '../engine/Prune.svelte';
 import NoContainerEngineEmptyScreen from '../image/NoContainerEngineEmptyScreen.svelte';
@@ -537,7 +537,7 @@ function key(item: ContainerGroupInfoUI | ContainerInfoUI): string {
 </NavPage>
 
 {#if openChoiceModal}
-  <Dialog
+  <LegacyDialog
     title="Create a new container"
     onclose={(): void => {
       openChoiceModal = false;
@@ -553,5 +553,5 @@ function key(item: ContainerGroupInfoUI | ContainerInfoUI): string {
       <Button type="primary" on:click={fromDockerfile}>Containerfile or Dockerfile</Button>
       <Button type="secondary" on:click={fromExistingImage}>Existing image</Button>
     </svelte:fragment>
-  </Dialog>
+  </LegacyDialog>
 {/if}

--- a/packages/renderer/src/lib/dialogs/LegacyDialog.spec.ts
+++ b/packages/renderer/src/lib/dialogs/LegacyDialog.spec.ts
@@ -1,0 +1,61 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { expect, test, vi } from 'vitest';
+
+import LegacyDialog from './LegacyDialog.svelte';
+
+test('dialog should be visible and have basic styling', async () => {
+  const title = 'A dialog';
+  render(LegacyDialog, { title: title });
+
+  const bg = screen.getByLabelText('fade-bg');
+  expect(bg).toBeDefined();
+  const dialog = screen.getByRole('dialog');
+  expect(dialog).toBeDefined();
+
+  const titleElem = screen.getByText(title);
+  expect(titleElem).toBeDefined();
+  expect(titleElem).toHaveClass('grow');
+  expect(titleElem).toHaveClass('text-lg ');
+  expect(titleElem).toHaveClass('font-bold');
+  expect(titleElem).toHaveClass('capitalize');
+  expect(titleElem.parentElement).toHaveClass('text-[var(--pd-modal-header-text)]');
+});
+
+test('bg click should trigger close event', async () => {
+  const closeMock = vi.fn();
+  render(LegacyDialog, { title: 'A dialog', onclose: closeMock });
+
+  const bg = screen.getByLabelText('fade-bg');
+  await userEvent.click(bg);
+
+  expect(closeMock).toHaveBeenCalled();
+});
+
+test('Escape key should trigger close', async () => {
+  const closeMock = vi.fn();
+  render(LegacyDialog, { title: 'A dialog', onclose: closeMock });
+
+  await userEvent.keyboard('{Escape}');
+  expect(closeMock).toHaveBeenCalled();
+});

--- a/packages/renderer/src/lib/dialogs/LegacyDialog.svelte
+++ b/packages/renderer/src/lib/dialogs/LegacyDialog.svelte
@@ -1,37 +1,34 @@
+<!--
+    @component
+    @deprecated Use Dialog component instead, this is kept for the time to migrate all components using it to Svelte 5 Runes mode.
+-->
+
 <script lang="ts">
 import { CloseButton, Modal } from '@podman-desktop/ui-svelte';
-import type { Snippet } from 'svelte';
 
-interface Props {
-  title: string;
-  onclose: () => void;
-  icon?: Snippet;
-  content?: Snippet;
-  validation?: Snippet;
-  buttons?: Snippet;
-}
+export let title: string;
 
-let { title, onclose, icon, content, validation, buttons }: Props = $props();
+export let onclose: () => void;
 </script>
 
 <Modal name={title} onclose={onclose}>
   <div class="flex items-center justify-between pl-4 pr-3 py-3 space-x-2 text-[var(--pd-modal-header-text)]">
-    {@render icon?.()}
+    <slot name="icon" />
     <h1 class="grow text-lg font-bold capitalize">{title}</h1>
 
     <CloseButton onclick={onclose} />
   </div>
 
   <div class="relative max-h-80 overflow-auto text-[var(--pd-modal-text)] px-10 py-4">
-    {@render content?.()}
+    <slot name="content" />
   </div>
 
   <div class="px-5 py-5 mt-2 flex flex-row w-full space-x-5">
-    {#if validation}
+    {#if $$slots.validation}
       <div class="grow">
-        {@render validation?.()}
+        <slot name="validation" />
       </div>
     {/if}
-    {@render buttons?.()}
+    <slot name="buttons" />
   </div>
 </Modal>

--- a/packages/renderer/src/lib/dialogs/LegacyDialogSpec.spec.ts
+++ b/packages/renderer/src/lib/dialogs/LegacyDialogSpec.spec.ts
@@ -21,31 +21,31 @@ import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/svelte';
 import { expect, test } from 'vitest';
 
-import DialogSpec from './DialogSpec.svelte';
+import LegacyDialogSpec from './LegacyDialogSpec.svelte';
 
 test('Expect icon is defined', async () => {
-  render(DialogSpec);
+  render(LegacyDialogSpec);
 
   const element = screen.getByLabelText('icon');
   expect(element).toBeInTheDocument();
 });
 
 test('Expect content is defined', async () => {
-  render(DialogSpec);
+  render(LegacyDialogSpec);
 
   const element = screen.getByLabelText('content');
   expect(element).toBeInTheDocument();
 });
 
 test('Expect validation is defined', async () => {
-  render(DialogSpec);
+  render(LegacyDialogSpec);
 
   const element = screen.getByLabelText('validation');
   expect(element).toBeInTheDocument();
 });
 
 test('Expect buttons is defined', async () => {
-  render(DialogSpec);
+  render(LegacyDialogSpec);
 
   const element = screen.getByLabelText('buttons');
   expect(element).toBeInTheDocument();

--- a/packages/renderer/src/lib/dialogs/LegacyDialogSpec.svelte
+++ b/packages/renderer/src/lib/dialogs/LegacyDialogSpec.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-import Dialog from './Dialog.svelte';
+import LegacyDialog from './LegacyDialog.svelte';
 </script>
 
-<Dialog title="Test dialog" onclose={(): void => {}}>
+<LegacyDialog title="Test dialog" onclose={(): void => {}}>
   <i slot="icon" aria-label="icon">Icon</i>
 
   <i slot="content" aria-label="content">Content</i>
@@ -10,4 +10,4 @@ import Dialog from './Dialog.svelte';
   <i slot="validation" aria-label="validation">Validation</i>
 
   <i slot="buttons" aria-label="buttons">Buttons</i>
-</Dialog>
+</LegacyDialog>

--- a/packages/renderer/src/lib/dialogs/MessageBox.svelte
+++ b/packages/renderer/src/lib/dialogs/MessageBox.svelte
@@ -8,7 +8,7 @@ import Fa from 'svelte-fa';
 import { type ButtonsType, type DropdownType, type IconButtonType } from '/@api/dialog';
 
 import Markdown from '../markdown/Markdown.svelte';
-import Dialog from './Dialog.svelte';
+import LegacyDialog from './LegacyDialog.svelte';
 import type { MessageBoxOptions } from './messagebox-input';
 
 let currentId = 0;
@@ -116,7 +116,7 @@ function getButtonType(b: boolean): ButtonType {
 </script>
 
 {#if display}
-  <Dialog title={title} onclose={onClose}>
+  <LegacyDialog title={title} onclose={onClose}>
     <svelte:fragment slot="icon">
       {#if type === 'error'}
         <Fa class="h-4 w-4 text-[var(--pd-state-error)]" icon={faCircleExclamation} />
@@ -174,5 +174,5 @@ function getButtonType(b: boolean): ButtonType {
         {/if}
       {/each}
     </svelte:fragment>
-  </Dialog>
+  </LegacyDialog>
 {/if}

--- a/packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.svelte
+++ b/packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.svelte
@@ -3,7 +3,7 @@ import { faCloudDownload } from '@fortawesome/free-solid-svg-icons';
 import { Button, Input } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 
-import Dialog from '../dialogs/Dialog.svelte';
+import LegacyDialog from '../dialogs/LegacyDialog.svelte';
 
 export let closeCallback: () => void;
 let imageName = '';
@@ -90,7 +90,7 @@ async function handleKeydown(e: KeyboardEvent): Promise<void> {
 
 <svelte:window on:keydown={handleKeydown} />
 
-<Dialog
+<LegacyDialog
   title="Install Custom Extension"
   onclose={closeCallback}>
   <div slot="content" class="flex flex-col leading-5 space-y-5">
@@ -145,4 +145,4 @@ async function handleKeydown(e: KeyboardEvent): Promise<void> {
       <Button on:click={closeCallback}>Done</Button>
     {/if}
   </svelte:fragment>
-</Dialog>
+</LegacyDialog>

--- a/packages/renderer/src/lib/image/PushImageModal.svelte
+++ b/packages/renderer/src/lib/image/PushImageModal.svelte
@@ -6,7 +6,7 @@ import { onMount, tick } from 'svelte';
 import Fa from 'svelte-fa';
 import { router } from 'tinro';
 
-import Dialog from '../dialogs/Dialog.svelte';
+import LegacyDialog from '../dialogs/LegacyDialog.svelte';
 import TerminalWindow from '../ui/TerminalWindow.svelte';
 import type { ImageInfoUI } from './ImageInfoUI';
 
@@ -79,7 +79,7 @@ $: window
   .catch((err: unknown) => console.error(`Error getting authentication required for image ${imageInfoToPush.id}`, err));
 </script>
 
-<Dialog
+<LegacyDialog
   title="Push image"
   onclose={closeCallback}>
   <div slot="content" class="flex flex-col text-sm leading-5 space-y-5">
@@ -134,4 +134,4 @@ $: window
       <Button on:click={pushImageFinished} class="w-auto">Done</Button>
     {/if}
   </svelte:fragment>
-</Dialog>
+</LegacyDialog>

--- a/packages/renderer/src/lib/image/PushManifestModal.svelte
+++ b/packages/renderer/src/lib/image/PushManifestModal.svelte
@@ -5,7 +5,7 @@ import type { Terminal } from '@xterm/xterm';
 import { tick } from 'svelte';
 import { router } from 'tinro';
 
-import Dialog from '../dialogs/Dialog.svelte';
+import LegacyDialog from '../dialogs/LegacyDialog.svelte';
 import TerminalWindow from '../ui/TerminalWindow.svelte';
 import type { ImageInfoUI } from './ImageInfoUI';
 
@@ -43,7 +43,7 @@ async function pushManifestFinished(): Promise<void> {
 }
 </script>
 
-<Dialog
+<LegacyDialog
   title="Push manifest"
   onclose={(): void => {
     closeCallback();
@@ -80,4 +80,4 @@ async function pushManifestFinished(): Promise<void> {
       <Button on:click={pushManifestFinished} class="w-auto">Done</Button>
     {/if}
   </svelte:fragment>
-</Dialog>
+</LegacyDialog>

--- a/packages/renderer/src/lib/image/RenameImageModal.svelte
+++ b/packages/renderer/src/lib/image/RenameImageModal.svelte
@@ -3,7 +3,7 @@ import { Button, ErrorMessage, Input } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 import { router } from 'tinro';
 
-import Dialog from '../dialogs/Dialog.svelte';
+import LegacyDialog from '../dialogs/LegacyDialog.svelte';
 import type { ImageInfoUI } from './ImageInfoUI';
 
 export let closeCallback: () => void;
@@ -65,7 +65,7 @@ async function renameImage(imageName: string, imageTag: string): Promise<void> {
 }
 </script>
 
-<Dialog
+<LegacyDialog
   title="Edit Image"
   onclose={closeCallback}>
   <div slot="content" class="w-full">
@@ -107,4 +107,4 @@ async function renameImage(imageName: string, imageTag: string): Promise<void> {
         await renameImage(imageName, imageTag);
       }}>Save</Button>
   </svelte:fragment>
-</Dialog>
+</LegacyDialog>

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRenderingEditModal.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRenderingEditModal.svelte
@@ -7,7 +7,7 @@ import { router } from 'tinro';
 import { kubernetesContexts } from '/@/stores/kubernetes-contexts';
 import type { KubeContext } from '/@api/kubernetes-context';
 
-import Dialog from '../dialogs/Dialog.svelte';
+import LegacyDialog from '../dialogs/LegacyDialog.svelte';
 
 interface Props {
   detailed?: boolean;
@@ -103,7 +103,7 @@ function onUserStateChange(key: unknown): void {
 }
 </script>
 
-<Dialog
+<LegacyDialog
     title="Edit Context"
     onclose={closeCallback}>
     <div slot="content" class="w-full">
@@ -169,5 +169,5 @@ function onUserStateChange(key: unknown): void {
         await editContext(contextName, contextNamespace, contextUser, contextCluster);
         }}>Save</Button>
     </svelte:fragment>
-</Dialog>
+</LegacyDialog>
     

--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
@@ -8,7 +8,7 @@ import PasswordInput from '/@/lib/ui/PasswordInput.svelte';
 
 import { registriesInfos, registriesSuggestedInfos } from '../../stores/registries';
 import IconImage from '../appearance/IconImage.svelte';
-import Dialog from '../dialogs/Dialog.svelte';
+import LegacyDialog from '../dialogs/LegacyDialog.svelte';
 import SettingsPage from './SettingsPage.svelte';
 
 // contains the original instances of registries when user clicks on `Edit password` menu item
@@ -447,7 +447,7 @@ async function removeExistingRegistry(registry: containerDesktopAPI.Registry): P
 </SettingsPage>
 
 {#if showNewRegistryForm}
-  <Dialog
+  <LegacyDialog
     title="Add Registry"
     onclose={(): void => {
       setNewRegistryFormVisible(false);
@@ -489,5 +489,5 @@ async function removeExistingRegistry(registry: containerDesktopAPI.Registry): P
         inProgress={loggingIn}
         on:click={(): Promise<void> => loginToRegistry(newRegistryRequest)}>Add</Button>
     </svelte:fragment>
-  </Dialog>
+  </LegacyDialog>
 {/if}

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStoreDetails.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStoreDetails.svelte
@@ -6,7 +6,7 @@ import moment from 'moment';
 
 import type { EventStoreInfo } from '/@/stores/event-store';
 
-import Dialog from '../dialogs/Dialog.svelte';
+import LegacyDialog from '../dialogs/LegacyDialog.svelte';
 
 export let closeCallback: () => void;
 
@@ -23,7 +23,7 @@ async function fetch(): Promise<void> {
 }
 </script>
 
-<Dialog title="Details of {eventStoreInfo.name}" onclose={closeCallback}>
+<LegacyDialog title="Details of {eventStoreInfo.name}" onclose={closeCallback}>
   <svelte:component this={eventStoreInfo.iconComponent} slot="icon" size="20" />
 
   <div slot="content" class="inline-block w-full overflow-hidden overflow-y-auto text-left transition-all">
@@ -96,4 +96,4 @@ async function fetch(): Promise<void> {
     <Button aria-label="Cancel" class="mr-3" type="link" on:click={closeCallback}>Cancel</Button>
     <Button aria-label="OK" on:click={closeCallback}>OK</Button>
   </svelte:fragment>
-</Dialog>
+</LegacyDialog>


### PR DESCRIPTION
### What does this PR do?

Introduce a copied/pasted dialog component for Svelte 5. It is not possible to migrate Dialog component to Svelte 5 because we would have to migrate all components using it at the same time.

This PR also deprecates dialog of Svelte 4 to avoid further usage.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/13387

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
