### PR TITLE
chore(test): add workaround to e2e tests to apply kube yaml

### DIFF
--- a/tests/playwright/src/specs/kubernetes-image-push.spec.ts
+++ b/tests/playwright/src/specs/kubernetes-image-push.spec.ts
@@ -67,6 +67,8 @@ test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
     await settingsBar.cliToolsTab.click();
 
     await ensureCliInstalled(page, 'Kind');
+    // workaround for https://github.com/podman-desktop/podman-desktop/issues/13980
+    await ensureCliInstalled(page, 'kubectl');
   }
 
   await createKindCluster(page, CLUSTER_NAME, CLUSTER_CREATION_TIMEOUT, {

--- a/tests/playwright/src/specs/kubernetes-networking.spec.ts
+++ b/tests/playwright/src/specs/kubernetes-networking.spec.ts
@@ -224,12 +224,12 @@ test.describe('Kubernetes networking E2E test', { tag: '@k8s_e2e' }, () => {
       await configurePortForwarding(page, KubernetesResources.Pods, POD_NAME);
     });
 
-    test('Verify new local port response', async () => {
-      await verifyLocalPortResponse(PORT_FORWARDING_ADDRESS, RESPONSE_MESSAGE);
-    });
-
     test('Verify Kubernetes port forwarding page', async ({ page }) => {
       await verifyPortForwardingConfiguration(page, CONTAINER_NAME, LOCAL_PORT, REMOTE_PORT);
+    });
+
+    test('Verify new local port response', async () => {
+      await verifyLocalPortResponse(PORT_FORWARDING_ADDRESS, RESPONSE_MESSAGE);
     });
 
     test('Delete configuration', async ({ page }) => {

--- a/tests/playwright/src/specs/kubernetes-networking.spec.ts
+++ b/tests/playwright/src/specs/kubernetes-networking.spec.ts
@@ -105,6 +105,8 @@ test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
     await settingsBar.cliToolsTab.click();
 
     await ensureCliInstalled(page, 'Kind');
+    // workaround for https://github.com/podman-desktop/podman-desktop/issues/13980
+    await ensureCliInstalled(page, 'kubectl');
   }
 
   await createKindCluster(page, CLUSTER_NAME, CLUSTER_CREATION_TIMEOUT, {

--- a/tests/playwright/src/specs/kubernetes.spec.ts
+++ b/tests/playwright/src/specs/kubernetes.spec.ts
@@ -119,6 +119,8 @@ test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
     await settingsBar.cliToolsTab.click();
 
     await ensureCliInstalled(page, 'Kind');
+    // Workaround for https://github.com/podman-desktop/podman-desktop/issues/13980
+    await ensureCliInstalled(page, 'kubectl');
   }
 
   await createKindCluster(page, CLUSTER_NAME, CLUSTER_CREATION_TIMEOUT, {

--- a/tests/playwright/src/utility/kubernetes.ts
+++ b/tests/playwright/src/utility/kubernetes.ts
@@ -260,10 +260,15 @@ export async function verifyPortForwardingConfiguration(
 
 export async function verifyLocalPortResponse(forwardAddress: string, responseMessage: string): Promise<void> {
   return test.step('Verify local port response', async () => {
-    const response: Response = await fetch(forwardAddress, { cache: 'no-store' });
-    const blob: Blob = await response.blob();
-    const text: string = await blob.text();
-    playExpect(text).toContain(responseMessage);
+    playExpect.poll(
+      async () => {
+        const response: Response = await fetch(forwardAddress, { cache: 'no-store' });
+        const blob: Blob = await response.blob();
+        const text: string = await blob.text();
+        playExpect(text).toContain(responseMessage);
+      },
+      { timeout: 20_000, intervals: [1_000, 3_000, 5_000, 15_000] },
+    );
   });
 }
 

--- a/tests/playwright/src/utility/kubernetes.ts
+++ b/tests/playwright/src/utility/kubernetes.ts
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { execSync } from 'node:child_process';
+
 import type { Page } from '@playwright/test';
 import test, { expect as playExpect } from '@playwright/test';
 
@@ -23,7 +25,7 @@ import type { KubernetesResourceState } from '../model/core/states';
 import type { PlayKubernetesOptions } from '../model/core/types';
 import { KubernetesResources } from '../model/core/types';
 import { ContainerDetailsPage } from '../model/pages/container-details-page';
-import type { PodsPage } from '../model/pages/pods-page';
+import { PodsPage } from '../model/pages/pods-page';
 import { NavigationBar } from '../model/workbench/navigation';
 import { handleConfirmationDialog } from './operations';
 
@@ -133,14 +135,24 @@ export async function applyYamlFileToCluster(
   resourceYamlPath: string,
   kubernetesRuntime: PlayKubernetesOptions,
 ): Promise<PodsPage> {
-  return test.step(`Apply YAML file to Kubernetes cluster`, async () => {
-    const navigationBar = new NavigationBar(page);
-    const podsPage = await navigationBar.openPods();
-
-    await playExpect(podsPage.heading).toBeVisible();
-    const playYamlPage = await podsPage.openPodmanKubePlay();
-    await playExpect(playYamlPage.heading).toBeVisible();
-    return await playYamlPage.playYaml(resourceYamlPath, false, 180_000, kubernetesRuntime);
+  return test.step(`Apply YAML file to Kubernetes cluster (${kubernetesRuntime}) using Kubectl`, async () => {
+    // workaround for missing option to deploy kube yaml into cluster via UI
+    // test kubectl is present
+    try {
+      // eslint-disable-next-line sonarjs/no-os-command-from-path
+      const version = execSync('kubectl version').toString();
+      console.log(`Kubectl version stdout: ${version}`);
+    } catch (error) {
+      throw new Error(`Kubectl is not installed: ${error}`);
+    }
+    try {
+      // eslint-disable-next-line sonarjs/os-command
+      const kubectlApply = execSync(`kubectl apply -f ${resourceYamlPath}`).toString();
+      console.log(`Kube yaml ${resourceYamlPath} applied successfully via cli: ${kubectlApply}`);
+    } catch (error) {
+      throw new Error(`Error encountered when trying to apply kube yaml: ${error}`);
+    }
+    return new PodsPage(page);
   });
 }
 


### PR DESCRIPTION
### What does this PR do?
It uses kubectl installed on the test agent to apply given kube yaml on a cluster. workaround for #
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#13980
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
all kubernetes e2e tests should be passing. Will link runs.
<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
