### PR TITLE
docs: add mergify backporting instructions in the release doc

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -60,7 +60,7 @@ The release may be tested using the assets generated within the pre-release.
 If there are fixes that need to be made to the release as brought up by QE the following steps need to be completed:
 
 1. Create a branch **FROM THE RELEASE**. Example, 1.3.x of release 1.3.0. **IMPORTANT NOTE:** Literally `1.3.x` not `1.3.1`.
-2. Create PR(s) with the fixes that merge into the 1.3.x branch
+2. Create PR(s) with the fixes that merge into the main branch and use mergify.io to open a backport PR(s) to the 1.3.x branch by adding the following comment in the main PR(s): `@Mergifyio backport 1.3.x`
 3. Make sure all PR's are merged
 
 **Re-spin a release:**


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Adds new instructions on how to backport fixes to the bug fix branch in the release process using mergify.io

### Screenshot / video of UI
<img width="1008" height="196" alt="Screenshot 2025-07-30 at 1 10 40 PM" src="https://github.com/user-attachments/assets/d2615367-eaec-4a99-acca-bd30428a86ad" />


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/podman-desktop/issues/13432

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
