### PR TITLE
chore(ci): expand running e2e tests to windows arm

### DIFF
--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -176,7 +176,7 @@ jobs:
 
   win-update-e2e-test:
     name: win update e2e tests - ${{ matrix.installation }}
-    runs-on: windows-2025
+    runs-on: ${{ matrix.os }}
     # disable on forks as secrets are not available
     if: github.event.repository.fork == false
     permissions:
@@ -188,6 +188,7 @@ jobs:
       fail-fast: false
       matrix:
         installation: ['vanilla', 'custom-extensions']
+        os: [windows-2025, windows-11-arm]
         exclude:
         - installation: ${{ (github.event.inputs.update_with_extensions && github.event.inputs.update_with_extensions == 'true') && 'N/A' || 'custom-extensions' }}
     steps:
@@ -220,10 +221,24 @@ jobs:
         env:
           ELECTRON_ENABLE_INSPECT: true
         run: |
+          (Get-Content packages/main/src/plugin/updater.ts).Replace('autoUpdater.autoDownload = false;', 'autoUpdater.autoDownload = false;autoUpdater.allowPrerelease=true;') | Set-Content packages/main/src/plugin/updater.ts
           pnpm compile:current --win nsis
-          $path=('./dist/win-unpacked/Podman Desktop.exe' | resolve-path).ProviderPath
+          $runnerArch=$env:RUNNER_ARCH
+          $unpackedPath = "dist/win-unpacked"
+          if ($runnerArch -eq 'ARM64') {
+            $unpackedPath = "dist/win-arm64-unpacked"
+          }
+          echo ("PD_DIST_PATH=" + $unpackedPath) >> $env:GITHUB_ENV
+          $path=("./$unpackedPath/Podman Desktop.exe" | resolve-path).ProviderPath
           echo $path
           echo ("PODMAN_DESKTOP_BINARY=" + $path) >> $env:GITHUB_ENV
+
+      - name: Manually set testing-prereleases as update target
+        run: |
+          echo "Replace app-update.yml repo to a testing-prerelease, which are more stable update target then the prerelease"
+          (Get-Content "$Env:PD_DIST_PATH/resources/app-update.yml").Replace('repo: podman-desktop', 'repo: testing-prereleases') | Set-Content "$Env:PD_DIST_PATH/resources/app-update.yml"
+          echo "Show app-update.yml after replace..."
+          cat "$Env:PD_DIST_PATH/resources/app-update.yml"
 
       - name: Run E2E Update test
         env:
@@ -247,7 +262,7 @@ jobs:
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
-          name: update-e2e-test-${{ matrix.installation }}
+          name: ${{ matrix.os }}-update-e2e-test-${{ matrix.installation }}
           path: |
             ./tests/**/output/
             !./tests/**/traces/raw

--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -236,14 +236,15 @@ jobs:
       - name: Manually set testing-prereleases as update target
         run: |
           echo "Replace app-update.yml repo to a testing-prerelease, which are more stable update target then the prerelease"
-          $updateFile = "$Env:PD_DIST_PATH/resources/app-update.yml"
+          $updateFile = "$env:PD_DIST_PATH/resources/app-update.yml"
           if (-Not (Test-Path $updateFile)) {
             Write-Error "app-update.yml not found at $updateFile"
           }
           (Get-Content $updateFile).Replace('repo: podman-desktop', 'repo: testing-prereleases') |
             Set-Content -ErrorAction Stop $updateFile
           echo "Show app-update.yml after replace..."
-          cat "$Env:PD_DIST_PATH/resources/app-update.yml"
+          cat "$env:PD_DIST_PATH/resources/app-update.yml"
+
       - name: Run E2E Update test
         env:
           INSTALLATION_TYPE: ${{ matrix.installation }}

--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -175,7 +175,7 @@ jobs:
             !./tests/**/traces/raw
 
   win-update-e2e-test:
-    name: win update e2e tests - ${{ matrix.installation }}
+    name: ${{ matrix.os }} update e2e tests - ${{ matrix.installation }}
     runs-on: ${{ matrix.os }}
     # disable on forks as secrets are not available
     if: github.event.repository.fork == false

--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -236,10 +236,14 @@ jobs:
       - name: Manually set testing-prereleases as update target
         run: |
           echo "Replace app-update.yml repo to a testing-prerelease, which are more stable update target then the prerelease"
-          (Get-Content "$Env:PD_DIST_PATH/resources/app-update.yml").Replace('repo: podman-desktop', 'repo: testing-prereleases') | Set-Content "$Env:PD_DIST_PATH/resources/app-update.yml"
+          $updateFile = "$Env:PD_DIST_PATH/resources/app-update.yml"
+          if (-Not (Test-Path $updateFile)) {
+            Write-Error "app-update.yml not found at $updateFile"
+          }
+          (Get-Content $updateFile).Replace('repo: podman-desktop', 'repo: testing-prereleases') |
+            Set-Content -ErrorAction Stop $updateFile
           echo "Show app-update.yml after replace..."
           cat "$Env:PD_DIST_PATH/resources/app-update.yml"
-
       - name: Run E2E Update test
         env:
           INSTALLATION_TYPE: ${{ matrix.installation }}

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -434,7 +434,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: 
-        os: [windows-2025]
+        os: [windows-2025, windows-11-arm]
     if: contains(github.event.pull_request.labels.*.name, 'area/update') || needs.detect_pnpm_changes.outputs.pnpm_lock_changed == 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -531,19 +531,9 @@ jobs:
 
       - name: Adjust/Downgrade local podman desktop version
         run: |
-<<<<<<< HEAD
           node tests/playwright/scripts/version-util.cjs ./package.json --update
           actualVersion=$(jq -r '.version' package.json)
           echo "PD_VERSION=$actualVersion" >> $GITHUB_ENV
-=======
-          testingVersion="1.20.0"
-          actualVersion=$(jq -r '.version' package.json)
-          echo "Current version: $actualVersion, testing version: $testingVersion"
-          version=$testingVersion
-          echo "PD_VERSION=$version" >> $GITHUB_ENV
-          jq --arg version "$version" '.version = $version' package.json > package.json_tmp
-          mv package.json_tmp package.json
->>>>>>> 13148ef923f (fix: revert dynamic vrsion downgrading)
 
       - name: Build Podman Desktop locally and allow prereleases on update
         env:

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -531,9 +531,19 @@ jobs:
 
       - name: Adjust/Downgrade local podman desktop version
         run: |
+<<<<<<< HEAD
           node tests/playwright/scripts/version-util.cjs ./package.json --update
           actualVersion=$(jq -r '.version' package.json)
           echo "PD_VERSION=$actualVersion" >> $GITHUB_ENV
+=======
+          testingVersion="1.20.0"
+          actualVersion=$(jq -r '.version' package.json)
+          echo "Current version: $actualVersion, testing version: $testingVersion"
+          version=$testingVersion
+          echo "PD_VERSION=$version" >> $GITHUB_ENV
+          jq --arg version "$version" '.version = $version' package.json > package.json_tmp
+          mv package.json_tmp package.json
+>>>>>>> 13148ef923f (fix: revert dynamic vrsion downgrading)
 
       - name: Build Podman Desktop locally and allow prereleases on update
         env:


### PR DESCRIPTION
### What does this PR do?
Expands update e2e tests to windows-arm runners and enables using prerelease bits in e2e-test-main workflow.
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#13353 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
Check the outcome of PR check and also linked runs.
<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
