### PR TITLE
chore(renderer): migrate tooltip.svelte to svelte 5

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
@@ -237,7 +237,7 @@ function getLoggerHandler(_cliToolId: string): ConnectionCallback {
         {#if cliTool.version}
           <div
             class="flex flex-row justify-between align-center bg-[var(--pd-invert-content-bg)] p-2 rounded-lg min-w-[320px] w-fit">
-            <Tooltip area-label="cli-full-path" bottomRight={true} tip="Path: {cliTool.path}">
+            <Tooltip aria-label="cli-full-path" bottomRight={true} tip="Path: {cliTool.path}">
               <div
                 class="flex text-[var(--pd-invert-content-card-text)] font-bold text-sm items-center"
                 aria-label="cli-version">

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -340,11 +340,15 @@ async function connect(contextName: string): Promise<void> {
                       <div class="ml-1 text-xs text-[var(--pd-status-dead)]" aria-label="Error">
                         <Tooltip>
                           <div>ERROR</div>
-                          <div slot="tip" class="p-2">
-                            {#each context.errorMessage.split('\n').filter(l => l) as line, index (index)}
-                              <p>{line}</p>
-                            {/each}
+                          {#snippet tipSnippet()}
+                          <div class="p-2">
+                            {#if context.errorMessage}
+                              {#each context.errorMessage.split('\n').filter(l => l) as line, index (index)}
+                                <p>{line}</p>
+                              {/each}
+                            {/if}
                           </div>
+                          {/snippet}
                         </Tooltip>
                       </div>
                     {:else}

--- a/packages/renderer/src/lib/statusbar/ProviderWidget.svelte
+++ b/packages/renderer/src/lib/statusbar/ProviderWidget.svelte
@@ -38,22 +38,24 @@ let connections = $derived.by(() => {
 </script>
 
 <Tooltip top={!tooltipTopRight} topRight={tooltipTopRight} class="mb-[20px]">
-  <div slot="tip" class="py-2 px-4" hidden={disableTooltip}>
-    <div class="flex flex-col">
-      {#if entry.updateInfo?.version}
-        <div class="flex flex-row h-fit pb-1">
-          Update available
-        </div>
-      {/if}
-      {#each connections as connection (connection.name)}
-        <div class="flex flex-row items-center h-fit">
-          <ProviderWidgetStatus status={connection.status} class="mr-1"/>
-          <ProviderWidgetStatusStyle status={connection.status}/>
-          : {connection.name}
-        </div>
-      {/each}
+  {#snippet tipSnippet()}
+    <div class="py-2 px-4" hidden={disableTooltip}>
+      <div class="flex flex-col">
+        {#if entry.updateInfo?.version}
+          <div class="flex flex-row h-fit pb-1">
+            Update available
+          </div>
+        {/if}
+        {#each connections as connection (connection.name)}
+          <div class="flex flex-row items-center h-fit">
+            <ProviderWidgetStatus status={connection.status} class="mr-1"/>
+            <ProviderWidgetStatusStyle status={connection.status}/>
+            : {connection.name}
+          </div>
+        {/each}
+      </div>
     </div>
-  </div>
+  {/snippet}
   <ProviderButton
     class={className}
     provider={entry}

--- a/packages/ui/MIGRATION.md
+++ b/packages/ui/MIGRATION.md
@@ -1,5 +1,9 @@
 # @podman-desktop/ui-svelte
 
+## Version 1.22
+
+- ([#14026](https://github.com/podman-desktop/podman-desktop/pull/14026))The `Tooltip` component has been migrated to Svelte 5. The `tip` prop remains unchanged for simple text tooltips. The `tip` slot has been replaced with `tipSnippet` snippet for complex HTML content. You can have a look at [this blog post](https://sveltekit.io/blog/snippets) to learn more about `slot` to `snippet` migration.
+
 ## Version 1.19
 
 - ([#12559](https://github.com/podman-desktop/podman-desktop/pull/12559)) The `breadcrumbTitle` property has been removed from the `Page`, `FormPage`, and `DetailsPage` components. You can safely remove this `breadcrumbTitle` property from the calls to these components, as its value was not used.

--- a/packages/ui/src/lib/tooltip/Tooltip.svelte
+++ b/packages/ui/src/lib/tooltip/Tooltip.svelte
@@ -1,53 +1,53 @@
 <style>
-  .tooltip.top {
-    left: 50%;
-    transform: translate(-50%, -100%);
-    margin-top: -8px;
-  }
-  .tooltip.bottom {
-    left: 50%;
-    bottom: 0;
-    transform: translate(-50%, 100%);
-    margin-bottom: -8px;
-  }
-  .tooltip.left {
-    left: 0;
-    transform: translateX(-100%);
-    margin-left: -8px;
-  }
-  .tooltip.right {
-    right: 0;
-    transform: translate(100%, -50%);
-    margin-top: -10px;
-    margin-right: -8px;
-  }
-  .tooltip.top-left {
-    left: 0;
-    transform: translate(-80%, -100%);
-    margin-top: -8px;
-  }
-  .tooltip.bottom-left {
-    left: 0;
-    bottom: 0;
-    transform: translate(-80%, 100%);
-    margin-top: -8px;
-  }
-  .tooltip.bottom-right {
-    left: 0;
-    bottom: 0;
-    transform: translate(0%, 100%);
-    margin-top: -8px;
-  }
-  .tooltip.top-right {
-    left: 0;
-    transform: translate(0%, -100%);
-    margin-top: -8px;
-  }
-  .tooltip-slot:hover + .tooltip {
-    opacity: 1;
-    visibility: initial;
-  }
-  </style>
+.tooltip.top {
+  left: 50%;
+  transform: translate(-50%, -100%);
+  margin-top: -8px;
+}
+.tooltip.bottom {
+  left: 50%;
+  bottom: 0;
+  transform: translate(-50%, 100%);
+  margin-bottom: -8px;
+}
+.tooltip.left {
+  left: 0;
+  transform: translateX(-100%);
+  margin-left: -8px;
+}
+.tooltip.right {
+  right: 0;
+  transform: translate(100%, -50%);
+  margin-top: -10px;
+  margin-right: -8px;
+}
+.tooltip.top-left {
+  left: 0;
+  transform: translate(-80%, -100%);
+  margin-top: -8px;
+}
+.tooltip.bottom-left {
+  left: 0;
+  bottom: 0;
+  transform: translate(-80%, 100%);
+  margin-top: -8px;
+}
+.tooltip.bottom-right {
+  left: 0;
+  bottom: 0;
+  transform: translate(0%, 100%);
+  margin-top: -8px;
+}
+.tooltip.top-right {
+  left: 0;
+  transform: translate(0%, -100%);
+  margin-top: -8px;
+}
+.tooltip-slot:hover + .tooltip {
+  opacity: 1;
+  visibility: initial;
+}
+</style>
 
 <script lang="ts">
 import type { Snippet } from 'svelte';

--- a/packages/ui/src/lib/tooltip/Tooltip.svelte
+++ b/packages/ui/src/lib/tooltip/Tooltip.svelte
@@ -1,71 +1,95 @@
 <style>
-.tooltip.top {
-  left: 50%;
-  transform: translate(-50%, -100%);
-  margin-top: -8px;
-}
-.tooltip.bottom {
-  left: 50%;
-  bottom: 0;
-  transform: translate(-50%, 100%);
-  margin-bottom: -8px;
-}
-.tooltip.left {
-  left: 0;
-  transform: translateX(-100%);
-  margin-left: -8px;
-}
-.tooltip.right {
-  right: 0;
-  transform: translate(100%, -50%);
-  margin-top: -10px;
-  margin-right: -8px;
-}
-.tooltip.top-left {
-  left: 0;
-  transform: translate(-80%, -100%);
-  margin-top: -8px;
-}
-.tooltip.bottom-left {
-  left: 0;
-  bottom: 0;
-  transform: translate(-80%, 100%);
-  margin-top: -8px;
-}
-.tooltip.bottom-right {
-  left: 0;
-  bottom: 0;
-  transform: translate(0%, 100%);
-  margin-top: -8px;
-}
-.tooltip.top-right {
-  left: 0;
-  transform: translate(0%, -100%);
-  margin-top: -8px;
-}
-.tooltip-slot:hover + .tooltip {
-  opacity: 1;
-  visibility: initial;
-}
-</style>
+  .tooltip.top {
+    left: 50%;
+    transform: translate(-50%, -100%);
+    margin-top: -8px;
+  }
+  .tooltip.bottom {
+    left: 50%;
+    bottom: 0;
+    transform: translate(-50%, 100%);
+    margin-bottom: -8px;
+  }
+  .tooltip.left {
+    left: 0;
+    transform: translateX(-100%);
+    margin-left: -8px;
+  }
+  .tooltip.right {
+    right: 0;
+    transform: translate(100%, -50%);
+    margin-top: -10px;
+    margin-right: -8px;
+  }
+  .tooltip.top-left {
+    left: 0;
+    transform: translate(-80%, -100%);
+    margin-top: -8px;
+  }
+  .tooltip.bottom-left {
+    left: 0;
+    bottom: 0;
+    transform: translate(-80%, 100%);
+    margin-top: -8px;
+  }
+  .tooltip.bottom-right {
+    left: 0;
+    bottom: 0;
+    transform: translate(0%, 100%);
+    margin-top: -8px;
+  }
+  .tooltip.top-right {
+    left: 0;
+    transform: translate(0%, -100%);
+    margin-top: -8px;
+  }
+  .tooltip-slot:hover + .tooltip {
+    opacity: 1;
+    visibility: initial;
+  }
+  </style>
 
 <script lang="ts">
+import type { Snippet } from 'svelte';
+
 import { tooltipHidden } from './tooltip-store';
 
-export let tip: string | undefined = undefined;
-export let top = false;
-export let topLeft = false;
-export let topRight = false;
-export let right = false;
-export let bottom = false;
-export let bottomLeft = false;
-export let bottomRight = false;
-export let left = false;
+interface Props {
+  tip?: string;
+  top?: boolean;
+  topLeft?: boolean;
+  topRight?: boolean;
+  right?: boolean;
+  bottom?: boolean;
+  bottomLeft?: boolean;
+  bottomRight?: boolean;
+  left?: boolean;
+  class?: string;
+  tipSnippet?: Snippet;
+  children?: Snippet;
+  'aria-label'?: string;
+}
+
+let {
+  tip = undefined,
+  top = false,
+  topLeft = false,
+  topRight = false,
+  right = false,
+  bottom = false,
+  bottomLeft = false,
+  bottomRight = false,
+  left = false,
+  class: className,
+  tipSnippet,
+  children,
+  'aria-label': ariaLabel,
+}: Props = $props();
 </script>
 
-<div class="relative inline-block">
-  <span class="group tooltip-slot {$$props.class}">
-    <slot />
+<div class="relative inline-block" aria-label={ariaLabel}>
+  <span class="group tooltip-slot {className}">
+    {@render children?.()}
   </span>
   <div
     class="whitespace-nowrap absolute tooltip opacity-0 inline-block transition-opacity duration-150 ease-in-out pointer-events-none text-sm z-60"
@@ -79,16 +103,16 @@ export let left = false;
     class:bottom-right={bottomRight}>
     {#if tip && !$tooltipHidden}
       <div
-        class="inline-block py-2 px-4 rounded-md bg-[var(--pd-tooltip-bg)] text-[var(--pd-tooltip-text)] border-[1px] border-[var(--pd-tooltip-border)] {$$props.class}"
+        class="inline-block py-2 px-4 rounded-md bg-[var(--pd-tooltip-bg)] text-[var(--pd-tooltip-text)] border-[1px] border-[var(--pd-tooltip-border)] {className}"
         aria-label="tooltip">
         {tip}
       </div>
     {/if}
-    {#if $$slots.tip && !tip && !$tooltipHidden}
+    {#if tipSnippet && !tip && !$tooltipHidden}
       <div
-        class="inline-block rounded-md bg-[var(--pd-tooltip-bg)] text-[var(--pd-tooltip-text)] border-[1px] border-[var(--pd-tooltip-border)] {$$props.class}"
+        class="inline-block rounded-md bg-[var(--pd-tooltip-bg)] text-[var(--pd-tooltip-text)] border-[1px] border-[var(--pd-tooltip-border)] {className}"
         aria-label="tooltip">
-        <slot name="tip" />
+        {@render tipSnippet?.()}
       </div>
     {/if}
   </div>

--- a/packages/ui/src/lib/tooltip/TooltipSpec.svelte
+++ b/packages/ui/src/lib/tooltip/TooltipSpec.svelte
@@ -1,17 +1,33 @@
 <script lang="ts">
 import Tooltip from './Tooltip.svelte';
 
-export let tipProp: string | undefined = undefined;
-export let tipSlot: string | undefined = undefined;
-export let top = false;
-export let topLeft = false;
-export let topRight = false;
-export let right = false;
-export let bottom = false;
-export let bottomLeft = false;
-export let bottomRight = false;
-export let left = false;
-export let classStyle = '';
+interface Props {
+  tipProp?: string;
+  tipSlot?: string;
+  top?: boolean;
+  topLeft?: boolean;
+  topRight?: boolean;
+  right?: boolean;
+  bottom?: boolean;
+  bottomLeft?: boolean;
+  bottomRight?: boolean;
+  left?: boolean;
+  classStyle?: string;
+}
+
+let {
+  tipProp = undefined,
+  tipSlot = undefined,
+  top = false,
+  topLeft = false,
+  topRight = false,
+  right = false,
+  bottom = false,
+  bottomLeft = false,
+  bottomRight = false,
+  left = false,
+  classStyle = '',
+}: Props = $props();
 </script>
 
 <Tooltip
@@ -25,10 +41,9 @@ export let classStyle = '';
   bottomRight={bottomRight}
   left={left}
   class={classStyle}>
-  <slot />
-  <svelte:fragment slot="tip">
+  {#snippet tipSnippet()}
     {#if tipSlot}
       {tipSlot}
     {/if}
-  </svelte:fragment>
+  {/snippet}
 </Tooltip>


### PR DESCRIPTION
### What does this PR do?

Migrates Tooltip.svelte component to Svelte 5

### Screenshot / video of UI

### What issues does this PR fix or reference?

closes #11587

### How to test this PR?

- [ ] Tests are covering the bug fix or the new feature
