### PR TITLE
feat: added support for masking passwords

### DIFF
--- a/packages/main/src/plugin/input-quickpick/input-quickpick-registry.ts
+++ b/packages/main/src/plugin/input-quickpick/input-quickpick-registry.ts
@@ -71,6 +71,7 @@ export class InputQuickPickRegistry {
       prompt: options?.prompt,
       markdownDescription: options?.markdownDescription,
       multiline: options?.multiline,
+      password: options?.password,
       validate,
       ignoreFocusOut: options?.ignoreFocusOut,
     };

--- a/packages/renderer/src/lib/dialogs/QuickPickInput.spec.ts
+++ b/packages/renderer/src/lib/dialogs/QuickPickInput.spec.ts
@@ -208,6 +208,33 @@ describe('QuickPickInput', () => {
     expect(area).toBeInTheDocument();
   });
 
+  test.each([
+    { password: true, type: 'password' },
+    { password: false, type: 'text' },
+  ])('Expect that input is displayed correctly with type %s', async ({ password, type }) => {
+    const idRequest = 123;
+
+    const inputBoxOptions: InputBoxOptions = {
+      password: password,
+      validate: false,
+      placeHolder: 'Some placeholder',
+      prompt: 'Enter a value',
+      id: idRequest,
+    };
+
+    receiveFunctionMock.mockImplementation((message: string, callback: (options: InputBoxOptions) => void) => {
+      if (message === 'showInputBox:add') {
+        callback(inputBoxOptions);
+      }
+    });
+
+    render(QuickPickInput, {});
+
+    const area = await screen.findByPlaceholderText('Some placeholder');
+    expect(area).toBeInTheDocument();
+    expect(area).toHaveAttribute('type', type);
+  });
+
   test('Expect that filtering works', async () => {
     const idRequest = 123;
 

--- a/packages/renderer/src/lib/dialogs/QuickPickInput.spec.ts
+++ b/packages/renderer/src/lib/dialogs/QuickPickInput.spec.ts
@@ -215,6 +215,7 @@ describe('QuickPickInput', () => {
     const idRequest = 123;
 
     const inputBoxOptions: InputBoxOptions = {
+      multiline: false,
       password: password,
       validate: false,
       placeHolder: 'Some placeholder',
@@ -228,10 +229,9 @@ describe('QuickPickInput', () => {
       }
     });
 
-    render(QuickPickInput, {});
-
-    const area = await screen.findByPlaceholderText('Some placeholder');
-    expect(area).toBeInTheDocument();
+    const { getByPlaceholderText } = render(QuickPickInput, {});
+    const area = getByPlaceholderText('Some placeholder');
+    expect(area).toBeInstanceOf(HTMLInputElement);
     expect(area).toHaveAttribute('type', type);
   });
 

--- a/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
+++ b/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
@@ -16,6 +16,7 @@ let markdownDescription: string | undefined = '';
 let currentId = 0;
 let title: string | undefined = '';
 let multiline = false;
+let password = false;
 
 let validationEnabled = false;
 let validationError: string | undefined = '';
@@ -44,6 +45,7 @@ const showInputCallback = (inputCallpackParameter: unknown): void => {
   placeHolder = options?.placeHolder;
   title = options?.title;
   currentId = options?.id ?? 0;
+  password = options?.password ?? false;
   if (options?.prompt) {
     prompt = `${options.prompt} (${DEFAULT_PROMPT})`;
   } else {
@@ -333,7 +335,7 @@ async function handleKeydown(e: KeyboardEvent): Promise<void> {
             <input
               bind:this={inputElement}
               on:input={onInputChange}
-              type="text"
+              type={password ? 'password' : 'text'}
               bind:value={inputValue}
               class="px-1 w-full text-[var(--pd-input-select-hover-text)] border {validationError
                 ? 'border-[var(--pd-input-field-stroke-error)]'

--- a/packages/renderer/src/lib/dialogs/quickpick-input.ts
+++ b/packages/renderer/src/lib/dialogs/quickpick-input.ts
@@ -42,6 +42,7 @@ export interface InputBoxOptions {
   id: number;
   title?: string;
   ignoreFocusOut?: boolean;
+  password?: boolean;
 }
 
 export interface CustomPickOptions {


### PR DESCRIPTION
### What does this PR do?
Adds support to QuickPickInput to be able to mask password when passord is set to true

### Screenshot / video of UI
Old:

<img width="1457" height="1142" alt="image" src="https://github.com/user-attachments/assets/36f90a27-75eb-41e4-964c-d4b0008184cd" />


Current:

<img width="1456" height="1142" alt="image" src="https://github.com/user-attachments/assets/b27a1685-fd87-4958-bc28-d085ca7b8b80" />


### What issues does this PR fix or reference?
Closes #13476 

### How to test this PR?
Unit tests 

Steps in the issue

- [x] Tests are covering the bug fix or the new feature
