### PR TITLE
chore: Have file items by default be editable.

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
@@ -197,9 +197,27 @@ test('Expect a fileinput when record is type string and format file', async () =
   expect(readOnlyInput).toBeInTheDocument();
   expect(readOnlyInput instanceof HTMLInputElement).toBe(true);
   expect((readOnlyInput as HTMLInputElement).placeholder).toBe(record.placeholder);
-  expect((readOnlyInput as HTMLInputElement).readOnly).toBeTruthy();
+  // readOnly by default is false now
+  expect((readOnlyInput as HTMLInputElement).readOnly).toBeFalsy();
   const input = screen.getByLabelText('browse');
   expect(input).toBeInTheDocument();
+});
+
+test('Expect a fileinput with readonly being true, to show readOnly in element', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    title: 'record',
+    parentId: 'parent.record',
+    placeholder: 'Example: text',
+    description: 'record-description',
+    type: 'string',
+    format: 'file',
+    readonly: true,
+  };
+  await awaitRender(record, {});
+  const readOnlyInput = screen.getByLabelText('record-description');
+  expect(readOnlyInput).toBeInTheDocument();
+  expect(readOnlyInput instanceof HTMLInputElement).toBe(true);
+  expect((readOnlyInput as HTMLInputElement).readOnly).toBe(true);
 });
 
 test('Expect an editable text fileinput when record is type string and format file', async () => {

--- a/packages/renderer/src/lib/preferences/item-formats/FileItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/FileItem.spec.ts
@@ -142,3 +142,36 @@ test('Ensure there is a clear button for the input', async () => {
   expect(inputField).toBeInTheDocument();
   expect((inputField as HTMLInputElement).value).toBe('');
 });
+
+test('By default when creating, expect FileItem to be editable / NOT have readonly', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'string',
+    format: 'file',
+  };
+
+  render(FileItem, { record, value: '' });
+  const input = screen.getByLabelText('record-description');
+  expect(input).toBeInTheDocument();
+  expect((input as HTMLInputElement).readOnly).toBe(false);
+});
+
+test('If FileItem has readonly = true, then expect readonly to show in the element', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'string',
+    format: 'file',
+    readonly: true,
+  };
+
+  render(FileItem, { record, value: '' });
+  const input = screen.getByLabelText('record-description');
+  expect(input).toBeInTheDocument();
+  expect((input as HTMLInputElement).readOnly).toBe(true);
+});

--- a/packages/renderer/src/lib/preferences/item-formats/FileItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/FileItem.svelte
@@ -22,12 +22,14 @@ function onChangeFileInput(value: string): void {
 </script>
 
 <div class="w-full flex">
+  <!-- By default, we set 'readonly' to FALSE unless explicitly defined within
+   .record of the schema. This allows edits to the fileinput. -->
   <FileInput
     id="input-standard-{record.id}"
     name={record.id}
     bind:value={value}
     onChange={onChangeFileInput}
-    readonly={record.readonly ?? true}
+    readonly={record.readonly ?? false}
     clearable={true}
     placeholder={record.placeholder}
     options={dialogOptions}


### PR DESCRIPTION
chore: Have file items by default be editable.

### What does this PR do?

Makes file items (that you can "press and select"), be editable by default.
This makes it easier to "copy and paste" file locations over.

Adds tests too to cover the scenario.

### Screenshot / video of UI


https://github.com/user-attachments/assets/08aa6368-8528-4d3c-a1bb-ece80eee71da


https://github.com/user-attachments/assets/eaf7d5a3-f5ae-4bb3-84f1-40caa69522f0





### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/podman-desktop/issues/13603
Closes https://github.com/podman-desktop/podman-desktop/issues/7620
Closes https://github.com/podman-desktop/podman-desktop/issues/5479

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
