### PR TITLE
chore: send provider status update event and check lifecycle methods for tray menu

### DIFF
--- a/packages/main/src/plugin/provider-registry.spec.ts
+++ b/packages/main/src/plugin/provider-registry.spec.ts
@@ -43,7 +43,6 @@ import type {
   CheckStatus,
   PreflightChecksCallback,
   ProviderContainerConnectionInfo,
-  ProviderInfo,
   ProviderKubernetesConnectionInfo,
   ProviderVmConnectionInfo,
 } from '/@api/provider-info.js';
@@ -74,10 +73,6 @@ class TestProviderRegistry extends ProviderRegistry {
 
   override getMatchingProvider(internalId: string): ProviderImpl {
     return super.getMatchingProvider(internalId);
-  }
-
-  override toProviderInfo(provider: ProviderImpl): ProviderInfo {
-    return super.toProviderInfo(provider);
   }
 }
 
@@ -222,7 +217,7 @@ test('should send status update event on status change', async () => {
 
   expect(providerListenerMock).toHaveBeenCalledWith(
     'provider:update-status',
-    expect.objectContaining({ id: 'internalId', name: 'internalName', status: 'installed', status: 'started' }),
+    expect.objectContaining({ id: 'internalId', name: 'internalName', status: 'started' }),
   );
 });
 

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -227,6 +227,12 @@ export class ProviderRegistry {
     this.telemetryService.aggregateTrack('createProviders', trackOpts);
     this.apiSender.send('provider-create', id);
     providerImpl.onDidUpdateVersion(() => this.apiSender.send('provider:update-version'));
+    providerImpl.onDidUpdateStatus((status: ProviderStatus) => {
+      const provider = this.getMatchingProvider(id);
+      this.listeners.forEach(listener =>
+        listener('provider:update-status', { ...this.toProviderInfo(provider), status: status }),
+      );
+    });
     return providerImpl;
   }
 

--- a/packages/main/src/tray-menu.spec.ts
+++ b/packages/main/src/tray-menu.spec.ts
@@ -142,6 +142,7 @@ test('Tray provider start enabled when configured state', () => {
     name: 'TestProv',
     internalId: 'internalId',
     status: 'configured',
+    lifecycleMethods: ['start'],
   } as ProviderInfo);
 
   const startItem = (menuBuild.mock.lastCall?.[0]?.[0]?.submenu as Array<MenuItemConstructorOptions>)?.find(
@@ -149,6 +150,29 @@ test('Tray provider start enabled when configured state', () => {
   );
   expect(startItem).toBeDefined();
   expect(startItem?.enabled).toBeTruthy();
+});
+
+test('Tray provider start or stop should not be visible when provider has no lifecycle methods', () => {
+  const menuBuild = vi.spyOn(Menu, 'buildFromTemplate');
+
+  trayMenu = new TrayMenu(tray, animatedTray);
+
+  trayMenu.addProviderItems({
+    id: 'testId',
+    name: 'TestProv',
+    internalId: 'internalId',
+    status: 'configured',
+  } as ProviderInfo);
+
+  const startItem = (menuBuild.mock.lastCall?.[0]?.[0]?.submenu as Array<MenuItemConstructorOptions>)?.find(
+    it => it.label === 'Start',
+  );
+  expect(startItem).toBeUndefined();
+
+  const stopItem = (menuBuild.mock.lastCall?.[0]?.[0]?.submenu as Array<MenuItemConstructorOptions>)?.find(
+    it => it.label === 'Stop',
+  );
+  expect(stopItem).toBeUndefined();
 });
 
 test('Tray click trigger is only added on Windows devices', () => {

--- a/packages/main/src/tray-menu.ts
+++ b/packages/main/src/tray-menu.ts
@@ -321,22 +321,24 @@ export class TrayMenu {
       submenu: [],
     };
 
-    (result.submenu as MenuItemConstructorOptions[]).push({
-      label: 'Start',
-      enabled: item.status === 'stopped' || item.status === 'configured',
-      click: () => {
-        this.sendItemClick({ action: 'Start', providerInfo: item });
-      },
-    });
+    if ((item.lifecycleMethods ?? []).length > 0) {
+      (result.submenu as MenuItemConstructorOptions[]).push({
+        label: 'Start',
+        enabled: item.status === 'stopped' || item.status === 'configured',
+        click: () => {
+          this.sendItemClick({ action: 'Start', providerInfo: item });
+        },
+      });
 
-    (result.submenu as MenuItemConstructorOptions[]).push({
-      label: 'Stop',
-      enabled: item.status === 'started',
-      click: () => {
-        this.sendItemClick({ action: 'Stop', providerInfo: item });
-      },
-    });
-    (result.submenu as MenuItemConstructorOptions[]).push({ type: 'separator' });
+      (result.submenu as MenuItemConstructorOptions[]).push({
+        label: 'Stop',
+        enabled: item.status === 'started',
+        click: () => {
+          this.sendItemClick({ action: 'Stop', providerInfo: item });
+        },
+      });
+      (result.submenu as MenuItemConstructorOptions[]).push({ type: 'separator' });
+    }
 
     if (item.childItems.length > 0) {
       (result.submenu as MenuItemConstructorOptions[]).push(...item.childItems);


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR adds a `provider:update-status` event to be sent to provider listeners upon provider status update so that the provider status will be updated accordingly in the tray menu. It also check for existing provider lifecycle methods to add the start and stop options to the trey menu.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Fixes https://github.com/podman-desktop/podman-desktop/issues/13615

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

1. Download the OpenShift Local ext
2. Make sure the OpenShift Local provider is visible in the tray menu with 5 actions in the submenu (without start and stop since this provider doesn't have lifecycle methods registered)
3. Create an OpenShift Local instance and check that the provider status changes based on the state of the instance (starting, running, etc). You might need to close and reopen the tray menu to see the updated status

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
