### PR TITLE
chore: add commitlint to its group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,7 @@ updates:
       commitlint:
         applies-to: version-updates
         patterns:
+          - "commitlint"
           - "@commitlint/*"
       docusaurus:
         applies-to: version-updates


### PR DESCRIPTION
### What does this PR do?

I don't see PRs created by dependabot for the latest commitlint update (20.0.0) yet, but based on the bootc extension (https://github.com/podman-desktop/extension-bootc/pull/1953) this repo has the same issue: commitlint isn't in the dependabot group with its name. This just moves it in so that the group is correctly batched.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Merge, see when dependabot pushes the update.