### PR TITLE
fix(ContainerList): group containers missing engineName

### DIFF
--- a/packages/renderer/src/lib/container/container-utils.spec.ts
+++ b/packages/renderer/src/lib/container/container-utils.spec.ts
@@ -159,6 +159,7 @@ test('container group status should be stopped when any compose container is sto
     Names: ['container1'],
     State: 'RUNNING',
     ImageID: 'sha256:dummy-sha256',
+    engineName: 'podman',
   } as unknown as ContainerInfo;
   const containerInfo2 = {
     Id: 'container2',
@@ -167,6 +168,7 @@ test('container group status should be stopped when any compose container is sto
     Names: ['container2'],
     State: 'STOPPED',
     ImageID: 'sha256:dummy-sha256',
+    engineName: 'podman',
   } as unknown as ContainerInfo;
   const groups = containerUtils.getContainerGroups([
     containerUtils.getContainerInfoUI(containerInfo),
@@ -177,6 +179,7 @@ test('container group status should be stopped when any compose container is sto
   expect(group.name).toBe(groupName);
   expect(group.type).toBe(ContainerGroupInfoTypeUI.COMPOSE);
   expect(group.status).toBe('STOPPED');
+  expect(group.engineName).toBe('podman');
 });
 
 test('container group status should be running when the pod status is running', async () => {
@@ -193,6 +196,7 @@ test('container group status should be running when the pod status is running', 
     State: 'RUNNING',
     pod: pod,
     ImageID: 'sha256:dummy-sha256',
+    engineName: 'podman',
   } as unknown as ContainerInfo;
   const containerInfo2 = {
     Id: 'container2',
@@ -201,6 +205,7 @@ test('container group status should be running when the pod status is running', 
     State: 'RUNNING',
     pod: pod,
     ImageID: 'sha256:dummy-sha256',
+    engineName: 'podman',
   } as unknown as ContainerInfo;
   const groups = containerUtils.getContainerGroups([
     containerUtils.getContainerInfoUI(containerInfo),
@@ -210,6 +215,7 @@ test('container group status should be running when the pod status is running', 
   expect(group.name).toBe(groupName);
   expect(group.type).toBe(ContainerGroupInfoTypeUI.POD);
   expect(group.status).toBe('RUNNING');
+  expect(group.engineName).toBe('podman');
 });
 
 test('container group status should be degraded when the pod status is degraded', async () => {

--- a/packages/renderer/src/lib/container/container-utils.ts
+++ b/packages/renderer/src/lib/container/container-utils.ts
@@ -193,6 +193,7 @@ export class ContainerUtils {
         type: ContainerGroupInfoTypeUI.COMPOSE,
         engineId: containerInfo.engineId,
         engineType: containerInfo.engineType,
+        engineName: containerInfo.engineName,
       };
     }
 
@@ -206,6 +207,7 @@ export class ContainerUtils {
         status: (podInfo.status ?? '').toUpperCase(),
         engineId: containerInfo.engineId,
         engineType: containerInfo.engineType,
+        engineName: containerInfo.engineName,
       };
     }
 
@@ -216,6 +218,7 @@ export class ContainerUtils {
       status: (containerInfo.Status ?? '').toUpperCase(),
       engineType: containerInfo.engineType,
       id: containerInfo.Id, // since the container is standalone, let's use its ID as groupInfo#id
+      engineName: containerInfo.engineName,
     };
   }
 
@@ -244,6 +247,7 @@ export class ContainerUtils {
             status: group.status,
             engineId: group.engineId,
             engineType: group.engineType,
+            engineName: group.engineName,
             allContainersCount: 0,
             containers: [],
           });


### PR DESCRIPTION
### What does this PR do?

Update `ContainerUtils` to properly provide the `engineName` when creating `ContainerGroupInfoUI` objects

### Screenshot / video of UI

| Before | After |
| --- | --- |
| <img width="1288" height="688" alt="Image" src="https://github.com/user-attachments/assets/f9e594a4-5f0d-4684-9d66-5dc14ebb75e6" /> | <img width="1288" height="688" alt="image" src="https://github.com/user-attachments/assets/29876d56-5e23-4808-84f9-e230cbe1725a" /> |

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/13553

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
