### PR TITLE
chore(test): add e2e test for namespace switching

### DIFF
--- a/tests/playwright/src/index.ts
+++ b/tests/playwright/src/index.ts
@@ -66,6 +66,7 @@ export * from './model/pages/image-edit-page';
 export * from './model/pages/images-page';
 export * from './model/pages/kubernetes-bar';
 export * from './model/pages/kubernetes-context-page';
+export * from './model/pages/kubernetes-dashboard-page';
 export * from './model/pages/kubernetes-resource-details-page';
 export * from './model/pages/kubernetes-resource-page';
 export * from './model/pages/main-page';

--- a/tests/playwright/src/model/pages/kubernetes-bar.ts
+++ b/tests/playwright/src/model/pages/kubernetes-bar.ts
@@ -19,6 +19,7 @@
 import type { Locator, Page } from '@playwright/test';
 
 import type { KubernetesResources } from '../core/types';
+import { KubernetesDashboardPage } from './kubernetes-dashboard-page';
 import { KubernetesResourcePage } from './kubernetes-resource-page';
 
 export class KubernetesBar {
@@ -46,6 +47,12 @@ export class KubernetesBar {
       default:
         return new KubernetesResourcePage(this.page, kubernetesResource);
     }
+  }
+
+  public async openKubernetesDashboardPage(): Promise<KubernetesDashboardPage> {
+    const dashboardLink = this.kubernetesNavBar.getByRole('link', { name: 'Dashboard', exact: true });
+    await dashboardLink.click();
+    return new KubernetesDashboardPage(this.page);
   }
 
   public getSettingsNavBarTabLocator(name: string): Locator {

--- a/tests/playwright/src/model/pages/kubernetes-dashboard-page.ts
+++ b/tests/playwright/src/model/pages/kubernetes-dashboard-page.ts
@@ -36,6 +36,7 @@ export class KubernetesDashboardPage extends MainPage {
   async changeNamespace(name: string): Promise<void> {
     await playExpect(this.currentNamespace).not.toHaveValue(name, { timeout: 10_000 });
     await this.selectNamespaceByName(name);
+    await playExpect(this.currentNamespace).toHaveValue(name, { timeout: 10_000 });
   }
 
   async selectNamespaceByName(name: string): Promise<void> {
@@ -45,8 +46,6 @@ export class KubernetesDashboardPage extends MainPage {
     const namespaceLocator = this.namespaceLocatorByName(name);
     await playExpect(namespaceLocator).toBeVisible({ timeout: 10_000 });
     await namespaceLocator.click();
-
-    await playExpect(this.currentNamespace).toHaveValue(name, { timeout: 10_000 });
   }
 
   private namespaceLocatorByName(name: string): Locator {

--- a/tests/playwright/src/model/pages/kubernetes-dashboard-page.ts
+++ b/tests/playwright/src/model/pages/kubernetes-dashboard-page.ts
@@ -22,15 +22,15 @@ import { expect as playExpect } from '@playwright/test';
 import { MainPage } from './main-page';
 
 export class KubernetesDashboardPage extends MainPage {
-  readonly namepaceLocator: Locator;
+  readonly namespaceLocator: Locator;
   readonly namespaceDropdownButton: Locator;
   readonly currentNamespace: Locator;
 
   constructor(page: Page) {
     super(page, 'Dashboard');
-    this.namepaceLocator = this.page.getByLabel('Kubernetes Namespace', { exact: true });
-    this.namespaceDropdownButton = this.namepaceLocator.getByRole('button', { name: 'Namespace' });
-    this.currentNamespace = this.namepaceLocator.getByLabel('hidden input', { exact: true });
+    this.namespaceLocator = this.page.getByLabel('Kubernetes Namespace', { exact: true });
+    this.namespaceDropdownButton = this.namespaceLocator.getByRole('button', { name: 'Namespace' });
+    this.currentNamespace = this.namespaceLocator.getByLabel('hidden input', { exact: true });
   }
 
   async changeNamespace(name: string): Promise<void> {
@@ -50,6 +50,6 @@ export class KubernetesDashboardPage extends MainPage {
   }
 
   private namespaceLocatorByName(name: string): Locator {
-    return this.namepaceLocator.getByRole('button', { name, exact: true });
+    return this.namespaceLocator.getByRole('button', { name, exact: true });
   }
 }

--- a/tests/playwright/src/model/pages/kubernetes-dashboard-page.ts
+++ b/tests/playwright/src/model/pages/kubernetes-dashboard-page.ts
@@ -1,0 +1,55 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Locator, Page } from '@playwright/test';
+import { expect as playExpect } from '@playwright/test';
+
+import { MainPage } from './main-page';
+
+export class KubernetesDashboardPage extends MainPage {
+  readonly namepaceLocator: Locator;
+  readonly namespaceDropdownButton: Locator;
+  readonly currentNamespace: Locator;
+
+  constructor(page: Page) {
+    super(page, 'Dashboard');
+    this.namepaceLocator = this.page.getByLabel('Kubernetes Namespace', { exact: true });
+    this.namespaceDropdownButton = this.namepaceLocator.getByRole('button', { name: 'Namespace' });
+    this.currentNamespace = this.namepaceLocator.getByLabel('hidden input', { exact: true });
+  }
+
+  async changeNamespace(name: string): Promise<void> {
+    await playExpect(this.currentNamespace).not.toHaveValue(name, { timeout: 10_000 });
+    await this.selectNamespaceByName(name);
+  }
+
+  async selectNamespaceByName(name: string): Promise<void> {
+    await playExpect(this.namespaceDropdownButton).toBeVisible();
+    await this.namespaceDropdownButton.click();
+
+    const namespaceLocator = this.namespaceLocatorByName(name);
+    await playExpect(namespaceLocator).toBeVisible({ timeout: 10_000 });
+    await namespaceLocator.click();
+
+    await playExpect(this.currentNamespace).toHaveValue(name, { timeout: 10_000 });
+  }
+
+  private namespaceLocatorByName(name: string): Locator {
+    return this.namepaceLocator.getByRole('button', { name, exact: true });
+  }
+}

--- a/tests/playwright/src/specs/kubernetes.spec.ts
+++ b/tests/playwright/src/specs/kubernetes.spec.ts
@@ -19,6 +19,8 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { expect as playExpect } from '@playwright/test';
+
 import { PlayYamlRuntime } from '../model/core/operations';
 import { KubernetesResourceState } from '../model/core/states';
 import { KubernetesResources } from '../model/core/types';
@@ -138,6 +140,21 @@ test.describe('Kubernetes resources End-to-End test', { tag: '@k8s_e2e' }, () =>
   test('Kubernetes Nodes test', async ({ page }) => {
     await checkKubernetesResourceState(page, KubernetesResources.Nodes, KIND_NODE, KubernetesResourceState.Running);
   });
+
+  test('Kubernetes Namespaces test', async ({ navigationBar }) => {
+    const kubernetesBar = await navigationBar.openKubernetes();
+    const dashboardPage = await kubernetesBar.openKubernetesDashboardPage();
+
+    await playExpect(dashboardPage.namespaceDropdownButton).toBeVisible({ timeout: 10_000 });
+    await playExpect(dashboardPage.currentNamespace).toHaveValue('default');
+
+    await dashboardPage.changeNamespace('kube-public');
+    await playExpect(dashboardPage.currentNamespace).toHaveValue('kube-public');
+
+    await dashboardPage.changeNamespace('default');
+    await playExpect(dashboardPage.currentNamespace).toHaveValue('default');
+  });
+
   test.describe
     .serial('PVC lifecycle test', () => {
       test('Create a new PVC resource', async ({ page }) => {

--- a/tests/playwright/src/specs/kubernetes.spec.ts
+++ b/tests/playwright/src/specs/kubernetes.spec.ts
@@ -149,10 +149,7 @@ test.describe('Kubernetes resources End-to-End test', { tag: '@k8s_e2e' }, () =>
     await playExpect(dashboardPage.currentNamespace).toHaveValue('default');
 
     await dashboardPage.changeNamespace('kube-public');
-    await playExpect(dashboardPage.currentNamespace).toHaveValue('kube-public');
-
     await dashboardPage.changeNamespace('default');
-    await playExpect(dashboardPage.currentNamespace).toHaveValue('default');
   });
 
   test.describe


### PR DESCRIPTION
### What does this PR do?
Created k8s e2e test for check namespace switching functionality

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/12222
