### PR TITLE
fix: e2e test fails to push image to remote cr with new name

### DIFF
--- a/tests/playwright/src/specs/image-push-to-registry-smoke.spec.ts
+++ b/tests/playwright/src/specs/image-push-to-registry-smoke.spec.ts
@@ -126,18 +126,6 @@ test.describe.serial('Push image to container registry', { tag: '@smoke' }, () =
       .toBeTruthy();
   });
 
-  test('Registry removal verification', async ({ page, navigationBar }) => {
-    await navigationBar.openSettings();
-    const settingsBar = new SettingsBar(page);
-    const registryPage = await settingsBar.openTabPage(RegistriesPage);
-    await playExpect(registryPage.heading).toBeVisible();
-
-    await registryPage.removeRegistry(registryName);
-    const registryBox = registryPage.registriesTable.getByLabel(registryName);
-    const username = registryBox.getByText(registryUsername);
-    await playExpect(username).toBeHidden();
-  });
-
   test('Pull image from github repo under new name', async ({ navigationBar }) => {
     let imagesPage = await navigationBar.openImages();
     await playExpect(imagesPage.heading).toBeVisible();
@@ -149,5 +137,17 @@ test.describe.serial('Push image to container registry', { tag: '@smoke' }, () =
     await playExpect
       .poll(async () => await imagesPage.waitForRowToExists(fullName, 15_000), { timeout: 0 })
       .toBeTruthy();
+  });
+
+  test('Registry removal verification', async ({ page, navigationBar }) => {
+    await navigationBar.openSettings();
+    const settingsBar = new SettingsBar(page);
+    const registryPage = await settingsBar.openTabPage(RegistriesPage);
+    await playExpect(registryPage.heading).toBeVisible();
+
+    await registryPage.removeRegistry(registryName);
+    const registryBox = registryPage.registriesTable.getByLabel(registryName);
+    const username = registryBox.getByText(registryUsername);
+    await playExpect(username).toBeHidden();
   });
 });


### PR DESCRIPTION
### What does this PR do?

Fix registry tests failure to push image to remote registry under new name.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fix #14050.

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

1. Pull the branch
2. Run smoke tests with command mentioned in #14050.

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
