### PR TITLE
fix: configuration not detected by handler

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -540,12 +540,6 @@ export class PluginSystem {
 
     container.bind<MessageBox>(MessageBox).toSelf().inSingletonScope();
 
-    container.bind<ExperimentalFeatureFeedbackHandler>(ExperimentalFeatureFeedbackHandler).toSelf().inSingletonScope();
-    const experimentalFeatureFeedbackHandler = container.get<ExperimentalFeatureFeedbackHandler>(
-      ExperimentalFeatureFeedbackHandler,
-    );
-    await experimentalFeatureFeedbackHandler.init();
-
     // Don't show the tray icon options on Mac
     if (!isMac()) {
       container.bind<TrayIconColor>(TrayIconColor).toSelf().inSingletonScope();
@@ -750,6 +744,12 @@ export class PluginSystem {
     const customPickRegistry = container.get<CustomPickRegistry>(CustomPickRegistry);
     const authentication = container.get<AuthenticationImpl>(AuthenticationImpl);
     const imageRegistry = container.get<ImageRegistry>(ImageRegistry);
+
+    container.bind<ExperimentalFeatureFeedbackHandler>(ExperimentalFeatureFeedbackHandler).toSelf().inSingletonScope();
+    const experimentalFeatureFeedbackHandler = container.get<ExperimentalFeatureFeedbackHandler>(
+      ExperimentalFeatureFeedbackHandler,
+    );
+    await experimentalFeatureFeedbackHandler.init();
 
     await this.setupSecurityRestrictionsOnLinks(messageBox);
 


### PR DESCRIPTION
### What does this PR do?
Moves feedback handler so it detects more/all experimental configuration (now is was not detecting appearance-init.ts config)

With latest main you should have in config "titleBar.searchBar":{}" after enabling it in experimental features

With this PR it should look like this ±: 
  "titleBar.searchBar": {
    "remindAt": 1756882802859,
    "disabled": false
  },

### Screenshot / video of UI

### What issues does this PR fix or reference?

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
