### PR TITLE
chore(test): centralize values for states

### DIFF
--- a/tests/playwright/src/model/core/states.ts
+++ b/tests/playwright/src/model/core/states.ts
@@ -74,3 +74,8 @@ export enum ImageState {
   Used = 'USED',
   Unused = 'UNUSED',
 }
+
+export enum TaskState {
+  Canceled = 'canceled',
+  Success = 'success',
+}

--- a/tests/playwright/src/specs/cancelable-task-smoke.spec.ts
+++ b/tests/playwright/src/specs/cancelable-task-smoke.spec.ts
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { TaskState } from '../model/core/states';
 import { CommandPalette } from '../model/pages/command-palette';
 import { ExperimentalPage } from '../model/pages/experimental-page';
 import { SettingsBar } from '../model/pages/settings-bar';
@@ -62,6 +63,6 @@ test.describe.serial('Cancelable task verification', { tag: '@smoke' }, () => {
     const tasksPage = await statusBar.openTasksPage();
     await playExpect(tasksPage.heading).toBeVisible();
     await tasksPage.cancelLatestTask();
-    await playExpect.poll(async () => await tasksPage.getStatusForLatestTask()).toContain('canceled');
+    await playExpect.poll(async () => await tasksPage.getStatusForLatestTask()).toContain(TaskState.Canceled);
   });
 });

--- a/tests/playwright/src/specs/container-smoke.spec.ts
+++ b/tests/playwright/src/specs/container-smoke.spec.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { ContainerState } from '../model/core/states';
+import { ContainerState, ImageState } from '../model/core/states';
 import type { ContainerInteractiveParams } from '../model/core/types';
 import { ContainersPage } from '../model/pages/containers-page';
 import { ImageDetailsPage } from '../model/pages/image-details-page';
