### PR TITLE
chore: remove -no-minify from website build

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "typecheck:extensions:registries": "tsc --noEmit --project extensions/registries",
     "typecheck:extensions:kubectl-cli": "tsc --noEmit --project extensions/kubectl-cli",
     "typecheck": "pnpm run typecheck:main && pnpm run typecheck:preload && pnpm run typecheck:ui && pnpm run typecheck:renderer && pnpm run typecheck:preload-dd-extension && pnpm run typecheck:preload-webview && pnpm run typecheck:extensions && pnpm run typecheck:extension-api",
-    "website:build": "pnpm run storybook:build && cd website && pnpm run docusaurus clear && pnpm run docusaurus build --no-minify",
+    "website:build": "pnpm run storybook:build && cd website && pnpm run docusaurus clear && pnpm run docusaurus build",
     "website:prod": "pnpm run website:build && cd website/build && pnpm serve",
     "website:dev": "pnpm run storybook:build && cd website && pnpm run docusaurus start",
     "website:screenshots": "cd website-argos && pnpm run screenshot",


### PR DESCRIPTION
chore: remove -no-minify from website build

### What does this PR do?

Removes "no-minify" when building the website, as previously it had
incurred some problems when building the website.

However, we've updated to 3.8.1 and the bug (should) be cleared now.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A, see Netlify / website comparison. Should show no changes.

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/podman-desktop/issues/12238

References https://github.com/podman-desktop/podman-desktop/issues/13843

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

See there are ZERO changes before and after using --no-minify.

Content of the website should not change.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
