### PR TITLE
fix: download cli tools behind transparent proxy 'self signed cert' error

### DIFF
--- a/extensions/compose/src/extension.ts
+++ b/extensions/compose/src/extension.ts
@@ -66,7 +66,11 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   handler.handleConfigurationChanges(extensionContext);
 
   // Create new classes to handle the onboarding sequence
-  const octokit = new Octokit();
+  const octokit = new Octokit({
+    request: {
+      fetch,
+    },
+  });
   const detect = new Detect(os, extensionContext.storagePath);
 
   const composeGitHubReleases = new ComposeGitHubReleases(octokit);

--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -389,7 +389,11 @@ async function registerCliTool(
   extensionContext: extensionApi.ExtensionContext,
   telemetryLogger: extensionApi.TelemetryLogger,
 ): Promise<void> {
-  const octokit = new Octokit();
+  const octokit = new Octokit({
+    request: {
+      fetch,
+    },
+  });
   installer = new KindInstaller(extensionContext.storagePath, telemetryLogger, octokit);
 
   let binary: { path: string; version: string } | undefined = undefined;

--- a/extensions/kubectl-cli/src/extension.ts
+++ b/extensions/kubectl-cli/src/extension.ts
@@ -83,7 +83,11 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   handler.handleConfigurationChanges(extensionContext);
 
   // Create new classes to handle the onboarding sequence
-  const octokit = new Octokit();
+  const octokit = new Octokit({
+    request: {
+      fetch,
+    },
+  });
   const detect = new Detect(os, extensionContext.storagePath);
 
   const kubectlGitHubReleases = new KubectlGitHubReleases(octokit);


### PR DESCRIPTION
### What does this PR do?

switches Oktokit to use fetch as http client, because of (probably) fetch proxy wrapper discovers all local certificates and avoids errors like 'self signed certificate in certificate chain'.  

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Fix #13497 (needs test with transparent proxy in use).

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
