### PR TITLE
chore(deps): remove pnpm#overrides for `vitest>vite`

### DIFF
--- a/package.json
+++ b/package.json
@@ -224,7 +224,6 @@
       "express>cookie": "^0.7.0",
       "webpack-dev-server>http-proxy-middleware": "^2.0.9",
       "@kubernetes/client-node>jsonpath-plus": "^10.3.0",
-      "vitest>vite": "^6.1.0",
       "esbuild-register>esbuild": "^0.25.0",
       "tsx>esbuild": "^0.25.0",
       "vite>esbuild": "^0.25.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,6 @@ overrides:
   express>cookie: ^0.7.0
   webpack-dev-server>http-proxy-middleware: ^2.0.9
   '@kubernetes/client-node>jsonpath-plus': ^10.3.0
-  vitest>vite: ^6.1.0
   esbuild-register>esbuild: ^0.25.0
   tsx>esbuild: ^0.25.0
   vite>esbuild: ^0.25.0


### PR DESCRIPTION
### What does this PR do?

Removing the vitest>vite pnpm overrides as Vitest now support all vite versions up to 7.X

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/13845

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- Pipeline should be :green_circle: 
