### PR TITLE
feat: added new way how to apply YAML

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -965,12 +965,15 @@ export class PluginSystem {
         return containerProviderRegistry.playKube(yamlFilePath, selectedProvider, options);
       },
     );
-    this.ipcHandle('temp-file-service:createTempKubeFile', async (_listener, content: string): Promise<string> => {
-      return tempFileService.createTempKubeFile(content);
+
+    this.ipcHandle('temp-file-service:createTempFile', async (_listener, content: string): Promise<string> => {
+      return tempFileService.createTempFile(content);
     });
+
     this.ipcHandle('temp-file-service:removeTempFile', async (_listener, filePath: string): Promise<void> => {
       return tempFileService.removeTempFile(filePath);
     });
+
     this.ipcHandle(
       'container-provider-registry:startContainer',
       async (_listener, engine: string, containerId: string): Promise<void> => {

--- a/packages/main/src/plugin/temp-file-service.spec.ts
+++ b/packages/main/src/plugin/temp-file-service.spec.ts
@@ -1,0 +1,288 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { TempFileService } from './temp-file-service.js';
+
+vi.mock('node:fs');
+vi.mock('node:os');
+vi.mock('node:path');
+
+const mockWriteFile = vi.fn();
+const mockUnlink = vi.fn();
+const mockTmpDir = vi.fn().mockReturnValue('/tmp');
+const mockJoin = vi.fn().mockImplementation((...args) => args.join('/'));
+
+vi.mocked(fs.promises).writeFile = mockWriteFile;
+vi.mocked(fs.promises).unlink = mockUnlink;
+vi.mocked(os).tmpdir = mockTmpDir;
+vi.mocked(path).join = mockJoin;
+
+describe('TempFileService', () => {
+  let tempFileService: TempFileService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    tempFileService = new TempFileService();
+  });
+
+  describe('createTempFile', () => {
+    test('creates temporary file with default parameters', async () => {
+      const content = 'test content';
+      const mockPath = '/tmp/temp-123456789-.yaml';
+
+      // Mock Date.now() to return a predictable timestamp
+      const mockTimestamp = 123456789;
+      vi.spyOn(Date, 'now').mockReturnValue(mockTimestamp);
+
+      mockJoin.mockReturnValue(mockPath);
+      mockWriteFile.mockResolvedValue(undefined);
+
+      const result = await tempFileService.createTempFile(content);
+
+      expect(mockTmpDir).toHaveBeenCalled();
+      expect(mockJoin).toHaveBeenCalledWith('/tmp', 'temp-123456789.yaml');
+      expect(mockWriteFile).toHaveBeenCalledWith(mockPath, content, 'utf-8');
+      expect(result).toBe(mockPath);
+      expect(tempFileService.getTempFiles()).toContain(mockPath);
+    });
+
+    test('creates temporary file with custom prefix and extension', async () => {
+      const content = 'custom content';
+      const prefix = 'custom';
+      const extension = '.json';
+      const mockPath = '/tmp/custom-123456789-.json';
+
+      vi.spyOn(Date, 'now').mockReturnValue(123456789);
+      mockJoin.mockReturnValue(mockPath);
+      mockWriteFile.mockResolvedValue(undefined);
+
+      const result = await tempFileService.createTempFile(content, prefix, extension);
+
+      expect(mockJoin).toHaveBeenCalledWith('/tmp', 'custom-123456789.json');
+      expect(mockWriteFile).toHaveBeenCalledWith(mockPath, content, 'utf-8');
+      expect(result).toBe(mockPath);
+      expect(tempFileService.getTempFiles()).toContain(mockPath);
+    });
+
+    test('throws error when file creation fails', async () => {
+      const content = 'test content';
+      const error = new Error('Permission denied');
+
+      mockWriteFile.mockRejectedValue(error);
+
+      await expect(tempFileService.createTempFile(content)).rejects.toThrow('Permission denied');
+    });
+
+    test('tracks multiple temporary files', async () => {
+      const content1 = 'content 1';
+      const content2 = 'content 2';
+      const mockPath1 = '/tmp/temp-111-.yaml';
+      const mockPath2 = '/tmp/temp-222-.yaml';
+
+      vi.spyOn(Date, 'now').mockReturnValueOnce(111).mockReturnValueOnce(222);
+
+      mockJoin.mockReturnValueOnce(mockPath1).mockReturnValueOnce(mockPath2);
+      mockWriteFile.mockResolvedValue(undefined);
+
+      await tempFileService.createTempFile(content1);
+      await tempFileService.createTempFile(content2);
+
+      const trackedFiles = tempFileService.getTempFiles();
+      expect(trackedFiles).toContain(mockPath1);
+      expect(trackedFiles).toContain(mockPath2);
+      expect(trackedFiles).toHaveLength(2);
+    });
+  });
+
+  describe('createTempKubeFile', () => {
+    test('creates Kubernetes YAML file with correct prefix', async () => {
+      const yamlContent = 'apiVersion: v1\nkind: Pod';
+      const mockPath = '/tmp/kube-123456789-.yaml';
+
+      vi.spyOn(Date, 'now').mockReturnValue(123456789);
+      mockJoin.mockReturnValue(mockPath);
+      mockWriteFile.mockResolvedValue(undefined);
+
+      const result = await tempFileService.createTempKubeFile(yamlContent);
+
+      expect(mockJoin).toHaveBeenCalledWith('/tmp', 'kube-123456789.yaml');
+      expect(mockWriteFile).toHaveBeenCalledWith(mockPath, yamlContent, 'utf-8');
+      expect(result).toBe(mockPath);
+      expect(tempFileService.getTempFiles()).toContain(mockPath);
+    });
+  });
+
+  describe('removeTempFile', () => {
+    test('removes tracked temporary file successfully', async () => {
+      const filePath = '/tmp/test-file.yaml';
+
+      // Add file to tracking first
+      mockWriteFile.mockResolvedValue(undefined);
+      vi.spyOn(Date, 'now').mockReturnValue(123);
+      mockJoin.mockReturnValue(filePath);
+      await tempFileService.createTempFile('content');
+
+      mockUnlink.mockResolvedValue(undefined);
+
+      await tempFileService.removeTempFile(filePath);
+
+      expect(mockUnlink).toHaveBeenCalledWith(filePath);
+      expect(tempFileService.getTempFiles()).not.toContain(filePath);
+    });
+
+    test('does not attempt to remove untracked file', async () => {
+      const filePath = '/tmp/untracked-file.yaml';
+
+      await tempFileService.removeTempFile(filePath);
+
+      expect(mockUnlink).not.toHaveBeenCalled();
+      expect(tempFileService.getTempFiles()).not.toContain(filePath);
+    });
+
+    test('handles file removal error gracefully', async () => {
+      const filePath = '/tmp/test-file.yaml';
+      const error = new Error('File not found');
+
+      // Add file to tracking first
+      mockWriteFile.mockResolvedValue(undefined);
+      vi.spyOn(Date, 'now').mockReturnValue(123);
+      mockJoin.mockReturnValue(filePath);
+      await tempFileService.createTempFile('content');
+
+      mockUnlink.mockRejectedValue(error);
+
+      // Should not throw, but file should remain in tracking since deletion failed
+      await expect(tempFileService.removeTempFile(filePath)).resolves.not.toThrow();
+      expect(tempFileService.getTempFiles()).toContain(filePath);
+    });
+
+    test('logs warning when file removal fails', async () => {
+      const filePath = '/tmp/test-file.yaml';
+      const error = new Error('Permission denied');
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      // Add file to tracking first
+      mockWriteFile.mockResolvedValue(undefined);
+      vi.spyOn(Date, 'now').mockReturnValue(123);
+      mockJoin.mockReturnValue(filePath);
+      await tempFileService.createTempFile('content');
+
+      mockUnlink.mockRejectedValue(error);
+
+      await tempFileService.removeTempFile(filePath);
+
+      expect(consoleSpy).toHaveBeenCalledWith(`Failed to remove temporary file ${filePath}:`, error);
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('cleanup', () => {
+    test('removes all tracked temporary files', async () => {
+      const filePath1 = '/tmp/file1.yaml';
+      const filePath2 = '/tmp/file2.yaml';
+      const filePath3 = '/tmp/file3.yaml';
+
+      // Add files to tracking
+      mockWriteFile.mockResolvedValue(undefined);
+      vi.spyOn(Date, 'now').mockReturnValueOnce(111).mockReturnValueOnce(222).mockReturnValueOnce(333);
+      mockJoin.mockReturnValueOnce(filePath1).mockReturnValueOnce(filePath2).mockReturnValueOnce(filePath3);
+
+      await tempFileService.createTempFile('content1');
+      await tempFileService.createTempFile('content2');
+      await tempFileService.createTempFile('content3');
+
+      mockUnlink.mockResolvedValue(undefined);
+
+      await tempFileService.cleanup();
+
+      expect(mockUnlink).toHaveBeenCalledTimes(3);
+      expect(mockUnlink).toHaveBeenCalledWith(filePath1);
+      expect(mockUnlink).toHaveBeenCalledWith(filePath2);
+      expect(mockUnlink).toHaveBeenCalledWith(filePath3);
+      expect(tempFileService.getTempFiles()).toHaveLength(0);
+    });
+
+    test('handles mixed success and failure during cleanup', async () => {
+      const filePath1 = '/tmp/file1.yaml';
+      const filePath2 = '/tmp/file2.yaml';
+      const error = new Error('Permission denied');
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      // Add files to tracking
+      mockWriteFile.mockResolvedValue(undefined);
+      vi.spyOn(Date, 'now').mockReturnValueOnce(111).mockReturnValueOnce(222);
+      mockJoin.mockReturnValueOnce(filePath1).mockReturnValueOnce(filePath2);
+
+      await tempFileService.createTempFile('content1');
+      await tempFileService.createTempFile('content2');
+
+      mockUnlink
+        .mockResolvedValueOnce(undefined) // file1 succeeds
+        .mockRejectedValueOnce(error); // file2 fails
+
+      await tempFileService.cleanup();
+
+      expect(mockUnlink).toHaveBeenCalledTimes(2);
+      expect(consoleSpy).toHaveBeenCalledWith(`Failed to remove temporary file ${filePath2}:`, error);
+      // Only file1 removed from tracking, file2 remains due to failed deletion
+      expect(tempFileService.getTempFiles()).toEqual([filePath2]);
+
+      consoleSpy.mockRestore();
+    });
+
+    test('handles cleanup when no files are tracked', async () => {
+      await tempFileService.cleanup();
+
+      expect(mockUnlink).not.toHaveBeenCalled();
+      expect(tempFileService.getTempFiles()).toHaveLength(0);
+    });
+  });
+
+  describe('getTempFiles', () => {
+    test('returns empty array when no files are tracked', () => {
+      const result = tempFileService.getTempFiles();
+
+      expect(result).toEqual([]);
+      expect(result).toHaveLength(0);
+    });
+
+    test('returns copy of tracked files array', async () => {
+      const filePath = '/tmp/test-file.yaml';
+
+      mockWriteFile.mockResolvedValue(undefined);
+      vi.spyOn(Date, 'now').mockReturnValue(123);
+      mockJoin.mockReturnValue(filePath);
+      await tempFileService.createTempFile('content');
+
+      const result1 = tempFileService.getTempFiles();
+      const result2 = tempFileService.getTempFiles();
+
+      expect(result1).toEqual([filePath]);
+      expect(result2).toEqual([filePath]);
+      expect(result1).not.toBe(result2); // Should be different array instances
+    });
+  });
+});

--- a/packages/main/src/plugin/temp-file-service.ts
+++ b/packages/main/src/plugin/temp-file-service.ts
@@ -80,7 +80,7 @@ export class TempFileService implements AsyncDisposable {
   /**
    * Get the list of currently tracked temporary files
    */
-  getTempFiles(): string[] {
+  protected getTempFiles(): string[] {
     return Array.from(this.tempFiles);
   }
 }

--- a/packages/main/src/plugin/temp-file-service.ts
+++ b/packages/main/src/plugin/temp-file-service.ts
@@ -37,13 +37,12 @@ export class TempFileService implements AsyncDisposable {
   /**
    * Creates a temporary file with the provided content
    * @param content The content to write to the temporary file
-   * @param prefix Optional prefix for the filename (default: 'temp')
-   * @param extension Optional file extension (default: '.yaml')
+   * @param extension Optional file extension (default: 'yaml')
    * @returns The path to the created temporary file
    */
-  async createTempFile(content: string, prefix: string = 'temp', extension: string = '.yaml'): Promise<string> {
+  async createTempFile(content: string, extension: string = 'yaml'): Promise<string> {
     const tempDir = tmpdir();
-    const tempFileName = `${prefix}-${Date.now()}${extension}`;
+    const tempFileName = `temp-${new Date().getTime()}.${extension}`;
     const tempFilePath = join(tempDir, tempFileName);
 
     await writeFile(tempFilePath, content, 'utf-8');
@@ -52,15 +51,6 @@ export class TempFileService implements AsyncDisposable {
     this.tempFiles.add(tempFilePath);
 
     return tempFilePath;
-  }
-
-  /**
-   * Creates a temporary Kubernetes YAML file with the provided content
-   * @param content The YAML content to write to the temporary file
-   * @returns The path to the created temporary file
-   */
-  async createTempKubeFile(content: string): Promise<string> {
-    return this.createTempFile(content, 'kube', '.yaml');
   }
 
   /**

--- a/packages/main/src/plugin/temp-file-service.ts
+++ b/packages/main/src/plugin/temp-file-service.ts
@@ -1,0 +1,91 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { injectable } from 'inversify';
+
+/**
+ * Service for managing temporary files (YAML, configuration files, etc.)
+ */
+@injectable()
+export class TempFileService {
+  private tempFiles: Set<string> = new Set();
+
+  /**
+   * Creates a temporary file with the provided content
+   * @param content The content to write to the temporary file
+   * @param prefix Optional prefix for the filename (default: 'temp')
+   * @param extension Optional file extension (default: '.yaml')
+   * @returns The path to the created temporary file
+   */
+  async createTempFile(content: string, prefix: string = 'temp', extension: string = '.yaml'): Promise<string> {
+    const tempDir = os.tmpdir();
+    const tempFileName = `${prefix}-${Date.now()}${extension}`;
+    const tempFilePath = path.join(tempDir, tempFileName);
+
+    await fs.promises.writeFile(tempFilePath, content, 'utf-8');
+
+    // Track the temporary file for cleanup
+    this.tempFiles.add(tempFilePath);
+
+    return tempFilePath;
+  }
+
+  /**
+   * Creates a temporary Kubernetes YAML file with the provided content
+   * @param content The YAML content to write to the temporary file
+   * @returns The path to the created temporary file
+   */
+  async createTempKubeFile(content: string): Promise<string> {
+    return this.createTempFile(content, 'kube', '.yaml');
+  }
+
+  /**
+   * Removes a temporary file
+   * @param filePath The path to the temporary file to remove
+   */
+  async removeTempFile(filePath: string): Promise<void> {
+    try {
+      if (this.tempFiles.has(filePath)) {
+        await fs.promises.unlink(filePath);
+        this.tempFiles.delete(filePath);
+      }
+    } catch (error: unknown) {
+      // File might already be deleted, log but don't throw
+      console.warn(`Failed to remove temporary file ${filePath}:`, error);
+    }
+  }
+
+  /**
+   * Cleanup all tracked temporary files
+   */
+  async cleanup(): Promise<void> {
+    const cleanupPromises = Array.from(this.tempFiles).map(filePath => this.removeTempFile(filePath));
+    await Promise.allSettled(cleanupPromises);
+  }
+
+  /**
+   * Get the list of currently tracked temporary files
+   */
+  getTempFiles(): string[] {
+    return Array.from(this.tempFiles);
+  }
+}

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -375,8 +375,8 @@ export function initExposure(): void {
     },
   );
 
-  contextBridge.exposeInMainWorld('createTempKubeFile', async (content: string): Promise<string> => {
-    return ipcInvoke('temp-file-service:createTempKubeFile', content);
+  contextBridge.exposeInMainWorld('createTempFile', async (content: string): Promise<string> => {
+    return ipcInvoke('temp-file-service:createTempFile', content);
   });
 
   contextBridge.exposeInMainWorld('removeTempFile', async (filePath: string): Promise<void> => {

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -375,6 +375,14 @@ export function initExposure(): void {
     },
   );
 
+  contextBridge.exposeInMainWorld('createTempKubeFile', async (content: string): Promise<string> => {
+    return ipcInvoke('temp-file-service:createTempKubeFile', content);
+  });
+
+  contextBridge.exposeInMainWorld('removeTempFile', async (filePath: string): Promise<void> => {
+    return ipcInvoke('temp-file-service:removeTempFile', filePath);
+  });
+
   contextBridge.exposeInMainWorld('stopPod', async (engine: string, podId: string): Promise<void> => {
     return ipcInvoke('container-provider-registry:stopPod', engine, podId);
   });

--- a/packages/renderer/src/lib/kube/KubePlayYAML.spec.ts
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.spec.ts
@@ -149,10 +149,6 @@ test('error: When pressing the Play button, expect us to show the errors to the 
   expect(browseButton).toBeInTheDocument();
   await userEvent.click(browseButton);
 
-  // Simulate selecting a runtime
-  const runtimeOption = screen.getByText('Podman container engine');
-  expect(runtimeOption).toBeInTheDocument();
-
   // Simulate clicking the "Play" button
   const playButton = screen.getByRole('button', { name: 'Play' });
   expect(playButton).toBeInTheDocument();
@@ -181,10 +177,6 @@ test('expect done button is there at the end and redirects to pods', async () =>
   expect(browseButton).toBeInTheDocument();
   await userEvent.click(browseButton);
 
-  // Simulate selecting a runtime
-  const runtimeOption = screen.getByText('Podman container engine');
-  expect(runtimeOption).toBeInTheDocument();
-
   // Simulate clicking the "Play" button
   const playButton = screen.getByRole('button', { name: 'Play' });
   expect(playButton).toBeInTheDocument();
@@ -211,12 +203,6 @@ test('expect workflow selection boxes have the correct selection borders', async
   setup();
   render(KubePlayYAML, {});
 
-  // check the current borders - Podman should be selected by default
-  const podmanOption = screen.getByText('Podman container engine');
-  expect(podmanOption).toBeInTheDocument();
-  expect(podmanOption.parentElement?.parentElement).toHaveClass('border-[var(--pd-content-card-border-selected)]');
-  expect(podmanOption.parentElement?.parentElement).not.toHaveClass('border-[var(--pd-content-card-border)]');
-
   const customOption = screen.getByText('Create file from scratch');
   expect(customOption).toBeInTheDocument();
   expect(customOption.parentElement?.parentElement).not.toHaveClass('border-[var(--pd-content-card-border-selected)]');
@@ -224,10 +210,6 @@ test('expect workflow selection boxes have the correct selection borders', async
 
   // now switch selection to Create file from scratch
   await userEvent.click(customOption);
-
-  // and expect opposite selection borders
-  expect(podmanOption.parentElement?.parentElement).not.toHaveClass('border-[var(--pd-content-card-border-selected)]');
-  expect(podmanOption.parentElement?.parentElement).toHaveClass('border-[var(--pd-content-card-border)]');
 
   expect(customOption.parentElement?.parentElement).toHaveClass('border-[var(--pd-content-card-border-selected)]');
   expect(customOption.parentElement?.parentElement).not.toHaveClass('border-[var(--pd-content-card-border)]');
@@ -324,10 +306,6 @@ describe('Custom YAML mode', () => {
     // Monaco editor should be visible
     expect(screen.getByText('Custom Kubernetes YAML Content')).toBeInTheDocument();
 
-    // Switch back to file mode
-    const fileOption = screen.getByText('Podman container engine');
-    await userEvent.click(fileOption);
-
     // Monaco editor should be hidden again
     expect(screen.queryByLabelText('Custom Kubernetes YAML Content')).not.toBeInTheDocument();
   });
@@ -381,10 +359,6 @@ test('switching between modes clears custom content', async () => {
 
   // Monaco editor should be visible
   expect(screen.getByText('Custom Kubernetes YAML Content')).toBeInTheDocument();
-
-  // Switch back to file mode
-  const fileOption = screen.getByText('Podman container engine');
-  await userEvent.click(fileOption);
 
   // Monaco editor should be hidden again
   expect(screen.queryByLabelText('Custom Kubernetes YAML Content')).not.toBeInTheDocument();

--- a/packages/renderer/src/lib/kube/KubePlayYAML.svelte
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.svelte
@@ -93,14 +93,14 @@ async function playKubeFile(): Promise<void> {
   runFinished = false;
   runError = '';
 
-  let tempFilePath: string | undefined = undefined;
+  let tempFilePath: string = '';
 
   try {
     let yamlFilePath: string;
 
     if (userChoice === 'custom') {
       // Create a temporary file with the custom YAML content
-      tempFilePath = await window.createTempKubeFile(customYamlContent);
+      tempFilePath = await window.createTempFile(customYamlContent);
       yamlFilePath = tempFilePath;
     } else {
       yamlFilePath = kubernetesYamlFilePath!;

--- a/packages/renderer/src/lib/kube/KubePlayYAML.svelte
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.svelte
@@ -215,7 +215,7 @@ function goBackToPodsPage(): void {
       <div class="flex flex-col">
         <button
           hidden={providerConnections.length === 0}
-          class="rounded-md p-5 cursor-pointer bg-[var(--pd-content-card-inset-bg)]"
+          class="border-2 rounded-md p-5 cursor-pointer bg-[var(--pd-content-card-inset-bg)]"
           aria-label="Podman Container Engine Runtime"
           aria-pressed={userChoice === 'podman' ? 'true' : 'false'}
           class:border-[var(--pd-content-card-border-selected)]={userChoice === 'podman'}
@@ -223,29 +223,23 @@ function goBackToPodsPage(): void {
           on:click={(): void => {
              userChoice = 'podman';
            }}>
-          <div class="flex flex-row align-middle items-center pb-2">
+          <div class="flex flex-row align-middle items-center">
             <div
-              class="text-2xl"
+              class="text-2xl pr-2"
               class:text-[var(--pd-content-card-border-selected)]={userChoice === 'podman'}
               class:text-[var(--pd-content-card-border)]={userChoice !== 'podman'}>
               <Fa icon={faCircleCheck} />
             </div>
-            <div
-              class="pl-2"
-              class:text-[var(--pd-content-card-text)]={userChoice === 'podman'}
-              class:text-[var(--pd-input-field-disabled-text)]={userChoice !== 'podman'}>
-              Podman container engine
-            </div>
+            <FileInput
+              name="containerFilePath"
+              id="containerFilePath"
+              readonly
+              required
+              bind:value={kubernetesYamlFilePath}
+              placeholder="Select a .yaml file to play"
+              options={kubeFileDialogOptions}
+              class="w-full p-2" />
           </div>
-          <FileInput
-            name="containerFilePath"
-            id="containerFilePath"
-            readonly
-            required
-            bind:value={kubernetesYamlFilePath}
-            placeholder="Select a .yaml file to play"
-            options={kubeFileDialogOptions}
-            class="w-full p-2" />
           <div hidden={runStarted}>
             {#if providerConnections.length > 1}
               <label


### PR DESCRIPTION
Assisted by: Cursor

### What does this PR do?
Replaces apply to Kubernetes workflow with apply custom YAML using monaco editor

### Screenshot / video of UI


Uploading Screen Recording 2025-08-29 at 19.17.58.mov…


### What issues does this PR fix or reference?
Closes #12172 

### How to test this PR?
Go to Pods => Apply YAML => Paste YAML file into editor and confirm

- [x] Tests are covering the bug fix or the new feature
