### PR TITLE
fix: address unhandled race condition for logs to console after windo…

### DIFF
--- a/packages/main/src/plugin/index.spec.ts
+++ b/packages/main/src/plugin/index.spec.ts
@@ -778,30 +778,17 @@ describe('Log race condition fix', () => {
   });
 
   test('should not throw error when window is destroyed during shutdown', () => {
-    // Simulate the race condition: window destroyed, getWebContentsSender throws
     vi.spyOn(pluginSystem, 'getWebContentsSender').mockImplementation(() => {
       throw new Error('Unable to find the main window');
     });
     (pluginSystem as any).isQuitting = false;
 
     const logger = pluginSystem.getLogHandler('test-channel', 'test-logger');
-
-    // The core test: no exceptions should be thrown
     expect(() => {
       logger.log('test');
       logger.warn('test');
       logger.error('test');
       logger.onEnd();
     }).not.toThrow();
-  });
-
-  test('should not attempt to send when isQuitting=true', () => {
-    const spy = vi.spyOn(pluginSystem, 'getWebContentsSender');
-    (pluginSystem as any).isQuitting = true;
-
-    const logger = pluginSystem.getLogHandler('test-channel', 'test-logger');
-    logger.log('test');
-
-    expect(spy).not.toHaveBeenCalled();
   });
 });

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -3178,8 +3178,6 @@ export class PluginSystem {
 
   getLogHandler(channel: string, loggerId: string): LoggerWithEnd {
     const safeSend = (messageType: string, data?: unknown): void => {
-      if (this.isQuitting) return;
-
       try {
         this.getWebContentsSender().send(channel, loggerId, messageType, data);
       } catch (err) {

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -3177,14 +3177,13 @@ export class PluginSystem {
   }
 
   getLogHandler(channel: string, loggerId: string): LoggerWithEnd {
-    // Helper function to safely send to renderer, handling shutdown race condition
     const safeSend = (messageType: string, data?: unknown): void => {
-      if (!this.isQuitting) {
-        try {
-          this.getWebContentsSender().send(channel, loggerId, messageType, data);
-        } catch (err) {
-          // Silently ignore errors during shutdown race condition
-        }
+      if (this.isQuitting) return;
+
+      try {
+        this.getWebContentsSender().send(channel, loggerId, messageType, data);
+      } catch (err) {
+        console.error('Failed to send log message to renderer:', err);
       }
     };
 


### PR DESCRIPTION
…w is destroyed

more specifically this race condition happened under a very narrow window. If the user quits the app while podman vm is stopping the code would try to log to the console during quiting and there was no safetly measure during the small window to prevent those logs from happening after the window shutdown.

### What does this PR do?

Fixes: https://github.com/podman-desktop/podman-desktop/issues/13630

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

You're in for a rough time if you want to test this since the window is so narrow for the error to show up
dont checkout this pr 
Follow the instructions here with a small catch
https://github.com/podman-desktop/podman-desktop/issues/13630
when exiting podman desktop wait a moment to see maybe 2 logs before quitting
if your luckly you should spot the os crash dialog for the uncaught exception
this pr aims to catch this error and avoid the dialog crash

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ x] Tests are covering the bug fix or the new feature
