### PR TITLE
fix(website): added github button to the mobile menu

### DIFF
--- a/website/src/components/GitHubStarsButton.tsx
+++ b/website/src/components/GitHubStarsButton.tsx
@@ -3,7 +3,7 @@ import { faGithub } from '@fortawesome/free-brands-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import type { GitHubMetadata } from '@site/src/plugins/github-metadata';
 
-export function GitHubStarsButton(): JSX.Element {
+export function GitHubStarsButton({ mobile = false }: { readonly mobile?: boolean }): JSX.Element {
   const { stargazersCount } = usePluginData('docusaurus-plugin-github-metadata') as GitHubMetadata;
 
   return (
@@ -12,7 +12,12 @@ export function GitHubStarsButton(): JSX.Element {
       target="_blank"
       id="github-stars-button"
       rel="noopener noreferrer"
-      className="hidden xl:flex items-center gap-2 px-4 py-[9px] border border-black dark:border-white rounded-lg navbar__item navbar__link font-medium min-w-[9rem]">
+      // check for mobile or large screen
+      className={
+        mobile
+          ? 'dropdown__link flex items-center gap-2 px-4 py-[9px] font-medium text-base'
+          : 'navbar__item navbar__link hidden xl:flex items-center gap-2 px-4 py-[9px] border border-black dark:border-white rounded-lg font-medium min-w-[9rem]'
+      }>
       <FontAwesomeIcon icon={faGithub} />
       <span>Star</span>
       <span

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -239,3 +239,7 @@ article .markdown ol {
 article .markdown ol ol {
   list-style-type: lower-roman;
 }
+.dropdown__link:hover {
+  background-color: transparent;
+  color: var(--ifm-color-primary);
+}

--- a/website/src/theme/NavbarItem/ComponentTypes.js
+++ b/website/src/theme/NavbarItem/ComponentTypes.js
@@ -12,5 +12,6 @@ export default {
     </TelemetryLink>
   ),
   'custom-downloadButton': () => <HeaderDownloadButton className="navbar__item navbar__link" />,
-  'custom-githubStarsButton': () => <GitHubStarsButton className="navbar__item navbar__link" />,
+  // passing mobile as property
+  'custom-githubStarsButton': props => <GitHubStarsButton mobile={props.mobile} />,
 };


### PR DESCRIPTION
### What does this PR do?
added github button to the mobile menu 
fixes #12491 
### Screenshot / video of UI
**regular screen**
<img width="1902" height="1157" alt="Screenshot From 2025-07-31 18-09-08" src="https://github.com/user-attachments/assets/16348d10-17f8-4dd8-80e3-baa0b05c924c" />

**mobile screen**
<img width="542" height="1014" alt="Screenshot From 2025-07-31 18-09-33" src="https://github.com/user-attachments/assets/835e90dc-9cf6-423b-a8ee-c9b0118156c8" />

**menu on mobile screen**
<img width="542" height="1014" alt="Screenshot From 2025-07-31 18-09-48" src="https://github.com/user-attachments/assets/83b964be-5721-451c-91c7-5d69dd3f6083" />


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
