### PR TITLE
chore(renderer): rename the `Play Kubernetes YAML` by `Podman Kube Play`

### DIFF
--- a/packages/renderer/src/lib/kube/PodmanKubePlay.spec.ts
+++ b/packages/renderer/src/lib/kube/PodmanKubePlay.spec.ts
@@ -1,0 +1,73 @@
+/*********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render } from '@testing-library/svelte';
+import { router } from 'tinro';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import PodmanKubePlay from './PodmanKubePlay.svelte';
+
+// Mock the router
+vi.mock('tinro', () => ({
+  router: {
+    goto: vi.fn(),
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test('Expect button to be visible with correct text and title', () => {
+  const { getByRole } = render(PodmanKubePlay);
+
+  const button = getByRole('button', { name: 'Podman Kube Play' });
+  expect(button).toBeInTheDocument();
+  expect(button).toHaveTextContent('Podman Kube Play');
+  expect(button).toHaveAttribute('title', 'Create containers, pods and volumes based on Kubernetes YAML');
+});
+
+test('Expect button to have the KubePlay icon', () => {
+  const { getByRole } = render(PodmanKubePlay);
+
+  const button = getByRole('button', { name: 'Podman Kube Play' });
+  expect(button).toBeInTheDocument();
+
+  // Check that the icon is present (looking for SVG element inside the button)
+  const svg = button.querySelector('svg');
+  expect(svg).toBeInTheDocument();
+});
+
+test('Expect click on button to navigate to kube play page', async () => {
+  const { getByRole } = render(PodmanKubePlay);
+
+  const button = getByRole('button', { name: 'Podman Kube Play' });
+  expect(button).toBeInTheDocument();
+
+  // Verify router.goto hasn't been called yet
+  expect(router.goto).not.toHaveBeenCalled();
+
+  // Click the button
+  await fireEvent.click(button);
+
+  // Verify navigation was triggered
+  expect(router.goto).toHaveBeenCalledWith('/kube/play');
+  expect(router.goto).toHaveBeenCalledTimes(1);
+});

--- a/packages/renderer/src/lib/kube/PodmanKubePlay.spec.ts
+++ b/packages/renderer/src/lib/kube/PodmanKubePlay.spec.ts
@@ -44,17 +44,6 @@ test('Expect button to be visible with correct text and title', () => {
   expect(button).toHaveAttribute('title', 'Create containers, pods and volumes based on Kubernetes YAML');
 });
 
-test('Expect button to have the KubePlay icon', () => {
-  const { getByRole } = render(PodmanKubePlay);
-
-  const button = getByRole('button', { name: 'Podman Kube Play' });
-  expect(button).toBeInTheDocument();
-
-  // Check that the icon is present (looking for SVG element inside the button)
-  const svg = button.querySelector('svg');
-  expect(svg).toBeInTheDocument();
-});
-
 test('Expect click on button to navigate to kube play page', async () => {
   const { getByRole } = render(PodmanKubePlay);
 

--- a/packages/renderer/src/lib/kube/PodmanKubePlay.svelte
+++ b/packages/renderer/src/lib/kube/PodmanKubePlay.svelte
@@ -9,6 +9,6 @@ function runContainerYaml(): void {
 }
 </script>
 
-<Button on:click={runContainerYaml} title="Play pod/containers from kubernetes YAML file" icon={KubePlayIcon}>
-  Play Kubernetes YAML
+<Button onclick={runContainerYaml} title="Create containers, pods and volumes based on Kubernetes YAML" icon={KubePlayIcon}>
+  Podman Kube Play
 </Button>

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -20,7 +20,7 @@ import type { EngineInfoUI } from '../engine/EngineInfoUI';
 import Prune from '../engine/Prune.svelte';
 import NoContainerEngineEmptyScreen from '../image/NoContainerEngineEmptyScreen.svelte';
 import PodIcon from '../images/PodIcon.svelte';
-import KubePlayButton from '../kube/KubePlayButton.svelte';
+import PodmanKubePlay from '../kube/PodmanKubePlay.svelte';
 import { PodUtils } from './pod-utils';
 import PodColumnActions from './PodColumnActions.svelte';
 import PodColumnContainers from './PodColumnContainers.svelte';
@@ -161,7 +161,7 @@ const row = new TableRow<PodInfoUI>({ selectable: (_pod): boolean => true });
       <Prune type="pods" engines={enginesList} />
     {/if}
     {#if providerPodmanConnections.length > 0}
-      <KubePlayButton />
+      <PodmanKubePlay />
     {/if}
   {/snippet}
 

--- a/tests/playwright/src/model/pages/containers-page.ts
+++ b/tests/playwright/src/model/pages/containers-page.ts
@@ -28,7 +28,6 @@ import { MainPage } from './main-page';
 export class ContainersPage extends MainPage {
   readonly pruneContainersButton: Locator;
   readonly createContainerButton: Locator;
-  readonly playKubernetesYAMLButton: Locator;
   readonly pruneConfirmationButton: Locator;
   readonly runAllContainersButton: Locator;
 
@@ -39,9 +38,6 @@ export class ContainersPage extends MainPage {
     });
     this.createContainerButton = this.additionalActions.getByRole('button', {
       name: 'Create',
-    });
-    this.playKubernetesYAMLButton = this.additionalActions.getByRole('button', {
-      name: 'Play Kubernetes YAML',
     });
     this.pruneConfirmationButton = this.page.getByRole('button', {
       name: 'Yes',

--- a/tests/playwright/src/model/pages/play-kube-yaml-page.ts
+++ b/tests/playwright/src/model/pages/play-kube-yaml-page.ts
@@ -64,7 +64,7 @@ export class PlayKubeYamlPage extends BasePage {
       kubernetesContext: 'kind-kind-cluster',
     },
   ): Promise<PodsPage> {
-    return test.step('Play Kubernetes YAML', async () => {
+    return test.step('Podman Kube Play', async () => {
       if (!pathToYaml) {
         throw Error(`Path to Yaml file is incorrect or not provided!`);
       }

--- a/tests/playwright/src/model/pages/pods-page.ts
+++ b/tests/playwright/src/model/pages/pods-page.ts
@@ -25,13 +25,13 @@ import { PlayKubeYamlPage } from './play-kube-yaml-page';
 import { PodDetailsPage } from './pods-details-page';
 
 export class PodsPage extends MainPage {
-  readonly playKubernetesYAMLButton: Locator;
+  readonly podmanKubePlayButton: Locator;
   readonly prunePodsButton: Locator;
   readonly pruneConfirmationButton: Locator;
 
   constructor(page: Page) {
     super(page, 'pods');
-    this.playKubernetesYAMLButton = this.page.getByRole('button', {
+    this.podmanKubePlayButton = this.page.getByRole('button', {
       name: 'Podman Kube Play',
     });
     this.prunePodsButton = this.page.getByRole('button', { name: 'Prune' });
@@ -61,10 +61,10 @@ export class PodsPage extends MainPage {
     return (await this.getPodRowByName(name)) !== undefined;
   }
 
-  async openPlayKubeYaml(): Promise<PlayKubeYamlPage> {
-    return test.step('Open Play Kubernetes YAML', async () => {
-      await playExpect(this.playKubernetesYAMLButton).toBeEnabled();
-      await this.playKubernetesYAMLButton.click();
+  async openPodmanKubePlay(): Promise<PlayKubeYamlPage> {
+    return test.step('Open Podman Kube Play', async () => {
+      await playExpect(this.podmanKubePlayButton).toBeEnabled();
+      await this.podmanKubePlayButton.click();
       return new PlayKubeYamlPage(this.page);
     });
   }

--- a/tests/playwright/src/model/pages/pods-page.ts
+++ b/tests/playwright/src/model/pages/pods-page.ts
@@ -32,7 +32,7 @@ export class PodsPage extends MainPage {
   constructor(page: Page) {
     super(page, 'pods');
     this.playKubernetesYAMLButton = this.page.getByRole('button', {
-      name: 'Play Kubernetes YAML',
+      name: 'Podman Kube Play',
     });
     this.prunePodsButton = this.page.getByRole('button', { name: 'Prune' });
     this.pruneConfirmationButton = this.page.getByRole('button', {

--- a/tests/playwright/src/specs/play-yaml-build-smoke.spec.ts
+++ b/tests/playwright/src/specs/play-yaml-build-smoke.spec.ts
@@ -57,7 +57,7 @@ test.describe.serial('Deploy pod via Play YAML using locally built image', { tag
   test('Deploy pod from YAML using build option and verify it is running', async ({ navigationBar }) => {
     const podsPage = await navigationBar.openPods();
     await playExpect(podsPage.heading).toBeVisible();
-    const playYamlPage = await podsPage.openPlayKubeYaml();
+    const playYamlPage = await podsPage.openPodmanKubePlay();
     await playExpect(playYamlPage.heading).toBeVisible();
 
     await playYamlPage.playYaml(POD_YAML_PATH, true);

--- a/tests/playwright/src/specs/yaml-smoke.spec.ts
+++ b/tests/playwright/src/specs/yaml-smoke.spec.ts
@@ -56,7 +56,7 @@ test.describe.serial(`Play yaml file to pull images and create pod for app ${pod
     let podsPage = await navigationBar.openPods();
     await playExpect(podsPage.heading).toBeVisible();
 
-    const playYamlPage = await podsPage.openPlayKubeYaml();
+    const playYamlPage = await podsPage.openPodmanKubePlay();
     await playExpect(playYamlPage.heading).toBeVisible();
 
     const yamlFilePath = path.resolve(__dirname, '..', '..', 'resources', `${podAppName}.yaml`);

--- a/tests/playwright/src/utility/kubernetes.ts
+++ b/tests/playwright/src/utility/kubernetes.ts
@@ -138,7 +138,7 @@ export async function applyYamlFileToCluster(
     const podsPage = await navigationBar.openPods();
 
     await playExpect(podsPage.heading).toBeVisible();
-    const playYamlPage = await podsPage.openPlayKubeYaml();
+    const playYamlPage = await podsPage.openPodmanKubePlay();
     await playExpect(playYamlPage.heading).toBeVisible();
     return await playYamlPage.playYaml(resourceYamlPath, false, 180_000, kubernetesRuntime);
   });


### PR DESCRIPTION
### What does this PR do?

Part of https://github.com/podman-desktop/podman-desktop/issues/13753. 

The `Play Kubernetes YAML` is a feature specific to Podman, the real podman command is `podman kube play`. To avoid user confusion, and make the UI closer to the Podman implementation, renaming this button to `Podman Kube Play` and improving the title tooltip to use the description from https://docs.podman.io/en/latest/markdown/podman-kube-play.1.html

### Screenshot / video of UI

<img width="434" height="280" alt="image" src="https://github.com/user-attachments/assets/0321ae9e-15f7-4c01-8aaf-2c3fbab2aff1" />

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/13974

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] I added unit test for the component in a separate commit ( https://github.com/podman-desktop/podman-desktop/commit/ad957dadd07f7e6a224bd908b272d5d54400d6ae )
- [x]  playwright tests have been updated to use the new name
