### PR TITLE
fix(renderer): copy object to avoid error when opening Files tab of an Image

### DIFF
--- a/packages/renderer/src/lib/image/ImageDetailsFiles.svelte
+++ b/packages/renderer/src/lib/image/ImageDetailsFiles.svelte
@@ -36,7 +36,7 @@ async function fetchImageLayers(provider: ImageFilesInfo, img: ImageInfo): Promi
   try {
     loading = true;
     cancellableTokenId = await window.getCancellableTokenSource();
-    imageLayers = await window.imageGetFilesystemLayers(provider.id, img, cancellableTokenId);
+    imageLayers = await window.imageGetFilesystemLayers(provider.id, $state.snapshot(img), cancellableTokenId);
   } catch (err: unknown) {
     error = String(err);
   } finally {


### PR DESCRIPTION
### What does this PR do?

With the `Image Layers Explorer extension`, image files can be fetched but there was an error passing the img object to the window method, it is fixed by passing a snapshot of this object.

### Screenshot / video of UI

<img width="1162" height="812" alt="Screenshot 2025-08-26 at 09 53 20" src="https://github.com/user-attachments/assets/a1109af9-fe3f-4198-adaf-d70bd6d5b26d" />


### What issues does this PR fix or reference?

Fixes #13710 

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
