### PR TITLE
chore(test): remove the skip for podman machine onboarding e2e tests

### DIFF
--- a/tests/playwright/src/specs/z-podman-machine-onboarding.spec.ts
+++ b/tests/playwright/src/specs/z-podman-machine-onboarding.spec.ts
@@ -28,7 +28,7 @@ import { ResourcesPage } from '../model/pages/resources-page';
 import type { SettingsBar } from '../model/pages/settings-bar';
 import { expect as playExpect, test } from '../utility/fixtures';
 import { createPodmanMachineFromCLI, deletePodmanMachine } from '../utility/operations';
-import { isLinux, isMac } from '../utility/platform';
+import { isLinux } from '../utility/platform';
 import { waitForPodmanMachineStartup } from '../utility/wait';
 
 const PODMAN_MACHINE_STARTUP_TIMEOUT: number = 360_000;
@@ -73,11 +73,6 @@ test.afterAll(async ({ runner }) => {
 
   await runner.close();
 });
-
-test.skip(
-  isMac,
-  'Skip this test suite on MacOS until issue https://github.com/podman-desktop/podman-desktop/issues/12334 is fixed',
-);
 
 test.describe
   .serial('Podman Machine verification', () => {


### PR DESCRIPTION
### What does this PR do?
Remove the skip for podman-machine-onboarding.spec.ts tests on Mac since underlying issue was fixed.
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#13453 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
We need to run it on particular CI.

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
