### PR TITLE
chore(pnpm): specify sha512

### DIFF
--- a/package.json
+++ b/package.json
@@ -236,5 +236,5 @@
       "@kubernetes/client-node": "patches/@kubernetes__client-node.patch"
     }
   },
-  "packageManager": "pnpm@10.15.0"
+  "packageManager": "pnpm@10.15.0+sha512.486ebc259d3e999a4e8691ce03b5cac4a71cbeca39372a9b762cb500cfdf0873e2cb16abe3d951b1ee2cf012503f027b98b6584e4df22524e0c7450d9ec7aa7b"
 }


### PR DESCRIPTION
### What does this PR do?

Updating using `corepack use pnpm@latest`. Following https://github.com/podman-desktop/podman-desktop/pull/13717 updating the package manager with the sha512

pnpm documentation https://pnpm.io/installation#using-corepack

## Related issues

Upstream issue to have the ``pnpm self-update` includes the sha512 https://github.com/pnpm/pnpm/issues/9906

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- Pipeline should be 🟢 
