### PR TITLE
refactor(renderer): migrate PasswordInput to Svelte5

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
@@ -478,7 +478,7 @@ test('Expect boolean record to be updated from checked to not checked', async ()
 });
 
 test('Expect a password input when record is type string and format is password', async () => {
-  const record: IConfigurationPropertyRecordedSchema = {
+  const record: IConfigurationPropertyRecordedSchema & { description: string } = {
     id: 'record',
     title: 'record',
     parentId: 'parent.record',
@@ -487,7 +487,7 @@ test('Expect a password input when record is type string and format is password'
     type: 'string',
   };
   await awaitRender(record, {});
-  const passwordInput = screen.getByLabelText('password input-standard-record');
+  const passwordInput = screen.getByLabelText(record.description);
   expect(passwordInput).toBeInTheDocument();
   expect(passwordInput).toBeInstanceOf(HTMLInputElement);
 

--- a/packages/renderer/src/lib/preferences/item-formats/PasswordStringItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/PasswordStringItem.spec.ts
@@ -26,7 +26,7 @@ import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/m
 import PasswordStringItem from './PasswordStringItem.svelte';
 
 test('Ensure HTMLInputElement', async () => {
-  const record: IConfigurationPropertyRecordedSchema = {
+  const record: IConfigurationPropertyRecordedSchema & { description: string } = {
     id: 'record',
     title: 'record',
     parentId: 'parent.record',
@@ -35,13 +35,13 @@ test('Ensure HTMLInputElement', async () => {
   };
 
   render(PasswordStringItem, { record, value: '', onChange: vi.fn() });
-  const input = screen.getByLabelText('password input-standard-record');
+  const input = screen.getByLabelText(record.description);
   expect(input).toBeInTheDocument();
   expect(input).toBeInstanceOf(HTMLInputElement);
 });
 
 test('Ensure HTMLInputElement readonly', async () => {
-  const record: IConfigurationPropertyRecordedSchema = {
+  const record: IConfigurationPropertyRecordedSchema & { description: string } = {
     id: 'record',
     title: 'record',
     parentId: 'parent.record',
@@ -52,7 +52,7 @@ test('Ensure HTMLInputElement readonly', async () => {
   };
 
   render(PasswordStringItem, { record, value: '', onChange: vi.fn() });
-  const input = screen.getByLabelText('password input-standard-record');
+  const input = screen.getByLabelText(record.description);
   expect(input).toBeInTheDocument();
   expect((input as HTMLInputElement).readOnly).toBeTruthy();
 });

--- a/packages/renderer/src/lib/preferences/item-formats/PasswordStringItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/PasswordStringItem.svelte
@@ -20,11 +20,11 @@ function onInput(event: Event): void {
 </script>
 
 <PasswordInput
-  on:input={onInput}
+  oninput={onInput}
   class="grow"
   name={record.id}
   placeholder={record.placeholder}
-  bind:value={value}
+  password={value}
   readonly={!!record.readonly}
   id="input-standard-{record.id}"
   aria-invalid={invalidEntry}

--- a/packages/renderer/src/lib/ui/PasswordInput.svelte
+++ b/packages/renderer/src/lib/ui/PasswordInput.svelte
@@ -1,22 +1,26 @@
 <script lang="ts">
 import { faEye, faEyeSlash } from '@fortawesome/free-regular-svg-icons';
 import { Input } from '@podman-desktop/ui-svelte';
-import { createEventDispatcher, onMount } from 'svelte';
+import type { ComponentProps } from 'svelte';
+import { createEventDispatcher } from 'svelte';
 import Fa from 'svelte-fa';
 
-export let id: string;
-export let name: string | undefined = undefined;
-export let password: string | undefined = undefined;
-export let passwordHidden: boolean = true;
-export let readonly: boolean = false;
+type Props = Omit<ComponentProps<Input>, 'value'> & {
+  password?: string;
+  passwordHidden?: boolean;
+};
 
-let element: HTMLInputElement;
+let {
+  id,
+  name,
+  password = $bindable(),
+  passwordHidden = $bindable(true),
+  readonly = false,
+  ...restProps
+}: Props = $props();
 
+let type: 'text' | 'password' = $derived(passwordHidden ? 'password' : 'text');
 const dispatch = createEventDispatcher();
-
-onMount(() => {
-  element.type = 'password';
-});
 
 // show/hide if the parent doesn't override
 async function onShowHide(event: MouseEvent): Promise<void> {
@@ -24,27 +28,26 @@ async function onShowHide(event: MouseEvent): Promise<void> {
   event.preventDefault();
   if (dispatch('toggleShowHide', { cancelable: true })) {
     passwordHidden = !passwordHidden;
-    element.type = passwordHidden ? 'password' : 'text';
   }
 }
 </script>
 
 <Input
-  class={$$props.class ?? ''}
   id="password-{id}"
   name={name ?? `password-${id}`}
   placeholder="password"
   bind:value={password}
   aria-label="password {id}"
   bind:readonly={readonly}
-  on:input
-  bind:element={element}>
+  type={type}
+  {...restProps}
+>
   {#snippet right()}
     <button
       class="px-1 cursor-pointer text-[var(--pd-input-field-stroke)] group-hover:text-[var(--pd-input-field-hover-stroke)] group-focus-within:text-[var(--pd-input-field-hover-stroke)]"
       class:hidden={!password || readonly}
       aria-label="show/hide"
-      on:click={onShowHide}
+      onclick={onShowHide}
       >{#if passwordHidden}
         <Fa icon={faEye} />
       {:else}


### PR DESCRIPTION
### What does this PR do?

Migrate the PasswordInput component to Svelte5, the props were incomplete and poorly typed. This component must extend the props of the Input component.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/13964

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] I added test to properly cover the migration in a separate commit (https://github.com/podman-desktop/podman-desktop/commit/99189a8860163cb268b1b69858ae71605152962b)
