### PR TITLE
chore(test): skip compose onboarding test based on env. var

### DIFF
--- a/tests/playwright/src/specs/compose-onboarding-smoke.spec.ts
+++ b/tests/playwright/src/specs/compose-onboarding-smoke.spec.ts
@@ -35,7 +35,9 @@ const RESOURCE_NAME: string = 'Compose';
 let composeVersion: string;
 // property that will make sure that on linux we can run only partial tests, by default this is turned off
 const composePartialInstallation = process.env.COMPOSE_PARTIAL_INSTALL ?? false;
+const skipComposeOnboardingTest = process.env.SKIP_COMPOSE_ONBOARDING_TEST ?? false;
 
+test.skip(!!skipComposeOnboardingTest, 'Skip test suite based on env. variable');
 test.skip(!!isCI && isLinux, 'Tests suite should not run on Linux platform');
 
 test.beforeAll(async ({ runner, welcomePage }) => {


### PR DESCRIPTION
Signed-off-by: Anton Misskii <amisskii@redhat.com>

### What does this PR do?
Skips the Compose onboarding test based on an environment variable; this is specifically relevant for Testing Farm.

### How to test this PR?
https://github.com/podman-desktop/e2e/actions/runs/16833756342
