### PR TITLE
fix: avoid propagating event of PasswordInput component for show/hide

### DIFF
--- a/packages/renderer/src/lib/ui/PasswordInput.spec.ts
+++ b/packages/renderer/src/lib/ui/PasswordInput.spec.ts
@@ -20,10 +20,11 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { render, screen } from '@testing-library/svelte';
-import { expect, test } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { expect, test, vi } from 'vitest';
 
 import PasswordInput from './PasswordInput.svelte';
+import PasswordInputTest from './PasswordInputTest.svelte';
 
 function renderInput(password: string, readonly: boolean, onClick?: any): void {
   render(PasswordInput, { password: password, readonly: readonly, onClick: onClick });
@@ -37,4 +38,23 @@ test('Expect basic styling', async () => {
   expect(element).toBeInTheDocument();
   expect(element).toHaveAttribute('aria-label', 'show/hide');
   expect(element).toHaveClass('cursor-pointer');
+});
+
+test('clicking show/hide button does not submit form', async () => {
+  const handleSubmit = vi.fn(e => e.preventDefault());
+
+  render(PasswordInputTest, { onSubmit: handleSubmit });
+
+  const showHideButton = screen.getByRole('button', { name: /show\/hide/i });
+  const submitButton = screen.getByText('Submit');
+
+  // Click the show/hide button
+  await fireEvent.click(showHideButton);
+
+  // Form should NOT have been submitted
+  expect(handleSubmit).not.toHaveBeenCalled();
+
+  // Clicking the real submit button should call the handler
+  await fireEvent.click(submitButton);
+  expect(handleSubmit).toHaveBeenCalledTimes(1);
 });

--- a/packages/renderer/src/lib/ui/PasswordInput.spec.ts
+++ b/packages/renderer/src/lib/ui/PasswordInput.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/renderer/src/lib/ui/PasswordInput.svelte
+++ b/packages/renderer/src/lib/ui/PasswordInput.svelte
@@ -18,7 +18,9 @@ onMount(() => {
 });
 
 // show/hide if the parent doesn't override
-async function onShowHide(): Promise<void> {
+async function onShowHide(event: MouseEvent): Promise<void> {
+  // avoid to propagate event
+  event.preventDefault();
   if (dispatch('toggleShowHide', { cancelable: true })) {
     passwordHidden = !passwordHidden;
     element.type = passwordHidden ? 'password' : 'text';

--- a/packages/renderer/src/lib/ui/PasswordInputTest.svelte
+++ b/packages/renderer/src/lib/ui/PasswordInputTest.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+import PasswordInput from './PasswordInput.svelte';
+
+export let onSubmit: (event: Event) => void;
+</script>
+
+<form on:submit={onSubmit}>
+  <PasswordInput id="foo" password="secret" readonly={false} />
+  <button type="submit">Submit</button>
+</form>

--- a/packages/renderer/src/lib/ui/PasswordInputTest.svelte
+++ b/packages/renderer/src/lib/ui/PasswordInputTest.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
 import PasswordInput from './PasswordInput.svelte';
 
-export let onSubmit: (event: Event) => void;
+interface Props {
+  onSubmit: (event: Event) => void;
+}
+const { onSubmit }: Props = $props();
 </script>
 
 <form on:submit={onSubmit}>


### PR DESCRIPTION
### What does this PR do?
clicking on show/hide button was submitting the form

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/podman-desktop/podman-desktop/issues/13798

### How to test this PR?

unit test provided
- [x] Tests are covering the bug fix or the new feature
