### PR TITLE
Fix onboarding ui e2e test getting blocked by extension loading

### DIFF
--- a/tests/playwright/src/model/pages/welcome-page.ts
+++ b/tests/playwright/src/model/pages/welcome-page.ts
@@ -53,7 +53,9 @@ export class WelcomePage extends BasePage {
       const isUpdateTest = test.info().tags.includes('@update-install');
 
       if (!isUpdateTest) {
-        await playExpect(this.startOnboarding).toBeEnabled({ timeout: 20_000 });
+        // Extensions load sequentially (faster speed but can block ui)
+        // Each extension timeout is 20s use 60s to provide a decent bufffer
+        await playExpect(this.startOnboarding).toBeEnabled({ timeout: 60_000 });
       }
 
       if (await this.telemetryConsent.isChecked()) {


### PR DESCRIPTION
### What does this PR do?

The e2e test for welcome-page.ts had a timeout of 20 seconds which conflicts with each extension timeout being 20 seconds. If an extension used the full timeout it would crash the e2e test. Added a new timeout of 60s to have up to 3 extensions use the max time before the error

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/13047

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

in extensions/kind/src/extension.ts 
add a timout like this in line 588

export async function activate(extensionContext: extensionApi.ExtensionContext): Promise<void> {
  // Add a 20s delay to simulate a slow activation
  await new Promise(resolve => setTimeout(resolve, 20_000));
  console.log('Kind extension simulate slow activation');

then run 

pnpm run test:e2e:build
pnpm exec playwright test tests/playwright/src/specs/welcome-page-smoke.spec.ts --headed


<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
