### PR TITLE
fix(renderer): svelte-check errors

### DIFF
--- a/packages/renderer/src/lib/container/ContainerList.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerList.spec.ts
@@ -62,7 +62,9 @@ beforeEach(() => {
   };
 });
 
-async function waitRender(customProperties: object): Promise<RenderResult<Component<ComponentProps<ContainerList>>>> {
+async function waitRender(
+  customProperties: object,
+): Promise<RenderResult<Component<ComponentProps<typeof ContainerList>>>> {
   const result = render(ContainerList, { ...customProperties });
   await tick();
   return result;

--- a/packages/renderer/src/lib/dialogs/Dialog.spec.ts
+++ b/packages/renderer/src/lib/dialogs/Dialog.spec.ts
@@ -26,7 +26,7 @@ import Dialog from './Dialog.svelte';
 
 test('dialog should be visible and have basic styling', async () => {
   const title = 'A dialog';
-  render(Dialog, { title: title });
+  render(Dialog, { title: title, onclose: vi.fn() });
 
   const bg = screen.getByLabelText('fade-bg');
   expect(bg).toBeDefined();

--- a/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.spec.ts
@@ -302,7 +302,7 @@ describe('includeExtensionInfo', () => {
   });
 });
 
-test.each(['bug', 'feature'])('Expect %s to have specific telemetry track events', async category => {
+test.each<FeedbackCategory>(['bug', 'feature'])('Expect %s to have specific telemetry track events', async category => {
   const { title, description, preview } = renderGitHubIssueFeedback({
     category: category,
     onCloseForm: vi.fn(),
@@ -320,7 +320,7 @@ test.each(['bug', 'feature'])('Expect %s to have specific telemetry track events
   );
 });
 
-test.each(['bug', 'feature'])(
+test.each<FeedbackCategory>(['bug', 'feature'])(
   'Expect %s to have specific telemetry track events with error if the preview on GitHub fails',
   async category => {
     vi.mocked(window.previewOnGitHub).mockRejectedValue('error: unable to preview on GitHub');

--- a/packages/renderer/src/lib/image/ImageDetailsCheck.spec.ts
+++ b/packages/renderer/src/lib/image/ImageDetailsCheck.spec.ts
@@ -70,6 +70,7 @@ test('expect to display wait message before to receive results', async () => {
       SharedSize: 0,
       Labels: {},
       Containers: 0,
+      Digest: 'digest',
     },
   });
 
@@ -105,6 +106,7 @@ test('expect to cancel when clicking the Cancel button', async () => {
       SharedSize: 0,
       Labels: {},
       Containers: 0,
+      Digest: 'digest',
     },
   });
 
@@ -146,6 +148,7 @@ test('expect to cancel when destroying the component', async () => {
       SharedSize: 0,
       Labels: {},
       Containers: 0,
+      Digest: 'digest',
     },
   });
 
@@ -184,6 +187,7 @@ test('expect to not cancel again when destroying the component after manual canc
       SharedSize: 0,
       Labels: {},
       Containers: 0,
+      Digest: 'digest',
     },
   });
 
@@ -235,6 +239,7 @@ test('expect to display results from image checker provider', async () => {
       SharedSize: 0,
       Labels: {},
       Containers: 0,
+      Digest: 'digest',
     },
   });
 
@@ -281,6 +286,7 @@ test('expect to not cancel when destroying the component after displaying result
       SharedSize: 0,
       Labels: {},
       Containers: 0,
+      Digest: 'digest',
     },
   });
 

--- a/packages/renderer/src/lib/kube/details/KubeContainerArtifact.spec.ts
+++ b/packages/renderer/src/lib/kube/details/KubeContainerArtifact.spec.ts
@@ -24,6 +24,7 @@ import { readable } from 'svelte/store';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import * as kubeContextStore from '/@/stores/kubernetes-contexts-state'; // Adjust the import path as necessary
+import { WorkloadKind } from '/@api/kubernetes-port-forward-model';
 
 import KubeContainerArtifact from './KubeContainerArtifact.svelte';
 
@@ -54,7 +55,10 @@ beforeEach(() => {
 });
 
 test('Container artifact renders with correct values', async () => {
-  render(KubeContainerArtifact, { artifact: fakeContainer });
+  render(KubeContainerArtifact, {
+    kind: WorkloadKind.POD,
+    artifact: fakeContainer,
+  });
 
   // Check if basic container info is displayed
   expect(screen.getByText('Name')).toBeInTheDocument();

--- a/packages/renderer/src/lib/kubernetes-port-forward/PortForwardNameColumn.spec.ts
+++ b/packages/renderer/src/lib/kubernetes-port-forward/PortForwardNameColumn.spec.ts
@@ -52,10 +52,11 @@ test('name should be visible', () => {
 
   const { getByText } = render(PodNameColumn, {
     object: {
+      id: '',
       name: 'dummy-pod-name',
       namespace: 'dummy-ns',
       kind: WorkloadKind.POD,
-      mapping: DUMMY_MAPPING,
+      forward: DUMMY_MAPPING,
     },
   });
 
@@ -77,7 +78,8 @@ test('click on name should redirect to pod page', async () => {
       name: 'dummy-pod-name',
       namespace: 'dummy-ns',
       kind: WorkloadKind.POD,
-      mapping: DUMMY_MAPPING,
+      id: '',
+      forward: DUMMY_MAPPING,
     },
   });
 

--- a/packages/renderer/src/lib/node/NodeDetailsSummary.spec.ts
+++ b/packages/renderer/src/lib/node/NodeDetailsSummary.spec.ts
@@ -72,7 +72,7 @@ beforeEach(() => {
 });
 
 test('Expect to render node details when node data is available', async () => {
-  render(NodeDetailsSummary, { node: node });
+  render(NodeDetailsSummary, { node: node, events: [] });
 
   expect(screen.getByText('node-01')).toBeInTheDocument();
   expect(screen.getByText('provider-123')).toBeInTheDocument();
@@ -80,7 +80,7 @@ test('Expect to render node details when node data is available', async () => {
 });
 
 test('Expect to show error message when there is a kube error', async () => {
-  render(NodeDetailsSummary, { node: node, kubeError: kubeError });
+  render(NodeDetailsSummary, { node: node, kubeError: kubeError, events: [] });
 
   const errorMessage = screen.getByText(kubeError);
   expect(errorMessage).toBeInTheDocument();

--- a/packages/renderer/src/lib/node/NodeDetailsSummary.spec.ts
+++ b/packages/renderer/src/lib/node/NodeDetailsSummary.spec.ts
@@ -72,7 +72,9 @@ beforeEach(() => {
 });
 
 test('Expect to render node details when node data is available', async () => {
-  render(NodeDetailsSummary, { node: node, events: [] });
+  render(NodeDetailsSummary, {
+    props: { node: node, events: [] },
+  });
 
   expect(screen.getByText('node-01')).toBeInTheDocument();
   expect(screen.getByText('provider-123')).toBeInTheDocument();
@@ -80,7 +82,9 @@ test('Expect to render node details when node data is available', async () => {
 });
 
 test('Expect to show error message when there is a kube error', async () => {
-  render(NodeDetailsSummary, { node: node, kubeError: kubeError, events: [] });
+  render(NodeDetailsSummary, {
+    props: { node: node, kubeError: kubeError, events: [] },
+  });
 
   const errorMessage = screen.getByText(kubeError);
   expect(errorMessage).toBeInTheDocument();

--- a/packages/renderer/src/lib/preferences/PreferencesProviderInstallationModal.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesProviderInstallationModal.spec.ts
@@ -120,18 +120,6 @@ test('Expect to call doCreateNew if clicking on Next', async () => {
   expect(doCreateNew).toBeCalled();
 });
 
-test('Expect no modal if providerToBeInstalled is undefined', async () => {
-  render(PreferencesProviderInstallationModal, {
-    providerToBeInstalled: undefined,
-    closeCallback,
-    doCreateNew,
-    preflightChecks: [],
-  });
-
-  const modal = screen.queryByLabelText('install provider');
-  expect(modal).not.toBeInTheDocument();
-});
-
 test('Expect preflight check entry if preflights checks has some value', async () => {
   render(PreferencesProviderInstallationModal, {
     providerToBeInstalled: {

--- a/packages/renderer/src/lib/preferences/PreferencesProviderInstallationModal.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProviderInstallationModal.svelte
@@ -8,7 +8,7 @@ import type { CheckStatus, ProviderInfo } from '/@api/provider-info';
 import IconImage from '../appearance/IconImage.svelte';
 
 interface Props {
-  providerToBeInstalled: { provider: ProviderInfo; displayName: string };
+  providerToBeInstalled: { provider: ProviderInfo; displayName: string } | undefined;
   preflightChecks: CheckStatus[];
   closeCallback: () => void;
   doCreateNew: (provider: ProviderInfo, displayName: string) => void;

--- a/packages/renderer/src/lib/preferences/PreferencesProviderInstallationModal.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProviderInstallationModal.svelte
@@ -8,7 +8,7 @@ import type { CheckStatus, ProviderInfo } from '/@api/provider-info';
 import IconImage from '../appearance/IconImage.svelte';
 
 interface Props {
-  providerToBeInstalled: { provider: ProviderInfo; displayName: string } | undefined;
+  providerToBeInstalled: { provider: ProviderInfo; displayName: string };
   preflightChecks: CheckStatus[];
   closeCallback: () => void;
   doCreateNew: (provider: ProviderInfo, displayName: string) => void;

--- a/packages/renderer/src/lib/preferences/item-formats/BooleanItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/BooleanItem.spec.ts
@@ -30,7 +30,7 @@ beforeAll(() => {
 });
 
 test('Checkbox checked', async () => {
-  const record: IConfigurationPropertyRecordedSchema = {
+  const record: IConfigurationPropertyRecordedSchema & { default: boolean } = {
     id: 'record',
     title: 'record',
     parentId: 'parent.record',
@@ -48,7 +48,7 @@ test('Checkbox checked', async () => {
 });
 
 test('Checkbox no default', async () => {
-  const record: IConfigurationPropertyRecordedSchema = {
+  const record: IConfigurationPropertyRecordedSchema & { default?: boolean } = {
     id: 'record',
     title: 'record',
     parentId: 'parent.record',
@@ -65,7 +65,7 @@ test('Checkbox no default', async () => {
 });
 
 test('Expect to see the checkbox disabled / unable to press when readonly is passed into record', async () => {
-  const record: IConfigurationPropertyRecordedSchema = {
+  const record: IConfigurationPropertyRecordedSchema & { default: boolean } = {
     title: 'my boolean property',
     id: 'myid',
     parentId: '',
@@ -82,7 +82,7 @@ test('Expect to see the checkbox disabled / unable to press when readonly is pas
 });
 
 test('Expect to see checkbox not checked if default is false', async () => {
-  const record: IConfigurationPropertyRecordedSchema = {
+  const record: IConfigurationPropertyRecordedSchema & { default: boolean } = {
     title: 'my boolean property',
     id: 'myid',
     parentId: '',

--- a/packages/renderer/src/lib/preferences/item-formats/EnumItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/EnumItem.spec.ts
@@ -38,14 +38,14 @@ test('Enum without default', async () => {
     enum: ['hello', 'world'],
   };
 
-  render(EnumItem, { record });
+  render(EnumItem, { record, value: undefined });
   const input = screen.getByLabelText('record-description');
   expect(input).toBeInTheDocument();
   expect(input).toHaveTextContent('hello');
 });
 
 test('Enum with default', async () => {
-  const record: IConfigurationPropertyRecordedSchema = {
+  const record: IConfigurationPropertyRecordedSchema & { default: string } = {
     id: 'record',
     title: 'record',
     parentId: 'parent.record',

--- a/packages/renderer/src/lib/preferences/item-formats/PasswordStringItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/PasswordStringItem.spec.ts
@@ -19,7 +19,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import { render, screen } from '@testing-library/svelte';
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 
 import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
 
@@ -34,7 +34,7 @@ test('Ensure HTMLInputElement', async () => {
     type: 'string',
   };
 
-  render(PasswordStringItem, { record, value: '' });
+  render(PasswordStringItem, { record, value: '', onChange: vi.fn() });
   const input = screen.getByLabelText('password input-standard-record');
   expect(input).toBeInTheDocument();
   expect(input).toBeInstanceOf(HTMLInputElement);
@@ -51,7 +51,7 @@ test('Ensure HTMLInputElement readonly', async () => {
     readonly: true,
   };
 
-  render(PasswordStringItem, { record, value: '' });
+  render(PasswordStringItem, { record, value: '', onChange: vi.fn() });
   const input = screen.getByLabelText('password input-standard-record');
   expect(input).toBeInTheDocument();
   expect((input as HTMLInputElement).readOnly).toBeTruthy();

--- a/packages/renderer/src/lib/service/ServiceDetailsSummary.spec.ts
+++ b/packages/renderer/src/lib/service/ServiceDetailsSummary.spec.ts
@@ -65,7 +65,7 @@ test('Expect basic rendering', async () => {
   kubernetesGetCurrentNamespaceMock.mockResolvedValue('default');
   kubernetesReadNamespacedServiceMock.mockResolvedValue(service);
 
-  render(ServiceDetailsSummary, { service: service });
+  render(ServiceDetailsSummary, { service: service, events: [] });
 
   expect(screen.getByText('my-service')).toBeInTheDocument();
 });
@@ -74,7 +74,7 @@ test('Check more properties', async () => {
   kubernetesGetCurrentNamespaceMock.mockResolvedValue('default');
   kubernetesReadNamespacedServiceMock.mockResolvedValue(undefined);
 
-  render(ServiceDetailsSummary, { service: service });
+  render(ServiceDetailsSummary, { service: service, events: [] });
 
   expect(screen.getByText('my-service')).toBeInTheDocument();
   expect(screen.getByText('default')).toBeInTheDocument();

--- a/packages/renderer/src/lib/service/ServiceDetailsSummary.spec.ts
+++ b/packages/renderer/src/lib/service/ServiceDetailsSummary.spec.ts
@@ -65,7 +65,7 @@ test('Expect basic rendering', async () => {
   kubernetesGetCurrentNamespaceMock.mockResolvedValue('default');
   kubernetesReadNamespacedServiceMock.mockResolvedValue(service);
 
-  render(ServiceDetailsSummary, { service: service, events: [] });
+  render(ServiceDetailsSummary, { props: { service: service, events: [] } });
 
   expect(screen.getByText('my-service')).toBeInTheDocument();
 });
@@ -74,7 +74,7 @@ test('Check more properties', async () => {
   kubernetesGetCurrentNamespaceMock.mockResolvedValue('default');
   kubernetesReadNamespacedServiceMock.mockResolvedValue(undefined);
 
-  render(ServiceDetailsSummary, { service: service, events: [] });
+  render(ServiceDetailsSummary, { props: { service: service, events: [] } });
 
   expect(screen.getByText('my-service')).toBeInTheDocument();
   expect(screen.getByText('default')).toBeInTheDocument();

--- a/packages/renderer/src/lib/ui/NavItem.spec.ts
+++ b/packages/renderer/src/lib/ui/NavItem.spec.ts
@@ -21,6 +21,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen } from '@testing-library/svelte';
+import type { TinroRouteMeta } from 'tinro';
 import { expect, test } from 'vitest';
 
 import NavItem from './NavItem.svelte';
@@ -144,7 +145,7 @@ test('Expect that counter is rendered', async () => {
   const href = '/href';
   let counter = 0;
 
-  const result = render(NavItem, { counter, tooltip, href, meta: { url: '/test' } });
+  const result = render(NavItem, { counter, tooltip, href, meta: { url: '/test' } as TinroRouteMeta });
 
   const element = screen.getByLabelText(tooltip);
   expect(element).toBeInTheDocument();
@@ -157,7 +158,7 @@ test('Expect that counter is rendered', async () => {
   counter = 4;
 
   // check tooltip is working if counter is updated
-  render(NavItem, { counter, tooltip, href, meta: { url: '/test' } });
+  render(NavItem, { counter, tooltip, href, meta: { url: '/test' } as TinroRouteMeta });
 
   // get div with label tooltip
   const element2 = screen.getByLabelText('Foo');

--- a/packages/renderer/src/lib/ui/NavRegistryEntry.spec.ts
+++ b/packages/renderer/src/lib/ui/NavRegistryEntry.spec.ts
@@ -50,7 +50,7 @@ test('Expect entry is rendered', async () => {
     type: 'entry',
   };
   const meta = { url: '/test' } as TinroRouteMeta;
-  render(NavRegistryEntry, { entry, meta });
+  render(NavRegistryEntry, { entry, meta, iconWithTitle: false });
 
   const content = screen.queryByLabelText('Item1');
   expect(content).toBeInTheDocument();
@@ -69,7 +69,7 @@ test('Expect hidden entry is not rendered', async () => {
     type: 'entry',
   };
   const meta = { url: '/test' } as TinroRouteMeta;
-  render(NavRegistryEntry, { entry, meta });
+  render(NavRegistryEntry, { entry, meta, iconWithTitle: false });
 
   const content = screen.queryByLabelText('Item1');
   expect(content).not.toBeInTheDocument();
@@ -108,7 +108,7 @@ test('Expect entry to not have title by default', async () => {
     type: 'entry',
   };
   const meta = { url: '/test' } as TinroRouteMeta;
-  render(NavRegistryEntry, { entry, meta });
+  render(NavRegistryEntry, { entry, meta, iconWithTitle: false });
 
   const content = screen.queryByLabelText('Item1 title');
   expect(content).not.toBeInTheDocument();

--- a/packages/renderer/src/lib/ui/PasswordInput.spec.ts
+++ b/packages/renderer/src/lib/ui/PasswordInput.spec.ts
@@ -27,7 +27,7 @@ import PasswordInput from './PasswordInput.svelte';
 import PasswordInputTest from './PasswordInputTest.svelte';
 
 function renderInput(password: string, readonly: boolean, onClick?: any): void {
-  render(PasswordInput, { password: password, readonly: readonly, onClick: onClick });
+  render(PasswordInput, { id: '', password: password, readonly: readonly, onClick: onClick });
 }
 
 test('Expect basic styling', async () => {


### PR DESCRIPTION
### What does this PR do?

Step 1 of https://github.com/podman-desktop/podman-desktop/issues/13891 where I just fixes all the typescript issues

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/13891

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- Pipeline should be :green_circle: 

Locally, `svelte-check --tsconfig packages/renderer/tsconfig.json` should exit 0
