### PR TITLE
chore(test): re-structure skip conditions on podman-machine-resources E2E test

### DIFF
--- a/tests/playwright/src/specs/z-podman-machine-resources.spec.ts
+++ b/tests/playwright/src/specs/z-podman-machine-resources.spec.ts
@@ -122,6 +122,11 @@ test.afterAll(async ({ runner, page, navigationBar }) => {
   }
 });
 
+test.skip(
+  isLinux || process.env.TEST_PODMAN_MACHINE !== 'true',
+  'Tests suite should not run on Linux platform or if TEST_PODMAN_MACHINE is not true',
+);
+
 for (const { PODMAN_MACHINE_NAME, MACHINE_VISIBLE_NAME, isRoot, userNet } of machineTypes) {
   test.afterAll(async () => {
     test.setTimeout(60_000);
@@ -130,18 +135,12 @@ for (const { PODMAN_MACHINE_NAME, MACHINE_VISIBLE_NAME, isRoot, userNet } of mac
     }
   });
 
-  test.skip(
-    isLinux || process.env.TEST_PODMAN_MACHINE !== 'true',
-    'Tests suite should not run on Linux platform or if TEST_PODMAN_MACHINE is not true',
-  );
-
-  test.skip(
-    PODMAN_MACHINE_NAME === 'podman-machine-user-networking' && !isWindows,
-    'Testing user networking machine only on Windows',
-  );
-
   test.describe
     .serial(`${MACHINE_VISIBLE_NAME} Resources workflow Verification`, () => {
+      test.skip(
+        PODMAN_MACHINE_NAME === 'podman-machine-user-networking' && !isWindows,
+        'Testing user networking machine only on Windows',
+      );
       test('Create machine through Resources page', async ({ page, navigationBar }) => {
         test.setTimeout(200_000);
 


### PR DESCRIPTION
### What does this PR do?
This PR fixes the current skip setup on `podman-machine-resources.spec.ts`, where the test is getting skipped on mac when it shouldn't due to how the skip condition is being evaluated

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
https://github.com/podman-desktop/e2e/issues/367
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
