### PR TITLE
docs: use unambiguous name for Apple silicon in GPU docs

### DIFF
--- a/website/docs/podman/gpu.md
+++ b/website/docs/podman/gpu.md
@@ -121,11 +121,11 @@ You might need to restart your Podman machine.
 - [NVIDIA Container Toolkit Installation](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html#installing-with-yum-or-dnf)
 
 </TabItem>
-   <TabItem value="macOS" label="macOS (Silicon)" className="markdown">
+   <TabItem value="macOS" label="macOS (Apple silicon)" className="markdown">
 
 #### Prerequisites
 
-- macOS Silicon (M1 or later)
+- Mac with Apple silicon (M1 or later)
 
 #### Procedure
 
@@ -216,7 +216,7 @@ Important note that the virtualized GPU (Virtio-GPU Venus (Apple M1 Pro)) only s
 
 4. Configure SELinux (if applicable)
 
-   On SELinux-enabled OSes, such as OSs from the Fedora family, the default policy usually disallows containers to have direct access to devices. We make sure it's allowed.
+   On SELinux-enabled operating systems, such as the Fedora family, the default policy usually disallows containers to have direct access to devices. We make sure it's allowed.
 
    Check whether SELinux is installed and enabled:
 

--- a/website/docs/troubleshooting/troubleshooting-podman-on-macos.md
+++ b/website/docs/troubleshooting/troubleshooting-podman-on-macos.md
@@ -40,7 +40,7 @@ or any similar error denoting that Podman Engine does not exist.
 
 #### Explanation
 
-The Podman Installer and Homebrew use different locations to store the Podman Engine files in the file system. For example, Podman Installer installs Podman Engine in the path `/opt/podman` whereas Homebrew uses the path `/usr/local` for macOS Intel, `/opt/homebrew` for Apple Silicon and `/home/linuxbrew/.linuxbrew` for Linux.
+The Podman Installer and Homebrew use different locations to store the Podman Engine files in the file system. For example, Podman Installer installs Podman Engine in the path `/opt/podman` whereas Homebrew uses the path `/usr/local` for macOS Intel, `/opt/homebrew` for Apple silicon and `/home/linuxbrew/.linuxbrew` for Linux.
 
 #### Solution
 
@@ -68,11 +68,11 @@ Here, you would replace `path-where-podman-exists` with the output of `which pod
 
 You can now proceed for a fresh installation of Podman Desktop
 
-## Podman machine on Apple Silicon
+## Podman machine on Apple silicon
 
 #### Issue
 
-If you are using an Apple Silicon and brew, you might encounter the following error when starting Podman from Podman Desktop
+If you are using an Apple silicon and brew, you might encounter the following error when starting Podman from Podman Desktop
 
 ```shell-session
 Error: qemu exited unexpectedly with exit code 1, stderr: qemu-system-x86_64: invalid accelerator hvf
@@ -163,9 +163,9 @@ Keep your brew-based installation and apply one of these workarounds:
 - [Homebrew issue #140244](https://github.com/Homebrew/homebrew-core/issues/140244).
 - [Podman issue #19708](https://github.com/containers/podman/issues/19708).
 
-## On Apple Silicon, the Podman Machine does not start
+## On Apple silicon, the Podman Machine does not start
 
-On Apple Silicon, when Podman Machine starts, it stays indefinitely blocked with a _Waiting for VM_ message.
+On Apple silicon, when Podman Machine starts, it stays indefinitely blocked with a _Waiting for VM_ message.
 
 #### Solution
 


### PR DESCRIPTION
### What does this PR do?

Use the term from Apple's style guide to refer to Apple silicon since "Silicon" by itself is ambiguous and confusing.

https://help.apple.com/pdf/applestyleguide/en_US/apple-style-guide.pdf

Remove the plural abbreviation for "OS" since it was written two different ways close together and it's less confusing to use the words rather than the abbreviation.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

None

### How to test this PR?

Read the updated documentation.
