### PR TITLE
chore: allow to specify name of the underlying input component

### DIFF
--- a/packages/renderer/src/lib/ui/PasswordInput.spec.ts
+++ b/packages/renderer/src/lib/ui/PasswordInput.spec.ts
@@ -58,3 +58,20 @@ test('clicking show/hide button does not submit form', async () => {
   await fireEvent.click(submitButton);
   expect(handleSubmit).toHaveBeenCalledTimes(1);
 });
+
+test('check specific name is applied', async () => {
+  const name = 'my-special-password';
+  render(PasswordInput, { id: 'foo', name: name });
+
+  const input = screen.getByLabelText('password foo') as HTMLInputElement;
+  expect(input).toBeInTheDocument();
+  expect(input.name).toBe(name);
+});
+
+test('check default name is set if not specified', async () => {
+  render(PasswordInput, { id: 'foo' });
+
+  const input = screen.getByLabelText('password foo') as HTMLInputElement;
+  expect(input).toBeInTheDocument();
+  expect(input.name).toBe('password-foo');
+});

--- a/packages/renderer/src/lib/ui/PasswordInput.svelte
+++ b/packages/renderer/src/lib/ui/PasswordInput.svelte
@@ -5,6 +5,7 @@ import { createEventDispatcher, onMount } from 'svelte';
 import Fa from 'svelte-fa';
 
 export let id: string;
+export let name: string | undefined = undefined;
 export let password: string | undefined = undefined;
 export let passwordHidden: boolean = true;
 export let readonly: boolean = false;
@@ -31,7 +32,7 @@ async function onShowHide(event: MouseEvent): Promise<void> {
 <Input
   class={$$props.class ?? ''}
   id="password-{id}"
-  name="password-{id}"
+  name={name ?? `password-${id}`}
   placeholder="password"
   bind:value={password}
   aria-label="password {id}"


### PR DESCRIPTION
### What does this PR do?
When using PasswordInput we may want to specify the name to be used for the input field
Add this option

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/podman-desktop/podman-desktop/issues/13807

### How to test this PR?

unit test added

- [x] Tests are covering the bug fix or the new feature
