### PR TITLE
fix(icons): fix various alignment inconsistencies in loading icons

### DIFF
--- a/packages/renderer/src/lib/compose/ComposeActions.svelte
+++ b/packages/renderer/src/lib/compose/ComposeActions.svelte
@@ -138,8 +138,7 @@ if (dropdownMenu) {
   enabled={!compose.actionInProgress}
   detailed={detailed}
   inProgress={compose.actionInProgress && compose.status === 'STARTING'}
-  icon={faPlay}
-  iconOffset="pl-[0.15rem]" />
+  icon={faPlay} />
 
 <ListItemButtonIcon
   title="Stop Compose"

--- a/packages/renderer/src/lib/container/ContainerActions.svelte
+++ b/packages/renderer/src/lib/container/ContainerActions.svelte
@@ -191,8 +191,7 @@ if (dropdownMenu) {
   hidden={container.state === 'RUNNING' || container.state === 'STOPPING'}
   detailed={detailed}
   inProgress={container.actionInProgress && container.state === 'STARTING'}
-  icon={faPlay}
-  iconOffset="pl-[0.15rem]" />
+  icon={faPlay}/>
 
 <ListItemButtonIcon
   title="Stop Container"

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleDelete.svelte
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleDelete.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faTrashCan } from '@fortawesome/free-solid-svg-icons';
+import { faTrash } from '@fortawesome/free-solid-svg-icons';
 
 import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
 
@@ -24,11 +24,8 @@ async function deleteExtension(): Promise<void> {
 }
 </script>
 
-<div class="text-sm">
   <LoadingIconButton
     clickAction={deleteExtension}
     action="delete"
-    icon={faTrashCan}
-    state={{ status: extension.type === 'dd' ? 'stopped' : extension.removable ? extension.state : '', inProgress }}
-    leftPosition="left-[0.2rem]" />
-</div>
+    icon={faTrash}
+    state={{ status: extension.type === 'dd' ? 'stopped' : extension.removable ? extension.state : '', inProgress }} />

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleStart.svelte
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleStart.svelte
@@ -26,5 +26,5 @@ async function startExtension(): Promise<void> {
     action="start"
     icon={faPlay}
     state={{ status: extension.state, inProgress }}
-    leftPosition="left-[0.15rem]" />
+    />
 {/if}

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleStop.svelte
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleStop.svelte
@@ -25,6 +25,5 @@ async function stopExtension(): Promise<void> {
     clickAction={stopExtension}
     action="stop"
     icon={faStop}
-    state={{ status: extension.type === 'dd' ? 'unsupported' : extension.state, inProgress }}
-    leftPosition="left-[0.15rem]" />
+    state={{ status: extension.type === 'dd' ? 'unsupported' : extension.state, inProgress }} />
 {/if}

--- a/packages/renderer/src/lib/featured/FeaturedExtensionDownload.svelte
+++ b/packages/renderer/src/lib/featured/FeaturedExtensionDownload.svelte
@@ -81,10 +81,6 @@ async function installExtension(): Promise<void> {
   <LoadingIcon
     icon={faDownload}
     iconSize="1x"
-    loadingWidthClass="w-7"
-    loadingHeightClass="h-7"
-    positionTopClass="top-[2px]"
-    positionLeftClass="left-[4px]"
     loading={installInProgress} />
   <span
     class:hidden={!installInProgress}

--- a/packages/renderer/src/lib/pod/PodActions.svelte
+++ b/packages/renderer/src/lib/pod/PodActions.svelte
@@ -146,8 +146,7 @@ if (dropdownMenu) {
   hidden={pod.status === 'RUNNING' || pod.status === 'STOPPING'}
   detailed={detailed}
   inProgress={pod.actionInProgress && pod.status === 'STARTING'}
-  icon={faPlay}
-  iconOffset="pl-[0.15rem]" />
+  icon={faPlay} />
 <ListItemButtonIcon
   title="Stop Pod"
   onClick={stopPod}

--- a/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
@@ -178,7 +178,6 @@ function getLoggerHandler(_cliToolId: string): ConnectionCallback {
                   }
                 }}
                 icon={faCircleArrowDown}
-                leftPosition="left-[0.25rem]"
                 state={cliToolInstallStatus}
                 color="primary"
                 tooltip={`Install ${cliTool.displayName}`} />
@@ -194,7 +193,6 @@ function getLoggerHandler(_cliToolId: string): ConnectionCallback {
                   }
                 }}
                 icon={faCircleArrowUp}
-                leftPosition="left-[0.25rem]"
                 state={cliToolUpdateStatus}
                 color="primary"
                 tooltip={!cliTool.canUpdate
@@ -214,7 +212,6 @@ function getLoggerHandler(_cliToolId: string): ConnectionCallback {
                   }
                 }}
                 icon={faTrash}
