### PR TITLE
fix: experimental feature: a malformed key should skip to the next iteration, not exit the function

### DIFF
--- a/packages/main/src/plugin/experimental-feature-feedback-handler.ts
+++ b/packages/main/src/plugin/experimental-feature-feedback-handler.ts
@@ -73,7 +73,7 @@ export class ExperimentalFeatureFeedbackHandler {
       const parts = configurationKey.split('.');
       const firstPart = parts[0];
       const secondPart = parts[1];
-      if (!secondPart) return;
+      if (!secondPart) continue;
 
       const conf = this.#configurationRegistry.getConfiguration(firstPart).get(secondPart);
       // Configuration does not exist (feature is not enabled)


### PR DESCRIPTION
### What does this PR do?

Follow up of comment https://github.com/podman-desktop/podman-desktop/pull/13317/files#r2238935259, when we find a malformed key, we should not exit the function entirey, but skip to the next iteration

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Follow up of https://github.com/podman-desktop/podman-desktop/pull/13317

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
