### PR TITLE
docs: add info about pre-release and release versions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -75,6 +75,8 @@ You'll need to create another release from the 1.3.x branch. This can be done by
 
 ✅ If QE agrees with the release, we have a green light!
 
+**IMPORTANT NOTE:** Only the .z version that was approved by QE should be changed from pre-release to release. Any previous blocked versions need to stay as pre-release. For example, if the respin version `1.3.1` was approved by QE after finding bugs in `1.3.0`, only `1.3.1` should be moved from pre-release to release
+
 1. Ensure release notes PR is ready
 1. Merge the release notes before flagging the release as the 'latest': It is because Podman Desktop is displaying in the UI the release notes of the new release, so as soon as there is an update, the data needs to be there.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -75,8 +75,6 @@ You'll need to create another release from the 1.3.x branch. This can be done by
 
 ✅ If QE agrees with the release, we have a green light!
 
-**IMPORTANT NOTE:** Only the .z version that was approved by QE should be changed from pre-release to release. Any previous blocked versions need to stay as pre-release. For example, if the respin version `1.3.1` was approved by QE after finding bugs in `1.3.0`, only `1.3.1` should be moved from pre-release to release
-
 1. Ensure release notes PR is ready
 1. Merge the release notes before flagging the release as the 'latest': It is because Podman Desktop is displaying in the UI the release notes of the new release, so as soon as there is an update, the data needs to be there.
 
@@ -89,6 +87,8 @@ This is done on your release URL
 1.  Go to your release: https://github.com/containers/podman-desktop/releases/tag/vX.X.X
 2.  Press the edit button.
 3.  Uncheck `Set as a pre-release`
+
+**IMPORTANT NOTE:** Only the .z version that was approved by QE should be changed from pre-release to release. Any previous blocked versions need to stay as pre-release. For example, if the respin version `1.3.1` was approved by QE after finding bugs in `1.3.0`, only `1.3.1` should be moved from pre-release to release.
 
 ## Updating package managers (Brew, Winget, Chocolatey, Flathub)
 


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Adds information about which release version should be moved from pre-release to release

### Screenshot / video of UI
<img width="989" height="221" alt="Screenshot 2025-07-30 at 4 53 07 PM" src="https://github.com/user-attachments/assets/d2dfa68f-e895-49cb-8767-cf107b523fe7" />


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
