### PR TITLE
feat: use min-h-screen for downloads page layout

### DIFF
--- a/website/src/pages/downloads/linux.tsx
+++ b/website/src/pages/downloads/linux.tsx
@@ -130,7 +130,7 @@ export default function Home(): JSX.Element {
           <h1 className="title-font sm:text-3xl text-2xl lg:text-5xl mb-10 font-medium text-charcoal-300 dark:text-white">
             Linux Downloads
           </h1>
-          <main className="h-screen">
+          <main className="min-h-screen">
             <LinuxDownloads />
           </main>
         </div>

--- a/website/src/pages/downloads/macos.tsx
+++ b/website/src/pages/downloads/macos.tsx
@@ -145,7 +145,7 @@ export default function Home(): JSX.Element {
           <h1 className="title-font sm:text-3xl text-2xl lg:text-5xl mb-10 font-medium text-charcoal-300 dark:text-white">
             macOS Downloads
           </h1>
-          <main className="h-screen">
+          <main className="min-h-screen">
             <MacOSDownloads />
           </main>
         </div>

--- a/website/src/pages/downloads/windows.tsx
+++ b/website/src/pages/downloads/windows.tsx
@@ -183,7 +183,7 @@ export default function Home(): JSX.Element {
           <h1 className="title-font sm:text-3xl text-2xl lg:text-5xl mb-10 font-medium text-charcoal-300 dark:text-white">
             Windows Downloads
           </h1>
-          <main className="h-screen">
+          <main className="min-h-screen">
             <WindowsDownloads />
           </main>
         </div>


### PR DESCRIPTION
Signed-off-by: Tanmay shirbhayyye <tanmays@Tanmays-MacBook-Air.local>

### What does this PR do?

Fixes the layout of the Downloads page for all OS layout. Previously, extra download information could get hidden behind the footer when the content exceeded the viewport height. This was due to h-screen being used in the components. This PR replaces h-screen with min-h-screen, allowing sections to expand dynamically based on content height.

   **Before:**  
<img width="1451" height="842" alt="Screenshot 2025-09-06 at 3 47 12 PM" src="https://github.com/user-attachments/assets/28532032-775b-4f92-8404-612f5c2c5c4e" />


**After:**  
<img width="1451" height="842" alt="Screenshot 2025-09-06 at 5 01 50 PM" src="https://github.com/user-attachments/assets/e2b71795-ff11-41e4-a486-11bc87b21a4d" />


Closes: #13830

### How to test this PR?

1.Open the Downloads page in the browser.

2.Go to the Windows section (or any section with more download info).

3.Verify that all download links and information are visible and not hidden behind the footer.

4.Resize the browser window to smaller heights to ensure the content still expands correctly.

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

