### PR TITLE
chore(searchbar): disabled go to option

### DIFF
--- a/packages/renderer/src/lib/dialogs/CommandPalette.spec.ts
+++ b/packages/renderer/src/lib/dialogs/CommandPalette.spec.ts
@@ -347,11 +347,11 @@ describe('Command Palette', () => {
       shortcut: '{Control>}k{/Control}',
       expectedTabText: 'Documentation',
     },
-    {
-      description: 'Ctrl+F',
-      shortcut: '{Control>}f{/Control}',
-      expectedTabText: 'Go to',
-    },
+    // {
+    //   description: 'Ctrl+F',
+    //   shortcut: '{Control>}f{/Control}',
+    //   expectedTabText: 'Go to',
+    // },
   ];
 
   test.each(shortcutTabTestCases)(
@@ -378,9 +378,7 @@ describe('Command Palette', () => {
       // check other tabs don't have selected styling
       const allTabButtons = screen
         .getAllByRole('button')
-        .filter(button =>
-          ['All', 'Commands', 'Documentation', 'Go to'].some(tabName => button.textContent?.includes(tabName)),
-        );
+        .filter(button => ['All', 'Commands', 'Documentation'].some(tabName => button.textContent?.includes(tabName)));
 
       allTabButtons.forEach(button => {
         if (button !== expectedTab) {
@@ -413,9 +411,7 @@ describe('Command Palette', () => {
     // get all tab buttons
     const allTabButtons = screen
       .getAllByRole('button')
-      .filter(button =>
-        ['All', 'Commands', 'Documentation', 'Go to'].some(tabName => button.textContent?.includes(tabName)),
-      );
+      .filter(button => ['All', 'Commands', 'Documentation'].some(tabName => button.textContent?.includes(tabName)));
 
     // initially "All" tab should be selected (index 0)
     expect(allTabButtons[0]).toHaveClass('text-[var(--pd-button-tab-text-selected)]');
@@ -429,16 +425,6 @@ describe('Command Palette', () => {
     await userEvent.keyboard('{Tab}');
     expect(allTabButtons[2]).toHaveClass('text-[var(--pd-button-tab-text-selected)]');
     expect(allTabButtons[1]).not.toHaveClass('text-[var(--pd-button-tab-text-selected)]');
-
-    // press Tab again to move to next tab
-    await userEvent.keyboard('{Tab}');
-    expect(allTabButtons[3]).toHaveClass('text-[var(--pd-button-tab-text-selected)]');
-    expect(allTabButtons[2]).not.toHaveClass('text-[var(--pd-button-tab-text-selected)]');
-
-    // press Tab again to wrap around to first tab
-    await userEvent.keyboard('{Tab}');
-    expect(allTabButtons[0]).toHaveClass('text-[var(--pd-button-tab-text-selected)]');
-    expect(allTabButtons[3]).not.toHaveClass('text-[var(--pd-button-tab-text-selected)]');
   });
 
   test('Expect that Shift+Tab switches between tabs backward', async () => {
@@ -463,22 +449,15 @@ describe('Command Palette', () => {
     // get all tab buttons
     const allTabButtons = screen
       .getAllByRole('button')
-      .filter(button =>
-        ['All', 'Commands', 'Documentation', 'Go to'].some(tabName => button.textContent?.includes(tabName)),
-      );
+      .filter(button => ['All', 'Commands', 'Documentation'].some(tabName => button.textContent?.includes(tabName)));
 
     // initially "All" tab should be selected (index 0)
     expect(allTabButtons[0]).toHaveClass('text-[var(--pd-button-tab-text-selected)]');
 
-    // press Shift+Tab to move to previous tab (should wrap to last)
-    await userEvent.keyboard('{Shift>}{Tab}{/Shift}');
-    expect(allTabButtons[3]).toHaveClass('text-[var(--pd-button-tab-text-selected)]');
-    expect(allTabButtons[0]).not.toHaveClass('text-[var(--pd-button-tab-text-selected)]');
-
     // press Shift+Tab again to move to previous tab
     await userEvent.keyboard('{Shift>}{Tab}{/Shift}');
     expect(allTabButtons[2]).toHaveClass('text-[var(--pd-button-tab-text-selected)]');
-    expect(allTabButtons[3]).not.toHaveClass('text-[var(--pd-button-tab-text-selected)]');
+    expect(allTabButtons[0]).not.toHaveClass('text-[var(--pd-button-tab-text-selected)]');
 
     // press Shift+Tab again to move to previous tab
     await userEvent.keyboard('{Shift>}{Tab}{/Shift}');

--- a/packages/renderer/src/lib/dialogs/CommandPalette.svelte
+++ b/packages/renderer/src/lib/dialogs/CommandPalette.svelte
@@ -55,7 +55,7 @@ let searchOptions: SearchOption[] = $derived([
   { text: 'All', shortCut: [`${modifierC}${modifierS}P`] },
   { text: 'Commands', shortCut: [`${F1}`, '>'] },
   { text: 'Documentation', shortCut: [`${modifierC}K`] },
-  { text: 'Go to', shortCut: [`${modifierC}F`] },
+  // { text: 'Go to', shortCut: [`${modifierC}F`] },
 ]);
 let searchOptionsSelectedIndex: number = $state(0);
 
@@ -136,10 +136,10 @@ async function handleKeydown(e: KeyboardEvent): Promise<void> {
       searchOptionsSelectedIndex = 2;
       displaySearchBar();
       e.preventDefault();
-    } else if (e.key.toLowerCase() === 'f') {
-      searchOptionsSelectedIndex = 3;
-      displaySearchBar();
-      e.preventDefault();
+      // } else if (e.key.toLowerCase() === 'f') {
+      //   searchOptionsSelectedIndex = 3;
+      //   displaySearchBar();
+      //   e.preventDefault();
     }
   }
 


### PR DESCRIPTION
### What does this PR do?
Disabled go to option 

### Screenshot / video of UI
<img width="884" height="762" alt="image" src="https://github.com/user-attachments/assets/882e6313-1d7c-4647-bf30-02991239879f" />


### What issues does this PR fix or reference?
Will be implemented in github.com/podman-desktop/podman-desktop/issues/13959

### How to test this PR?
Open searchbar, you should not see the go to option

- [x] Tests are covering the bug fix or the new feature
