### PR TITLE
fix(Table): incorrect grid template column on uncollapse

### DIFF
--- a/packages/ui/src/lib/table/Table.spec.ts
+++ b/packages/ui/src/lib/table/Table.spec.ts
@@ -385,7 +385,7 @@ test('Expect duration cell to be empty when undefined', async () => {
   }
 });
 
-test('Expect table is scoped for css manipulation', async () => {
+test('Expect row component to have proper css style', async () => {
   render(TestTable, {});
 
   // Wait for the table to update
@@ -397,8 +397,12 @@ test('Expect table is scoped for css manipulation', async () => {
   const rows = await within(table).findAllByRole('row');
   // expect each row of the table has the grid-template-columns style applied
   for (const element of rows) {
-    expect(element.style.gridTemplateColumns).toBe('20px 32px 1fr 3fr 1fr 1fr 1fr 5px');
+    expect(element).toHaveClass('grid-table');
   }
+
+  expect(table).toHaveStyle({
+    '--table-grid-table-columns': '20px 32px 1fr 3fr 1fr 1fr 1fr 5px',
+  });
 
   // ok so now look at our dummy component
   const dummyComponent = await screen.findByRole('group', { name: 'dummy component' });

--- a/packages/ui/src/lib/table/Table.spec.ts
+++ b/packages/ui/src/lib/table/Table.spec.ts
@@ -385,7 +385,7 @@ test('Expect duration cell to be empty when undefined', async () => {
   }
 });
 
-test('Expect row component to have proper css style', async () => {
+test('Expect table to have proper css style', async () => {
   render(TestTable, {});
 
   // Wait for the table to update

--- a/packages/ui/src/lib/table/Table.svelte
+++ b/packages/ui/src/lib/table/Table.svelte
@@ -1,6 +1,7 @@
 <style>
 .grid-table {
   display: grid;
+  grid-template-columns: var(--table-grid-table-columns);
 }
 </style>
 
@@ -8,7 +9,7 @@
 /* eslint-disable import/no-duplicates */
 // https://github.com/import-js/eslint-plugin-import/issues/1479
 import { faChevronDown, faChevronRight } from '@fortawesome/free-solid-svg-icons';
-import { afterUpdate, onMount, tick } from 'svelte';
+import { onMount, tick } from 'svelte';
 
 import Checkbox from '../checkbox/Checkbox.svelte';
 import Icon from '../icons/Icon.svelte';
@@ -139,13 +140,8 @@ onMount(async () => {
   }
 });
 
-afterUpdate(() => {
-  tick()
-    .then(() => setGridColumns())
-    .catch((err: unknown) => console.error('unable to refresh grid columns', err));
-});
-
-function setGridColumns(): void {
+let gridTemplateColumns: string;
+$: {
   // section and checkbox columns
   let columnWidths: string[] = ['20px'];
 
@@ -159,13 +155,7 @@ function setGridColumns(): void {
   // final spacer
   columnWidths.push('5px');
 
-  let wid = columnWidths.join(' ');
-  if (tableHtmlDivElement) {
-    let grids: HTMLCollection = tableHtmlDivElement.getElementsByClassName('grid-table');
-    for (const element of grids) {
-      (element as HTMLElement).style.setProperty('grid-template-columns', wid);
-    }
-  }
+  gridTemplateColumns = columnWidths.join(' ');
 }
 
 function objectChecked(object: T): void {
@@ -197,7 +187,13 @@ function toggleChildren(name: string | undefined): void {
 }
 </script>
 
-<div class="w-full mx-5" class:hidden={data.length === 0} role="table" aria-label={kind} bind:this={tableHtmlDivElement}>
+<div
+  style="--table-grid-table-columns: {gridTemplateColumns}"
+  class="w-full mx-5"
+  class:hidden={data.length === 0}
+  role="table"
+  aria-label={kind}
+  bind:this={tableHtmlDivElement}>
   <!-- Table header -->
   <div role="rowgroup">
     <div

--- a/packages/ui/src/lib/table/TestMultiTables.spec.ts
+++ b/packages/ui/src/lib/table/TestMultiTables.spec.ts
@@ -18,7 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { render, screen, within } from '@testing-library/svelte';
+import { render, screen } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import { expect, test } from 'vitest';
 
@@ -29,25 +29,7 @@ test('Expect each table receive its own grid-tables-column values', async () => 
     const table = await screen.findByRole('table', { name: tableName });
     expect(table).toBeDefined();
 
-    // get the elements having the role "row" inside the table html element
-    const rows = await within(table).findAllByRole('row');
-    const gridTableColumnsValuesSet = new Set<string>();
-    for (const element of rows) {
-      gridTableColumnsValuesSet.add(element.style.gridTemplateColumns);
-    }
-
-    // all values should be the same in the set gridTableColumnsValues
-    const items = Array.from(gridTableColumnsValuesSet.values());
-    expect(items.length).toBe(1);
-
-    const item = items[0];
-
-    // split by space and keep the second value
-    const values = item.split(' ');
-
-    expect(values.length).toBe(3);
-
-    return values[1];
+    return table.style.getPropertyValue('--table-grid-table-columns');
   };
 
   render(TestMultiTables, {});
@@ -57,8 +39,8 @@ test('Expect each table receive its own grid-tables-column values', async () => 
 
   // expect to receive for each table, the good values of the width (which is different for each table)
   const gridTableColumnsValuesPersonWidth = await extractGridTableColumnsWidth('person');
-  expect(gridTableColumnsValuesPersonWidth).toBe('3fr');
+  expect(gridTableColumnsValuesPersonWidth).toBe('20px 3fr 5px');
 
   const gridTableColumnsValuesBookWidth = await extractGridTableColumnsWidth('book');
-  expect(gridTableColumnsValuesBookWidth).toBe('2fr');
+  expect(gridTableColumnsValuesBookWidth).toBe('20px 2fr 5px');
 });


### PR DESCRIPTION
### What does this PR do?

The current mechanism of computing the `grid-template-column` has some flaw: every time the DOM changes, it need to be re-applied.

An alternative (this PR) is to instead have a CSS property (named `table-grid-table-columns`), and update the `grid-able` css class to use it. Then we can easily set a css variable value using svelte, without having to update manually the DOM or use `getElementsByClassName` functions.
 
### Screenshot / video of UI

https://github.com/user-attachments/assets/57751d4d-0a83-4b8f-b9f0-ebfd46e122b2

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/13495

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

1. Go to containers page
2. assert everything look goods
3. try collpasing group of containers (E.g. pod / compose project)