### PR TITLE
fix: do not re-write registiries to auth.json if the values have not changed

### DIFF
--- a/extensions/podman/packages/extension/src/utils/registry-setup.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/registry-setup.spec.ts
@@ -187,15 +187,15 @@ test('should work with JSON auth file and alias', async () => {
 
 test('should send a warning in console if registry auth value is invalid', async () => {
   // mock the existSync
-  const existSyncSpy = vi.spyOn(fs, 'existsSync');
-  existSyncSpy.mockReturnValue(true);
+  const existSyncMock = vi.mocked(fs.existsSync);
+  existSyncMock.mockReturnValue(true);
 
   // mock the readFile
-  const readFileSpy = vi.spyOn(fs, 'readFile') as unknown as MockedFunction<ReadFileType>;
+  const readFileMock = vi.mocked(fs.readFile) as unknown as MockedFunction<ReadFileType>;
   const auth = Buffer.from('user:password').toString('base64');
   const invalidAuth = Buffer.from('userpassword').toString('base64');
 
-  readFileSpy.mockImplementation(
+  readFileMock.mockImplementation(
     (_path: string, _encoding: string, callback: (err: Error | undefined, data: string | Buffer) => void) => {
       // mock the error
 
@@ -219,7 +219,7 @@ test('should send a warning in console if registry auth value is invalid', async
   await registrySetup.updateRegistries();
 
   // expect read with the correct file
-  expect(readFileSpy).toHaveBeenCalledWith(authJsonLocation, 'utf-8', expect.anything());
+  expect(readFileMock).toHaveBeenCalledWith(authJsonLocation, 'utf-8', expect.anything());
   expect(consoleWarnMock).toHaveBeenCalledWith('Invalid auth value for myinvalidregistry.io');
 });
 
@@ -254,13 +254,13 @@ test.each([
   'do not write existing registries that did not change values to auth.json',
   async ({ fileAuth, registeredRegistry, timesCalled }) => {
     // mock the existSync
-    const existSyncSpy = vi.spyOn(fs, 'existsSync');
-    existSyncSpy.mockReturnValue(true);
+    const existSyncMock = vi.mocked(fs.existsSync);
+    existSyncMock.mockReturnValue(true);
 
     // mock the readFile
-    const readFileSpy = vi.spyOn(fs, 'readFile') as unknown as MockedFunction<ReadFileType>;
+    const readFileMock = vi.mocked(fs.readFile) as unknown as MockedFunction<ReadFileType>;
 
-    readFileSpy.mockImplementation(
+    readFileMock.mockImplementation(
       (_path: string, _encoding: string, callback: (err: Error | undefined, data: string | Buffer) => void) => {
         // mock the error
 
@@ -283,11 +283,11 @@ test.each([
       };
     });
 
-    const writeFileSpy = vi.spyOn(fs, 'writeFile') as unknown as MockedFunction<ReadFileType>;
+    const writeFileMock = vi.mocked(fs.writeFile);
 
     await registrySetup.setup();
 
-    readFileSpy.mockImplementation(
+    readFileMock.mockImplementation(
       (_path: string, _encoding: string, callback: (err: Error | undefined, data: string | Buffer) => void) => {
         // mock the error
 
@@ -299,6 +299,6 @@ test.each([
 
     onRegisterRegistry?.(registeredRegistry);
 
-    await vi.waitFor(() => expect(writeFileSpy).toHaveBeenCalledTimes(timesCalled));
+    await vi.waitFor(() => expect(writeFileMock).toHaveBeenCalledTimes(timesCalled));
   },
 );

--- a/extensions/podman/packages/extension/src/utils/registry-setup.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/registry-setup.spec.ts
@@ -18,6 +18,7 @@
 
 import * as fs from 'node:fs';
 
+import * as extensionApi from '@podman-desktop/api';
 import type { MockedFunction } from 'vitest';
 import { afterEach, beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
@@ -33,6 +34,10 @@ export class TestRegistrySetup extends RegistrySetup {
   getAuthFileLocation(): string {
     return super.getAuthFileLocation();
   }
+
+  updateRegistries(): Promise<void> {
+    return super.updateRegistries();
+  }
 }
 
 let registrySetup: TestRegistrySetup;
@@ -40,8 +45,23 @@ let registrySetup: TestRegistrySetup;
 // mock the fs module
 vi.mock('node:fs');
 
+vi.mock('@podman-desktop/api', async () => {
+  return {
+    registry: {
+      registerRegistryProvider: vi.fn(),
+      registerRegistry: vi.fn(),
+      unregisterRegistry: vi.fn(),
+      onDidRegisterRegistry: vi.fn(),
+      onDidUnregisterRegistry: vi.fn(),
+      onDidUpdateRegistry: vi.fn(),
+    },
+  };
+});
+
 const originalConsoleError = console.error;
+const originalConsoleWarn = console.warn;
 const consoleErroMock = vi.fn();
+const consoleWarnMock = vi.fn();
 
 beforeAll(() => {
   registrySetup = new TestRegistrySetup();
@@ -50,10 +70,12 @@ beforeAll(() => {
 beforeEach(() => {
   vi.resetAllMocks();
   console.error = consoleErroMock;
+  console.warn = consoleWarnMock;
 });
 
 afterEach(() => {
   console.error = originalConsoleError;
+  console.warn = originalConsoleWarn;
 });
 
 type ReadFileType = (
@@ -162,3 +184,121 @@ test('should work with JSON auth file and alias', async () => {
   // expect read with the correct file
   expect(readFileSpy).toHaveBeenCalledWith(authJsonLocation, 'utf-8', expect.anything());
 });
+
+test('should send a warning in console if registry auth value is invalid', async () => {
+  // mock the existSync
+  const existSyncSpy = vi.spyOn(fs, 'existsSync');
+  existSyncSpy.mockReturnValue(true);
+
+  // mock the readFile
+  const readFileSpy = vi.spyOn(fs, 'readFile') as unknown as MockedFunction<ReadFileType>;
+  const auth = Buffer.from('user:password').toString('base64');
+  const invalidAuth = Buffer.from('userpassword').toString('base64');
+
+  readFileSpy.mockImplementation(
+    (_path: string, _encoding: string, callback: (err: Error | undefined, data: string | Buffer) => void) => {
+      // mock the error
+
+      callback(
+        undefined,
+        JSON.stringify({
+          auths: {
+            'myregistry.io': { auth: auth, podmanDesktopAlias: 'alias' },
+            'myinvalidregistry.io': { auth: invalidAuth, podmanDesktopAlias: 'alias1' },
+          },
+        }),
+      );
+    },
+  );
+
+  // mock the location
+  const authJsonLocation = '/tmp/containers/auth.json';
+  const mockGetAuthFileLocation = vi.spyOn(registrySetup, 'getAuthFileLocation');
+  mockGetAuthFileLocation.mockReturnValue(authJsonLocation);
+
+  await registrySetup.updateRegistries();
+
+  // expect read with the correct file
+  expect(readFileSpy).toHaveBeenCalledWith(authJsonLocation, 'utf-8', expect.anything());
+  expect(consoleWarnMock).toHaveBeenCalledWith('Invalid auth value for myinvalidregistry.io');
+});
+
+const [username, secret] = 'userpassword'.split(':');
+
+test.each([
+  {
+    fileAuth: {
+      'myregistry1.io': { auth: Buffer.from('user:password').toString('base64'), podmanDesktopAlias: 'alias' },
+    },
+    registeredRegistry: {
+      source: 'podman',
+      serverUrl: 'myregistry1.io',
+      username: 'user',
+      secret: 'password1',
+    },
+    timesCalled: 1,
+  },
+  {
+    fileAuth: {
+      'myinvalidregistry1.io': { auth: Buffer.from('userpassword').toString('base64'), podmanDesktopAlias: 'alias1' },
+    },
+    registeredRegistry: {
+      source: 'podman',
+      serverUrl: 'myinvalidregistry1.io',
+      username: username,
+      secret: secret,
+    },
+    timesCalled: 0,
+  },
+])(
+  'do not write existing registries that did not change values to auth.json',
+  async ({ fileAuth, registeredRegistry, timesCalled }) => {
+    // mock the existSync
+    const existSyncSpy = vi.spyOn(fs, 'existsSync');
+    existSyncSpy.mockReturnValue(true);
+
+    // mock the readFile
+    const readFileSpy = vi.spyOn(fs, 'readFile') as unknown as MockedFunction<ReadFileType>;
+
+    readFileSpy.mockImplementation(
+      (_path: string, _encoding: string, callback: (err: Error | undefined, data: string | Buffer) => void) => {
+        // mock the error
+
+        callback(undefined, JSON.stringify({}));
+      },
+    );
+
+    // mock the location
+    const authJsonLocation = '/tmp/containers/auth.json';
+    const mockGetAuthFileLocation = vi.spyOn(registrySetup, 'getAuthFileLocation');
+    mockGetAuthFileLocation.mockReturnValue(authJsonLocation);
+
+    let onRegisterRegistry: ((e: extensionApi.Registry) => unknown) | undefined;
+
+    vi.mocked(extensionApi.registry.onDidRegisterRegistry).mockImplementation(callback => {
+      onRegisterRegistry = callback;
+
+      return {
+        dispose: vi.fn(),
+      };
+    });
+
+    const writeFileSpy = vi.spyOn(fs, 'writeFile') as unknown as MockedFunction<ReadFileType>;
+
+    await registrySetup.setup();
+
+    readFileSpy.mockImplementation(
+      (_path: string, _encoding: string, callback: (err: Error | undefined, data: string | Buffer) => void) => {
+        // mock the error
+
+        callback(undefined, JSON.stringify({ auths: fileAuth }));
+      },
+    );
+
+    expect(onRegisterRegistry).toBeDefined();
+
+    onRegisterRegistry?.(registeredRegistry);
+
+    await vi.waitFor(() => expect(writeFileSpy).toHaveBeenCalledTimes(timesCalled));
+  },
+);

--- a/extensions/podman/packages/extension/src/utils/registry-setup.ts
+++ b/extensions/podman/packages/extension/src/utils/registry-setup.ts
@@ -126,7 +126,7 @@ export class RegistrySetup {
           // split the decoded string into username and password separated by :
           const [username, secret] = decoded.split(':');
 
-          // do not encode the registry again if the values are not different from the ones file
+          // do not encode the registry again if the values are not different from the ones in the file
           encode = !(username === registry.username && secret === registry.secret);
         }
 

--- a/extensions/podman/packages/extension/src/utils/registry-setup.ts
+++ b/extensions/podman/packages/extension/src/utils/registry-setup.ts
@@ -126,7 +126,7 @@ export class RegistrySetup {
           // split the decoded string into username and password separated by :
           const [username, secret] = decoded.split(':');
 
-          // do not encode the registry again if the values are not different from the ones in the file
+          // only encode if values have changed from what's stored in the auth file
           encode = !(username === registry.username && secret === registry.secret);
         }
 

--- a/extensions/podman/packages/extension/src/utils/registry-setup.ts
+++ b/extensions/podman/packages/extension/src/utils/registry-setup.ts
@@ -64,6 +64,10 @@ export class RegistrySetup {
         // split the decoded string into username and password separated by :
         const [username, secret] = decoded.split(':');
 
+        if (!secret) {
+          console.warn(`Invalid auth value for ${serverUrl}`);
+        }
+
         const registry = {
           source,
           serverUrl,
@@ -109,16 +113,31 @@ export class RegistrySetup {
     extensionApi.registry.onDidRegisterRegistry(async registry => {
       // external change, update the local registries
       if (!this.localRegistries.has(registry.serverUrl)) {
+        let encode = true;
         this.localRegistries.set(registry.serverUrl, registry);
-        // update the file
+        // read the file
         const authFile = await this.readAuthFile();
         authFile.auths ??= {};
-        authFile.auths[registry.serverUrl] = {
-          auth: Buffer.from(`${registry.username}:${registry.secret}`).toString('base64'),
-          podmanDesktopAlias: registry.alias,
-        };
 
-        await this.writeAuthFile(JSON.stringify(authFile, undefined, 8));
+        // if the registry already exists in the file, check if it has the same value as the registered registry
+        if (authFile.auths[registry.serverUrl]) {
+          const decoded = Buffer.from(authFile.auths[registry.serverUrl].auth, 'base64').toString();
+
+          // split the decoded string into username and password separated by :
+          const [username, secret] = decoded.split(':');
+
+          // do not encode the registry again if the values are not different from the ones file
+          encode = !(username === registry.username && secret === registry.secret);
+        }
+
+        if (encode) {
+          authFile.auths[registry.serverUrl] = {
+            auth: Buffer.from(`${registry.username}:${registry.secret}`).toString('base64'),
+            podmanDesktopAlias: registry.alias,
+          };
+
+          await this.writeAuthFile(JSON.stringify(authFile, undefined, 8));
+        }
       }
     });
 


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?

More info about the root of this bug and possible solutions can be found here https://github.com/podman-desktop/podman-desktop/issues/13061#issuecomment-3145694137

This fix doesn't solve the error, which is expected in this case of an invalid base64 auth value, but it makes sure to have a similar behavior between Podman and Podman Desktop.

With this fix, Podman Desktop doesn't re-write auth value that haven't changed to `auth.json`, so now the invalid base64 value stays, and the error also keeps showing up with Podman and Podman Desktop. 
Without this fix, Podman Desktop would re-encode the values to base64 and re-write them to `auth.json`, so values that were invalid base64 before, are now valid when Podman uses them.

There are other possible solutions, but some of them might lead to different Podman and Podman Desktop behavior in this case.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Fixes https://github.com/podman-desktop/podman-desktop/issues/13061

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

1. Podman 5.5.2, Podman Desktop nightly
2. Start up podman machine (any virt. provider)
3. Add invalid registry (add valid registry first, then open ~/.config/containers/auth.json and adjust the auth token to invalidate it by removing one char)
4. Restart Podman Desktop
5. Try to build an image
Expected: an error pops up both in Podman Desktop and Podman

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
