### PR TITLE
refactor(renderer): make PodsList uses the TableSvelte5 component

### DIFF
--- a/packages/renderer/src/lib/pod/PodInfoUI.ts
+++ b/packages/renderer/src/lib/pod/PodInfoUI.ts
@@ -39,7 +39,6 @@ export interface PodInfoUI {
   status: string;
   age: string;
   created: string;
-  selected: boolean;
   containers: PodInfoContainerUI[];
   actionInProgress?: boolean;
   actionError?: string;

--- a/packages/renderer/src/lib/table/TableSvelte5.spec.ts
+++ b/packages/renderer/src/lib/table/TableSvelte5.spec.ts
@@ -1,0 +1,381 @@
+/*********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom/vitest';
+
+import { TableColumn, TableDurationColumn, TableRow, TableSimpleColumn } from '@podman-desktop/ui-svelte';
+import { fireEvent, render, within } from '@testing-library/svelte';
+import { SvelteSet } from 'svelte/reactivity';
+import { assert, describe, expect, test, vi } from 'vitest';
+
+import TableSvelte5 from '/@/lib/table/TableSvelte5.svelte';
+
+type Person = {
+  id: number;
+  name: string;
+  age: number;
+  hobby: string;
+  duration?: number;
+};
+
+const PARENTS: Array<Person> = [
+  { id: 1, name: 'John', age: 57, hobby: 'Skydiving' },
+  { id: 2, name: 'Henry', age: 27, hobby: 'Cooking' },
+  { id: 3, name: 'Charlie', age: 43, hobby: 'Biking', duration: new Date().getTime() - 3600000 },
+];
+
+const CHILDREN: Record<number, Array<Person>> = {
+  1: [
+    { id: 4, name: 'John Junior', age: 12, hobby: 'Eating potatoes' },
+    { id: 5, name: 'Johny Junior', age: 14, hobby: 'Eating chicken' },
+  ],
+  3: [{ id: 6, name: 'Charlie Junior', age: 10, hobby: 'Drinking' }],
+};
+
+const ALL_PERSON: Array<Person> = [...PARENTS, ...Object.values(CHILDREN).flat()];
+
+const ID_COLUMN: TableColumn<Person, string> = new TableColumn('Id', {
+  align: 'right',
+  renderMapping: obj => obj.id.toString(),
+  renderer: TableSimpleColumn,
+  comparator: (a, b) => a.id - b.id,
+});
+
+const NAME_COLUMN: TableColumn<Person, string> = new TableColumn('Name', {
+  width: '3fr',
+  renderMapping: obj => obj.name,
+  renderer: TableSimpleColumn,
+  comparator: (a, b) => a.name.localeCompare(b.name),
+});
+
+const AGE_COLUMN: TableColumn<Person, string> = new TableColumn('Age', {
+  align: 'right',
+  renderMapping: obj => obj.age.toString(),
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => {
+    return a.age - b.age;
+  },
+  initialOrder: 'descending',
+  overflow: true,
+});
+
+const HOBBY_COLUMN: TableColumn<Person, string> = new TableColumn('Hobby', {
+  renderMapping: obj => obj.hobby,
+  renderer: TableSimpleColumn,
+  initialOrder: 'ascending',
+});
+
+const DURATION_COLUMN = new TableColumn<Person, Date | undefined>('Duration', {
+  renderMapping: (obj): Date | undefined => (obj.duration ? new Date(obj.duration) : undefined),
+  renderer: TableDurationColumn,
+});
+
+const COLUMNS = [ID_COLUMN, NAME_COLUMN, AGE_COLUMN, HOBBY_COLUMN, DURATION_COLUMN];
+
+const SIMPLE_ROW = new TableRow<Person>({});
+
+const ADVANCED_ROW = new TableRow<Person>({
+  selectable: (person: Person): boolean => person.age < 50,
+  children: (person: Person): Array<Person> => CHILDREN[person.id] || [],
+  disabledText: 'People over 50 cannot be deleted',
+});
+
+function key(person: Person): string {
+  return String(person.id);
+}
+
+function label(person: Person): string {
+  return person.name;
+}
+
+describe('column header', () => {
+  test('expect number of column header equal to columns', () => {
+    const { getAllByRole } = render(TableSvelte5<Person>, {
+      kind: 'persons',
+      data: PARENTS,
+      row: SIMPLE_ROW,
+      columns: COLUMNS,
+      key,
+      label,
+    });
+
+    const columns = getAllByRole('columnheader');
+    expect(columns).toHaveLength(COLUMNS.length);
+  });
+
+  test.each<TableColumn<any, any>>(COLUMNS)('column header with $title should exists', async column => {
+    const { getByRole } = render(TableSvelte5<Person>, {
+      kind: 'persons',
+      data: PARENTS,
+      row: SIMPLE_ROW,
+      columns: COLUMNS,
+      key,
+      label,
+    });
+
+    const header = getByRole('columnheader', { name: column.title });
+    expect(header).toHaveTextContent(column.title);
+  });
+});
+
+describe('sorting', () => {
+  test.each<TableColumn<any, any>>(COLUMNS)('should default sort by column $title', async column => {
+    const { getByRole } = render(TableSvelte5<Person>, {
+      kind: 'persons',
+      data: PARENTS,
+      row: SIMPLE_ROW,
+      columns: COLUMNS,
+      key,
+      label,
+      // Specify default sort column
+      defaultSortColumn: column.title,
+    });
+
+    const header = getByRole('columnheader', { name: column.title });
+    if (!column.info.comparator) {
+      expect(header).not.toHaveClass('cursor-pointer');
+      return; // test stop here as no comparator provided
+    }
+
+    expect(header).toHaveClass('cursor-pointer');
+    const image = within(header).getByRole('img');
+
+    // sort icon should not be visible
+    expect(image).not.toHaveClass('fa-sort');
+
+    switch (column.info.initialOrder) {
+      case 'ascending':
+        expect(image).toHaveClass('fa-sort-up');
+        expect(image).not.toHaveClass('fa-sort-down');
+        break;
+      case 'descending':
+      case undefined:
+        expect(image).toHaveClass('fa-sort-down');
+        expect(image).not.toHaveClass('fa-sort-up');
+        break;
+      default:
+        throw new Error(`Unexpected initial order: ${column.info.initialOrder}`);
+    }
+  });
+
+  test.each<TableColumn<any, any>>(COLUMNS.filter(column => column.info.comparator))(
+    'column $title should be sortable',
+    async column => {
+      assert(column.info.comparator, 'column should have comparator');
+
+      const { getByRole } = render(TableSvelte5<Person>, {
+        kind: 'persons',
+        data: PARENTS,
+        row: SIMPLE_ROW,
+        columns: COLUMNS,
+        key,
+        label,
+      });
+
+      // Get corresponding header
+      const header = getByRole('columnheader', { name: column.title });
+
+      // Get icon
+      const image = within(header).getByRole('img');
+      expect(image).toHaveClass('fa-sort');
+
+      // click on sort
+      await fireEvent.click(header);
+
+      // wait for icon to change
+      await vi.waitFor(() => {
+        switch (column.info.initialOrder) {
+          case 'ascending':
+          case undefined:
+            expect(image).toHaveClass('fa-sort-up');
+            expect(image).not.toHaveClass('fa-sort-down');
+            break;
+          case 'descending':
+            expect(image).toHaveClass('fa-sort-down');
+            expect(image).not.toHaveClass('fa-sort-up');
+            break;
+          default:
+            throw new Error(`Unexpected initial order: ${column.info.initialOrder}`);
+        }
+      });
+
+      // click to invert sorting order
+      await fireEvent.click(header);
+
+      // wait for icon to be inverted
+      await vi.waitFor(() => {
+        switch (column.info.initialOrder) {
+          case 'ascending':
+          case undefined:
+            expect(image).toHaveClass('fa-sort-down');
+            expect(image).not.toHaveClass('fa-sort-up');
+            break;
+          case 'descending':
+            expect(image).toHaveClass('fa-sort-up');
+            expect(image).not.toHaveClass('fa-sort-down');
+            break;
+          default:
+            throw new Error(`Unexpected initial order: ${column.info.initialOrder}`);
+        }
+      });
+    },
+  );
+});
+
+describe('collapsed', () => {
+  test.each<Person>(PARENTS)('row $id should have proper corner', person => {
+    const { getByRole } = render(TableSvelte5<Person>, {
+      kind: 'persons',
+      data: PARENTS,
+      row: ADVANCED_ROW,
+      columns: COLUMNS,
+      key,
+      label,
+    });
+
+    const row = getByRole('row', { name: label(person) });
+
+    const hasChildren = (ADVANCED_ROW.info.children?.(person) ?? []).length > 0;
+    if (hasChildren) {
+      // with children expect no bottom corner
+      expect(row).toHaveClass('rounded-t-lg');
+    } else {
+      // without children expect bottom corner
+      expect(row).toHaveClass('rounded-lg');
+    }
+  });
+
+  test.each<Person>(PARENTS.filter(person => (ADVANCED_ROW.info.children?.(person) ?? []).length > 0))(
+    'collapsed row $id should have proper aria',
+    person => {
+      const { getByRole } = render(TableSvelte5<Person>, {
+        kind: 'persons',
+        data: PARENTS,
+        row: ADVANCED_ROW,
+        columns: COLUMNS,
+        key,
+        label,
+        // Specify collapsed set
+        collapsed: new SvelteSet([key(person)]),
+      });
+
+      const row = getByRole('row', { name: label(person) });
+
+      // Ensure the button has aria-expanded="false"
+      const collapseBtn = within(row).getByRole('button');
+      expect(collapseBtn).toHaveAttribute('aria-expanded', 'false');
+    },
+  );
+});
+
+describe('selected', () => {
+  test('check boxes should not appear when row has not selectable', async () => {
+    const { queryByRole } = render(TableSvelte5<Person>, {
+      kind: 'persons',
+      data: PARENTS,
+      row: SIMPLE_ROW,
+      columns: COLUMNS,
+      key,
+      label,
+    });
+
+    const checkbox = queryByRole('checkbox');
+    expect(checkbox).toBeNull();
+  });
+
+  test.each<Person>(ALL_PERSON)('row $id should not be selected by default', person => {
+    const { getByRole } = render(TableSvelte5<Person>, {
+      kind: 'persons',
+      data: PARENTS,
+      row: ADVANCED_ROW,
+      columns: COLUMNS,
+      key,
+      label,
+    });
+
+    const row = getByRole('row', { name: label(person) });
+    const checkbox = within(row).getByRole('checkbox');
+
+    expect(checkbox).not.toBeChecked();
+  });
+
+  test.each<Person>(ALL_PERSON)('row $id should have appropriate check value on toggle all', async person => {
+    const { getByRole } = render(TableSvelte5<Person>, {
+      kind: 'persons',
+      data: PARENTS,
+      row: ADVANCED_ROW,
+      columns: COLUMNS,
+      key,
+      label,
+    });
+
+    const toggleAll = getByRole('checkbox', { name: 'Toggle all' });
+    await fireEvent.click(toggleAll);
+
+    await vi.waitFor(() => {
+      const row = getByRole('row', { name: label(person) });
+      const checkbox = within(row).getByRole('checkbox');
+
+      if (ADVANCED_ROW.info.selectable?.(person)) {
+        expect(checkbox).toBeChecked();
+      } else {
+        expect(checkbox).not.toBeChecked();
+      }
+    });
+  });
+});
+
+describe('grid', () => {
+  test.each<{
+    row: TableRow<Person>;
+    gridTemplateColumns: string;
+    name: string;
+  }>([
+    {
+      row: SIMPLE_ROW,
+      gridTemplateColumns: '20px 1fr 3fr 1fr 1fr 1fr 5px',
+      name: 'row with no selectable should not include space for checkbox',
+    },
+    {
+      row: ADVANCED_ROW,
+      gridTemplateColumns: '20px 32px 1fr 3fr 1fr 1fr 1fr 5px',
+      name: 'row with selectable should include space for checkbox',
+    },
+  ])('$name', async ({ row, gridTemplateColumns }) => {
+    const { getAllByRole, getByRole } = render(TableSvelte5<Person>, {
+      kind: 'persons',
+      data: PARENTS,
+      row: row,
+      columns: COLUMNS,
+      key,
+      label,
+    });
+
+    const container = getByRole('table');
+    expect(container).toHaveStyle({
+      '--table-grid-table-columns': gridTemplateColumns,
+    });
+
+    const rows = getAllByRole('row');
+    for (const row of rows) {
+      expect(row).toHaveClass('grid-table');
+    }
+  });
+});

--- a/packages/renderer/src/lib/table/TableSvelte5.spec.ts
+++ b/packages/renderer/src/lib/table/TableSvelte5.spec.ts
@@ -106,7 +106,7 @@ function label(person: Person): string {
 }
 
 describe('column header', () => {
-  test('expect number of column header equal to columns', () => {
+  test('expect number of column header equal to columns plus one', () => {
     const { getAllByRole } = render(TableSvelte5<Person>, {
       kind: 'persons',
       data: PARENTS,
@@ -117,7 +117,7 @@ describe('column header', () => {
     });
 
     const columns = getAllByRole('columnheader');
-    expect(columns).toHaveLength(COLUMNS.length);
+    expect(columns).toHaveLength(COLUMNS.length + 1);
   });
 
   test.each<TableColumn<any, any>>(COLUMNS)('column header with $title should exists', async column => {

--- a/packages/renderer/src/lib/table/TableSvelte5.svelte
+++ b/packages/renderer/src/lib/table/TableSvelte5.svelte
@@ -209,7 +209,6 @@ function onToggle(keyItem: string): void {
     <div
       class="grid grid-table gap-x-0.5 h-7 sticky top-0 text-[var(--pd-table-header-text)] uppercase z-2"
       role="row">
-      <div class="whitespace-nowrap justify-self-start" role="columnheader"></div>
       {#if row.info.selectable}
         <div class="whitespace-nowrap place-self-center" role="columnheader">
           <Checkbox
@@ -232,18 +231,22 @@ function onToggle(keyItem: string): void {
               : 'justify-self-start'} self-center select-none"
           class:cursor-pointer={column.info.comparator}
           onclick={sort.bind(undefined, column)}
-          role="columnheader">
+          role="columnheader"
+          aria-label={column.title}
+        >
           <div class="overflow-hidden text-ellipsis">
             {column.title}
           </div>
-          {#if column.info.comparator}<i
-            class="fas pl-0.5"
-            class:fa-sort={sortCol !== column}
-            class:fa-sort-up={sortCol === column && sortAscending}
-            class:fa-sort-down={sortCol === column && !sortAscending}
-            class:text-[var(--pd-table-header-unsorted)]={sortCol !== column}
-            aria-hidden="true"></i
-          >{/if}
+          {#if column.info.comparator}
+            <i class="fas pl-0.5"
+              class:fa-sort={sortCol !== column}
+              class:fa-sort-up={sortCol === column && sortAscending}
+              class:fa-sort-down={sortCol === column && !sortAscending}
+              class:text-[var(--pd-table-header-unsorted)]={sortCol !== column}
+              role="img"
+              aria-label={sortCol !== column ? 'Not sorted' : sortAscending ? 'Sorted ascending' : 'Sorted descending'}
+            ></i>
+          {/if}
         </div>
       {/each}
     </div>

--- a/packages/renderer/src/lib/table/TableSvelte5.svelte
+++ b/packages/renderer/src/lib/table/TableSvelte5.svelte
@@ -45,6 +45,27 @@ let {
   label,
 }: Props = $props();
 
+// All keys of the data
+let keys: Set<string> = $derived(
+  new Set(data.flatMap((item: T) => [key(item), ...(row.info.children?.(item)?.map(child => key(child)) ?? [])])),
+);
+
+$effect(() => {
+  // cleanup selected set
+  selected.values().forEach((item: string) => {
+    if (!keys.has(item)) {
+      selected.delete(item);
+    }
+  });
+
+  // cleanup collapsed set
+  collapsed.values().forEach((item: string) => {
+    if (!keys.has(item)) {
+      collapsed.delete(item);
+    }
+  });
+});
+
 /**
  * Svelte states
  */
@@ -221,6 +242,7 @@ function onToggle(keyItem: string): void {
     <div
       class="grid grid-table gap-x-0.5 h-7 sticky top-0 text-[var(--pd-table-header-text)] uppercase z-2"
       role="row">
+      <div class="whitespace-nowrap justify-self-start" role="columnheader"></div>
       {#if row.info.selectable}
         <div class="whitespace-nowrap place-self-center" role="columnheader">
           <Checkbox

--- a/packages/renderer/src/lib/table/TableSvelte5.svelte
+++ b/packages/renderer/src/lib/table/TableSvelte5.svelte
@@ -124,9 +124,37 @@ function onToggle(keyItem: string): void {
 }
 </script>
 
-{#snippet RowGroup(object: T)}
+{#snippet RowItem(object: T, itemKey: string)}
+  {#if row.info.selectable}
+    <div class="whitespace-nowrap place-self-center" role="cell">
+      <Checkbox
+        title="Toggle {kind}"
+        checked={selected.has(itemKey)}
+        disabled={!row.info.selectable(object)}
+        disabledTooltip={row.info.disabledText}
+        onclick={onChecked.bind(undefined, object)} />
+    </div>
+  {/if}
+  {#each columns as column, index (index)}
+    {@const Render = column.info.renderer}
+    <div
+      class="whitespace-nowrap {column.info.align === 'right'
+                ? 'justify-self-end'
+                : column.info.align === 'center'
+                  ? 'justify-self-center'
+                  : 'justify-self-start'} self-center {column.info.overflow === true
+                ? ''
+                : 'overflow-hidden'} max-w-full py-1.5"
+      role="cell">
+      {#if column.info.renderer}
+        <Render object={column.info.renderMapping ? column.info.renderMapping(object) : object}/>
+      {/if}
+    </div>
+  {/each}
+{/snippet}
+
+{#snippet RowGroup(object: T, itemKey: string)}
   {@const children = row.info.children?.(object) ?? []}
-  {@const itemKey = key(object)}
   <div class="min-h-[48px] h-fit bg-[var(--pd-content-card-bg)] rounded-lg mb-2 border border-[var(--pd-content-table-border)]">
     <div
       class="grid grid-table gap-x-0.5 min-h-[48px] hover:bg-[var(--pd-content-card-hover-bg)]"
@@ -149,70 +177,21 @@ function onToggle(keyItem: string): void {
           </button>
         {/if}
       </div>
-      {#if row.info.selectable}
-        <div class="whitespace-nowrap place-self-center" role="cell">
-          <Checkbox
-            title="Toggle {kind}"
-            checked={selected.has(itemKey)}
-            disabled={!row.info.selectable(object)}
-            disabledTooltip={row.info.disabledText}
-            onclick={onChecked.bind(undefined, object)} />
-        </div>
-      {/if}
-      {#each columns as column, index (index)}
-        {@const Render = column.info.renderer}
-        <div
-          class="whitespace-nowrap {column.info.align === 'right'
-                ? 'justify-self-end'
-                : column.info.align === 'center'
-                  ? 'justify-self-center'
-                  : 'justify-self-start'} self-center {column.info.overflow === true
-                ? ''
-                : 'overflow-hidden'} max-w-full py-1.5"
-          role="cell">
-          {#if column.info.renderer}
-            <Render object={column.info.renderMapping ? column.info.renderMapping(object) : object}/>
-          {/if}
-        </div>
-      {/each}
+      <!-- eslint-disable-next-line sonarjs/no-use-of-empty-return-value -->
+      {@render RowItem(object, itemKey)}
     </div>
 
     <!-- Child objects -->
     {#if !collapsed.has(itemKey) && children.length > 0}
       {#each children as child, i (child)}
-        {@const childKey = key(child)}
         <div
           class="grid grid-table gap-x-0.5 hover:bg-[var(--pd-content-card-hover-bg)]"
           class:rounded-b-lg={i === children.length - 1}
           role="row"
           aria-label={label(child)}>
           <div class="whitespace-nowrap justify-self-start" role="cell"></div>
-          {#if row.info.selectable}
-            <div class="whitespace-nowrap place-self-center" role="cell">
-              <Checkbox
-                title="Toggle {kind}"
-                checked={selected.has(childKey)}
-                disabled={!row.info.selectable(child)}
-                disabledTooltip={row.info.disabledText}
-                onclick={onChecked.bind(undefined, child)} />
-            </div>
-          {/if}
-          {#each columns as column, index (index)}
-            {@const Render = column.info.renderer}
-            <div
-              class="whitespace-nowrap {column.info.align === 'right'
-                    ? 'justify-self-end'
-                    : column.info.align === 'center'
-                      ? 'justify-self-center'
-                      : 'justify-self-start'} self-center {column.info.overflow === true
-                    ? ''
-                    : 'overflow-hidden'} max-w-full py-1.5"
-              role="cell">
-              {#if column.info.renderer}
-                <Render object={column.info.renderMapping ? column.info.renderMapping(object) : object}/>
-              {/if}
-            </div>
-          {/each}
+          <!-- eslint-disable-next-line sonarjs/no-use-of-empty-return-value -->
+          {@render RowItem(child, key(child))}
         </div>
       {/each}
     {/if}
@@ -273,7 +252,7 @@ function onToggle(keyItem: string): void {
   <div role="rowgroup">
     {#each sortedData as object (object)}
       <!-- eslint-disable-next-line sonarjs/no-use-of-empty-return-value -->
-      {@render RowGroup(object)}
+      {@render RowGroup(object, key(object))}
     {/each}
   </div>
 </div>

--- a/packages/renderer/src/lib/table/TableSvelte5.svelte
+++ b/packages/renderer/src/lib/table/TableSvelte5.svelte
@@ -1,0 +1,279 @@
+<style>
+.grid-table {
+  display: grid;
+  grid-template-columns: var(--table-grid-table-columns);
+}
+</style>
+
+<script lang="ts" generics="T">
+import { faChevronDown, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import type { TableColumn, TableRow } from '@podman-desktop/ui-svelte';
+import { Checkbox } from '@podman-desktop/ui-svelte';
+import { Icon } from '@podman-desktop/ui-svelte/icons';
+import { SvelteSet } from 'svelte/reactivity';
+
+interface Props {
+  /**
+   * aria-label of the root component
+   */
+  kind: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  columns: Array<TableColumn<T, any>>;
+  row: TableRow<T>;
+  data: Array<T>;
+  defaultSortColumn?: string;
+  collapsed?: SvelteSet<string>;
+  selected?: SvelteSet<string>;
+
+  /**
+   * To follow Svelte guideline about keyed-each-blocks, you must explicitly provide a key function.
+   * @param object
+   */
+  key(object: T): string;
+  label(object: T): string;
+}
+
+let {
+  kind,
+  data,
+  row,
+  columns,
+  defaultSortColumn,
+  collapsed = $bindable(new SvelteSet()),
+  selected = $bindable(new SvelteSet()),
+  key,
+  label,
+}: Props = $props();
+
+/**
+ * Svelte states
+ */
+let gridTemplateColumns: string = $derived.by(() => {
+  // section and checkbox columns
+  let columnWidths: string[] = ['20px'];
+
+  if (row.info.selectable) {
+    columnWidths.push('32px');
+  }
+
+  // custom columns
+  columns.map(c => c.info.width ?? '1fr').forEach(w => columnWidths.push(w));
+
+  // final spacer
+  columnWidths.push('5px');
+
+  return columnWidths.join(' ');
+});
+
+let selectedAllCheckboxes = $derived(data.every(object => selected.has(key(object))));
+let sortCol: TableColumn<T, unknown> | undefined = $state(
+  defaultSortColumn ? columns.find(column => column.title === defaultSortColumn) : undefined,
+);
+let sortAscending: boolean = $state(false);
+
+let sortedData: Array<T> = $derived.by(() => {
+  let comparator = sortCol?.info?.comparator;
+  if (!comparator) {
+    return data;
+  }
+
+  if (!sortAscending) {
+    // we're already sorted, switch to reverse order
+    let comparatorTemp = comparator;
+    comparator = (a, b): number => -comparatorTemp(a, b);
+  }
+
+  // do not sort in place
+  return data.toSorted(comparator);
+});
+
+/**
+ * Utility functions
+ */
+function onCheckedAll(checked: boolean): void {
+  data.forEach(object => onChecked(object, checked));
+}
+
+function onChecked(object: T, checked: boolean): void {
+  if (row.info.selectable?.(object)) {
+    if (checked) {
+      selected.add(key(object));
+    } else {
+      selected.delete(key(object));
+    }
+  }
+  const children = row.info.children?.(object);
+  children?.forEach(child => onChecked(child, checked));
+}
+
+function sort(column: TableColumn<T, unknown>): void {
+  if (sortCol === column) {
+    sortAscending = !sortAscending;
+  } else {
+    sortAscending = column.info.initialOrder ? column.info.initialOrder !== 'descending' : true;
+    sortCol = column;
+  }
+}
+
+function onToggle(keyItem: string): void {
+  if (collapsed.has(keyItem)) {
+    collapsed.delete(keyItem);
+  } else {
+    collapsed.add(keyItem);
+  }
+}
+</script>
+
+{#snippet RowGroup(object: T)}
+  {@const children = row.info.children?.(object) ?? []}
+  {@const itemKey = key(object)}
+  <div class="min-h-[48px] h-fit bg-[var(--pd-content-card-bg)] rounded-lg mb-2 border border-[var(--pd-content-table-border)]">
+    <div
+      class="grid grid-table gap-x-0.5 min-h-[48px] hover:bg-[var(--pd-content-card-hover-bg)]"
+      class:rounded-t-lg={!collapsed.has(itemKey) &&
+            children.length > 0}
+      class:rounded-lg={collapsed.has(itemKey) ||
+            children.length === 0}
+      role="row"
+      aria-label={label(object)}>
+      <div class="whitespace-nowrap place-self-center" role="cell">
+        {#if children.length > 0}
+          <button
+            title={collapsed.has(itemKey) ? 'Expand Row' : 'Collapse Row'}
+            aria-expanded={!collapsed.has(itemKey)}
+            onclick={onToggle.bind(undefined, itemKey)}
+          >
+            <Icon size="0.8x"
+                  class="text-[var(--pd-table-body-text)] cursor-pointer"
+                  icon={collapsed.has(itemKey) ? faChevronRight : faChevronDown}/>
+          </button>
+        {/if}
+      </div>
+      {#if row.info.selectable}
+        <div class="whitespace-nowrap place-self-center" role="cell">
+          <Checkbox
+            title="Toggle {kind}"
+            checked={selected.has(itemKey)}
+            disabled={!row.info.selectable(object)}
+            disabledTooltip={row.info.disabledText}
+            onclick={onChecked.bind(undefined, object)} />
+        </div>
+      {/if}
+      {#each columns as column, index (index)}
+        {@const Render = column.info.renderer}
+        <div
+          class="whitespace-nowrap {column.info.align === 'right'
+                ? 'justify-self-end'
+                : column.info.align === 'center'
+                  ? 'justify-self-center'
+                  : 'justify-self-start'} self-center {column.info.overflow === true
+                ? ''
+                : 'overflow-hidden'} max-w-full py-1.5"
+          role="cell">
+          {#if column.info.renderer}
+            <Render object={column.info.renderMapping ? column.info.renderMapping(object) : object}/>
+          {/if}
+        </div>
+      {/each}
+    </div>
+
+    <!-- Child objects -->
+    {#if !collapsed.has(itemKey) && children.length > 0}
+      {#each children as child, i (child)}
+        {@const childKey = key(child)}
+        <div
+          class="grid grid-table gap-x-0.5 hover:bg-[var(--pd-content-card-hover-bg)]"
+          class:rounded-b-lg={i === children.length - 1}
+          role="row"
+          aria-label={label(child)}>
+          <div class="whitespace-nowrap justify-self-start" role="cell"></div>
+          {#if row.info.selectable}
+            <div class="whitespace-nowrap place-self-center" role="cell">
+              <Checkbox
+                title="Toggle {kind}"
+                checked={selected.has(childKey)}
+                disabled={!row.info.selectable(child)}
+                disabledTooltip={row.info.disabledText}
+                onclick={onChecked.bind(undefined, child)} />
+            </div>
+          {/if}
+          {#each columns as column, index (index)}
+            {@const Render = column.info.renderer}
+            <div
+              class="whitespace-nowrap {column.info.align === 'right'
+                    ? 'justify-self-end'
+                    : column.info.align === 'center'
+                      ? 'justify-self-center'
+                      : 'justify-self-start'} self-center {column.info.overflow === true
+                    ? ''
+                    : 'overflow-hidden'} max-w-full py-1.5"
+              role="cell">
+              {#if column.info.renderer}
+                <Render object={column.info.renderMapping ? column.info.renderMapping(object) : object}/>
+              {/if}
+            </div>
+          {/each}
+        </div>
+      {/each}
+    {/if}
+  </div>
+{/snippet}
+
+<div
+  style="--table-grid-table-columns: {gridTemplateColumns}"
+  class="w-full mx-5"
+  class:hidden={data.length === 0}
+  role="table"
+  aria-label={kind}>
+  <!-- Table header -->
+  <div role="rowgroup">
+    <div
+      class="grid grid-table gap-x-0.5 h-7 sticky top-0 text-[var(--pd-table-header-text)] uppercase z-2"
+      role="row">
+      <div class="whitespace-nowrap justify-self-start" role="columnheader"></div>
+      {#if row.info.selectable}
+        <div class="whitespace-nowrap place-self-center" role="columnheader">
+          <Checkbox
+            title="Toggle all"
+            checked={selectedAllCheckboxes}
+            disabled={!row.info.selectable || data.filter(object => row.info.selectable?.(object)).length === 0}
+            indeterminate={selected.size > 0 && !selectedAllCheckboxes}
+            onclick={onCheckedAll} />
+        </div>
+      {/if}
+      {#each columns as column, index (index)}
+        <!-- svelte-ignore a11y_click_events_have_key_events -->
+        <!-- svelte-ignore a11y_interactive_supports_focus -->
+        <div
+          class="max-w-full overflow-hidden flex flex-row text-sm font-semibold items-center whitespace-nowrap {column
+            .info.align === 'right'
+            ? 'justify-self-end'
+            : column.info.align === 'center'
+              ? 'justify-self-center'
+              : 'justify-self-start'} self-center select-none"
+          class:cursor-pointer={column.info.comparator}
+          onclick={sort.bind(undefined, column)}
+          role="columnheader">
+          <div class="overflow-hidden text-ellipsis">
+            {column.title}
+          </div>
+          {#if column.info.comparator}<i
+            class="fas pl-0.5"
+            class:fa-sort={sortCol !== column}
+            class:fa-sort-up={sortCol === column && sortAscending}
+            class:fa-sort-down={sortCol === column && !sortAscending}
+            class:text-[var(--pd-table-header-unsorted)]={sortCol !== column}
+            aria-hidden="true"></i
+          >{/if}
+        </div>
+      {/each}
+    </div>
+  </div>
+  <!-- Table body -->
+  <div role="rowgroup">
+    {#each sortedData as object (object)}
+      <!-- eslint-disable-next-line sonarjs/no-use-of-empty-return-value -->
+      {@render RowGroup(object)}
+    {/each}
+  </div>
+</div>


### PR DESCRIPTION
### What does this PR do?

Make PodsList uses the TableSvelte5 component, part of the full EPIC migration https://github.com/podman-desktop/podman-desktop/issues/13889

### Screenshot / video of UI

<img width="1528" height="949" alt="image" src="https://github.com/user-attachments/assets/1af68f85-93d8-4c82-bf33-e8b21cb68cf3" />

### What issues does this PR fix or reference?

Requires rebase after
- https://github.com/podman-desktop/podman-desktop/pull/13718

Fixes 
- https://github.com/podman-desktop/podman-desktop/issues/14175

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
