### PR TITLE
feat: allow to declare properties using password formatting

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
@@ -489,14 +489,16 @@ test('Expect a password input when record is type string and format is password'
   await awaitRender(record, {});
   const passwordInput = screen.getByLabelText('password input-standard-record');
   expect(passwordInput).toBeInTheDocument();
-  expect(passwordInput instanceof HTMLInputElement).toBe(true);
+  expect(passwordInput).toBeInstanceOf(HTMLInputElement);
 
   // enter the value foobar from keyboard
   await userEvent.click(passwordInput);
   await userEvent.keyboard('foobar');
 
-  // check the type is hidden
-  expect((passwordInput as HTMLInputElement).type).toBe('password');
-  expect((passwordInput as HTMLInputElement).name).toBe('password-input-standard-record');
-  expect((passwordInput as HTMLInputElement).value).toBe('foobar');
+  // check that the typed value is hidden
+  expect(passwordInput).toHaveAttribute('type', 'password');
+
+  // check that the name is properly set and the value too
+  expect(passwordInput).toHaveAttribute('name', 'record');
+  expect(passwordInput).toHaveValue('foobar');
 });

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
@@ -476,3 +476,27 @@ test('Expect boolean record to be updated from checked to not checked', async ()
   // checkbox should not be checked anymore
   await vi.waitFor(() => expect(checkbox).not.toBeChecked());
 });
+
+test('Expect a password input when record is type string and format is password', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    format: 'password',
+    type: 'string',
+  };
+  await awaitRender(record, {});
+  const passwordInput = screen.getByLabelText('password input-standard-record');
+  expect(passwordInput).toBeInTheDocument();
+  expect(passwordInput instanceof HTMLInputElement).toBe(true);
+
+  // enter the value foobar from keyboard
+  await userEvent.click(passwordInput);
+  await userEvent.keyboard('foobar');
+
+  // check the type is hidden
+  expect((passwordInput as HTMLInputElement).type).toBe('password');
+  expect((passwordInput as HTMLInputElement).name).toBe('password-input-standard-record');
+  expect((passwordInput as HTMLInputElement).value).toBe('foobar');
+});

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -12,6 +12,7 @@ import { onDidChangeConfiguration } from '/@/stores/configurationProperties';
 import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
 
 import Markdown from '../markdown/Markdown.svelte';
+import PasswordStringItem from './item-formats/PasswordStringItem.svelte';
 import { getInitialValue, getNormalizedDefaultNumberValue } from './Util';
 
 interface Props {
@@ -227,6 +228,11 @@ function numberItemValue(): number {
         onChange={onChange} />
     {:else if record.enum && record.enum.length > 0}
       <EnumItem record={record} value={typeof givenValue === 'string' ? givenValue : recordValue} onChange={onChange} />
+    {:else if record.format === 'password'}
+      <PasswordStringItem
+        record={record}
+        value={typeof givenValue === 'string' ? givenValue : recordValue}
+        onChange={onChange} />
     {:else}
       <StringItem
         record={record}

--- a/packages/renderer/src/lib/preferences/item-formats/PasswordStringItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/PasswordStringItem.spec.ts
@@ -1,0 +1,63 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { beforeAll, expect, test, vi } from 'vitest';
+
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
+
+import PasswordStringItem from './PasswordStringItem.svelte';
+
+beforeAll(() => {
+  Object.defineProperty(window, 'getConfigurationValue', { value: vi.fn() });
+});
+
+test('Ensure HTMLInputElement', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'string',
+  };
+
+  render(PasswordStringItem, { record, value: '' });
+  const input = screen.getByLabelText('password input-standard-record');
+  expect(input).toBeInTheDocument();
+
+  expect(input instanceof HTMLInputElement).toBe(true);
+});
+
+test('Ensure HTMLInputElement readonly', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'string',
+    format: 'password',
+    readonly: true,
+  };
+
+  render(PasswordStringItem, { record, value: '' });
+  const input = screen.getByLabelText('password input-standard-record');
+  expect(input).toBeInTheDocument();
+  expect((input as HTMLInputElement).readOnly).toBeTruthy();
+});

--- a/packages/renderer/src/lib/preferences/item-formats/PasswordStringItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/PasswordStringItem.spec.ts
@@ -19,15 +19,11 @@
 import '@testing-library/jest-dom/vitest';
 
 import { render, screen } from '@testing-library/svelte';
-import { beforeAll, expect, test, vi } from 'vitest';
+import { expect, test } from 'vitest';
 
 import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
 
 import PasswordStringItem from './PasswordStringItem.svelte';
-
-beforeAll(() => {
-  Object.defineProperty(window, 'getConfigurationValue', { value: vi.fn() });
-});
 
 test('Ensure HTMLInputElement', async () => {
   const record: IConfigurationPropertyRecordedSchema = {
@@ -41,8 +37,7 @@ test('Ensure HTMLInputElement', async () => {
   render(PasswordStringItem, { record, value: '' });
   const input = screen.getByLabelText('password input-standard-record');
   expect(input).toBeInTheDocument();
-
-  expect(input instanceof HTMLInputElement).toBe(true);
+  expect(input).toBeInstanceOf(HTMLInputElement);
 });
 
 test('Ensure HTMLInputElement readonly', async () => {

--- a/packages/renderer/src/lib/preferences/item-formats/PasswordStringItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/PasswordStringItem.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
+
+import PasswordInput from '../../ui/PasswordInput.svelte';
+
+export let record: IConfigurationPropertyRecordedSchema;
+export let value: string | undefined;
+export let onChange = async (_id: string, _value: string): Promise<void> => {};
+
+let invalidEntry = false;
+
+function onInput(event: Event): void {
+  const target = event.target as HTMLInputElement;
+  if (record.id && target.value !== value)
+    onChange(record.id, target.value).catch((_: unknown) => (invalidEntry = true));
+}
+</script>
+
+<PasswordInput
+  on:input={onInput}
+  class="grow"
+  name={record.id}
+  placeholder={record.placeholder}
+  bind:value={value}
+  readonly={!!record.readonly}
+  id="input-standard-{record.id}"
+  aria-invalid={invalidEntry}
+  aria-label={record.description} />

--- a/packages/renderer/src/lib/preferences/item-formats/PasswordStringItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/PasswordStringItem.svelte
@@ -1,13 +1,16 @@
 <script lang="ts">
+import PasswordInput from '/@/lib/ui/PasswordInput.svelte';
 import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
 
-import PasswordInput from '../../ui/PasswordInput.svelte';
+interface Props {
+  record: IConfigurationPropertyRecordedSchema;
+  value: string | undefined;
+  onChange: (id: string, value: string) => Promise<void>;
+}
 
-export let record: IConfigurationPropertyRecordedSchema;
-export let value: string | undefined;
-export let onChange = async (_id: string, _value: string): Promise<void> => {};
+let { record, value, onChange }: Props = $props();
 
-let invalidEntry = false;
+let invalidEntry = $state(false);
 
 function onInput(event: Event): void {
   const target = event.target as HTMLInputElement;


### PR DESCRIPTION
### What does this PR do?
display password input if formatter is set to password for string properties

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/podman-desktop/podman-desktop/issues/13800

### How to test this PR?

unit test provided

- [x] Tests are covering the bug fix or the new feature
