### PR TITLE
chore: introduce github labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,32 @@
+#
+# Copyright (C) 2025 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Visual changes
+"area/ui":
+  - changed-files:
+    - any-glob-to-any-file:
+      - "packages/renderer/**/*"
+      - "packages/ui/**/*"
+      - "storybook/**/*"
+      - "**/*.svelte"
+      - "**/*.css"
+
+# Website changes
+"area/website":
+  - changed-files:
+    - any-glob-to-any-file:
+      - "website/**/*"

--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -1,0 +1,36 @@
+#
+# Copyright (C) 2025 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: "PR Labeler"
+
+on:
+  pull_request_target:
+    types: [labeled, synchronize, opened, ready_for_review, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  labeler:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Labeler
+        uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9
+        with:
+          repo-token: "${{ secrets.PODMAN_DESKTOP_BOT_TOKEN }}"
+          configuration-path: .github/labeler.yml


### PR DESCRIPTION
### What does this PR do?
This adds a workflow for PRs which matches paths/extensions for files and based on that assign corresponding label. Currently this tries to detect any visual changes and website changes for UX awareness, but could be updated with more logic to provide more robust labeling.

Don't merge before correct tokens are set-up.

Let's discuss ideas or improvements as part of this PR.