### PR TITLE
fix(extension: podman): powershell should use absolute path for whoami binary

### DIFF
--- a/extensions/podman/packages/extension/src/checks/hyperv-check.spec.ts
+++ b/extensions/podman/packages/extension/src/checks/hyperv-check.spec.ts
@@ -105,7 +105,7 @@ test('expect HyperV preflight skips podman version check if installationPrefligh
   // exec should only be called once inside the isUserAdmin function, if so the podman check has been skipped as expected
   expect(execSpy).toBeCalledTimes(1);
   expect(execSpy).toBeCalledWith('powershell.exe', [
-    '$null -ne (whoami /groups /fo csv | ConvertFrom-Csv | Where-Object {$_.SID -eq "S-1-5-32-544"})',
+    '$null -ne (& "$env:WINDIR\\System32\\whoami.exe" /groups /fo csv | ConvertFrom-Csv | Where-Object {$_.SID -eq "S-1-5-32-544"})',
   ]);
   expect(result.successful).toBeFalsy();
 });

--- a/extensions/podman/packages/extension/src/utils/powershell.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/powershell.spec.ts
@@ -1,0 +1,93 @@
+/*********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************/
+
+import type { TelemetryLogger } from '@podman-desktop/api';
+import { process as processAPI } from '@podman-desktop/api';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { PowerShellClient } from './powershell';
+import { getPowerShellClient } from './powershell';
+
+vi.mock('@podman-desktop/api', () => ({
+  process: {
+    exec: vi.fn(),
+  },
+}));
+
+const TELEMETRY_LOGGER_MOCK = {
+  logUsage: vi.fn(),
+} as unknown as TelemetryLogger;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+interface IsUserAdminTestCase {
+  name: string;
+  stdout: string;
+  expected: boolean;
+}
+
+describe('PowerShellClient#isUserAdmin', () => {
+  let client: PowerShellClient;
+
+  beforeEach(async () => {
+    client = await getPowerShellClient(TELEMETRY_LOGGER_MOCK);
+  });
+
+  test.each<IsUserAdminTestCase>([
+    {
+      name: 'should return true when user is admin',
+      stdout: 'True',
+      expected: true,
+    },
+    {
+      name: 'should return true when user is admin with extra whitespace\n',
+      stdout: '\r  True  \n',
+
+      expected: true,
+    },
+    {
+      name: 'should return false when user is not admin',
+      stdout: 'False',
+      expected: false,
+    },
+    {
+      name: 'should return false with unrecognised stdout',
+      stdout: 'foo bar',
+      expected: false,
+    },
+  ])('$name', async ({ stdout, expected }) => {
+    vi.mocked(processAPI.exec).mockResolvedValue({
+      stdout: stdout,
+      stderr: '',
+      command: 'powershell.exe',
+    });
+
+    const result = await client.isUserAdmin();
+    expect(result).toBe(expected);
+  });
+
+  test('should return false when exec throws error', async () => {
+    vi.mocked(processAPI.exec).mockRejectedValue(new Error('Command failed'));
+
+    const result = await client.isUserAdmin();
+
+    expect(result).toBe(false);
+  });
+});

--- a/extensions/podman/packages/extension/src/utils/powershell.ts
+++ b/extensions/podman/packages/extension/src/utils/powershell.ts
@@ -69,7 +69,7 @@ class PowerShell5Client implements PowerShellClient {
   async isUserAdmin(): Promise<boolean> {
     try {
       const { stdout: res } = await extensionApi.process.exec(PowerShell5Exe, [
-        '$null -ne (whoami /groups /fo csv | ConvertFrom-Csv | Where-Object {$_.SID -eq "S-1-5-32-544"})',
+        '$null -ne (& "$env:WINDIR\\System32\\whoami.exe" /groups /fo csv | ConvertFrom-Csv | Where-Object {$_.SID -eq "S-1-5-32-544"})',
       ]);
       return res.trim() === 'True';
     } catch (err: unknown) {


### PR DESCRIPTION
### What does this PR do?

As raised in https://github.com/podman-desktop/podman-desktop/issues/12168#issuecomment-3319249295 if you have a [Git Bash](https://gitforwindows.org/) or [msys2](https://www.msys2.org/) installed on your windows machine you may have multiple binary for `whoami`, you can verify by running `where.exe whoami`.

To solve this problem without parsing the where, we can just use the absolute path, which is `%windir%\System32\whoami.exe` on 64 bit system.

> ℹ️ Since we run in a powershell, we can use `& "$env:WINDIR\\System32\\whoami.exe"` to resolve the `WINDIR` and interpret the string as an executable.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/12168#issuecomment-3319249295

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

On windows, you can run the following `$null -ne (& "$env:WINDIR\\System32\\whoami.exe" /groups /fo csv | ConvertFrom-Csv | Where-Object {$_.SID -eq "S-1-5-32-544"})` and check if it output `True` or `False`.