### PR TITLE
feat: added support for images in markdown component

### DIFF
--- a/packages/renderer/src/lib/markdown/Markdown.spec.ts
+++ b/packages/renderer/src/lib/markdown/Markdown.spec.ts
@@ -125,6 +125,29 @@ describe('Custom link', () => {
   });
 });
 
+describe('Custom image', () => {
+  test('Expect image to be rendered as a image without attributes', async () => {
+    await waitRender({ markdown: ':image[Name of the image]{src=path/to/image.png}' });
+    const markdownContent = screen.getByRole('region', { name: 'markdown-content' });
+    expect(markdownContent).toBeInTheDocument();
+    expect(markdownContent).toContainHTML(
+      '<img src="path/to/image.png" alt="Name of the image" class="max-w-full h-auto rounded-md shadow-md block transition-shadow duration-300" loading="lazy"/>',
+    );
+  });
+
+  test('Expect image to be rendered as a image with all attributes', async () => {
+    await waitRender({
+      markdown: ':image[Name of the image]{src=path/to/image.png title="Image title" width="300" height="200"}',
+    });
+    const markdownImage = screen.getByRole('img');
+    expect(markdownImage).toBeInTheDocument();
+    expect(markdownImage).toHaveAttribute('alt', 'Name of the image');
+    expect(markdownImage).toHaveAttribute('height', '200');
+    expect(markdownImage).toHaveAttribute('width', '300');
+    expect(markdownImage).toHaveAttribute('title', 'Image title');
+  });
+});
+
 describe('Custom warnings', () => {
   test('Expect warning failed status and description', async () => {
     const warnings = [

--- a/packages/renderer/src/lib/markdown/Markdown.svelte
+++ b/packages/renderer/src/lib/markdown/Markdown.svelte
@@ -42,6 +42,14 @@ UI guidelines -->
 .markdown :global(a):hover {
   background-color: var(--pd-link-hover-bg);
 }
+.markdown :global(.markdown-image) {
+  max-width: 100%;
+  height: auto;
+  border-radius: 6px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
+  transition: box-shadow 0.3s ease;
+  display: block;
+}
 </style>
 
 <script lang="ts">
@@ -50,6 +58,7 @@ import { directive, directiveHtml } from 'micromark-extension-directive';
 import { onDestroy, onMount } from 'svelte';
 
 import { button } from './micromark-button-directive';
+import { image } from './micromark-image-directive';
 import { link } from './micromark-link-directive';
 import { createListener } from './micromark-listener-handler';
 import { warnings } from './micromark-warnings-directive';
@@ -77,7 +86,7 @@ const eventListeners: EventListener[] = [];
 $: markdown
   ? (html = micromark(markdown, {
       extensions: [directive()],
-      htmlExtensions: [directiveHtml({ button, link, warnings })],
+      htmlExtensions: [directiveHtml({ button, image, link, warnings })],
     }))
   : undefined;
 
@@ -89,7 +98,7 @@ onMount(() => {
   // Provide micromark + extensions
   html = micromark(text, {
     extensions: [directive()],
-    htmlExtensions: [directiveHtml({ button, link, warnings })],
+    htmlExtensions: [directiveHtml({ button, image, link, warnings })],
   });
 
   // remove href values in each anchor using # for links

--- a/packages/renderer/src/lib/markdown/Markdown.svelte
+++ b/packages/renderer/src/lib/markdown/Markdown.svelte
@@ -42,14 +42,6 @@ UI guidelines -->
 .markdown :global(a):hover {
   background-color: var(--pd-link-hover-bg);
 }
-.markdown :global(.markdown-image) {
-  max-width: 100%;
-  height: auto;
-  border-radius: 6px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
-  transition: box-shadow 0.3s ease;
-  display: block;
-}
 </style>
 
 <script lang="ts">

--- a/packages/renderer/src/lib/markdown/micromark-image-directive.ts
+++ b/packages/renderer/src/lib/markdown/micromark-image-directive.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2025 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,7 +72,7 @@ export function image(d: Directive): void {
   }
 
   // Add default styling class and any additional classes
-  let cssClasses = 'markdown-image';
+  let cssClasses = 'max-w-full h-auto rounded-md shadow-md block transition-shadow duration-300';
   if (d.attributes.class) {
     cssClasses += ' ' + this.encode(d.attributes.class);
   }

--- a/packages/renderer/src/lib/markdown/micromark-image-directive.ts
+++ b/packages/renderer/src/lib/markdown/micromark-image-directive.ts
@@ -1,0 +1,86 @@
+/**********************************************************************
+ * Copyright (C) 2023-2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+// @ts-nocheck
+import type { Directive } from 'micromark-extension-directive';
+
+/**
+ * Allow to generate an image markdown directive
+ * syntax is the following:
+ * :image[Alt text]{src=path/to/image.png title="Image title" width="300" height="200"}
+ * or
+ * :image[Alt text]{src=path/to/image.gif title="GIF title" width="300"}
+ *
+ * Supported attributes:
+ * - src: (required) path to the image/GIF
+ * - title: tooltip text when hovering over the image
+ * - width: image width (optional)
+ * - height: image height (optional)
+ * - class: additional CSS classes (optional)
+ */
+/**
+ * @this {import('micromark-util-types').CompileContext}
+ * @type {import('micromark-extension-directive').Handle}
+ */
+export function image(d: Directive): void {
+  // Make sure it's not part of a text directive
+  if (d.type !== 'textDirective') {
+    return false;
+  }
+
+  // Make sure src attribute is provided
+  if (!d.attributes || !('src' in d.attributes)) {
+    return false;
+  }
+
+  // Start the img tag
+  this.tag('<img');
+
+  // Add the src attribute (required)
+  this.tag(' src="' + this.encode(d.attributes.src) + '"');
+
+  // Add alt text from the label
+  this.tag(' alt="' + this.encode(d.label ?? '') + '"');
+
+  // Add optional attributes
+  if (d.attributes.title) {
+    this.tag(' title="' + this.encode(d.attributes.title) + '"');
+  }
+
+  if (d.attributes.width) {
+    this.tag(' width="' + this.encode(d.attributes.width) + '"');
+  }
+
+  if (d.attributes.height) {
+    this.tag(' height="' + this.encode(d.attributes.height) + '"');
+  }
+
+  // Add default styling class and any additional classes
+  let cssClasses = 'markdown-image';
+  if (d.attributes.class) {
+    cssClasses += ' ' + this.encode(d.attributes.class);
+  }
+  this.tag(' class="' + cssClasses + '"');
+
+  // Add loading="lazy" for better performance
+  this.tag(' loading="lazy"');
+
+  // Close the self-closing img tag
+  this.tag(' />');
+}


### PR DESCRIPTION
### What does this PR do?
Adds support for image/gifs in markdown 

### Screenshot / video of UI

e.g.



[Screencast_20250807_105858.webm](https://github.com/user-attachments/assets/e1e1782f-6020-4c37-ac42-b15422d475ab)


### What issues does this PR fix or reference?
Closes #13518 

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
