### PR TITLE
fix(website): fixed trimmed podman desktop logo

### DIFF
--- a/website/src/components/GitHubStarsButton.tsx
+++ b/website/src/components/GitHubStarsButton.tsx
@@ -16,7 +16,7 @@ export function GitHubStarsButton({ mobile = false }: { readonly mobile?: boolea
       className={
         mobile
           ? 'dropdown__link flex items-center gap-2 px-4 py-[9px] font-medium text-base'
-          : 'navbar__item navbar__link hidden xl:flex items-center gap-2 px-4 py-[9px] border border-black dark:border-white rounded-lg font-medium min-w-[9rem]'
+          : 'navbar__item navbar__link hidden xl:flex items-center gap-2 px-4 py-[9px] border border-black dark:border-white rounded-lg font-medium min-w-[9rem] text-base'
       }>
       <FontAwesomeIcon icon={faGithub} />
       <span>Star</span>

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -120,6 +120,7 @@ li.footer__item a svg {
   font-size: 1.2em;
   font-weight: 500;
   padding-right: 1em;
+  white-space: nowrap;
 }
 
 .navbar__logo img {
@@ -179,7 +180,7 @@ li.footer__item a svg {
   background-color: transparent !important;
 }
 
-@media (min-width: 1230px) {
+@media (min-width: 1380px) {
   .navbar__title {
     font-size: 1.7em;
   }


### PR DESCRIPTION
### What does this PR do?
Fixes timing podman desktop logo on some window sizes

### Screenshot / video of UI
Previous:

 [Screencast_20250806_071638.webm](https://github.com/user-attachments/assets/0d303073-8d43-4755-bcce-482f379b744e)

Current: 

[Screencast_20250811_081933.webm](https://github.com/user-attachments/assets/d9999d6a-0829-443e-8017-1ba0b6d84b74)


### What issues does this PR fix or reference?
Closes #13510 

### How to test this PR?


- [ ] Tests are covering the bug fix or the new feature
