### PR TITLE
chore: display the stop button in a compose section

### DIFF
--- a/packages/renderer/src/lib/compose/ComposeActions.spec.ts
+++ b/packages/renderer/src/lib/compose/ComposeActions.spec.ts
@@ -19,6 +19,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { tick } from 'svelte';
 import { afterEach, beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
 import type { ContainerInfoUI } from '../container/ContainerInfoUI';
@@ -142,4 +143,26 @@ test('Expect no error and status deleting compose', async () => {
   expect(compose.containers[0].state).toEqual('DELETING');
   expect(compose.containers[0].actionError).toEqual('');
   expect(updateMock).toHaveBeenCalled();
+});
+
+test('Hide start button when stop is pressed and vice versa', async () => {
+  render(ComposeActions, { compose, onUpdate: updateMock });
+
+  const startBtn = screen.getByRole('button', { name: 'Start Compose' });
+
+  await fireEvent.click(startBtn);
+  await tick();
+
+  expect(screen.getByRole('button', { name: 'Stop Compose' })).toHaveClass('hidden');
+
+  compose.status = 'RUNNING';
+  compose.containers[0].state = 'RUNNING';
+  compose.actionInProgress = false;
+  await tick();
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Stop Compose' }));
+  await tick();
+
+  const startBtnDuringStop = screen.getByRole('button', { name: 'Start Compose' });
+  expect(startBtnDuringStop).toHaveClass('hidden');
 });

--- a/packages/renderer/src/lib/compose/ComposeActions.spec.ts
+++ b/packages/renderer/src/lib/compose/ComposeActions.spec.ts
@@ -18,9 +18,9 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import { within } from '@testing-library/dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
-import { tick } from 'svelte';
-import { afterEach, beforeAll, beforeEach, expect, test, vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, expect, type Mock, test, vi } from 'vitest';
 
 import type { ContainerInfoUI } from '../container/ContainerInfoUI';
 import ComposeActions from './ComposeActions.svelte';
@@ -64,6 +64,21 @@ const compose: ComposeInfoUI = new ComposeInfoUIImpl(
 const getContributedMenusMock = vi.fn();
 const updateMock = vi.fn();
 const showMessageBoxMock = vi.fn();
+
+type Deferred<T = void> = {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+};
+const createDeferred = <T = void>(): Deferred<T> => {
+  let resolve!: (v: T | PromiseLike<T>) => void;
+  let reject!: (e?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
 
 beforeAll(() => {
   Object.defineProperty(window, 'showMessageBox', { value: showMessageBoxMock });
@@ -145,24 +160,111 @@ test('Expect no error and status deleting compose', async () => {
   expect(updateMock).toHaveBeenCalled();
 });
 
-test('Hide start button when stop is pressed and vice versa', async () => {
-  render(ComposeActions, { compose, onUpdate: updateMock });
+test('Stop keeps Start hidden during STOPPING (all containers are running)', async () => {
+  const composeAllRunning: ComposeInfoUI = new ComposeInfoUIImpl(
+    'podman',
+    'podman',
+    'compose-all-running',
+    'RUNNING',
+    false,
+    undefined,
+    [
+      { state: 'RUNNING', actionInProgress: false } as ContainerInfoUI,
+      { state: 'RUNNING', actionInProgress: false } as ContainerInfoUI,
+    ],
+  );
 
-  const startBtn = screen.getByRole('button', { name: 'Start Compose' });
+  const { container } = render(ComposeActions, { compose: composeAllRunning, onUpdate: updateMock });
+  const ui = within(container);
 
-  await fireEvent.click(startBtn);
-  await tick();
+  expect(ui.getByRole('button', { name: 'Start Compose', hidden: true })).toHaveClass('hidden');
+  expect(ui.getByRole('button', { name: 'Stop Compose' })).not.toHaveClass('hidden');
 
-  expect(screen.getByRole('button', { name: 'Stop Compose' })).toHaveClass('hidden');
+  const dStop = createDeferred<void>();
+  (window.stopContainersByLabel as unknown as Mock).mockReturnValueOnce(dStop.promise);
 
-  compose.status = 'RUNNING';
-  compose.containers[0].state = 'RUNNING';
-  compose.actionInProgress = false;
-  await tick();
+  await fireEvent.click(ui.getByRole('button', { name: 'Stop Compose' }));
 
-  await fireEvent.click(screen.getByRole('button', { name: 'Stop Compose' }));
-  await tick();
+  await waitFor(() => {
+    expect(composeAllRunning.actionInProgress).toBe(true);
+    expect(composeAllRunning.status).toBe('STOPPING');
+  });
 
-  const startBtnDuringStop = screen.getByRole('button', { name: 'Start Compose' });
-  expect(startBtnDuringStop).toHaveClass('hidden');
+  dStop.resolve();
+
+  expect(ui.getByRole('button', { name: 'Start Compose', hidden: true })).toHaveClass('hidden');
+  expect(ui.getByRole('button', { name: 'Stop Compose' })).not.toHaveClass('hidden');
+});
+
+test('Start keeps Stop hidden during STARTING (all containers are stopped)', async () => {
+  const composeAllStopped: ComposeInfoUI = new ComposeInfoUIImpl(
+    'podman',
+    'podman',
+    'compose-all-stopped',
+    'STOPPED',
+    false,
+    undefined,
+    [
+      { state: 'STOPPED', actionInProgress: false } as ContainerInfoUI,
+      { state: 'STOPPED', actionInProgress: false } as ContainerInfoUI,
+    ],
+  );
+
+  const { container } = render(ComposeActions, { compose: composeAllStopped, onUpdate: updateMock });
+  const ui = within(container);
+
+  expect(ui.getByRole('button', { name: 'Start Compose' })).not.toHaveClass('hidden');
+  expect(ui.getByRole('button', { name: 'Stop Compose', hidden: true })).toHaveClass('hidden');
+
+  const dStart = createDeferred<void>();
+  (window.startContainersByLabel as unknown as Mock).mockReturnValueOnce(dStart.promise);
+
+  await fireEvent.click(ui.getByRole('button', { name: 'Start Compose' }));
+
+  await waitFor(() => {
+    expect(composeAllStopped.actionInProgress).toBe(true);
+    expect(composeAllStopped.status).toBe('STARTING');
+  });
+
+  dStart.resolve();
+
+  expect(ui.getByRole('button', { name: 'Stop Compose', hidden: true })).toHaveClass('hidden');
+  expect(ui.getByRole('button', { name: 'Start Compose' })).not.toHaveClass('hidden');
+});
+
+test('Stop keeps both visible during STOPPING (some containers are running)', async () => {
+  const composePartial: ComposeInfoUI = new ComposeInfoUIImpl(
+    'podman',
+    'podman',
+    'compose-partial',
+    'RUNNING',
+    false,
+    undefined,
+    [
+      { state: 'RUNNING', actionInProgress: false } as ContainerInfoUI,
+      { state: 'STOPPED', actionInProgress: false } as ContainerInfoUI,
+      { state: 'RUNNING', actionInProgress: false } as ContainerInfoUI,
+    ],
+  );
+
+  const { container } = render(ComposeActions, { compose: composePartial, onUpdate: updateMock });
+  const ui = within(container);
+
+  expect(ui.getByRole('button', { name: 'Start Compose' })).not.toHaveClass('hidden');
+  expect(ui.getByRole('button', { name: 'Stop Compose' })).not.toHaveClass('hidden');
+
+  const dStop = createDeferred<void>();
+  (window.stopContainersByLabel as unknown as Mock).mockReturnValueOnce(dStop.promise);
+
+  await fireEvent.click(ui.getByRole('button', { name: 'Stop Compose' }));
+
+  await waitFor(() => {
+    expect(composePartial.actionInProgress).toBe(true);
+    expect(composePartial.status).toBe('STOPPING');
+  });
+
+  dStop.resolve();
+
+  expect(ui.getByRole('button', { name: 'Start Compose' })).not.toHaveClass('hidden');
+  expect(ui.getByRole('button', { name: 'Stop Compose' })).not.toHaveClass('hidden');
 });

--- a/packages/renderer/src/lib/compose/ComposeActions.svelte
+++ b/packages/renderer/src/lib/compose/ComposeActions.svelte
@@ -28,6 +28,11 @@ onMount(async () => {
   contributions = await window.getContributedMenus(MenuContext.DASHBOARD_COMPOSE);
 });
 
+$: isStarting = compose.actionInProgress && compose.status === 'STARTING';
+$: isStopping = compose.actionInProgress && compose.status === 'STOPPING';
+$: someRunning = compose.containers?.some(c => c.state === 'RUNNING');
+$: someStopped = compose.containers?.some(c => c.state !== 'RUNNING');
+
 function inProgress(inProgress: boolean, state?: string): void {
   compose.actionInProgress = inProgress;
   // reset error when starting task
@@ -122,18 +127,18 @@ if (dropdownMenu) {
 <ListItemButtonIcon
   title="Start Compose"
   onClick={startCompose}
-  hidden={compose.status === 'RUNNING' || compose.status === 'STOPPING'}
+  hidden={compose.status === 'STOPPING' || !someStopped}
   detailed={detailed}
-  inProgress={compose.actionInProgress && compose.status === 'STARTING'}
+  inProgress={isStarting}
   icon={faPlay}
   iconOffset="pl-[0.15rem]" />
 
 <ListItemButtonIcon
   title="Stop Compose"
   onClick={stopCompose}
-  hidden={!(compose.status === 'RUNNING' || compose.status === 'STOPPING')}
+  hidden={compose.status === 'STARTING' || !someRunning}
   detailed={detailed}
-  inProgress={compose.actionInProgress && compose.status === 'STOPPING'}
+  inProgress={isStopping}
   icon={faStop} />
 
 <ListItemButtonIcon


### PR DESCRIPTION
### What does this PR do?

Display the stop button if any container in the compose section has running status.

### Screenshot / video of UI

<img width="983" height="237" src="https://github.com/user-attachments/assets/b5f1892e-57f7-4ba9-be1c-791e5fa08687" />


### What issues does this PR fix or reference?

#10406 

### How to test this PR?

Deploy the following compose file:

```yaml
# compose.yml
version: "3.9"

services:
  service_one:
    image: alpine:latest
    container_name: service_one
    command: ["sleep", "infinity"]
    restart: "no"

  service_two:
    image: alpine:latest
    container_name: service_two
    command: ["sleep", "infinity"]
    restart: "no"

  service_three:
    image: alpine:latest
    container_name: service_three
    command: ["sleep", "infinity"]
    restart: "no"

  service_four:
    image: alpine:latest
    container_name: service_four
    command: ["sleep", "infinity"]
    restart: "no"

```

and try to manually run/stop the containers in compose section of Container List.

- [x] Tests are covering the bug fix or the new feature
