### PR TITLE
fix: call extension loader dispose specifically to fix stack trace on quit

### DIFF
--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -60,8 +60,7 @@ app.once('before-quit', event => {
     return;
   }
   event.preventDefault();
-  extensionLoader
-    ?.stopAllExtensions()
+  extensionLoader[Symbol.asyncDispose]()
     .then(() => {
       console.log('Stopped all extensions');
     })


### PR DESCRIPTION
### What does this PR do?

The inversify dispose process is never called for the container.                                        
The electron app before	quit calls extension stopAllExtensions but 
it doesnt cleanup any maps that	could cause the	stack trace error on quit

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes: https://github.com/podman-desktop/podman-desktop/issues/12889

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

Build and run an e2e test like this for example

pnpm run test:e2e:build
pnpm exec playwright test tests/playwright/src/specs/welcome-page-smoke.spec.ts --headed

once the e2e closes you shouldnt see the stack trace anymore. I found this is the most reliable way to see the error before the fix

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x ] Tests are covering the bug fix or the new feature
