### PR TITLE
chore: load 'managed by' default-settings.json into configuration scope

### DIFF
--- a/packages/api/src/configuration/constants.ts
+++ b/packages/api/src/configuration/constants.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,3 +18,4 @@
 
 export const CONFIGURATION_DEFAULT_SCOPE = 'DEFAULT';
 export const CONFIGURATION_ONBOARDING_SCOPE = 'Onboarding';
+export const CONFIGURATION_SYSTEM_MANAGED_DEFAULTS_SCOPE = 'MANAGED_DEFAULTS';

--- a/packages/main/src/plugin/appearance-init.spec.ts
+++ b/packages/main/src/plugin/appearance-init.spec.ts
@@ -25,6 +25,7 @@ import type { ApiSenderType } from './api.js';
 import { AppearanceInit } from './appearance-init.js';
 import { AppearanceSettings } from './appearance-settings.js';
 import { ConfigurationRegistry } from './configuration-registry.js';
+import type { DefaultConfiguration } from './default-configuration.js';
 import type { Directories } from './directories.js';
 
 let configurationRegistry: ConfigurationRegistry;
@@ -42,7 +43,7 @@ const apiSender: ApiSenderType = {
 
 /* eslint-disable @typescript-eslint/no-empty-function */
 beforeAll(() => {
-  configurationRegistry = new ConfigurationRegistry({} as ApiSenderType, {} as Directories);
+  configurationRegistry = new ConfigurationRegistry({} as ApiSenderType, {} as Directories, {} as DefaultConfiguration);
   configurationRegistry.registerConfigurations = vi.fn();
   configurationRegistry.deregisterConfigurations = vi.fn();
 });

--- a/packages/main/src/plugin/autostart-engine.spec.ts
+++ b/packages/main/src/plugin/autostart-engine.spec.ts
@@ -25,6 +25,7 @@ import type { IConfigurationNode } from '/@api/configuration/models.js';
 
 import { AutostartEngine } from './autostart-engine.js';
 import { ConfigurationRegistry } from './configuration-registry.js';
+import type { DefaultConfiguration } from './default-configuration.js';
 import type { Directories } from './directories.js';
 import type { ProviderRegistry } from './provider-registry.js';
 
@@ -44,7 +45,7 @@ beforeEach(() => {
 
 /* eslint-disable @typescript-eslint/no-empty-function */
 beforeAll(() => {
-  configurationRegistry = new ConfigurationRegistry({} as ApiSenderType, {} as Directories);
+  configurationRegistry = new ConfigurationRegistry({} as ApiSenderType, {} as Directories, {} as DefaultConfiguration);
   providerRegistry = {} as unknown as ProviderRegistry;
   autostartEngine = new AutostartEngine(configurationRegistry, providerRegistry);
   configurationRegistry.registerConfigurations = mockRegisterConfiguration;

--- a/packages/main/src/plugin/close-behavior.spec.ts
+++ b/packages/main/src/plugin/close-behavior.spec.ts
@@ -22,6 +22,7 @@ import type { ApiSenderType } from '/@/plugin/api.js';
 import * as util from '../util.js';
 import { CloseBehavior } from './close-behavior.js';
 import { ConfigurationRegistry } from './configuration-registry.js';
+import type { DefaultConfiguration } from './default-configuration.js';
 import type { Directories } from './directories.js';
 
 vi.mock('./util', () => {
@@ -34,7 +35,7 @@ let closeBehavior: CloseBehavior;
 let configurationRegistry: ConfigurationRegistry;
 
 beforeEach(() => {
-  configurationRegistry = new ConfigurationRegistry({} as ApiSenderType, {} as Directories);
+  configurationRegistry = new ConfigurationRegistry({} as ApiSenderType, {} as Directories, {} as DefaultConfiguration);
   closeBehavior = new CloseBehavior(configurationRegistry);
 });
 

--- a/packages/main/src/plugin/configuration-impl.spec.ts
+++ b/packages/main/src/plugin/configuration-impl.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,11 @@
 
 import type * as containerDesktopAPI from '@podman-desktop/api';
 import { beforeEach, expect, test, vi } from 'vitest';
+
+import {
+  CONFIGURATION_DEFAULT_SCOPE,
+  CONFIGURATION_SYSTEM_MANAGED_DEFAULTS_SCOPE,
+} from '/@api/configuration/constants.js';
 
 import type { ApiSenderType } from './api.js';
 import { ConfigurationImpl } from './configuration-impl.js';
@@ -91,4 +96,131 @@ test('Uses localKey when deleting values', async () => {
     key: 'prefix.key',
     value: undefined,
   });
+});
+
+test('should return value from configuration when present', () => {
+  // Create the "scope" of the configuration
+  const map = new Map<string, { [key: string]: unknown }>();
+  map.set(CONFIGURATION_DEFAULT_SCOPE, { 'test.section.key': 'testValue' });
+
+  // Should return it fine
+  const config = new ConfigurationImpl(
+    { send: vi.fn() } as unknown as ApiSenderType,
+    vi.fn(),
+    map,
+    'test.section',
+    CONFIGURATION_DEFAULT_SCOPE,
+  );
+
+  const result = config.get<string>('key');
+  expect(result).toBe('testValue');
+});
+
+test('should return default value when configuration value is undefined', () => {
+  // Create the scope
+  const map = new Map<string, { [key: string]: unknown }>();
+  const config = new ConfigurationImpl(
+    { send: vi.fn() } as unknown as ApiSenderType,
+    vi.fn(),
+    map,
+    'test.section',
+    CONFIGURATION_DEFAULT_SCOPE,
+  );
+
+  // Expect the value to be set correctly
+  const result = config.get<string>('nonexistent', 'defaultValue');
+  expect(result).toBe('defaultValue');
+});
+
+test('should return true when value exists', () => {
+  // Create the scope
+  const map = new Map<string, { [key: string]: unknown }>();
+  map.set(CONFIGURATION_DEFAULT_SCOPE, { 'test.section.key': 'testValue' });
+  const config = new ConfigurationImpl(
+    { send: vi.fn() } as unknown as ApiSenderType,
+    vi.fn(),
+    map,
+    'test.section',
+    CONFIGURATION_DEFAULT_SCOPE,
+  );
+
+  // Should have the value
+  const result = config.has('key');
+  expect(result).toBe(true);
+});
+
+test('should return false when value does not exist', () => {
+  // Create the scope
+  const map = new Map<string, { [key: string]: unknown }>();
+  const config = new ConfigurationImpl(
+    { send: vi.fn() } as unknown as ApiSenderType,
+    vi.fn(),
+    map,
+    'test.section',
+    CONFIGURATION_DEFAULT_SCOPE,
+  );
+
+  // Should not exist when not set
+  const result = config.has('nonexistent');
+  expect(result).toBe(false);
+});
+
+test('should return admin defaults scope for admin defaults configuration', () => {
+  // Return the defaults
+  const map = new Map<string, { [key: string]: unknown }>();
+  const config = new ConfigurationImpl(
+    { send: vi.fn() } as unknown as ApiSenderType,
+    vi.fn(),
+    map,
+    'test.section',
+    CONFIGURATION_SYSTEM_MANAGED_DEFAULTS_SCOPE,
+  );
+  expect(config.getConfigurationKey()).toBe(CONFIGURATION_SYSTEM_MANAGED_DEFAULTS_SCOPE);
+});
+
+test('should get values from admin defaults scope configuration', () => {
+  // The below section makes sure that when retrieving from a separate section (managed defaults scope), it'll work the exact same way.
+  // kind of a silly test, but it still makes sure that the constants are set fine at least.
+  const map = new Map<string, { [key: string]: unknown }>();
+  map.set(CONFIGURATION_SYSTEM_MANAGED_DEFAULTS_SCOPE, { 'test.section.key': 'adminValue' });
+
+  const config = new ConfigurationImpl(
+    { send: vi.fn() } as unknown as ApiSenderType,
+    vi.fn(),
+    map,
+    'test.section',
+    CONFIGURATION_SYSTEM_MANAGED_DEFAULTS_SCOPE,
+  );
+
+  const result = config.get<string>('key');
+  expect(result).toBe('adminValue');
+});
+
+test('if there are multiple scopes with different values, make sure we get the right one', () => {
+  // Create the scopes
+  const map = new Map<string, { [key: string]: unknown }>();
+  map.set(CONFIGURATION_DEFAULT_SCOPE, { 'test.section.key': 'defaultValue' });
+  map.set(CONFIGURATION_SYSTEM_MANAGED_DEFAULTS_SCOPE, { 'test.section.key': 'adminValue' });
+
+  // Should return it fine
+  const configDefault = new ConfigurationImpl(
+    { send: vi.fn() } as unknown as ApiSenderType,
+    vi.fn(),
+    map,
+    'test.section',
+    CONFIGURATION_DEFAULT_SCOPE,
+  );
+  const configAdmin = new ConfigurationImpl(
+    { send: vi.fn() } as unknown as ApiSenderType,
+    vi.fn(),
+    map,
+    'test.section',
+    CONFIGURATION_SYSTEM_MANAGED_DEFAULTS_SCOPE,
+  );
+
+  // Expect that we can get the values and that they are correct (we aren't grabbing from the wrong scope)
+  const resultDefault = configDefault.get<string>('key');
+  expect(resultDefault).toBe('defaultValue');
+  const resultAdmin = configAdmin.get<string>('key');
+  expect(resultAdmin).toBe('adminValue');
 });

--- a/packages/main/src/plugin/configuration-impl.ts
+++ b/packages/main/src/plugin/configuration-impl.ts
@@ -18,7 +18,10 @@
 
 import type * as containerDesktopAPI from '@podman-desktop/api';
 
-import { CONFIGURATION_DEFAULT_SCOPE } from '/@api/configuration/constants.js';
+import {
+  CONFIGURATION_DEFAULT_SCOPE,
+  CONFIGURATION_SYSTEM_MANAGED_DEFAULTS_SCOPE,
+} from '/@api/configuration/constants.js';
 import type { IConfigurationChangeEvent } from '/@api/configuration/models.js';
 
 import type { ApiSenderType } from './api.js';
@@ -153,6 +156,8 @@ export class ConfigurationImpl implements containerDesktopAPI.Configuration {
       return `container-connection:${this.scope.name}.${this.scope.endpoint.socketPath}`;
     } else if (this.isKubernetesProviderConnection(this.scope)) {
       return `kubernetes-connection:${this.scope.endpoint.apiURL}`;
+    } else if (this.scope === CONFIGURATION_SYSTEM_MANAGED_DEFAULTS_SCOPE) {
+      return CONFIGURATION_SYSTEM_MANAGED_DEFAULTS_SCOPE;
     } else {
       return CONFIGURATION_DEFAULT_SCOPE;
     }

--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -24,7 +24,10 @@ import { isDeepStrictEqual } from 'node:util';
 import type * as containerDesktopAPI from '@podman-desktop/api';
 import { inject, injectable } from 'inversify';
 
-import { CONFIGURATION_DEFAULT_SCOPE } from '/@api/configuration/constants.js';
+import {
+  CONFIGURATION_DEFAULT_SCOPE,
+  CONFIGURATION_SYSTEM_MANAGED_DEFAULTS_SCOPE,
+} from '/@api/configuration/constants.js';
 import type {
   ConfigurationScope,
   IConfigurationChangeEvent,
@@ -38,6 +41,7 @@ import type { NotificationCardOptions } from '/@api/notification.js';
 
 import { ApiSenderType } from './api.js';
 import { ConfigurationImpl } from './configuration-impl.js';
+import { DefaultConfiguration } from './default-configuration.js';
 import { Directories } from './directories.js';
 import { Emitter } from './events/emitter.js';
 import { Disposable } from './types/disposable.js';
@@ -70,6 +74,7 @@ export class ConfigurationRegistry implements IConfigurationRegistry {
     this.configurationContributors = [];
     this.configurationValues = new Map();
     this.configurationValues.set(CONFIGURATION_DEFAULT_SCOPE, {});
+    this.configurationValues.set(CONFIGURATION_SYSTEM_MANAGED_DEFAULTS_SCOPE, {});
   }
 
   protected getSettingsFile(): string {
@@ -121,6 +126,12 @@ export class ConfigurationRegistry implements IConfigurationRegistry {
       configData = {};
     }
     this.configurationValues.set(CONFIGURATION_DEFAULT_SCOPE, configData);
+
+    // Load managed defaults
+    const defaultConfiguration = new DefaultConfiguration();
+    const defaults = await defaultConfiguration.getContent();
+    this.configurationValues.set(CONFIGURATION_SYSTEM_MANAGED_DEFAULTS_SCOPE, defaults);
+
     return notifications;
   }
 

--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -69,6 +69,8 @@ export class ConfigurationRegistry implements IConfigurationRegistry {
     private apiSender: ApiSenderType,
     @inject(Directories)
     private directories: Directories,
+    @inject(DefaultConfiguration)
+    private defaultConfiguration: DefaultConfiguration,
   ) {
     this.configurationProperties = {};
     this.configurationContributors = [];
@@ -128,8 +130,7 @@ export class ConfigurationRegistry implements IConfigurationRegistry {
     this.configurationValues.set(CONFIGURATION_DEFAULT_SCOPE, configData);
 
     // Load managed defaults
-    const defaultConfiguration = new DefaultConfiguration();
-    const defaults = await defaultConfiguration.getContent();
+    const defaults = await this.defaultConfiguration.getContent();
     this.configurationValues.set(CONFIGURATION_SYSTEM_MANAGED_DEFAULTS_SCOPE, defaults);
 
     return notifications;

--- a/packages/main/src/plugin/default-configuration.spec.ts
+++ b/packages/main/src/plugin/default-configuration.spec.ts
@@ -113,12 +113,12 @@ describe('DefaultConfiguration', () => {
     error.code = 'ENOENT';
     vi.mocked(fsPromises.readFile).mockRejectedValue(error);
 
-    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const consoleSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
 
     const result = await defaultConfiguration.getContent();
 
     expect(result).toEqual({});
-    expect(consoleSpy).not.toHaveBeenCalled();
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('No managed defaults file found'));
     consoleSpy.mockRestore();
   });
 

--- a/packages/main/src/plugin/default-configuration.spec.ts
+++ b/packages/main/src/plugin/default-configuration.spec.ts
@@ -1,0 +1,148 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import * as path from 'node:path';
+
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { DefaultConfiguration } from './default-configuration.js';
+
+// mock constants
+vi.mock('/@api/configuration/constants.js', () => ({
+  SYSTEM_DEFAULTS_FILE_MAC: '/Library/Application Support/com.podman.desktop/default-settings.json',
+  SYSTEM_DEFAULTS_FILE_WINDOWS_DIR: 'PodmanDesktop',
+  SYSTEM_DEFAULTS_FILE_WINDOWS_FILE: 'default-settings.json',
+  SYSTEM_DEFAULTS_FILE_LINUX: '/usr/share/podman-desktop/default-settings.json',
+}));
+
+// mock the fs module as we don't want to check the read file / exists / promises, but rather
+vi.mock('node:fs', () => ({
+  readFileSync: vi.fn(),
+  existsSync: vi.fn(),
+  promises: {
+    readFile: vi.fn(),
+  },
+}));
+
+// mock util functions
+vi.mock('../util.js', () => ({
+  isMac: vi.fn(),
+  isWindows: vi.fn(),
+  isLinux: vi.fn(),
+}));
+
+const { isMac, isWindows, isLinux } = await import('../util.js');
+const { promises: fsPromises } = await import('node:fs');
+
+let defaultConfiguration: DefaultConfiguration;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.clearAllMocks();
+  defaultConfiguration = new DefaultConfiguration();
+});
+
+describe('DefaultConfiguration', () => {
+  test('should get correct managed defaults file path for Mac', () => {
+    vi.mocked(isMac).mockReturnValue(true);
+    vi.mocked(isWindows).mockReturnValue(false);
+    vi.mocked(isLinux).mockReturnValue(false);
+
+    const managedDefaultsFile = defaultConfiguration['getManagedDefaultsFile']();
+    expect(managedDefaultsFile).toBe('/Library/Application Support/com.podman.desktop/default-settings.json');
+  });
+
+  test('should get correct managed defaults file path for Windows', () => {
+    vi.mocked(isMac).mockReturnValue(false);
+    vi.mocked(isWindows).mockReturnValue(true);
+    vi.mocked(isLinux).mockReturnValue(false);
+
+    process.env['PROGRAMDATA'] = 'C:\\ProgramData';
+    const managedDefaultsFile = defaultConfiguration['getManagedDefaultsFile']();
+    expect(managedDefaultsFile).toBe(path.join('C:\\ProgramData', 'PodmanDesktop', 'default-settings.json'));
+  });
+
+  test('should get correct managed defaults file path for Linux', () => {
+    vi.mocked(isMac).mockReturnValue(false);
+    vi.mocked(isWindows).mockReturnValue(false);
+    vi.mocked(isLinux).mockReturnValue(true);
+
+    const managedDefaultsFile = defaultConfiguration['getManagedDefaultsFile']();
+    expect(managedDefaultsFile).toBe('/usr/share/podman-desktop/default-settings.json');
+  });
+
+  test('should fallback to Linux path for unknown platforms', () => {
+    vi.mocked(isMac).mockReturnValue(false);
+    vi.mocked(isWindows).mockReturnValue(false);
+    vi.mocked(isLinux).mockReturnValue(false);
+
+    const managedDefaultsFile = defaultConfiguration['getManagedDefaultsFile']();
+    expect(managedDefaultsFile).toBe('/usr/share/podman-desktop/default-settings.json');
+  });
+
+  test('should load managed defaults when file exists', async () => {
+    const managedDefaults = { 'managed.setting': 'managedValue' };
+    vi.mocked(fsPromises.readFile).mockResolvedValue(JSON.stringify(managedDefaults));
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const result = await defaultConfiguration.getContent();
+
+    expect(result).toEqual(managedDefaults);
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Loaded managed defaults from:'));
+    consoleSpy.mockRestore();
+  });
+
+  test('should handle missing managed defaults file gracefully', async () => {
+    const error = new Error('ENOENT: no such file or directory') as NodeJS.ErrnoException;
+    error.code = 'ENOENT';
+    vi.mocked(fsPromises.readFile).mockRejectedValue(error);
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const result = await defaultConfiguration.getContent();
+
+    expect(result).toEqual({});
+    expect(consoleSpy).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  test('should handle corrupted managed defaults file gracefully', async () => {
+    vi.mocked(fsPromises.readFile).mockResolvedValue('invalid json');
+
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await defaultConfiguration.getContent();
+
+    expect(result).toEqual({});
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to parse managed defaults from'),
+      expect.anything(),
+    );
+    consoleErrorSpy.mockRestore();
+  });
+
+  test('should load managed defaults configuration with valid JSON', async () => {
+    const managedDefaults = { 'managed.setting': 'managedValue', 'another.setting': 'anotherValue' };
+    vi.mocked(fsPromises.readFile).mockResolvedValue(JSON.stringify(managedDefaults));
+
+    const result = await defaultConfiguration.getContent();
+
+    expect(result).toEqual(managedDefaults);
+  });
+});

--- a/packages/main/src/plugin/default-configuration.spec.ts
+++ b/packages/main/src/plugin/default-configuration.spec.ts
@@ -16,28 +16,16 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { promises as fsPromises } from 'node:fs';
 import * as path from 'node:path';
 
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
+import { isLinux, isMac, isWindows } from '../util.js';
 import { DefaultConfiguration } from './default-configuration.js';
 
-// mock constants
-vi.mock('/@api/configuration/constants.js', () => ({
-  SYSTEM_DEFAULTS_FILE_MAC: '/Library/Application Support/com.podman.desktop/default-settings.json',
-  SYSTEM_DEFAULTS_FILE_WINDOWS_DIR: 'PodmanDesktop',
-  SYSTEM_DEFAULTS_FILE_WINDOWS_FILE: 'default-settings.json',
-  SYSTEM_DEFAULTS_FILE_LINUX: '/usr/share/podman-desktop/default-settings.json',
-}));
-
 // mock the fs module as we don't want to check the read file / exists / promises, but rather
-vi.mock('node:fs', () => ({
-  readFileSync: vi.fn(),
-  existsSync: vi.fn(),
-  promises: {
-    readFile: vi.fn(),
-  },
-}));
+vi.mock(import('node:fs'));
 
 // mock util functions
 vi.mock('../util.js', () => ({
@@ -45,9 +33,6 @@ vi.mock('../util.js', () => ({
   isWindows: vi.fn(),
   isLinux: vi.fn(),
 }));
-
-const { isMac, isWindows, isLinux } = await import('../util.js');
-const { promises: fsPromises } = await import('node:fs');
 
 let defaultConfiguration: DefaultConfiguration;
 

--- a/packages/main/src/plugin/default-configuration.ts
+++ b/packages/main/src/plugin/default-configuration.ts
@@ -17,37 +17,23 @@
  ***********************************************************************/
 
 import * as fs from 'node:fs';
-import { join } from 'node:path';
+import * as path from 'node:path';
 
-import {
-  SYSTEM_DEFAULTS_FILE_LINUX,
-  SYSTEM_DEFAULTS_FILE_MAC,
-  SYSTEM_DEFAULTS_FILE_WINDOWS_DIR,
-  SYSTEM_DEFAULTS_FILE_WINDOWS_FILE,
-} from '/@api/configuration/system-defaults.js';
+import { inject, injectable } from 'inversify';
 
-import { isLinux, isMac, isWindows } from '../util.js';
+import { Directories } from './directories.js';
+import { SYSTEM_DEFAULTS_FILENAME } from './managed-by-constants.js';
 
+@injectable()
 export class DefaultConfiguration {
-  // If all else fails, we will fallback to Linux-style path as it's the most "generic" and
-  // likely to work in more environments where the OS isn't detected properly, such as "unix-like"
-  // platforms like FreeBSD, etc.
-  protected getManagedDefaultsFile(): string {
-    if (isMac()) {
-      return SYSTEM_DEFAULTS_FILE_MAC;
-    } else if (isWindows()) {
-      const programData = process.env['PROGRAMDATA'] ?? 'C:\\ProgramData';
-      return join(programData, SYSTEM_DEFAULTS_FILE_WINDOWS_DIR, SYSTEM_DEFAULTS_FILE_WINDOWS_FILE);
-    } else if (isLinux()) {
-      return SYSTEM_DEFAULTS_FILE_LINUX;
-    }
-    // Fallback to Linux-style path
-    return SYSTEM_DEFAULTS_FILE_LINUX;
-  }
+  constructor(
+    @inject(Directories)
+    private directories: Directories,
+  ) {}
 
   public async getContent(): Promise<{ [key: string]: unknown }> {
-    // "Create" the managed defaults file
-    const managedDefaultsFile = this.getManagedDefaultsFile();
+    // Get the managed defaults file path from directories
+    const managedDefaultsFile = path.join(this.directories.getManagedDefaultsDirectory(), SYSTEM_DEFAULTS_FILENAME);
     let managedDefaultsData = {};
 
     // It's important that we at least log to console what is happening here, as it's common for logs

--- a/packages/main/src/plugin/default-configuration.ts
+++ b/packages/main/src/plugin/default-configuration.ts
@@ -57,7 +57,13 @@ export class DefaultConfiguration {
       managedDefaultsData = JSON.parse(managedDefaultsContent);
       console.log(`[Managed-by]: Loaded managed defaults from: ${managedDefaultsFile}`);
     } catch (error) {
-      console.error(`[Managed-by]: Failed to parse managed defaults from ${managedDefaultsFile}:`, error);
+      // Handle file-not-found errors gracefully - this is expected when no managed config exists
+      if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+        console.debug(`[Managed-by]: No managed defaults file found at ${managedDefaultsFile}`);
+      } else {
+        // For other errors (like JSON parse errors), log as error
+        console.error(`[Managed-by]: Failed to parse managed defaults from ${managedDefaultsFile}:`, error);
+      }
     }
 
     return managedDefaultsData;

--- a/packages/main/src/plugin/default-configuration.ts
+++ b/packages/main/src/plugin/default-configuration.ts
@@ -1,0 +1,65 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import {
+  SYSTEM_DEFAULTS_FILE_LINUX,
+  SYSTEM_DEFAULTS_FILE_MAC,
+  SYSTEM_DEFAULTS_FILE_WINDOWS_DIR,
+  SYSTEM_DEFAULTS_FILE_WINDOWS_FILE,
+} from '/@api/configuration/system-defaults.js';
+
+import { isLinux, isMac, isWindows } from '../util.js';
+
+export class DefaultConfiguration {
+  // If all else fails, we will fallback to Linux-style path as it's the most "generic" and
+  // likely to work in more environments where the OS isn't detected properly, such as "unix-like"
+  // platforms like FreeBSD, etc.
+  protected getManagedDefaultsFile(): string {
+    if (isMac()) {
+      return SYSTEM_DEFAULTS_FILE_MAC;
+    } else if (isWindows()) {
+      const programData = process.env['PROGRAMDATA'] ?? 'C:\\ProgramData';
+      return path.join(programData, SYSTEM_DEFAULTS_FILE_WINDOWS_DIR, SYSTEM_DEFAULTS_FILE_WINDOWS_FILE);
+    } else if (isLinux()) {
+      return SYSTEM_DEFAULTS_FILE_LINUX;
+    }
+    // Fallback to Linux-style path
+    return SYSTEM_DEFAULTS_FILE_LINUX;
+  }
+
+  public async getContent(): Promise<{ [key: string]: unknown }> {
+    // "Create" the managed defaults file
+    const managedDefaultsFile = this.getManagedDefaultsFile();
+    let managedDefaultsData = {};
+
+    // It's important that we at least log to console what is happening here, as it's common for logs
+    // to be shared when there are issues loading "managed-by" defaults, so having this information in the logs is useful.
+    try {
+      const managedDefaultsContent = await fs.promises.readFile(managedDefaultsFile, 'utf-8');
+      managedDefaultsData = JSON.parse(managedDefaultsContent);
+      console.log(`[Managed-by]: Loaded managed defaults from: ${managedDefaultsFile}`);
+    } catch (error) {
+      console.error(`[Managed-by]: Failed to parse managed defaults from ${managedDefaultsFile}:`, error);
+    }
+
+    return managedDefaultsData;
+  }
+}

--- a/packages/main/src/plugin/default-configuration.ts
+++ b/packages/main/src/plugin/default-configuration.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import * as fs from 'node:fs';
-import * as path from 'node:path';
+import { join } from 'node:path';
 
 import {
   SYSTEM_DEFAULTS_FILE_LINUX,
@@ -37,7 +37,7 @@ export class DefaultConfiguration {
       return SYSTEM_DEFAULTS_FILE_MAC;
     } else if (isWindows()) {
       const programData = process.env['PROGRAMDATA'] ?? 'C:\\ProgramData';
-      return path.join(programData, SYSTEM_DEFAULTS_FILE_WINDOWS_DIR, SYSTEM_DEFAULTS_FILE_WINDOWS_FILE);
+      return join(programData, SYSTEM_DEFAULTS_FILE_WINDOWS_DIR, SYSTEM_DEFAULTS_FILE_WINDOWS_FILE);
     } else if (isLinux()) {
       return SYSTEM_DEFAULTS_FILE_LINUX;
     }

--- a/packages/main/src/plugin/docker/docker-compatibility.spec.ts
+++ b/packages/main/src/plugin/docker/docker-compatibility.spec.ts
@@ -28,6 +28,7 @@ import type { ProviderInfo } from '/@api/provider-info.js';
 import * as util from '../../util.js';
 import type { ApiSenderType } from '../api.js';
 import { ConfigurationRegistry } from '../configuration-registry.js';
+import type { DefaultConfiguration } from '../default-configuration.js';
 import type { Directories } from '../directories.js';
 import type { ProviderRegistry } from '../provider-registry.js';
 import { DockerCompatibility } from './docker-compatibility.js';
@@ -78,7 +79,7 @@ vi.mock('../../util', () => {
 
 /* eslint-disable @typescript-eslint/no-empty-function */
 beforeAll(() => {
-  configurationRegistry = new ConfigurationRegistry({} as ApiSenderType, {} as Directories);
+  configurationRegistry = new ConfigurationRegistry({} as ApiSenderType, {} as Directories, {} as DefaultConfiguration);
   configurationRegistry.registerConfigurations = vi.fn();
   configurationRegistry.deregisterConfigurations = vi.fn();
 });

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -152,6 +152,7 @@ import { ContainerProviderRegistry } from './container-registry.js';
 import { Context } from './context/context.js';
 import { ContributionManager } from './contribution-manager.js';
 import { CustomPickRegistry } from './custompick/custompick-registry.js';
+import { DefaultConfiguration } from './default-configuration.js';
 import { DialogRegistry } from './dialog-registry.js';
 import { Directories } from './directories.js';
 import { LegacyDirectories } from './directories-legacy.js';
@@ -483,6 +484,7 @@ export class PluginSystem {
     const safeStorageRegistry = container.get<SafeStorageRegistry>(SafeStorageRegistry);
     notifications.push(...(await safeStorageRegistry.init()));
 
+    container.bind<DefaultConfiguration>(DefaultConfiguration).toSelf().inSingletonScope();
     container.bind<ConfigurationRegistry>(ConfigurationRegistry).toSelf().inSingletonScope();
     container.bind<IConfigurationRegistry>(IConfigurationRegistry).toService(ConfigurationRegistry);
     const configurationRegistry = await this.initConfigurationRegistry(

--- a/packages/main/src/plugin/proxy.spec.ts
+++ b/packages/main/src/plugin/proxy.spec.ts
@@ -31,6 +31,7 @@ import type { IDisposable } from '/@api/disposable.js';
 import { ProxyState } from '/@api/proxy.js';
 
 import type { ApiSenderType } from './api.js';
+import type { DefaultConfiguration } from './default-configuration.js';
 import type { Directories } from './directories.js';
 import { getProxySettingsFromSystem } from './proxy-system.js';
 
@@ -77,10 +78,15 @@ const directories = {
   getContributionStorageDir: () => '/fake-contribution-storage-directory',
   getSafeStorageDirectory: () => '/fake-safe-storage-directory',
   getDataDirectory: () => '/fake-data-directory',
+  getManagedDefaultsDirectory: () => '/fake-managed-defaults-directory',
 } as unknown as Directories;
 
+const defaultConfiguration = {
+  getContent: vi.fn().mockResolvedValue({}),
+} as unknown as DefaultConfiguration;
+
 function getConfigurationRegistry(): ConfigurationRegistry {
-  return new ConfigurationRegistry(apiSender, directories);
+  return new ConfigurationRegistry(apiSender, directories, defaultConfiguration);
 }
 
 async function buildProxy(): Promise<ProxyServer> {


### PR DESCRIPTION
chore: load 'managed by' default-settings.json into configuration scope

### What does this PR do?

Part of the epic: https://github.com/podman-desktop/podman-desktop/issues/13898 to support
a managed configuration.

This PR will load a "managed by" default settings from a pre-defined file on the user's OS. These are listed in the issue: https://github.com/podman-desktop/podman-desktop/issues/13894

Mac: `/Library/Application\ Support/com.podman.desktop/default-settings.json`
Windows: `%PROGRAMDATA%\PodmanDesktop\default-settings.json`
Linux: `/usr/share/podman-desktop/default-settings.json`



This will then load it into a separate getConfiguration scope.
(MANAGED_DEFAULTS).

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A, this is internal code and no screenshots.

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/podman-desktop/issues/13894

### How to test this PR?

1. Create a separate "managed" configuration file.

Mac: `/Library/Application
Support/com.podman.desktop/default-settings.json`

By copying over your current one to see values change:

```
sudo  cp ~/.local/share/containers/podman-desktop/configuration/settings.json /Library/Application\ Support/com.podman.desktop/default-settings.json
```

2. Edit some "renderer" code to see if you can "get" the configuration
   through the scope. For example:
   `packages/renderer/src/lib/dashbvoard/DashboardPage.svelte`

```ts
onMount(async () => {
  try {
    console.log('Configuration scopes:', {
      DEFAULT: CONFIGURATION_DEFAULT_SCOPE,
      MANAGED_DEFAULTS: CONFIGURATION_MANAGED_DEFAULTS_SCOPE
    });

    // Show how configuration values can be fetched from default as well as managed default scopes
    const defaultScopeValue = await window.getConfigurationValue<string>('welcome.version', CONFIGURATION_DEFAULT_SCOPE);
    const managedScopeValue = await window.getConfigurationValue<string>('welcome.version', CONFIGURATION_MANAGED_DEFAULTS_SCOPE);
    console.log('Default scope value:', defaultScopeValue);
    console.log('Admin default scope value:', managedScopeValue);

  } catch (error) {
    console.error('Error fetching configuration values:', error);
  }
});
```

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
