### PR TITLE
refactor(extension: podman): split Hyper-V check in two

### DIFF
--- a/extensions/podman/packages/extension/src/checks/hyperv-check.spec.ts
+++ b/extensions/podman/packages/extension/src/checks/hyperv-check.spec.ts
@@ -15,143 +15,34 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import * as extensionApi from '@podman-desktop/api';
+import type { TelemetryLogger } from '@podman-desktop/api';
 import { beforeEach, expect, test, vi } from 'vitest';
 
+import type { PowerShellClient } from '../utils/powershell';
+import { getPowerShellClient } from '../utils/powershell';
 import { HyperVCheck } from './hyperv-check';
 
-vi.mock('@podman-desktop/api', async () => {
-  return {
-    commands: {
-      registerCommand: vi.fn(),
-    },
-    env: {
-      isMac: true,
-      openExternal: vi.fn(),
-    },
-    window: {
-      withProgress: vi.fn(),
-      showNotification: vi.fn(),
-      showErrorMessage: vi.fn(),
-      showInformationMessage: vi.fn(),
-      showWarningMessage: vi.fn(),
-    },
-    ProgressLocation: {},
-    process: {
-      exec: vi.fn(),
-    },
-    configuration: {
-      getConfiguration: vi.fn(),
-    },
-    Uri: {
-      parse: vi.fn(),
-    },
-    context: {
-      setValue: vi.fn(),
-    },
-  };
-});
+vi.mock(import('@podman-desktop/api'));
+vi.mock(import('../utils/powershell'), () => ({
+  getPowerShellClient: vi.fn(),
+}));
 
-vi.mock(import('../utils/util'), async () => {
-  return {
-    getAssetsFolder: vi.fn().mockReturnValue(''),
-    runCliCommand: vi.fn(),
-    appHomeDir: vi.fn().mockReturnValue(''),
-    normalizeWSLOutput: vi.fn().mockImplementation((s: string) => s),
-    isLinux: vi.fn(),
-    isWindows: vi.fn(),
-    isMac: vi.fn(),
-    execPodman: vi.fn(),
-  };
-});
+const mockTelemetryLogger = {} as TelemetryLogger;
 