-                leftPosition="left-[0.25rem]"
                 state={cliToolUninstallStatus}
                 color="secondary"
                 tooltip={`Uninstall ${cliTool.displayName}`} />

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionActions.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionActions.svelte
@@ -161,8 +161,7 @@ function getLoggerHandler(provider: ProviderInfo, containerConnectionInfo: Provi
               clickAction={(): Promise<void> => startConnectionProvider(provider, connection)}
               action="start"
               icon={faPlay}
-              state={connectionStatus}
-              leftPosition="left-[0.1rem]" />
+              state={connectionStatus} />
           </div>
         {/if}
         {#if connection.lifecycleMethods.includes('start') && connection.lifecycleMethods.includes('stop')}
@@ -171,7 +170,7 @@ function getLoggerHandler(provider: ProviderInfo, containerConnectionInfo: Provi
             action="restart"
             icon={faRotateRight}
             state={connectionStatus}
-            leftPosition="left-[0.25rem]" />
+            />
         {/if}
         {#if connection.lifecycleMethods.includes('stop')}
           <LoadingIconButton
@@ -179,7 +178,7 @@ function getLoggerHandler(provider: ProviderInfo, containerConnectionInfo: Provi
             action="stop"
             icon={faStop}
             state={connectionStatus}
-            leftPosition="left-[0.12rem]" />
+            />
         {/if}
         {#if connection.lifecycleMethods.includes('edit')}
           <LoadingIconButton
@@ -187,7 +186,7 @@ function getLoggerHandler(provider: ProviderInfo, containerConnectionInfo: Provi
             action="edit"
             icon={faEdit}
             state={connectionStatus}
-            leftPosition="left-[0.12rem]" />
+            />
         {/if}
         {#if connection.lifecycleMethods.includes('delete')}
           <LoadingIconButton
@@ -195,7 +194,7 @@ function getLoggerHandler(provider: ProviderInfo, containerConnectionInfo: Provi
             action="delete"
             icon={faTrash}
             state={connectionStatus}
-            leftPosition="left-[0.15rem]" />
+            />
         {/if}
         <div class="mr-2 text-sm">
           {@render advanced_actions?.()}

--- a/packages/renderer/src/lib/task-manager/button/TaskManagerClearAllButton.svelte
+++ b/packages/renderer/src/lib/task-manager/button/TaskManagerClearAllButton.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-import { faTrashCan } from '@fortawesome/free-solid-svg-icons';
+import { faTrash } from '@fortawesome/free-solid-svg-icons';
 import { Button } from '@podman-desktop/ui-svelte';
 
 import { clearNotifications } from '/@/stores/tasks';
 </script>
 
-<Button icon={faTrashCan} on:click={clearNotifications}>Clear all</Button>
+<Button icon={faTrash} on:click={clearNotifications}>Clear all</Button>

--- a/packages/renderer/src/lib/task-manager/table/action/TaskManagerActionsView.svelte
+++ b/packages/renderer/src/lib/task-manager/table/action/TaskManagerActionsView.svelte
@@ -20,5 +20,4 @@ async function viewAction(): Promise<void> {
   title="View action"
   onClick={viewAction}
   hidden={!task?.action}
-  icon={faEye}
-  iconOffset="pl-[0.15rem]" />
+  icon={faEye} />

--- a/packages/renderer/src/lib/ui/ListItemButtonIcon.svelte
+++ b/packages/renderer/src/lib/ui/ListItemButtonIcon.svelte
@@ -3,12 +3,12 @@ import type { IconDefinition } from '@fortawesome/fontawesome-common-types';
 import { DropdownMenu, isFontAwesomeIcon } from '@podman-desktop/ui-svelte';
 import { onDestroy, onMount } from 'svelte';
 import type { Unsubscriber } from 'svelte/store';
-import Fa from 'svelte-fa';
 
 import { context as storeContext } from '/@/stores/context';
 
 import type { ContextUI } from '../context/context';
 import { ContextKeyExpr } from '../context/contextKey';
+import LoadingIcon from './LoadingIcon.svelte';
 
 interface Props {
   title: string;
@@ -21,7 +21,6 @@ interface Props {
   menu?: boolean;
   detailed?: boolean;
   inProgress?: boolean;
-  iconOffset?: string;
   tooltip?: string;
   contextUI?: ContextUI;
 }
@@ -37,15 +36,9 @@ let {
   menu = false,
   detailed = false,
   inProgress = false,
-  iconOffset = '',
   tooltip = '',
   contextUI,
 }: Props = $props();
-
-let positionLeftClass = $state('left-1');
-if (detailed) positionLeftClass = 'left-2';
-let positionTopClass = $state('top-1');
-if (detailed) positionTopClass = '[0.2rem]';
 
 let globalContext: ContextUI;
 let contextsUnsubscribe: Unsubscriber;
@@ -136,13 +129,10 @@ const styleClass = $derived(
     class:inline-flex={!hidden}
     disabled={!enabled}>
     {#if fontAwesomeIcon}
-      <Fa class="h-4 w-4 {iconOffset}" icon={fontAwesomeIcon} />
+      <LoadingIcon
+        icon={fontAwesomeIcon}
+        loading={inProgress}
+      />
     {/if}
-
-    <div
-      aria-label="spinner"
-      class="w-6 h-6 rounded-full animate-spin border border-solid border-[var(--pd-action-button-spinner)] border-t-transparent absolute {positionTopClass} {positionLeftClass}"
-      class:hidden={!inProgress}>
-    </div>
   </button>
 {/if}

--- a/packages/renderer/src/lib/ui/LoadingIcon.spec.ts
+++ b/packages/renderer/src/lib/ui/LoadingIcon.spec.ts
@@ -28,8 +28,6 @@ test('Expect default size', async () => {
   const icon = faPlayCircle;
   const loadingWidthClass = 'w-10';
   const loadingHeightClass = 'h-10';
-  const positionTopClass = '';
-  const positionLeftClass = '';
   const loading = true;
   const iconSize = undefined;
   render(LoadingIcon, {
@@ -37,8 +35,6 @@ test('Expect default size', async () => {
     iconSize,
     loadingHeightClass,
     loadingWidthClass,
-    positionTopClass,
-    positionLeftClass,
     loading,
   });
   const loadingIcon = screen.getByRole('img', { hidden: true, name: '' });
@@ -52,8 +48,6 @@ test('Expect specified size', async () => {
   const icon = faPlayCircle;
   const loadingWidthClass = 'w-10';
   const loadingHeightClass = 'h-10';
-  const positionTopClass = '';
-  const positionLeftClass = '';
   const loading = true;
   const iconSize = '2x';
   render(LoadingIcon, {
@@ -61,8 +55,6 @@ test('Expect specified size', async () => {
     iconSize,
     loadingHeightClass,
     loadingWidthClass,
-    positionTopClass,
-    positionLeftClass,
     loading,
   });
   const loadingIcon = screen.getByRole('img', { hidden: true, name: '' });

--- a/packages/renderer/src/lib/ui/LoadingIcon.svelte
+++ b/packages/renderer/src/lib/ui/LoadingIcon.svelte
@@ -3,10 +3,8 @@ import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 import { Fa, type IconSize } from 'svelte-fa';
 
 export let icon: IconDefinition;
-export let loadingWidthClass: string;
-export let loadingHeightClass: string;
-export let positionTopClass: string;
-export let positionLeftClass: string;
+export let loadingWidthClass: string = 'w-6';
+export let loadingHeightClass: string = 'h-6';
 export let loading = false;
 export let iconSize: IconSize | undefined = undefined;
 </script>
@@ -17,6 +15,6 @@ export let iconSize: IconSize | undefined = undefined;
     aria-label="spinner"
     class="{loading
       ? ''
-      : 'hidden'} {loadingWidthClass} {loadingHeightClass} rounded-full animate-spin border border-solid border-[var(--pd-action-button-spinner)] border-t-transparent absolute {positionTopClass} {positionLeftClass}">
+      : 'hidden'} {loadingWidthClass} {loadingHeightClass} rounded-full animate-spin -translate-1/2 border border-solid border-[var(--pd-action-button-spinner)] border-t-transparent absolute left-1/2 top-1/2">
   </div>
 </div>

--- a/packages/renderer/src/lib/ui/LoadingIconButton.spec.ts
+++ b/packages/renderer/src/lib/ui/LoadingIconButton.spec.ts
@@ -63,7 +63,6 @@ test.each(['start', 'restart', 'stop', 'delete', 'update'])('action $action in p
       inProgress: true,
       status: 'unknown',
     },
-    leftPosition: '',
     icon: faPlayCircle,
     clickAction: vi.fn(),
   });
@@ -226,7 +225,6 @@ test.each([
     action: action,
     state: state,
     color: color,
-    leftPosition: '',
     icon: faPlayCircle,
     clickAction: vi.fn(),
   });

--- a/packages/renderer/src/lib/ui/LoadingIconButton.svelte
+++ b/packages/renderer/src/lib/ui/LoadingIconButton.svelte
@@ -10,21 +10,12 @@ interface Props {
   action: string;
   icon: IconDefinition;
   state?: ILoadingStatus;
-  leftPosition: string;
   color?: 'primary' | 'secondary';
   tooltip?: string;
   clickAction: () => Promise<void> | void;
 }
 
-const {
-  action,
-  icon,
-  state,
-  leftPosition,
-  color = 'secondary',
-  tooltip = capitalize(action),
-  clickAction,
-}: Props = $props();
+const { action, icon, state, color = 'secondary', tooltip = capitalize(action), clickAction }: Props = $props();
 
 const disable = $derived.by(() => {
   if (state?.inProgress || state?.status === 'unsupported') {
@@ -62,10 +53,6 @@ const style = $derived(
   <button aria-label={capitalize(action)} class="px-2.5 py-2 {style}" onclick={clickAction} disabled={disable}>
     <LoadingIcon
       icon={icon}
-      loadingWidthClass="w-6"
-      loadingHeightClass="h-6"
-      positionTopClass="top-0.5"
-      positionLeftClass={leftPosition}
       loading={loading} />
   </button>
 </Tooltip>


### PR DESCRIPTION
### What does this PR do?
This fixes position of the spinner around icons. This code change involves following changes:

1. Removes manual adjustments to spinner position, it is centered automatically now
2. Removes custom implementation of the spinner for list actions and uses LoadingIcon instead
3. On a few places there was "faTrashCan" used instead "faTrash", made it consistent
### Screenshot / video of UI

Before:
<img width="158" height="53" alt="image" src="https://github.com/user-attachments/assets/adb457e3-4ee1-40d8-8785-fd23b8f993cf" />

After:
<img width="34" height="35" alt="image" src="https://github.com/user-attachments/assets/730b6eb6-949a-4963-ba64-e76646a1ccca" />
<img width="33" height="36" alt="image" src="https://github.com/user-attachments/assets/cb143f9f-88cf-4fe4-b63f-f07d9b2c93e9" />
<img width="33" height="41" alt="image" src="https://github.com/user-attachments/assets/f50b8cee-cade-481c-897f-a04b2a1d59ec" />

### What issues does this PR fix or reference?
Fixes: #13811

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
