### PR TITLE
chore: use last log timestamp to clear container logs and store it

### DIFF
--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -2762,6 +2762,15 @@ test('container logs callback notified when messages arrive', async () => {
   });
   await containerRegistry.logsContainer({ engineId: 'podman', id: 'containerId', callback });
 
+  expect(dockerodeContainer.logs).toHaveBeenCalledWith({
+    follow: true,
+    stdout: true,
+    stderr: true,
+    abortSignal: undefined,
+    tail: undefined,
+    timestamps: undefined,
+  });
+
   setTimeout(() => {
     stream.emit('data', 'log message');
     stream.emit('end', '');

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -2762,7 +2762,9 @@ test('container logs callback notified when messages arrive', async () => {
   });
   await containerRegistry.logsContainer({ engineId: 'podman', id: 'containerId', callback });
 
-  expect(dockerodeContainer.logs).toHaveBeenCalledWith({
+  const callArgs = vi.mocked(dockerodeContainer.logs).mock.calls[0]?.[0];
+
+  expect(callArgs).toStrictEqual({
     follow: true,
     stdout: true,
     stderr: true,

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -1692,7 +1692,6 @@ export class ContainerProviderRegistry {
     let telemetryOptions = {};
     let firstMessage = true;
     const container = this.getMatchingContainer(logsParams.engineId, logsParams.id);
-    console.log('>>>>>>>>>>>>>>>>>: ' + (logsParams.since ?? undefined));
     const optionalParams: { [param: string]: unknown } = {};
     if (logsParams.since) {
       optionalParams['since'] = logsParams.since;

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -1685,16 +1685,27 @@ export class ContainerProviderRegistry {
     id: string;
     callback: (name: string, data: string) => void;
     abortController?: AbortController;
+    timestamps?: boolean;
+    tail?: number;
+    since?: string;
   }): Promise<void> {
     let telemetryOptions = {};
     let firstMessage = true;
     const container = this.getMatchingContainer(logsParams.engineId, logsParams.id);
+    console.log('>>>>>>>>>>>>>>>>>: ' + (logsParams.since ?? undefined));
+    const optionalParams: { [param: string]: unknown } = {};
+    if (logsParams.since) {
+      optionalParams['since'] = logsParams.since;
+    }
     container
       .logs({
         follow: true,
         stdout: true,
         stderr: true,
         abortSignal: logsParams.abortController?.signal,
+        tail: logsParams.tail,
+        timestamps: logsParams.timestamps,
+        ...optionalParams,
       })
       .then(containerStream => {
         containerStream.on('end', () => {

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1164,6 +1164,9 @@ export class PluginSystem {
           containerId: string;
           onDataId: number;
           cancellableTokenId?: number;
+          timestamps?: boolean;
+          tail?: number;
+          since?: string;
         },
       ): Promise<void> => {
         const abortController = this.createAbortControllerOnCancellationToken(
@@ -1183,6 +1186,9 @@ export class PluginSystem {
             );
           },
           abortController,
+          timestamps: logsParams.timestamps,
+          tail: logsParams.tail,
+          since: logsParams.since,
         });
       },
     );

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -539,6 +539,9 @@ export function initExposure(): void {
       containerId: string;
       callback: (name: string, data: string) => void;
       cancellableTokenId?: number;
+      timestamps?: boolean;
+      tail?: number;
+      since?: string;
     }): Promise<void> => {
       onDataCallbacksLogsContainerId++;
       onDataCallbacksLogsContainer.set(onDataCallbacksLogsContainerId, logsParams.callback);
@@ -547,6 +550,9 @@ export function initExposure(): void {
         containerId: logsParams.containerId,
         onDataId: onDataCallbacksLogsContainerId,
         cancellableTokenId: logsParams.cancellableTokenId,
+        timestamps: logsParams.timestamps,
+        tail: logsParams.tail,
+        since: logsParams.since,
       });
     },
   );

--- a/packages/renderer/src/lib/container/ContainerDetailsLogs.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerDetailsLogs.spec.ts
@@ -22,6 +22,8 @@ import { render, screen } from '@testing-library/svelte';
 import * as xterm from '@xterm/xterm';
 import { beforeAll, expect, test, vi } from 'vitest';
 
+import { containerLogsClearTimestamps } from '/@/stores/container-logs';
+
 import ContainerDetailsLogs from './ContainerDetailsLogs.svelte';
 import type { ContainerInfoUI } from './ContainerInfoUI';
 
@@ -69,6 +71,8 @@ const container: ContainerInfoUI = {
   id: 'foo',
 } as unknown as ContainerInfoUI;
 
+containerLogsClearTimestamps.set({ foo: '2025-07-31T21:10:35.000Z' });
+
 test('Render container logs ', async () => {
   // grab the xterm mock
   let writeMock: unknown | undefined;
@@ -81,7 +85,12 @@ test('Render container logs ', async () => {
 
   // expect a call to logsContainer
   await vi.waitFor(() => {
-    expect(window.logsContainer).toHaveBeenCalled();
+    expect(window.logsContainer).toHaveBeenCalledWith({
+      engineId: container.engineId,
+      containerId: container.id,
+      callback: expect.any(Function),
+      since: '2025-07-31T21:10:35.000Z',
+    });
   });
   // now, get the callback of the method
   const params = vi.mocked(window.logsContainer).mock.calls[0][0];

--- a/packages/renderer/src/lib/container/ContainerDetailsLogs.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsLogs.svelte
@@ -65,7 +65,6 @@ function callback(name: string, data: string): void {
 
 async function fetchContainerLogs(): Promise<void> {
   // grab logs of the container
-  console.log('>>>>>>> lasttimestamp: ' + lastLogTimestamp);
   await window.logsContainer({
     engineId: container.engineId,
     containerId: container.id,

--- a/packages/renderer/src/lib/container/ContainerDetailsLogs.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsLogs.svelte
@@ -5,6 +5,8 @@ import { EmptyScreen } from '@podman-desktop/ui-svelte';
 import type { Terminal } from '@xterm/xterm';
 import { mount, onDestroy, onMount } from 'svelte';
 
+import { containerLogsClearTimestamps } from '/@/stores/container-logs';
+
 import { isMultiplexedLog } from '../stream/stream-utils';
 import NoLogIcon from '../ui/NoLogIcon.svelte';
 import TerminalWindow from '../ui/TerminalWindow.svelte';
@@ -25,6 +27,8 @@ let logsTerminal = $state<Terminal>();
 
 // save previous container
 let refContainer: ContainerInfoUI;
+
+let lastLogTimestamp: string | undefined = $derived($containerLogsClearTimestamps[container.id] ?? undefined);
 
 // need to refresh logs when container is switched or state changes
 $effect(() => {
@@ -61,7 +65,13 @@ function callback(name: string, data: string): void {
 
 async function fetchContainerLogs(): Promise<void> {
   // grab logs of the container
-  await window.logsContainer({ engineId: container.engineId, containerId: container.id, callback });
+  console.log('>>>>>>> lasttimestamp: ' + lastLogTimestamp);
+  await window.logsContainer({
+    engineId: container.engineId,
+    containerId: container.id,
+    callback,
+    since: lastLogTimestamp,
+  });
 }
 
 function afterTerminalInit(): void {
@@ -76,6 +86,7 @@ function afterTerminalInit(): void {
     target: xtermElement,
     props: {
       terminal: logsTerminal,
+      container: container,
     },
   });
 }

--- a/packages/renderer/src/lib/container/ContainerDetailsLogsClear.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsLogsClear.svelte
@@ -12,6 +12,8 @@ const { terminal, container }: { terminal: Terminal; container: ContainerInfoUI 
 
 let clearTimestamp: string = $state('');
 
+let lastLog = false;
+
 $effect(() => {
   if (clearTimestamp) {
     $containerLogsClearTimestamps[container.id] = clearTimestamp;
@@ -19,6 +21,7 @@ $effect(() => {
 });
 
 async function getLastLogTimestamp(): Promise<void> {
+  lastLog = true;
   await window.logsContainer({
     engineId: container.engineId,
     containerId: container.id,
@@ -29,13 +32,9 @@ async function getLastLogTimestamp(): Promise<void> {
 }
 
 function callback(name: string, data: string): void {
-  let lastLog = '';
-  if (name === 'data') {
-    lastLog = data;
-  }
-
-  if (lastLog) {
-    let timestamp = lastLog.split(' ', 1)[0];
+  if (name === 'data' && data && lastLog) {
+    lastLog = false;
+    let timestamp = data.split(' ', 1)[0];
     const datenow = new SvelteDate(timestamp);
     datenow.setSeconds(datenow.getSeconds() + 1);
     clearTimestamp = datenow.toISOString();

--- a/packages/renderer/src/lib/container/ContainerDetailsLogsClear.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsLogsClear.svelte
@@ -11,7 +11,6 @@ import type { ContainerInfoUI } from './ContainerInfoUI';
 const { terminal, container }: { terminal: Terminal; container: ContainerInfoUI } = $props();
 
 let clearTimestamp: string = $state('');
-let lastLog: string = '';
 
 $effect(() => {
   if (clearTimestamp) {
@@ -30,6 +29,7 @@ async function getLastLogTimestamp(): Promise<void> {
 }
 
 function callback(name: string, data: string): void {
+  let lastLog = '';
   if (name === 'data') {
     lastLog = data;
   }

--- a/packages/renderer/src/lib/container/ContainerDetailsLogsClear.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsLogsClear.svelte
@@ -6,6 +6,7 @@ import Fa from 'svelte-fa';
 
 import { containerLogsClearTimestamps } from '/@/stores/container-logs';
 
+import { isMultiplexedLog } from '../stream/stream-utils';
 import type { ContainerInfoUI } from './ContainerInfoUI';
 
 const { terminal, container }: { terminal: Terminal; container: ContainerInfoUI } = $props();
@@ -32,9 +33,14 @@ async function getLastLogTimestamp(): Promise<void> {
 }
 
 function callback(name: string, data: string): void {
+  let timestamp: string;
   if (name === 'data' && data && lastLog) {
     lastLog = false;
-    let timestamp = data.split(' ', 1)[0];
+    if (isMultiplexedLog(data)) {
+      timestamp = data.substring(8).split(' ', 1)[0];
+    } else {
+      timestamp = data.split(' ', 1)[0];
+    }
     const datenow = new SvelteDate(timestamp);
     datenow.setSeconds(datenow.getSeconds() + 1);
     clearTimestamp = datenow.toISOString();

--- a/packages/renderer/src/stores/container-logs.ts
+++ b/packages/renderer/src/stores/container-logs.ts
@@ -1,0 +1,24 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { type Writable, writable } from 'svelte/store';
+
+/**
+ * Defines the store used to save the timestamps of the last container logs when cleared
+ */
+export const containerLogsClearTimestamps: Writable<{ [containerId: string]: string }> = writable({});


### PR DESCRIPTION
### What does this PR do?
This PR uses the timestamp of the last log line to clear the container logs and store it in a svelte store to keep the logs cleared while using Podman Desktop. Since it uses a svelte store to keep track of the last timestamps, it won't be persistent when Podman Desktop is closed and reopened.

### Screenshot / video of UI


https://github.com/user-attachments/assets/7e15be6e-953f-4d24-a96e-0bedcc3a09c9


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Fixes https://github.com/podman-desktop/podman-desktop/issues/11782

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
