### PR TITLE
fix: addressed multi port forwarding having the same port

### DIFF
--- a/packages/main/src/plugin/util/port.ts
+++ b/packages/main/src/plugin/util/port.ts
@@ -86,6 +86,7 @@ export async function isFreePort(port: number): Promise<boolean> {
 
   const intfs = getIPv4Interfaces();
 
+  await isFreeAddressPort('localhost', port);
   await isFreeAddressPort('0.0.0.0', port);
   await Promise.all(intfs.map(intf => isFreeAddressPort(intf, port)));
 


### PR DESCRIPTION
The issue was that in port.ts it was checking 0.0.0.0 instead of localhost. This mismatch should have led to an error out but the way the promise was handled the error wasnt properly shown to the ui. Nevertheless fixing this issue solves the problem!

### What does this PR do?

see above

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/podman-desktop/podman-desktop/issues/13279

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

You need a kind instance running

[pod.txt](https://github.com/user-attachments/files/21555497/pod.txt)

download docker.io/library/nginx
create a container from that image
create a pod using that image
generate the kube from that pod
Add additional ports like in the txt example above but it needs to be a .yaml file (you can use the example above just change the name I think)
click on generate kube play and load up the .yaml file that you created from the generate kube output
Go to pods under the kubernetes extension click on the name of the pod go to summary tab scroll down and click on the port fowarding do it multiple times for each port
it should work!

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
