### PR TITLE
fix(windows): fixed minimizing the app during startup

### DIFF
--- a/packages/main/src/system/windows-startup.ts
+++ b/packages/main/src/system/windows-startup.ts
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { existsSync } from 'node:fs';
+import { existsSync, unlink } from 'node:fs';
 import path from 'node:path';
 import { app } from 'electron';
 import type { IConfigurationRegistry } from '/@api/configuration/models.js';
@@ -54,6 +54,16 @@ export class WindowsStartup {
     }
     const preferencesConfig = this.configurationRegistry.getConfiguration('preferences');
     const minimize = preferencesConfig.get<boolean>('login.minimize');
+
+    // after https://github.com/podman-desktop/podman-desktop/pull/13056 there is a leftover startup file that we need to remove
+    const windowsStartupFoler = path.resolve(app.getPath('appData'), 'Microsoft/Windows/Start Menu/Programs/Startup');
+    const startupFile = path.resolve(windowsStartupFoler, 'podman-desktop.vbs');
+
+    if (existsSync(startupFile)) {
+      unlink(startupFile, (err: unknown) => {
+        console.error(`Got error when removing ${startupFile} file: ${err}`);
+      });
+    }
 
     // We pass in "--minimize" so electron can read the flag on first startup.
     const args = minimize ? ['--minimized'] : [];


### PR DESCRIPTION
### What does this PR do?
Fixes windows minimizing during startup
Removes *.vbs script that causes not expected behaviour during startup, this file was a leftover after refactoring after https://github.com/podman-desktop/podman-desktop/pull/13056

### Screenshot / video of UI


### What issues does this PR fix or reference?
Closes #13737 

### How to test this PR?
Install older version of PD e.g. 1.18 check that in startup application there is an podman-desktop.vbs script
Install & run version from this PR 
Go to settings enable 'minimize on startup'. Restart system, the app should be started in tray 

- [x] Tests are covering the bug fix or the new feature
