### PR TITLE
fix: resolve preferences input saving regression from Svelte 5 migration

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -101,7 +101,7 @@ $effect(() => {
 
 async function update(record: IConfigurationPropertyRecordedSchema): Promise<void> {
   // save the value
-  if (record.id && isEqual(currentRecord, record)) {
+  if (record.id) {
     try {
       // HACK: when setting `{}` as value we need to stringify and parse the svelte state
       let settings = recordValue;

--- a/packages/renderer/src/lib/preferences/item-formats/StringItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/StringItem.svelte
@@ -11,8 +11,9 @@ let invalidEntry = false;
 
 function onInput(event: Event): void {
   const target = event.target as HTMLInputElement;
-  if (record.id && target.value !== value)
+  if (record.id) {
     onChange(record.id, target.value).catch((_: unknown) => (invalidEntry = true));
+  }
 }
 </script>
 


### PR DESCRIPTION
Reactivity in Svelte 4 ran on every assignment, so checks skipped redundant saves but allowed edits. In Svelte 5 effect only runs on detected changes which blocks saves without the removal of those checks.

### What does this PR do?

Aims to solve why config inputs dont save. We still need to figure out why we cant edit configs that 
have the ability to select a path. I think that is a separate issue though.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes: https://github.com/podman-desktop/podman-desktop/issues/13601

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

See testing for https://github.com/podman-desktop/podman-desktop/issues/13601

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature

Needs tests
