### PR TITLE
chore: fix saving inputs in preferences

### DIFF
--- a/packages/renderer/src/lib/preferences/item-formats/StringItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/StringItem.spec.ts
@@ -19,6 +19,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
 import { beforeAll, expect, test, vi } from 'vitest';
 
 import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
@@ -75,4 +76,25 @@ test('Ensure HTMLInputElement readonly', async () => {
   const input = screen.getByLabelText('record-description');
   expect(input).toBeInTheDocument();
   expect((input as HTMLInputElement).readOnly).toBeTruthy();
+});
+
+test('Ensure that after typing into the input, that onChange is called each time', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'string',
+  };
+
+  // We "mock" the rejected value since catch() ends up invalidEntry = true anyways.
+  const onChange = vi.fn().mockRejectedValue(new Error('foo'));
+  render(StringItem, { record, value: '', onChange });
+
+  const input = screen.getByLabelText('record-description');
+  expect(input).toBeInTheDocument();
+
+  // Ensure it's been called 9 times as "new value" is 6 characters
+  await userEvent.type(input, 'foobar');
+  expect(onChange).toHaveBeenCalledTimes(6);
 });

--- a/packages/renderer/src/lib/preferences/item-formats/StringItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/StringItem.svelte
@@ -11,8 +11,9 @@ let invalidEntry = false;
 
 function onInput(event: Event): void {
   const target = event.target as HTMLInputElement;
-  if (record.id && target.value !== value)
+  if (record.id && target.value !== value) {
     onChange(record.id, target.value).catch((_: unknown) => (invalidEntry = true));
+  }
 }
 </script>
 
@@ -21,7 +22,7 @@ function onInput(event: Event): void {
   class="grow"
   name={record.id}
   placeholder={record.placeholder}
-  bind:value={value}
+  value={value}
   readonly={!!record.readonly}
   id="input-standard-{record.id}"
   aria-invalid={invalidEntry}


### PR DESCRIPTION
chore: fix saving inputs in preferences

### What does this PR do?

Fixes saving inputs in the preference settings.

This is because the value should be `value` rather than `bind:value`
(svelte5 convention).

Tests have also been added to cover the issue.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->


https://github.com/user-attachments/assets/12e1c252-5ed4-415c-8f04-2337519038ab



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/podman-desktop/issues/13601

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
