### PR TITLE
chore(ci): extend update e2e tests on macos-13 x86_64 architecture

### DIFF
--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -273,8 +273,12 @@ jobs:
             !./tests/**/traces/raw
 
   mac-update-e2e-test:
-    name: mac update e2e tests
-    runs-on: macos-15
+    name: ${{ matrix.os }} update e2e tests
+    strategy:
+      fail-fast: false
+      matrix: 
+        os: [macos-15, macos-13]
+    runs-on: ${{ matrix.os }}
     # disable on forks as secrets are not available
     if: github.event.repository.fork == false
     env:
@@ -350,7 +354,7 @@ jobs:
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
-          name: mac-update-e2e-test
+          name: ${{ matrix.os }}-update-e2e-test
           path: |
             ./tests/**/output/
             !./tests/**/traces/raw

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -429,13 +429,13 @@ jobs:
           fi
 
   win-update-e2e-test:
-    name: win update e2e tests
+    name: ${{ matrix.os }} update e2e tests
     needs: detect_pnpm_changes
+    if: contains(github.event.pull_request.labels.*.name, 'area/update') || needs.detect_pnpm_changes.outputs.pnpm_lock_changed == 'true'
     strategy:
       fail-fast: false
       matrix: 
         os: [windows-2025, windows-11-arm]
-    if: contains(github.event.pull_request.labels.*.name, 'area/update') || needs.detect_pnpm_changes.outputs.pnpm_lock_changed == 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
@@ -505,10 +505,14 @@ jobs:
             !./tests/**/traces/raw
 
   mac-update-e2e-test:
-    name: mac update e2e tests
+    name: ${{ matrix.os }} update e2e tests
     needs: detect_pnpm_changes
     if: contains(github.event.pull_request.labels.*.name, 'area/update') || needs.detect_pnpm_changes.outputs.pnpm_lock_changed == 'true'
-    runs-on: macos-15
+    strategy:
+      fail-fast: false
+      matrix: 
+        os: [macos-15, macos-13]
+    runs-on: ${{ matrix.os }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     timeout-minutes: 60
@@ -586,7 +590,7 @@ jobs:
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
-          name: mac-update-e2e-test
+          name: ${{ matrix.os}}-update-e2e-test
           path: |
             ./tests/**/output/
             !./tests/**/traces/raw


### PR DESCRIPTION
### What does this PR do?
Extends the update e2e tests in e2e-tests-main and pr-check to be also run on x86_64 intel based mac.
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#13354
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
Mac update e2e test now should be passing for both arch/systems: macos-15 and macos-13 (intel).
Last test case run in update-e2e test prints out the arch of the setup file it looks for. on macos-13 it should be x64, on macos-15 it should be arm64.
<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
