### PR TITLE
fix(renderer): import image pass snapshot so selectedProvider can be cloned

### DIFF
--- a/packages/renderer/src/lib/image/ImportContainersImages.svelte
+++ b/packages/renderer/src/lib/image/ImportContainersImages.svelte
@@ -83,7 +83,7 @@ async function importContainers(): Promise<void> {
   for (const containerImage of containersToImport) {
     try {
       await window.importContainer({
-        provider: selectedProvider,
+        provider: $state.snapshot(selectedProvider),
         archivePath: containerImage.imagePath,
         imageTag: containerImage.nameWhenImporting,
       });


### PR DESCRIPTION
### What does this PR do?

Passing a snapshot of the current state for selectedProvider to the window method in order to fix a bug where the image could not be imported because selectedProvider could not be cloned.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes #13658 

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
