### PR TITLE
fix(windows): updated text for matching errors

### DIFF
--- a/extensions/podman/packages/extension/src/checks/wsl2-check.ts
+++ b/extensions/podman/packages/extension/src/checks/wsl2-check.ts
@@ -147,7 +147,12 @@ export class WSL2Check extends BaseCheck {
       const runError = error as RunError;
       if (runError.stdout.includes('Wsl/WSL_E_WSL_OPTIONAL_COMPONENT_REQUIRED')) {
         return true;
-      } else if (runError.stdout.includes('Wsl/WSL_E_DEFAULT_DISTRO_NOT_FOUND')) {
+      } else if (
+        runError.stdout.includes('Wsl/WSL_E_DEFAULT_DISTRO_NOT_FOUND') ||
+        runError.stdout.includes('Windows Subsystem for Linux has no installed distributions')
+      ) {
+        // Previously the stdout has contained the "Wsl/WSL_E_DEFAULT_DISTRO_NOT_FOUND" text,
+        // now it is no longer true
         // treating this log differently as we install wsl without any distro
         console.log('WSL has been installed without the default distribution');
       } else {


### PR DESCRIPTION
### What does this PR do?
Updates text in wsl2 isRebootNeeded check, since the text we used for 
Actual output of `wsl -l` command: 
<img width="945" height="393" alt="image (1)" src="https://github.com/user-attachments/assets/eec2af25-eeed-4238-846a-23193c94c084" />

=> No `WSL_E_DEFAULT_DISTRO_NOT_FOUND` 
Old output of the command: 
<img width="907" height="298" alt="image" src="https://github.com/user-attachments/assets/7bdcdc17-38b5-4d6d-ab7c-a1c1717a23d6" />

### Screenshot / video of UI

### What issues does this PR fix or reference?
Closes #12515 

### How to test this PR?
On Windows uninstall any wsl distro, you should see the info or warning message, but no error message as in https://github.com/podman-desktop/podman-desktop/issues/12515

- [x] Tests are covering the bug fix or the new feature
