### PR TITLE
style: align download icon links

### DIFF
--- a/website/src/pages/downloads/linux.tsx
+++ b/website/src/pages/downloads/linux.tsx
@@ -45,11 +45,11 @@ export function LinuxDownloads(): JSX.Element {
           <h3 className="mt-0">Podman Desktop for Linux</h3>
           <div className="pt-8">
             <TelemetryLink
-              className="mt-auto no-underline hover:no-underline inline-flex text-white hover:text-white bg-purple-500 border-0 py-2 px-6 focus:outline-hidden hover:bg-purple-500 rounded-sm text-md font-semibold"
+              className="mt-auto no-underline hover:no-underline inline-flex text-white hover:text-white bg-purple-500 border-0 py-2 px-6 focus:outline-hidden hover:bg-purple-500 rounded-sm text-md font-semibold items-center"
               eventPath="download"
               eventTitle="download-linux"
               to={linux.flatpak}>
-              <FontAwesomeIcon size="1x" icon={faDownload} className="mr-2" />
+              <FontAwesomeIcon size="1x" icon={faDownload} className="mr-2 my-auto" />
               Download Now
             </TelemetryLink>
             <caption className="block w-full mt-1 text/50 dark:text-white/50">

--- a/website/src/pages/downloads/macos.tsx
+++ b/website/src/pages/downloads/macos.tsx
@@ -45,11 +45,11 @@ export function MacOSDownloads(): JSX.Element {
           <h3 className="mt-0">Podman Desktop for macOS</h3>
           <div className="pt-8">
             <TelemetryLink
-              className="mt-auto no-underline hover:no-underline inline-flex text-white hover:text-white bg-purple-500 border-0 py-2 px-6 focus:outline-hidden hover:bg-purple-500 rounded-sm text-md font-semibold"
+              className="mt-auto no-underline hover:no-underline inline-flex text-white hover:text-white bg-purple-500 border-0 py-2 px-6 focus:outline-hidden hover:bg-purple-500 rounded-sm text-md font-semibold items-center"
               eventPath="download"
               eventTitle="download-mac"
               to={macos.universal}>
-              <FontAwesomeIcon size="1x" icon={faDownload} className="mr-2" />
+              <FontAwesomeIcon size="1x" icon={faDownload} className="mr-2 my-auto" />
               Download Now
             </TelemetryLink>
             <caption className="block w-full mt-1 text/50 dark:text-white/50">

--- a/website/src/pages/downloads/windows.tsx
+++ b/website/src/pages/downloads/windows.tsx
@@ -46,11 +46,11 @@ export function WindowsDownloads(): JSX.Element {
           <h3 className="mt-0">Podman Desktop for Windows</h3>
           <div className="pt-8">
             <TelemetryLink
-              className="mt-auto no-underline hover:no-underline inline-flex text-white hover:text-white bg-purple-500 border-0 py-2 px-6 focus:outline-hidden hover:bg-purple-500 rounded-sm text-md font-semibold"
+              className="mt-auto no-underline hover:no-underline inline-flex text-white hover:text-white bg-purple-500 border-0 py-2 px-6 focus:outline-hidden hover:bg-purple-500 rounded-sm text-md font-semibold items-center"
               eventPath="download"
               eventTitle="download-windows"
               to={windows.setupX64}>
-              <FontAwesomeIcon size="1x" icon={faDownload} className="mr-2" />
+              <FontAwesomeIcon size="1x" icon={faDownload} className="mr-2 my-auto" />
               Download Now
             </TelemetryLink>
             <caption className="block w-full mt-1 text/50 dark:text-white/50">


### PR DESCRIPTION
Signed-off-by: Adrian Barrio <statickidz@gmail.com>

### What does this PR do?

- This PR improves the alignment of download icon links across all platform download.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

<img width="2515" height="1257" alt="image" src="https://github.com/user-attachments/assets/5355be45-ebef-4617-90c8-11ab342bb4fe" />

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes #13870 

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

1. Build and run the website locally

2. Navigate to the download pages:
   - Linux downloads: `/downloads/linux`
   - macOS downloads: `/downloads/macos`
   - Windows downloads: `/downloads/windows`

3. Verify the following:
   - Download icons are properly centered within their buttons
   - Icons maintain consistent alignment across all three platform pages
   - No visual regressions in button appearance or functionality
   - Download buttons still function correctly when clicked

- [ ] Tests are covering the bug fix or the new feature