-const mockTelemetryLogger = {} as extensionApi.TelemetryLogger;
+const POWERSHELL_CLIENT: PowerShellClient = {
+  isUserAdmin: vi.fn(),
+  isHyperVInstalled: vi.fn(),
+  isHyperVRunning: vi.fn(),
+  isVirtualMachineAvailable: vi.fn(),
+  isRunningElevated: vi.fn(),
+};
 
 beforeEach(() => {
   vi.resetAllMocks();
-  vi.mocked(extensionApi.configuration.getConfiguration).mockReturnValue({
-    get: () => '',
-    has: vi.fn(),
-    update: vi.fn(),
-  });
-});
-
-test('expect HyperV preflight check return failure result if podman is older than 5.2.0', async () => {
-  let index = 0;
-  vi.spyOn(extensionApi.process, 'exec').mockImplementation(() => {
-    if (index++ < 1) {
-      return Promise.resolve({
-        stdout: 'podman version 5.1.0',
-        stderr: '',
-        command: 'command',
-      });
-    }
-    throw new Error();
-  });
-
-  const hyperVCheck = new HyperVCheck(mockTelemetryLogger);
-  const result = await hyperVCheck.execute();
-  expect(result.successful).toBeFalsy();
-  expect(result.description).equal('Hyper-V is only supported with podman version >= 5.2.0.');
-});
-
-test('expect HyperV preflight skips podman version check if installationPreflightMode is true', async () => {
-  const execSpy = vi.spyOn(extensionApi.process, 'exec').mockImplementation(() => {
-    throw new Error();
-  });
-
-  const hyperVCheck = new HyperVCheck(mockTelemetryLogger, true);
-  const result = await hyperVCheck.execute();
-  // exec should only be called once inside the isUserAdmin function, if so the podman check has been skipped as expected
-  expect(execSpy).toBeCalledTimes(1);
-  expect(execSpy).toBeCalledWith('powershell.exe', [
-    '$null -ne (& "$env:WINDIR\\System32\\whoami.exe" /groups /fo csv | ConvertFrom-Csv | Where-Object {$_.SID -eq "S-1-5-32-544"})',
-  ]);
-  expect(result.successful).toBeFalsy();
-});
-
-test('expect HyperV preflight check return failure result if it fails when checking admin user', async () => {
-  let index = 0;
-  vi.spyOn(extensionApi.process, 'exec').mockImplementation(() => {
-    if (index++ < 1) {
-      return Promise.resolve({
-        stdout: 'podman version 5.2.0',
-        stderr: '',
-        command: 'command',
-      });
-    } else {
-      throw new Error();
-    }
-  });
-
-  const hyperVCheck = new HyperVCheck(mockTelemetryLogger);
-  const result = await hyperVCheck.execute();
-  expect(result.successful).toBeFalsy();
-  expect(result.description).equal('You must have administrative rights to run Hyper-V Podman machines');
-  expect(result.docLinks?.[0].url).equal(
-    'https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/enable-hyper-v',
-  );
-  expect(result.docLinks?.[0].title).equal('Hyper-V Manual Installation Steps');
+  vi.mocked(getPowerShellClient).mockResolvedValue(POWERSHELL_CLIENT);
 });
 
 test('expect HyperV preflight check return failure result if non admin user', async () => {
-  let index = 0;
-  vi.spyOn(extensionApi.process, 'exec').mockImplementation(() => {
-    if (index++ < 1) {
-      return Promise.resolve({
-        stdout: 'podman version 5.2.0',
-        stderr: '',
-        command: 'command',
-      });
-    } else {
-      return Promise.resolve({
-        stdout: 'False',
-        stderr: '',
-        command: 'command',
-      });
-    }
-  });
-
   const hyperVCheck = new HyperVCheck(mockTelemetryLogger);
   const result = await hyperVCheck.execute();
   expect(result.successful).toBeFalsy();
@@ -163,18 +54,7 @@ test('expect HyperV preflight check return failure result if non admin user', as
 });
 
 test('expect HyperV preflight check return failure result if Podman Desktop is not run with elevated privileges', async () => {
-  let index = 0;
-  vi.spyOn(extensionApi.process, 'exec').mockImplementation(() => {
-    if (index++ <= 1) {
-      return Promise.resolve({
-        stdout: index === 1 ? 'podman version 5.2.0' : 'True',
-        stderr: '',
-        command: 'command',
-      });
-    } else {
-      throw new Error();
-    }
-  });
+  vi.mocked(POWERSHELL_CLIENT.isUserAdmin).mockResolvedValue(true);
 
   const hyperVCheck = new HyperVCheck(mockTelemetryLogger);
   const result = await hyperVCheck.execute();
@@ -186,18 +66,8 @@ test('expect HyperV preflight check return failure result if Podman Desktop is n
 });
 
 test('expect HyperV preflight check return failure result if HyperV not installed', async () => {
-  let index = 0;
-  vi.spyOn(extensionApi.process, 'exec').mockImplementation(() => {
-    if (index++ <= 2) {
-      return Promise.resolve({
-        stdout: index === 1 ? 'podman version 5.2.0' : 'True',
-        stderr: '',
-        command: 'command',
-      });
-    } else {
-      throw new Error();
-    }
-  });
+  vi.mocked(POWERSHELL_CLIENT.isUserAdmin).mockResolvedValue(true);
+  vi.mocked(POWERSHELL_CLIENT.isRunningElevated).mockResolvedValue(true);
 
   const hyperVCheck = new HyperVCheck(mockTelemetryLogger);
   const result = await hyperVCheck.execute();
@@ -210,18 +80,9 @@ test('expect HyperV preflight check return failure result if HyperV not installe
 });
 
 test('expect HyperV preflight check return failure result if HyperV not running', async () => {
-  let index = 0;
-  vi.spyOn(extensionApi.process, 'exec').mockImplementation(() => {
-    if (index++ <= 3) {
-      return Promise.resolve({
-        stdout: index === 1 ? 'podman version 5.2.0' : 'True',
-        stderr: '',
-        command: 'command',
-      });
-    } else {
-      throw new Error();
-    }
-  });
+  vi.mocked(POWERSHELL_CLIENT.isUserAdmin).mockResolvedValue(true);
+  vi.mocked(POWERSHELL_CLIENT.isRunningElevated).mockResolvedValue(true);
+  vi.mocked(POWERSHELL_CLIENT.isHyperVInstalled).mockResolvedValue(true);
 
   const hyperVCheck = new HyperVCheck(mockTelemetryLogger);
   const result = await hyperVCheck.execute();
@@ -234,18 +95,10 @@ test('expect HyperV preflight check return failure result if HyperV not running'
 });
 
 test('expect HyperV preflight check return OK', async () => {
-  let index = 0;
-  vi.spyOn(extensionApi.process, 'exec').mockImplementation(() => {
-    if (index++ <= 4) {
-      return Promise.resolve({
-        stdout: index === 1 ? 'podman version 5.2.0' : index === 5 ? 'Running' : 'True',
-        stderr: '',
-        command: 'command',
-      });
-    } else {
-      throw new Error();
-    }
-  });
+  vi.mocked(POWERSHELL_CLIENT.isUserAdmin).mockResolvedValue(true);
+  vi.mocked(POWERSHELL_CLIENT.isRunningElevated).mockResolvedValue(true);
+  vi.mocked(POWERSHELL_CLIENT.isHyperVInstalled).mockResolvedValue(true);
+  vi.mocked(POWERSHELL_CLIENT.isHyperVRunning).mockResolvedValue(true);
 
   const hyperVCheck = new HyperVCheck(mockTelemetryLogger);
   const result = await hyperVCheck.execute();

--- a/extensions/podman/packages/extension/src/checks/hyperv-podman-version-check.spec.ts
+++ b/extensions/podman/packages/extension/src/checks/hyperv-podman-version-check.spec.ts
@@ -1,0 +1,87 @@
+/*********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************/
+
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { getPodmanInstallation } from '../utils/podman-cli';
+import { HyperVPodmanVersionCheck } from './hyperv-podman-version-check';
+
+vi.mock(import('@podman-desktop/api'));
+vi.mock(import('../utils/podman-cli'), () => ({
+  getPodmanInstallation: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+interface SuccessfulTestCase {
+  name: string;
+  version: string;
+}
+
+test.each<SuccessfulTestCase>([
+  {
+    name: 'expect HyperV Podman version check return success result if Podman version equals minimum',
+    version: '5.2.0',
+  },
+  {
+    name: 'expect HyperV Podman version check return success result if Podman version is much higher than minimum',
+    version: '6.0.0',
+  },
+  {
+    name: 'expect HyperV Podman version check handle pre-release versions correctly',
+    version: '5.3.0-dev',
+  },
+])('$name', async ({ version }) => {
+  vi.mocked(getPodmanInstallation).mockResolvedValue({
+    version: version,
+  });
+
+  const hyperVPodmanVersionCheck = new HyperVPodmanVersionCheck();
+  const result = await hyperVPodmanVersionCheck.execute();
+
+  expect(result.successful).toBeTruthy();
+});
+
+interface FailureTestCase {
+  name: string;
+  version: string;
+  errorDescription: string;
+}
+
+test.each<FailureTestCase>([
+  {
+    name: 'expect failure if Podman version minor bellow minimum',
+    errorDescription: 'Hyper-V is only supported with podman version >= 5.2.0.',
+    version: '5.1.0',
+  },
+  {
+    name: 'expect failure if Podman version major bellow minimum',
+    errorDescription: 'Hyper-V is only supported with podman version >= 5.2.0.',
+    version: '4.4.0',
+  },
+])('$name', async ({ version, errorDescription }) => {
+  vi.mocked(getPodmanInstallation).mockResolvedValue({
+    version: version,
+  });
+  const hyperVPodmanVersionCheck = new HyperVPodmanVersionCheck();
+  const result = await hyperVPodmanVersionCheck.execute();
+  expect(result.successful).toBeFalsy();
+  expect(result.description).equal(errorDescription);
+});

--- a/extensions/podman/packages/extension/src/checks/hyperv-podman-version-check.ts
+++ b/extensions/podman/packages/extension/src/checks/hyperv-podman-version-check.ts
@@ -1,0 +1,45 @@
+/*********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************/
+import type { CheckResult } from '@podman-desktop/api';
+import { compareVersions } from 'compare-versions';
+
+import { getPodmanInstallation } from '../utils/podman-cli';
+import { BaseCheck } from './base-check';
+
+export class HyperVPodmanVersionCheck extends BaseCheck {
+  title = 'Minimum Podman Version for Hyper-V';
+  static readonly PODMAN_MINIMUM_VERSION_FOR_HYPERV = '5.2.0';
+
+  async execute(): Promise<CheckResult> {
+    const isPodmanVersionSupported = await this.isPodmanVersionSupported();
+    if (!isPodmanVersionSupported) {
+      return this.createFailureResult({
+        description: `Hyper-V is only supported with podman version >= ${HyperVPodmanVersionCheck.PODMAN_MINIMUM_VERSION_FOR_HYPERV}.`,
+      });
+    }
+    return this.createSuccessfulResult();
+  }
+
+  private async isPodmanVersionSupported(): Promise<boolean> {
+    const installedPodman = await getPodmanInstallation();
+    if (installedPodman?.version) {
+      return compareVersions(installedPodman?.version, HyperVPodmanVersionCheck.PODMAN_MINIMUM_VERSION_FOR_HYPERV) >= 0;
+    }
+    return false;
+  }
+}

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -31,6 +31,7 @@ import type { PodmanExtensionApi, PodmanRunOptions } from '../../api/src/podman-
 import { SequenceCheck } from './checks/base-check';
 import { getDetectionChecks } from './checks/detection-checks';
 import { HyperVCheck } from './checks/hyperv-check';
+import { HyperVPodmanVersionCheck } from './checks/hyperv-podman-version-check';
 import { MacKrunkitPodmanMachineCreationCheck, MacPodmanInstallCheck } from './checks/macos-checks';
 import { WSLVersionCheck } from './checks/wsl-version-check';
 import { WSL2Check } from './checks/wsl2-check';
@@ -1984,7 +1985,10 @@ export async function isHyperVEnabled(): Promise<boolean> {
   if (!extensionApi.env.isWindows) {
     return false;
   }
-  const hyperVCheck = new HyperVCheck(telemetryLogger);
+  const hyperVCheck = new SequenceCheck('Hyper-V Platform', [
+    new HyperVPodmanVersionCheck(),
+    new HyperVCheck(telemetryLogger),
+  ]);
   const hyperVCheckResult = await hyperVCheck.execute();
   return hyperVCheckResult.successful;
 }

--- a/extensions/podman/packages/extension/src/installer/win-installer.ts
+++ b/extensions/podman/packages/extension/src/installer/win-installer.ts
@@ -59,7 +59,7 @@ export class WinInstaller extends BaseInstaller {
           new WSLVersionCheck(),
           new WSL2Check(this.telemetryLogger, this.extensionContext),
         ]),
-        new HyperVCheck(this.telemetryLogger, true),
+        new HyperVCheck(this.telemetryLogger),
       ),
     ];
   }


### PR DESCRIPTION
### What does this PR do?

The HyperVCheck class is instantiating in two places, this is a problem, as it prevents using a single instance, and cache the result of certain call, ensuring HyperV is installed is a costy operation, (see https://github.com/podman-desktop/podman-desktop/issues/13777).

To avoid recreating instance, and cache the result, we should first split the class in two, as each check has a specific usage.

### Notes

- introduce `HyperVPodmanVersionCheck` class to verify that the Podman version installed is `>= 5.2.0`
- cleanup tests in `extensions/podman/packages/extension/src/checks/hyperv-check.spec.ts`

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/14060

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