@@ -102,7 +102,7 @@ test.describe.serial('Verification of container creation workflow', { tag: '@smo
       .toContain(ContainerState.Running);
 
     images = await navigationBar.openImages();
-    playExpect(await images.getCurrentStatusOfImage(imageToPull)).toBe('USED');
+    playExpect(await images.getCurrentStatusOfImage(imageToPull)).toBe(ImageState.Used);
   });
 
   test('Test navigation between pages', async ({ navigationBar }) => {
@@ -237,7 +237,7 @@ test.describe.serial('Verification of container creation workflow', { tag: '@smo
       .toContain(ContainerState.Running);
 
     images = await navigationBar.openImages();
-    playExpect(await images.getCurrentStatusOfImage(imageToPull)).toBe('USED');
+    playExpect(await images.getCurrentStatusOfImage(imageToPull)).toBe(ImageState.Used);
 
     //delete it from containers page
     await navigationBar.openContainers();

--- a/tests/playwright/src/specs/docker-compatibility-smoke.spec.ts
+++ b/tests/playwright/src/specs/docker-compatibility-smoke.spec.ts
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { ResourceElementState } from '../model/core/states';
 import { DockerCompatibilityPage } from '../model/pages/docker-compatibility-page';
 import { PodmanMachineDetails } from '../model/pages/podman-machine-details-page';
 import { ResourcesPage } from '../model/pages/resources-page';
@@ -70,7 +71,9 @@ test.describe.serial('Verify docker compatibility feature', { tag: '@smoke' }, (
     const podmanMachineDetails = new PodmanMachineDetails(page, defaultMachine);
     await playExpect(podmanMachineDetails.podmanMachineStopButton).toBeEnabled();
     await podmanMachineDetails.podmanMachineStopButton.click();
-    await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('OFF', { timeout: 50_000 });
+    await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText(ResourceElementState.Off, {
+      timeout: 50_000,
+    });
 
     const dockerCompatibilityPage = await settingsBar.openTabPage(DockerCompatibilityPage);
     await playExpect
@@ -81,7 +84,9 @@ test.describe.serial('Verify docker compatibility feature', { tag: '@smoke' }, (
     await settingsBar.openTabPage(ResourcesPage);
     await playExpect(podmanMachineDetails.podmanMachineStartButton).toBeEnabled();
     await podmanMachineDetails.podmanMachineStartButton.click();
-    await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('RUNNING', { timeout: 50_000 });
+    await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText(ResourceElementState.Running, {
+      timeout: 50_000,
+    });
 
     await settingsBar.openTabPage(DockerCompatibilityPage);
     await playExpect

--- a/tests/playwright/src/specs/image-smoke.spec.ts
+++ b/tests/playwright/src/specs/image-smoke.spec.ts
@@ -20,6 +20,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { ArchitectureType } from '../model/core/platforms';
+import { ImageState } from '../model/core/states';
 import { ImageDetailsPage } from '../model/pages/image-details-page';
 import { expect as playExpect, test } from '../utility/fixtures';
 import { untagImagesFromPodman } from '../utility/operations';
@@ -57,7 +58,7 @@ test.describe.serial('Image workflow verification', { tag: '@smoke' }, () => {
       .poll(async () => updatedImages.waitForImageExists(helloContainer, 30_000), { timeout: 0 })
       .toBeTruthy();
 
-    playExpect(await updatedImages.getCurrentStatusOfImage(helloContainer)).toBe('UNUSED');
+    playExpect(await updatedImages.getCurrentStatusOfImage(helloContainer)).toBe(ImageState.Unused);
   });
 
   test('Pull image from search results', async ({ navigationBar }) => {

--- a/tests/playwright/src/specs/kind.spec.ts
+++ b/tests/playwright/src/specs/kind.spec.ts
@@ -20,7 +20,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { ResourceElementActions } from '../model/core/operations';
-import { ContainerState, ResourceElementState } from '../model/core/states';
+import { ContainerState, ExtensionState, ResourceElementState } from '../model/core/states';
 import type { ContainerInteractiveParams } from '../model/core/types';
 import { ResourceConnectionCardPage } from '../model/pages/resource-connection-card-page';
 import { ResourcesPage } from '../model/pages/resources-page';
@@ -109,7 +109,7 @@ test.describe('Kind End-to-End Tests', { tag: '@k8s_e2e' }, () => {
         await playExpect
           .poll(async () => await extensionsPage.extensionIsInstalled(EXTENSION_LABEL), { timeout: 10000 })
           .toBeTruthy();
-        await playExpect(kindExtension.status).toHaveText('ACTIVE');
+        await playExpect(kindExtension.status).toHaveText(ExtensionState.Active);
         await kindExtension.disableExtension();
         await navigationBar.openSettings();
         await playExpect.poll(async () => resourcesPage.resourceCardIsVisible(RESOURCE_NAME)).toBeFalsy();

--- a/tests/playwright/src/specs/podman-extension-smoke.spec.ts
+++ b/tests/playwright/src/specs/podman-extension-smoke.spec.ts
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { ExtensionState } from '../model/core/states';
 import type { DashboardPage } from '../model/pages/dashboard-page';
 import type { ExtensionDetailsPage } from '../model/pages/extension-details-page';
 import type { SettingsBar } from '../model/pages/settings-bar';
@@ -25,8 +26,6 @@ import { expect as playExpect, test } from '../utility/fixtures';
 const extensionLabel = 'podman-desktop.podman';
 const extensionLabelName = 'podman';
 const extensionHeading = 'podman';
-const PODMAN_EXTENSION_STATUS_ACTIVE: string = 'ACTIVE';
-const PODMAN_EXTENSION_STATUS_DISABLED: string = 'DISABLED';
 const SETTINGS_NAVBAR_PREFERENCES_PODMAN_EXTENSION: string = 'Extension: Podman';
 
 let dashboardPage: DashboardPage;
@@ -88,9 +87,9 @@ async function verifyPodmanExtensionStatus(enabled: boolean): Promise<void> {
   // --------------------------
 
   if (enabled) {
-    await playExpect(extensionStatusLabel).toContainText(PODMAN_EXTENSION_STATUS_ACTIVE, { timeout: 20_000 });
+    await playExpect(extensionStatusLabel).toContainText(ExtensionState.Active, { timeout: 20_000 });
   } else {
-    await playExpect(extensionStatusLabel).toContainText(PODMAN_EXTENSION_STATUS_DISABLED, { timeout: 20_000 });
+    await playExpect(extensionStatusLabel).toContainText(ExtensionState.Disabled, { timeout: 20_000 });
   }
   // always present and visible
   const extensionsPageAfter = await navigationBar.openExtensions();
@@ -108,7 +107,7 @@ async function verifyPodmanExtensionStatus(enabled: boolean): Promise<void> {
     await playExpect(podmanExtensionPage.disableButton).toBeVisible({
       timeout: 10_000,
     });
-    await playExpect(podmanExtensionPage.status.getByText(PODMAN_EXTENSION_STATUS_ACTIVE)).toBeVisible();
+    await playExpect(podmanExtensionPage.status.getByText(ExtensionState.Active)).toBeVisible();
   } else {
     await playExpect(podmanExtensionPage.enableButton).toBeVisible({
       timeout: 10_000,
@@ -116,7 +115,7 @@ async function verifyPodmanExtensionStatus(enabled: boolean): Promise<void> {
     await playExpect(podmanExtensionPage.disableButton).not.toBeVisible({
       timeout: 10_000,
     });
-    await playExpect(podmanExtensionPage.status.getByText(PODMAN_EXTENSION_STATUS_DISABLED)).toBeVisible();
+    await playExpect(podmanExtensionPage.status.getByText(ExtensionState.Disabled)).toBeVisible();
   }
 
   // expand Settings -> Preferences menu

--- a/tests/playwright/src/specs/yaml-smoke.spec.ts
+++ b/tests/playwright/src/specs/yaml-smoke.spec.ts
@@ -19,6 +19,7 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { ImageState } from '../model/core/states';
 import { expect as playExpect, test } from '../utility/fixtures';
 import { deleteImage, deletePod } from '../utility/operations';
 import { waitForPodmanMachineStartup } from '../utility/wait';
@@ -84,10 +85,10 @@ test.describe.serial(`Play yaml file to pull images and create pod for app ${pod
       await playExpect.poll(async () => await imagesPage.waitForImageExists(frontendImage)).toBeTruthy();
       await playExpect
         .poll(async () => await imagesPage.getCurrentStatusOfImage(backendImage), { timeout: 15_000 })
-        .toBe('UNUSED');
+        .toBe(ImageState.Unused);
       await playExpect
         .poll(async () => await imagesPage.getCurrentStatusOfImage(frontendImage), { timeout: 15_000 })
-        .toBe('UNUSED');
+        .toBe(ImageState.Unused);
     });
 
     await test.step(`Deleting image ${backendImage}`, async () => {

--- a/tests/playwright/src/specs/z-podman-machine-dashboard-onboarding.spec.ts
+++ b/tests/playwright/src/specs/z-podman-machine-dashboard-onboarding.spec.ts
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { ResourceElementState } from '../model/core/states';
 import { expect as playExpect, test } from '../utility/fixtures';
 import { createPodmanMachineFromCLI, deletePodmanMachine } from '../utility/operations';
 import { isLinux } from '../utility/platform';
@@ -61,7 +62,7 @@ test.describe
       const dashboardPage = await navigationBar.openDashboard();
       await playExpect(dashboardPage.podmanInitilizeAndStartButton).toBeEnabled({ timeout: 60000 });
       await dashboardPage.podmanInitilizeAndStartButton.click();
-      await playExpect(dashboardPage.podmanStatusLabel).toHaveText('RUNNING', { timeout: 300000 });
+      await playExpect(dashboardPage.podmanStatusLabel).toHaveText(ResourceElementState.Running, { timeout: 300000 });
     });
 
     test('Clean Up Podman Machine', async ({ page }) => {

--- a/tests/playwright/src/specs/z-podman-machine-onboarding.spec.ts
+++ b/tests/playwright/src/specs/z-podman-machine-onboarding.spec.ts
@@ -20,6 +20,7 @@ import * as os from 'node:os';
 
 import type { Locator, Page } from '@playwright/test';
 
+import { ResourceElementState } from '../model/core/states';
 import type { DashboardPage } from '../model/pages/dashboard-page';
 import { PodmanMachineDetails } from '../model/pages/podman-machine-details-page';
 import { PodmanOnboardingPage } from '../model/pages/podman-onboarding-page';
@@ -198,25 +199,35 @@ test.describe
 
             test('Podman machine operations - STOP', async ({ page }) => {
               const podmanMachineDetails = new PodmanMachineDetails(page, PODMAN_MACHINE_NAME);
-              await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('RUNNING', { timeout: 60_000 });
+              await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText(ResourceElementState.Running, {
+                timeout: 60_000,
+              });
               await playExpect(podmanMachineDetails.podmanMachineStopButton).toBeEnabled();
               await podmanMachineDetails.podmanMachineStopButton.click();
-              await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('OFF', { timeout: 60_000 });
+              await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText(ResourceElementState.Off, {
+                timeout: 60_000,
+              });
             });
 
             test('Podman machine operations - START', async ({ page }) => {
               const podmanMachineDetails = new PodmanMachineDetails(page, PODMAN_MACHINE_NAME);
               await playExpect(podmanMachineDetails.podmanMachineStartButton).toBeEnabled();
               await podmanMachineDetails.podmanMachineStartButton.click();
-              await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('RUNNING', { timeout: 90_000 });
+              await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText(ResourceElementState.Running, {
+                timeout: 90_000,
+              });
             });
 
             test('Podman machine operations - RESTART', async ({ page }) => {
               const podmanMachineDetails = new PodmanMachineDetails(page, PODMAN_MACHINE_NAME);
               await playExpect(podmanMachineDetails.podmanMachineRestartButton).toBeEnabled();
               await podmanMachineDetails.podmanMachineRestartButton.click();
-              await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('OFF', { timeout: 60_000 });
-              await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('RUNNING', { timeout: 90_000 });
+              await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText(ResourceElementState.Off, {
+                timeout: 60_000,
+              });
+              await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText(ResourceElementState.Running, {
+                timeout: 90_000,
+              });
             });
           });
       });

--- a/tests/playwright/src/specs/z-podman-machine-tests.spec.ts
+++ b/tests/playwright/src/specs/z-podman-machine-tests.spec.ts
@@ -18,6 +18,7 @@
 
 import type { Locator } from '@playwright/test';
 
+import { ResourceElementState } from '../model/core/states';
 import { PodmanMachineDetails } from '../model/pages/podman-machine-details-page';
 import { PodmanOnboardingPage } from '../model/pages/podman-onboarding-page';
 import { ResourceConnectionCardPage } from '../model/pages/resource-connection-card-page';
@@ -103,7 +104,9 @@ test.describe
           await playExpect(podmanMachineDetails.podmanMachineRestartButton).toBeVisible();
           await playExpect(podmanMachineDetails.podmanMachineStopButton).toBeVisible();
           await playExpect(podmanMachineDetails.podmanMachineDeleteButton).toBeVisible();
-          await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('RUNNING', { timeout: 60_000 });
+          await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText(ResourceElementState.Running, {
+            timeout: 60_000,
+          });
         });
 
         await test.step('Check terminal tab for podman machine', async () => {
@@ -119,7 +122,9 @@ test.describe
         await test.step('Stop default podman machine', async () => {
           await playExpect(podmanMachineDetails.podmanMachineStopButton).toBeEnabled();
           await podmanMachineDetails.podmanMachineStopButton.click();
-          await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('OFF', { timeout: 60_000 });
+          await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText(ResourceElementState.Off, {
+            timeout: 60_000,
+          });
           await playExpect(podmanMachineDetails.logsTab).toBeEnabled();
           await podmanMachineDetails.logsTab.click();
           await playExpect(
@@ -177,7 +182,7 @@ test.describe
         const podmanMachineDetails = new PodmanMachineDetails(page, ROOTLESS_PODMAN_MACHINE);
         await test.step('Ensure rootless podman machine is OFF', async () => {
           await playExpect(podmanMachineDetails.podmanMachineName).toBeVisible();
-          await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('OFF');
+          await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText(ResourceElementState.Off);
         });
 
         await test.step('Start rootless podman machine', async () => {
@@ -188,7 +193,9 @@ test.describe
           await handleConfirmationDialog(page, 'Podman', true, 'Yes');
           await handleConfirmationDialog(page, 'Podman', true, 'OK');
 
-          await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('RUNNING', { timeout: 90_000 });
+          await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText(ResourceElementState.Running, {
+            timeout: 90_000,
+          });
           await playExpect(podmanMachineDetails.logsTab).toBeEnabled();
           await podmanMachineDetails.logsTab.click();
           await playExpect(
@@ -199,8 +206,12 @@ test.describe
         await test.step('Restart rootless podman machine', async () => {
           await playExpect(podmanMachineDetails.podmanMachineRestartButton).toBeEnabled();
           await podmanMachineDetails.podmanMachineRestartButton.click();
-          await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('OFF', { timeout: 90_000 });
-          await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('RUNNING', { timeout: 90_000 });
+          await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText(ResourceElementState.Off, {
+            timeout: 90_000,
+          });
+          await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText(ResourceElementState.Running, {
+            timeout: 90_000,
+          });
           await playExpect(podmanMachineDetails.logsTab).toBeEnabled();
           await podmanMachineDetails.logsTab.click();
           await playExpect(
@@ -214,13 +225,15 @@ test.describe
       const podmanMachineDetails = new PodmanMachineDetails(page, ROOTLESS_PODMAN_MACHINE);
       await test.step('Ensure rootless podman machine is RUNNING', async () => {
         await playExpect(podmanMachineDetails.podmanMachineName).toBeVisible();
-        await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('RUNNING');
+        await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText(ResourceElementState.Running);
       });
 
       await test.step('Stop rootless podman machine', async () => {
         await playExpect(podmanMachineDetails.podmanMachineStopButton).toBeEnabled();
         await podmanMachineDetails.podmanMachineStopButton.click();
-        await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('OFF', { timeout: 60_000 });
+        await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText(ResourceElementState.Off, {
+          timeout: 60_000,
+        });
       });
     });
 
@@ -261,12 +274,18 @@ test.describe
           podmanMachineDetails.tabContent.getByText('Machine "podman-machine-default" started successfully').first(),
         ).toBeVisible({ timeout: 30_000 });
 
-        await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('RUNNING', { timeout: 90_000 });
+        await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText(ResourceElementState.Running, {
+          timeout: 90_000,
+        });
 
         await playExpect(podmanMachineDetails.podmanMachineRestartButton).toBeEnabled();
         await podmanMachineDetails.podmanMachineRestartButton.click();
-        await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('OFF', { timeout: 90_000 });
-        await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText('RUNNING', { timeout: 90_000 });
+        await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText(ResourceElementState.Off, {
+          timeout: 90_000,
+        });
+        await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText(ResourceElementState.Running, {
+          timeout: 90_000,
+        });
       });
     });
 


### PR DESCRIPTION
### What does this PR do?
Changes hardcoded values for the states of pods/containers/images/machines to their centralized equivalents
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#12674
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
