### PR TITLE
fix(website): replace expired linkedin image with gravatar 

### DIFF
--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -91,7 +91,6 @@ function Testimonials(): JSX.Element {
           />
           <TestimonialCard
             username="José Bayoán Santiago Calderón"
-            userImage="https://media.licdn.com/dms/image/v2/D5635AQG6ohtsrwtWFA/profile-framedphoto-shrink_200_200/profile-framedphoto-shrink_200_200/0/1737612334868?e=1747674000&v=beta&t=EruTwnMCgArUXZfCBwBZzWQJUbbQMaUB-whOPJag6QU"
             source="LinkedIn"
             text="I'm pleasantly surprised by how well Podman Desktop integrates with the Visual Studio Code Dev Containers extension. #dev #opensource #containers"
           />

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -91,6 +91,7 @@ function Testimonials(): JSX.Element {
           />
           <TestimonialCard
             username="José Bayoán Santiago Calderón"
+            userImage="https://s.gravatar.com/avatar/a8070ca24f919e30e60dce8a763c8177?s=200"
             source="LinkedIn"
             text="I'm pleasantly surprised by how well Podman Desktop integrates with the Visual Studio Code Dev Containers extension. #dev #opensource #containers"
           />


### PR DESCRIPTION
### What does this PR do?

The linkedin profil is expired, and there is no official way to get a permanent URL, (more in https://github.com/podman-desktop/podman-desktop/issues/13944).

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/13944

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- See deployement
