### PR TITLE
test(renderer): try fix instability by clearing mock when unmounting

### DIFF
--- a/packages/renderer/src/lib/container/ContainerDetailsTerminal.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerDetailsTerminal.spec.ts
@@ -263,7 +263,7 @@ test('prompt is not duplicated after restoring terminal from containerTerminals 
   let renderObject = render(ContainerDetailsTerminal, { container, screenReaderMode: true });
 
   // wait shellInContainerMock is called
-  await waitFor(() => expect(shellInContainerMock).toHaveBeenCalled());
+  await waitFor(() => expect(shellInContainerMock).toHaveBeenCalledOnce());
 
   // write some data on the terminal
   onDataCallback(Buffer.from('prompt$ \nhello\nworld\nprompt$ '));
@@ -281,13 +281,14 @@ test('prompt is not duplicated after restoring terminal from containerTerminals 
 
   // destroy the the terminal tab
   renderObject.unmount();
+  shellInContainerMock.mockClear();
 
   // render the same component again and check if terminal restored without calling
   // terminal.write
   renderObject = render(ContainerDetailsTerminal, { container, screenReaderMode: true });
 
   // wait shellInContainerMock is called
-  await waitFor(() => expect(shellInContainerMock).toHaveBeenCalled());
+  await waitFor(() => expect(shellInContainerMock).toHaveBeenCalledOnce());
 
   await waitFor(() => {
     const terminalLinesLiveRegion = renderObject.container.querySelector('div[aria-live="assertive"]');


### PR DESCRIPTION
### What does this PR do?

Try to fix UT instability by waiting for second call. Before this, we would wait for at least one call but it was already done above.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
