### PR TITLE
refactor(extension: podman): extract `checkRosettaMacArm` to dedicated file

### DIFF
--- a/extensions/podman/packages/extension/src/utils/rosetta.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/rosetta.spec.ts
@@ -1,0 +1,121 @@
+/*********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************/
+
+import { arch } from 'node:os';
+
+import type { RunError, RunResult } from '@podman-desktop/api';
+import { env as envAPI, process as processAPI, window as windowAPI } from '@podman-desktop/api';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { PodmanConfiguration } from './podman-configuration';
+import { checkRosettaMacArm } from './rosetta';
+
+vi.mock('@podman-desktop/api', () => ({
+  process: {
+    exec: vi.fn(),
+  },
+  window: {
+    showInformationMessage: vi.fn(),
+  },
+  env: {
+    isMac: false,
+    isLinux: false,
+    isWindows: false,
+  },
+}));
+
+vi.mock('node:os', async () => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  const osActual = await vi.importActual<typeof import('node:os')>('node:os');
+
+  return {
+    ...osActual,
+    release: vi.fn(),
+    platform: vi.fn(),
+    arch: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('checkRosettaMacArm', async () => {
+  const podmanConfiguration = {
+    isRosettaEnabled: vi.fn(),
+  } as unknown as PodmanConfiguration;
+
+  test('check do nothing on non-macOS', async () => {
+    await checkRosettaMacArm(podmanConfiguration);
+    // not called as not on macOS
+    expect(vi.mocked(podmanConfiguration.isRosettaEnabled)).not.toBeCalled();
+  });
+
+  test('check do nothing on macOS with intel', async () => {
+    vi.mocked(envAPI).isMac = true;
+    vi.mocked(arch).mockReturnValue('x64');
+    await checkRosettaMacArm(podmanConfiguration);
+    // not called as not on arm64
+    expect(vi.mocked(podmanConfiguration.isRosettaEnabled)).not.toBeCalled();
+  });
+
+  test('check no dialog on macOS with arm64 if rosetta is working', async () => {
+    vi.mocked(envAPI).isMac = true;
+    vi.mocked(arch).mockReturnValue('arm64');
+    // rosetta is being enabled per configuration
+    vi.mocked(podmanConfiguration.isRosettaEnabled).mockResolvedValue(true);
+
+    // mock rosetta is working when executing commands
+    vi.mocked(processAPI.exec).mockResolvedValue({} as RunResult);
+
+    await checkRosettaMacArm(podmanConfiguration);
+    // check showInformationMessage is not called
+    expect(processAPI.exec).toBeCalled();
+    expect(podmanConfiguration.isRosettaEnabled).toBeCalled();
+    expect(windowAPI.showInformationMessage).not.toBeCalled();
+  });
+
+  test('check no dialog on macOS with arm64 if rosetta is not enabled', async () => {
+    vi.mocked(envAPI).isMac = true;
+    vi.mocked(arch).mockReturnValue('arm64');
+    // rosetta is being enabled per configuration
+    vi.mocked(podmanConfiguration.isRosettaEnabled).mockResolvedValue(false);
+
+    await checkRosettaMacArm(podmanConfiguration);
+    // do not try to execute something as disabled
+    expect(processAPI.exec).not.toBeCalled();
+    expect(podmanConfiguration.isRosettaEnabled).toBeCalled();
+    expect(windowAPI.showInformationMessage).not.toBeCalled();
+  });
+
+  test('check dialog on macOS with arm64 if rosetta is not working', async () => {
+    vi.mocked(envAPI).isMac = true;
+    vi.mocked(arch).mockReturnValue('arm64');
+    // rosetta is being enabled per configuration
+    vi.mocked(podmanConfiguration.isRosettaEnabled).mockResolvedValue(true);
+
+    // mock rosetta is not working when executing commands
+    vi.mocked(processAPI.exec).mockRejectedValue({ stderr: 'Bad CPU' } as RunError);
+
+    await checkRosettaMacArm(podmanConfiguration);
+    // check showInformationMessage is not called
+    expect(processAPI.exec).toBeCalled();
+    expect(podmanConfiguration.isRosettaEnabled).toBeCalled();
+    expect(windowAPI.showInformationMessage).toBeCalled();
+  });
+});

--- a/extensions/podman/packages/extension/src/utils/rosetta.ts
+++ b/extensions/podman/packages/extension/src/utils/rosetta.ts
@@ -1,0 +1,57 @@
+/*********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************/
+
+import { arch } from 'node:os';
+
+import type { RunError } from '@podman-desktop/api';
+import { env, process as processAPI, window } from '@podman-desktop/api';
+
+import type { PodmanConfiguration } from './podman-configuration';
+
+export async function checkRosettaMacArm(podmanConfiguration: PodmanConfiguration): Promise<void> {
+  // check that rosetta is there for macOS / arm as the machine may fail to start
+  if (env.isMac && arch() === 'arm64') {
+    const isEnabled = await podmanConfiguration.isRosettaEnabled();
+    if (isEnabled) {
+      // call the command `arch -arch x86_64 uname -m` to check if rosetta is enabled
+      // if not installed, it will fail
+      try {
+        await processAPI.exec('arch', ['-arch', 'x86_64', 'uname', '-m']);
+      } catch (error: unknown) {
+        const runError = error as RunError;
+        if (runError.stderr?.includes('Bad CPU')) {
+          // rosetta is enabled but not installed, it will fail, stop from there and prompt the user to install rosetta or disable rosetta support
+          const result = await window.showInformationMessage(
+            'Podman machine is configured to use Rosetta but the support is not installed. The startup of the machine will fail.\nDo you want to install Rosetta? Rosetta is allowing to execute amd64 images on Apple silicon architecture.',
+            'Yes',
+            'No',
+            'Disable rosetta support',
+          );
+          if (result === 'Yes') {
+            // ask the person to perform the installation using cli
+            await window.showInformationMessage(
+              'Please install Rosetta from the command line by running `softwareupdate --install-rosetta`',
+            );
+          } else if (result === 'Disable rosetta support') {
+            await podmanConfiguration.updateRosettaSetting(false);
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### What does this PR do?

Extract `checkRosettaMacArm` function from the `extension.ts` file to a dedicated file & corresponding tests.

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/10327

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
