### PR TITLE
chore(podman): bump to 5.6.1

### DIFF
--- a/extensions/podman/packages/extension/src/podman5.json
+++ b/extensions/podman/packages/extension/src/podman5.json
@@ -1,24 +1,24 @@
 {
-  "version": "5.6.0",
+  "version": "5.6.1",
   "releaseNotes": {
-    "href": "https://github.com/containers/podman/releases/tag/v5.6.0"
+    "href": "https://github.com/containers/podman/releases/tag/v5.6.1"
   },
   "platform": {
     "win32": {
-      "version": "v5.6.0",
-      "fileName": "podman-5.6.0-setup.exe"
+      "version": "v5.6.1",
+      "fileName": "podman-5.6.1-setup.exe"
     },
     "darwin": {
-      "version": "v5.6.0",
+      "version": "v5.6.1",
       "arch": {
         "x64": {
-          "fileName": "podman-installer-macos-amd64-v5.6.0.pkg"
+          "fileName": "podman-installer-macos-amd64-v5.6.1.pkg"
         },
         "arm64": {
-          "fileName": "podman-installer-macos-aarch64-v5.6.0.pkg"
+          "fileName": "podman-installer-macos-aarch64-v5.6.1.pkg"
         },
         "universal": {
-          "fileName": "podman-installer-macos-universal-v5.6.0.pkg"
+          "fileName": "podman-installer-macos-universal-v5.6.1.pkg"
         }
       }
     }


### PR DESCRIPTION
### What does this PR do?

Podman 5.6.1 has been released on September 4th (ref https://github.com/containers/podman/releases/tag/v5.6.1)

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/13813

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- Pipeline should be :green_circle: 

---

:warning: QE approval required
