### PR TITLE
chore: add custom icon and iconColor property to notifications 

### DIFF
--- a/packages/api/src/notification.ts
+++ b/packages/api/src/notification.ts
@@ -16,6 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
+import type { Component } from 'svelte';
+
 type NotificationType = 'info' | 'warn' | 'error';
 
 export interface NotificationInfo {
@@ -34,6 +37,10 @@ export interface NotificationCardOptions extends NotificationInfo {
   highlight?: boolean;
   // whether or not to emit an OS notification noise when showing the notification.
   silent?: boolean;
+  // icon to display in the notification
+  icon?: IconDefinition | Component | string;
+  // icon color for custom icon
+  iconColor?: string;
 }
 
 export interface NotificationCard extends NotificationCardOptions {

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -1752,6 +1752,14 @@ declare module '@podman-desktop/api' {
      * this notification will be highlighted to the user so it draws attention
      */
     highlight?: boolean;
+    /**
+     * icon to display in the notification
+     */
+    icon?: string;
+    /**
+     * icon color for custom icon
+     */
+    iconColor?: string;
   }
 
   /**

--- a/packages/renderer/src/lib/dashboard/NotificationCardItem.spec.ts
+++ b/packages/renderer/src/lib/dashboard/NotificationCardItem.spec.ts
@@ -17,7 +17,6 @@
  ***********************************************************************/
 import '@testing-library/jest-dom/vitest';
 
-import { faCircleExclamation, faCircleInfo, faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { beforeAll, expect, test, vi } from 'vitest';
 
@@ -70,17 +69,14 @@ test('Test info notification style and icon', () => {
   const { getByTitle } = render(NotificationCardItem, {
     notification,
   });
-  const iconTitle = getByTitle('Notification icon', { exact: false });
-  const icon = iconTitle.parentElement;
-  // check icon shape
-  const pdIconPath = icon?.querySelector('path')?.getAttribute('d');
-  const faIconPath = faCircleInfo.icon[4]; // index 4 is the actual path as per FA IconDefinition
-  expect(pdIconPath).toBe(faIconPath);
+  const icon = getByTitle('Notification icon', { exact: false });
   // check icon color
   expect(icon).toHaveClass('text-[var(--pd-state-info)]');
-  // check icon title contains the text from nested title element
-  expect(iconTitle.textContent).toBe('Notification icon - info');
-  // check region top border
+  // check icon shape
+  expect(icon).toHaveClass('fa-info-circle');
+  // check icon title
+  expect(icon.title).toBe('Notification icon - info');
+  // check top border
   expect(screen.getByRole('region', { name: 'id: 1' })).toHaveClass('border-[var(--pd-state-info)]');
 });
 
@@ -95,17 +91,14 @@ test('Test warning notification style and icon', () => {
   const { getByTitle } = render(NotificationCardItem, {
     notification,
   });
-  const iconTitle = getByTitle('Notification icon', { exact: false });
-  const icon = iconTitle.parentElement;
-  // check icon shape
-  const pdIconPath = icon?.querySelector('path')?.getAttribute('d');
-  const faIconPath = faExclamationTriangle.icon[4]; // index 4 is the actual path as per FA IconDefinition
-  expect(pdIconPath).toBe(faIconPath);
+  const icon = getByTitle('Notification icon', { exact: false });
   // check icon color
   expect(icon).toHaveClass('text-[var(--pd-state-warning)]');
+  // check icon shape
+  expect(icon).toHaveClass('fa-exclamation-triangle');
   // check icon title
-  expect(iconTitle.textContent).toBe('Notification icon - warn');
-  // check region top border
+  expect(icon.title).toBe('Notification icon - warn');
+  // check top border
   expect(screen.getByRole('region', { name: 'id: 1' })).toHaveClass('border-[var(--pd-state-warning)]');
 });
 
@@ -120,16 +113,55 @@ test('Test error notification style and icon', () => {
   const { getByTitle } = render(NotificationCardItem, {
     notification,
   });
-  const iconTitle = getByTitle('Notification icon', { exact: false });
-  const icon = iconTitle.parentElement;
-  // check icon shape
-  const pdIconPath = icon?.querySelector('path')?.getAttribute('d');
-  const faIconPath = faCircleExclamation.icon[4]; // index 4 is the actual path as per FA IconDefinition
-  expect(pdIconPath).toBe(faIconPath);
+  const icon = getByTitle('Notification icon', { exact: false });
   // check icon color
   expect(icon).toHaveClass('text-[var(--pd-state-error)]');
+  // check icon shape
+  expect(icon).toHaveClass('fa-circle-exclamation');
   // check icon title
-  expect(iconTitle.textContent).toBe('Notification icon - error');
-  // check region top border
+  expect(icon.title).toBe('Notification icon - error');
+  // check top border
+  expect(screen.getByRole('region', { name: 'id: 1' })).toHaveClass('border-[var(--pd-state-error)]');
+});
+
+test('Test notification with custom icon, default color', () => {
+  const notification: NotificationCard = {
+    id: 1,
+    extensionId: 'extension',
+    title: 'Info notification title',
+    body: 'Info notification description',
+    type: 'info',
+    icon: 'fas fa-refresh',
+  };
+  const { getByTitle } = render(NotificationCardItem, {
+    notification,
+  });
+  const icon = getByTitle('Notification icon', { exact: false });
+  // check that custom icon is used instead of the default
+  expect(icon).toHaveClass('fa-refresh');
+  // check that default color is used
+  expect(icon).toHaveClass('text-[var(--pd-state-info)]');
+  // check top border
+  expect(screen.getByRole('region', { name: 'id: 1' })).toHaveClass('border-[var(--pd-state-info)]');
+});
+test('Test notification with custom icon, custom color', () => {
+  const notification: NotificationCard = {
+    id: 1,
+    extensionId: 'extension',
+    title: 'Error notification title',
+    body: 'Error notification description',
+    type: 'error',
+    icon: 'fas fa-refresh',
+    iconColor: 'text-red-600',
+  };
+  const { getByTitle } = render(NotificationCardItem, {
+    notification,
+  });
+  const icon = getByTitle('Notification icon', { exact: false });
+  // check that custom icon is used instead of the default
+  expect(icon).toHaveClass('fa-refresh');
+  // check that custom color is applied instead of the default
+  expect(icon).toHaveClass('text-red-600');
+  // check top border
   expect(screen.getByRole('region', { name: 'id: 1' })).toHaveClass('border-[var(--pd-state-error)]');
 });

--- a/packages/renderer/src/lib/dashboard/NotificationCardItem.svelte
+++ b/packages/renderer/src/lib/dashboard/NotificationCardItem.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faCircleExclamation, faCircleInfo, faExclamationTriangle, faXmark } from '@fortawesome/free-solid-svg-icons';
+import { faXmark } from '@fortawesome/free-solid-svg-icons';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 
 import type { NotificationCard } from '/@api/notification';
@@ -12,17 +12,17 @@ const notificationStyleMap = {
   info: {
     borderColor: 'border-[var(--pd-state-info)]',
     iconColor: 'text-[var(--pd-state-info)]',
-    icon: faCircleInfo,
+    icon: 'fas fa-info-circle',
   },
   warn: {
     borderColor: 'border-[var(--pd-state-warning)]',
     iconColor: 'text-[var(--pd-state-warning)]',
-    icon: faExclamationTriangle,
+    icon: 'fas fa-exclamation-triangle',
   },
   error: {
     borderColor: 'border-[var(--pd-state-error)]',
     iconColor: 'text-[var(--pd-state-error)]',
-    icon: faCircleExclamation,
+    icon: 'fas fa-circle-exclamation',
   },
 };
 
@@ -35,7 +35,11 @@ const notificationStyle = notificationStyleMap[notification.type];
   aria-label="id: {notification.id}">
   <div class="flex flex-row space-x-3">
     <div class="flex">
-        <Icon size="1.5x" icon={notificationStyle.icon} class={notificationStyle.iconColor} title={'Notification icon - ' + notification.type}/>
+      <Icon 
+        icon={notification.icon ?? notificationStyle.icon} 
+        class={`${notification.iconColor ?? notificationStyle.iconColor} text-xl`} 
+        title={`Notification icon - ${notification.type}`} 
+      />
     </div>
     <div class="flex flex-col space-y-2 flex-1">
       <div class="flex flex-row items-center justify-between">


### PR DESCRIPTION
### What does this PR do?

SSIA.

Some mockups on notifications use custom icons, sometimes with a different color from the default set of "info" "warn" "error". 

- [x] Tests are covering the bug fix or the new feature

Closes https://github.com/podman-desktop/podman-desktop/issues/13371