### PR TITLE
fix: wrong behaviour expanding preferences menu from expander icon

### DIFF
--- a/packages/ui/src/lib/settingsNavItem/SettingsNavItem.svelte
+++ b/packages/ui/src/lib/settingsNavItem/SettingsNavItem.svelte
@@ -66,7 +66,7 @@ function click(): void {
       <span>{title}</span>
     </span>
     {#if section}
-      <div class="px-2 relative w-4 h-4 text-[color:var(--pd-secondary-nav-expander)]">
+      <div class="px-2 relative w-4 h-4 text-[color:var(--pd-secondary-nav-expander)] pointer-events-none">
         {#if expanded}
           <Icon icon='fas fa-angle-down' class="text-md absolute left-0 top-0.5 transform origin-center transition-transform duration-200 -rotate-90" />
         {:else}


### PR DESCRIPTION
### What does this PR do?

This PR fixes a memory leak when clicking settings navigation expander icon. Icon's CSS positioning created duplicate event handling. Added de class `pointer-events-none` to ensure the click is handle by parent element.

### Screenshot / video of UI

### What issues does this PR fix or reference?

closes #13731

### How to test this PR?

1- Compile podman-desktop
2- Go to Settings.
3- To the right of the "Preferences" text, click the arrow.
4- The section must expands with any issue.

- [ ] Tests are covering the bug fix or the new feature
