### PR TITLE
feat(extension-api): adding inspectPod method

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -2666,6 +2666,73 @@ declare module '@podman-desktop/api' {
     Status: string;
   }
 
+  interface PodInspectInfo {
+    engineId: string;
+    engineName: string;
+    /**
+     * ID of the pod.
+     */
+    Id: string;
+    /**
+     * The name of the pod.
+     */
+    Name: string;
+    /**
+     * The time when the pod was created.
+     */
+    Created: string;
+    /**
+     * The current state of the pod.
+     */
+    State: 'Running' | 'Exited' | string;
+    /**
+     * Containers gives a brief summary of all containers in the pod and their current status.
+     */
+    Containers: PodContainerInfo[];
+    /**
+     * The exit policy of the pod when the last container exits.
+     */
+    ExitPolicy: 'continue' | 'stop';
+    /**
+     * Hostname that the pod will set.
+     */
+    Hostname: string;
+    /**
+     * RestartPolicy of the pod.
+     */
+    RestartPolicy: string;
+    /**
+     * Set of key-value labels that have been applied to the pod.
+     */
+    Labels: { [key: string]: string };
+    /**
+     * the ID of the pod's infra container, if one is present.
+     */
+    InfraContainerID?: string;
+    /**
+     * Contains the configuration of the pod's infra container.
+     */
+    InfraConfig: {
+      /**
+       * DNSOption is a set of DNS options that will be used by the infra container's resolv.conf and shared with the remainder of the pod.
+       */
+      DNSOption?: Array<string>;
+      /**
+       * DNSSearch is a set of DNS search domains that will be used by the infra container's resolv.conf and shared with the remainder of the pod.
+       */
+      DNSSearch?: Array<string>;
+      /**
+       * DNSServer is a set of DNS Servers that will be used by the infra container's resolv.conf and shared with the remainder of the pod.
+       */
+      DNSServer?: Array<string>;
+      PortBindings?: HostConfigPortBinding;
+      /**
+       * List of networks the pod will join.
+       */
+      Networks?: Array<string>;
+    };
+  }
+
   interface AuthConfig {
     username: string;
     password: string;
@@ -4011,10 +4078,13 @@ declare module '@podman-desktop/api' {
       target: { engineId: string },
       overrideParameters: PodmanContainerCreateOptions,
     ): Promise<{ Id: string; Warnings: string[] }>;
+
+    // Pod related methods
     export function startPod(engineId: string, podId: string): Promise<void>;
     export function listPods(): Promise<PodInfo[]>;
     export function stopPod(engineId: string, podId: string): Promise<void>;
     export function removePod(engineId: string, podId: string): Promise<void>;
+    export function inspectPod(engineId: string, podId: string): Promise<PodInspectInfo>;
 
     // Manifest related methods
     export function createManifest(options: ManifestCreateOptions): Promise<{ engineId: string; Id: string }>;

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.spec.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.spec.ts
@@ -418,3 +418,19 @@ test('Check prune default images (not all)', async () => {
   const api = new Dockerode({ protocol: 'http', host: 'localhost' });
   await (api as unknown as LibPod).pruneAllImages(false);
 });
+
+test('check pod inspect', async () => {
+  server = setupServer(
+    http.get('http://localhost/v4.2.0/libpod/pods/name1/json', () =>
+      HttpResponse.json({ Id: 'testId1' }, { status: 200 }),
+    ),
+  );
+  server.listen({ onUnhandledRequest: 'error' });
+  const api = new Dockerode({ protocol: 'http', host: 'localhost' });
+
+  const response = await (api as unknown as LibPod).getPodInspect('name1');
+
+  // Check that the response is correct
+  expect(response).toBeDefined();
+  expect(response.Id).toStrictEqual('testId1');
+});

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.ts
@@ -18,7 +18,12 @@
 
 import type { RequestOptions } from 'node:http';
 
-import type { ManifestCreateOptions, ManifestInspectInfo, ManifestPushOptions } from '@podman-desktop/api';
+import type {
+  HostConfigPortBinding,
+  ManifestCreateOptions,
+  ManifestInspectInfo,
+  ManifestPushOptions,
+} from '@podman-desktop/api';
 import type DockerModem from 'docker-modem';
 import type { DialOptions } from 'docker-modem';
 import type { VolumeCreateOptions, VolumeCreateResponse } from 'dockerode';
@@ -62,6 +67,16 @@ export interface PodInspectInfo {
   SharedNamespaces: string[];
   State: string;
   volumes_from: string[];
+  ExitPolicy: 'continue' | 'stop';
+  RestartPolicy: string;
+  Labels: { [key: string]: string };
+  InfraConfig: {
+    DNSOption?: Array<string>;
+    DNSSearch?: Array<string>;
+    DNSServer?: Array<string>;
+    PortBindings?: HostConfigPortBinding;
+    Networks?: Array<string>;
+  };
 }
 
 export interface PlayKubePodInfo {

--- a/packages/main/src/plugin/extension/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension/extension-loader.spec.ts
@@ -25,6 +25,7 @@ import type * as containerDesktopAPI from '@podman-desktop/api';
 import { app } from 'electron';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
+import type { PodInspectInfo } from '/@/plugin/api/pod-info.js';
 import type { Certificates } from '/@/plugin/certificates.js';
 import type { ContributionManager } from '/@/plugin/contribution-manager.js';
 import type { KubeGeneratorRegistry } from '/@/plugin/kubernetes/kube-generator-registry.js';
@@ -188,6 +189,7 @@ const containerProviderRegistry: ContainerProviderRegistry = {
   podmanListImages: vi.fn(),
   listInfos: vi.fn(),
   pullImage: vi.fn(),
+  getPodInspect: vi.fn(),
 } as unknown as ContainerProviderRegistry;
 
 const inputQuickPickRegistry: InputQuickPickRegistry = {} as unknown as InputQuickPickRegistry;
@@ -2196,6 +2198,21 @@ describe('containerEngine', async () => {
 
     // the signal should be marked as aborted
     expect(controller?.signal.aborted).toBeTruthy();
+  });
+
+  test('inspectPod', async () => {
+    const pod: PodInspectInfo = {
+      Id: 'podId',
+    } as PodInspectInfo;
+    vi.mocked(containerProviderRegistry.getPodInspect).mockResolvedValue(pod);
+    const api = createApi();
+
+    expect(api).toBeDefined();
+
+    const inspect = await api.containerEngine.inspectPod('engineId', 'podId');
+    expect(inspect).toEqual(pod);
+
+    expect(containerProviderRegistry.getPodInspect).toHaveBeenCalledWith('engineId', 'podId');
   });
 });
 

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -1275,6 +1275,9 @@ export class ExtensionLoader implements AsyncDisposable {
       listPods(): Promise<PodInfo[]> {
         return containerProviderRegistry.listPods();
       },
+      inspectPod(engineId: string, podId: string): Promise<containerDesktopAPI.PodInspectInfo> {
+        return containerProviderRegistry.getPodInspect(engineId, podId);
+      },
       stopPod(engineId: string, podId: string): Promise<void> {
         return containerProviderRegistry.stopPod(engineId, podId);
       },


### PR DESCRIPTION
### What does this PR do?

Adding the missing `inspectPod` method to the containerEngine of the extension-api. The types are took from https://docs.podman.io/en/latest/_static/api.html#tag/pods/operation/PodInspectLibpod

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/13631

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
