### PR TITLE
chore(test): add validation for jobs being finished

### DIFF
--- a/tests/playwright/src/model/core/states.ts
+++ b/tests/playwright/src/model/core/states.ts
@@ -61,6 +61,7 @@ export enum KubernetesResourceState {
   Stopped = 'STOPPED',
   Unknown = 'UNKNOWN',
   Succeeded = 'SUCCEEDED',
+  None = '',
 }
 export enum ExtensionState {
   Disabled = 'DISABLED',

--- a/tests/playwright/src/specs/kubernetes.spec.ts
+++ b/tests/playwright/src/specs/kubernetes.spec.ts
@@ -334,6 +334,15 @@ test.describe('Kubernetes resources End-to-End test', { tag: '@k8s_e2e' }, () =>
           KubernetesResourceState.Running,
           70_000,
         );
+
+        await checkKubernetesResourceState(
+          page,
+          KubernetesResources.Jobs,
+          CRON_JOB_NAME,
+          KubernetesResourceState.None, // Currently there is no 'Completed' state, using None which means the state column is empty
+          70_000,
+        );
+
         await checkKubernetesResourceState(
           page,
           KubernetesResources.Pods,

--- a/tests/playwright/src/utility/kubernetes.ts
+++ b/tests/playwright/src/utility/kubernetes.ts
@@ -126,7 +126,7 @@ export async function checkKubernetesResourceState(
     await playExpect(kubernetesResourceDetails.heading).toBeVisible();
     await playExpect
       .poll(async () => kubernetesResourceDetails.getState(), { timeout: timeout })
-      .toEqual(expectedResourceState);
+      .toBe(expectedResourceState);
   });
 }
 


### PR DESCRIPTION
### What does this PR do?
Adds validation in k8s e2e tests for jobs page to check that jobs are displayed and finished

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/12214