### PR TITLE
fix(docker-compatibility): do not show notification if status cannot be acquired

### DIFF
--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -1405,8 +1405,10 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
     // Create a modal dialog to ask the user if they want to enable or disable compatibility mode
     const command = extensionApi.commands.registerCommand('podman.socketCompatibilityMode', async () => {
       // Manually check to see if the socket is disguised (this will be called when pressing the status bar item)
-      const isDisguisedPodmanSocket = await isDisguisedPodman();
-      if (isDisguisedPodmanSocket === undefined) {
+      let isDisguisedPodmanSocket: boolean;
+      try {
+        isDisguisedPodmanSocket = await isDisguisedPodman();
+      } catch (error) {
         await extensionApi.window.showInformationMessage(`Could not get if Podman is disguised`);
         return;
       }

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -1408,6 +1408,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
       const isDisguisedPodmanSocket = await isDisguisedPodman();
       if (isDisguisedPodmanSocket === undefined) {
         await extensionApi.window.showInformationMessage(`Could not get if Podman is disguised`);
+        return;
       }
       // We use isEnabled() as we do not want to "renable" again if the user has already enabled it.
       if (!isDisguisedPodmanSocket && !socketCompatibilityMode.isEnabled()) {

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -1409,7 +1409,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
       try {
         isDisguisedPodmanSocket = await isDisguisedPodman();
       } catch (error) {
-        await extensionApi.window.showInformationMessage(`Could not get if Podman is disguised`);
+        await extensionApi.window.showInformationMessage('Could not get if Podman is disguised');
         return;
       }
       // We use isEnabled() as we do not want to "renable" again if the user has already enabled it.

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -1408,7 +1408,8 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
       let isDisguisedPodmanSocket: boolean;
       try {
         isDisguisedPodmanSocket = await isDisguisedPodman();
-      } catch (error) {
+      } catch (error: unknown) {
+        console.debug('Error while check if the socket is disguised', error);
         await extensionApi.window.showInformationMessage('Could not get if Podman is disguised');
         return;
       }

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -1406,7 +1406,9 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
     const command = extensionApi.commands.registerCommand('podman.socketCompatibilityMode', async () => {
       // Manually check to see if the socket is disguised (this will be called when pressing the status bar item)
       const isDisguisedPodmanSocket = await isDisguisedPodman();
-
+      if (isDisguisedPodmanSocket === undefined) {
+        await extensionApi.window.showInformationMessage(`Could not get if Podman is disguised`);
+      }
       // We use isEnabled() as we do not want to "renable" again if the user has already enabled it.
       if (!isDisguisedPodmanSocket && !socketCompatibilityMode.isEnabled()) {
         const result = await extensionApi.window.showInformationMessage(

--- a/extensions/podman/packages/extension/src/utils/notifications.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/notifications.spec.ts
@@ -242,6 +242,7 @@ describe('podman-mac-helper tests', () => {
 
   test('show setup podman mac helper notification if on mac and podman-mac-helper needs running', async () => {
     const extensionNotifications = new ExtensionNotifications();
+    vi.mocked(isDisguisedPodman).mockImplementation(async () => false);
     await extensionNotifications.checkMacSocket();
 
     await vi.waitFor(() => {

--- a/extensions/podman/packages/extension/src/utils/notifications.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/notifications.spec.ts
@@ -242,7 +242,7 @@ describe('podman-mac-helper tests', () => {
 
   test('show setup podman mac helper notification if on mac and podman-mac-helper needs running', async () => {
     const extensionNotifications = new ExtensionNotifications();
-    vi.mocked(isDisguisedPodman).mockImplementation(async () => false);
+    vi.mocked(isDisguisedPodman).mockResolvedValue(false);
     await extensionNotifications.checkMacSocket();
 
     await vi.waitFor(() => {

--- a/extensions/podman/packages/extension/src/utils/notifications.ts
+++ b/extensions/podman/packages/extension/src/utils/notifications.ts
@@ -131,6 +131,7 @@ export class ExtensionNotifications {
     try {
       isDisguisedPodmanSocket = await isDisguisedPodman();
     } catch (error) {
+      console.debug('Error while check if the socket is disguised', error);
       return;
     }
 
@@ -175,6 +176,7 @@ export class ExtensionNotifications {
     try {
       isDisguisedPodmanSocket = await isDisguisedPodman();
     } catch (error) {
+      console.debug('Error while check if the socket is disguised', error);
       return;
     }
 

--- a/extensions/podman/packages/extension/src/utils/notifications.ts
+++ b/extensions/podman/packages/extension/src/utils/notifications.ts
@@ -127,9 +127,10 @@ export class ExtensionNotifications {
       return;
     }
 
-    const isDisguisedPodmanSocket = await isDisguisedPodman();
-
-    if (isDisguisedPodmanSocket === undefined) {
+    let isDisguisedPodmanSocket: boolean;
+    try {
+      isDisguisedPodmanSocket = await isDisguisedPodman();
+    } catch (error) {
       return;
     }
 
@@ -170,9 +171,10 @@ export class ExtensionNotifications {
     const socketCompatibilityMode = getSocketCompatibility();
 
     // Check to see if we actually have a disguised podman socket, if it's false, we should notify.
-    const isDisguisedPodmanSocket = await isDisguisedPodman();
-
-    if (isDisguisedPodmanSocket === undefined) {
+    let isDisguisedPodmanSocket: boolean;
+    try {
+      isDisguisedPodmanSocket = await isDisguisedPodman();
+    } catch (error) {
       return;
     }
 

--- a/extensions/podman/packages/extension/src/utils/notifications.ts
+++ b/extensions/podman/packages/extension/src/utils/notifications.ts
@@ -130,7 +130,7 @@ export class ExtensionNotifications {
     let isDisguisedPodmanSocket: boolean;
     try {
       isDisguisedPodmanSocket = await isDisguisedPodman();
-    } catch (error) {
+    } catch (error: unknown) {
       console.debug('Error while check if the socket is disguised', error);
       return;
     }
@@ -175,7 +175,7 @@ export class ExtensionNotifications {
     let isDisguisedPodmanSocket: boolean;
     try {
       isDisguisedPodmanSocket = await isDisguisedPodman();
-    } catch (error) {
+    } catch (error: unknown) {
       console.debug('Error while check if the socket is disguised', error);
       return;
     }

--- a/extensions/podman/packages/extension/src/utils/notifications.ts
+++ b/extensions/podman/packages/extension/src/utils/notifications.ts
@@ -129,6 +129,10 @@ export class ExtensionNotifications {
 
     const isDisguisedPodmanSocket = await isDisguisedPodman();
 
+    if (isDisguisedPodmanSocket === undefined) {
+      return;
+    }
+
     // If the socket is not disguised, we should alert the user that compatibility was not ran.
     if (!isDisguisedPodmanSocket) {
       this.notifyDisguisedPodmanSocket();
@@ -167,6 +171,10 @@ export class ExtensionNotifications {
 
     // Check to see if we actually have a disguised podman socket, if it's false, we should notify.
     const isDisguisedPodmanSocket = await isDisguisedPodman();
+
+    if (isDisguisedPodmanSocket === undefined) {
+      return;
+    }
 
     // Notify if we need to run podman-mac-helper only if isDisguisedPodmanSocket is set to false
     // and we are on macOS, as the helper is only required for macOS.

--- a/extensions/podman/packages/extension/src/utils/warnings.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/warnings.spec.ts
@@ -51,7 +51,7 @@ test('isDisguisedPodman with timeout', async () => {
   server = setupServer(...handlers);
   server.listen({ onUnhandledRequest: 'error' });
 
-  const response = await isDisguisedPodmanPath('http://localhost:10000/socket', 50);
-
-  expect(response).toBe(undefined);
+  await expect(isDisguisedPodmanPath('http://localhost:10000/socket', 50)).rejects.toThrow(
+    'Socket unreachable due to timeout.',
+  );
 });

--- a/extensions/podman/packages/extension/src/utils/warnings.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/warnings.spec.ts
@@ -53,5 +53,5 @@ test('isDisguisedPodman with timeout', async () => {
 
   const response = await isDisguisedPodmanPath('http://localhost:10000/socket', 50);
 
-  expect(response).toBe(false);
+  expect(response).toBe(undefined);
 });

--- a/extensions/podman/packages/extension/src/utils/warnings.ts
+++ b/extensions/podman/packages/extension/src/utils/warnings.ts
@@ -26,12 +26,12 @@ const windowsSocketPath = '//./pipe/docker_engine';
 const defaultSocketPath = '/var/run/docker.sock';
 
 // Async function that checks to see if the current Docker socket is a disguised Podman socket
-export async function isDisguisedPodman(): Promise<boolean> {
+export async function isDisguisedPodman(): Promise<boolean | undefined> {
   const socketPath = getSocketPath();
   return isDisguisedPodmanPath(socketPath, DEFAULT_TIMEOUT);
 }
 
-export async function isDisguisedPodmanPath(socketPath: string, timeout?: number): Promise<boolean> {
+export async function isDisguisedPodmanPath(socketPath: string, timeout?: number): Promise<boolean | undefined> {
   const options: http.RequestOptions = {
     path: '/libpod/_ping',
     socketPath,
@@ -42,7 +42,7 @@ export async function isDisguisedPodmanPath(socketPath: string, timeout?: number
     options.timeout = timeout;
   }
 
-  return new Promise<boolean>(resolve => {
+  return new Promise<boolean | undefined>(resolve => {
     const req = http.request(options, res => {
       res.on('data', () => {
         // do nothing
@@ -57,12 +57,12 @@ export async function isDisguisedPodmanPath(socketPath: string, timeout?: number
     // in case of error, it's not reachable
     req.once('error', err => {
       console.debug('Error while pinging docker as podman', err);
-      resolve(false);
+      resolve(undefined);
     });
 
     // in case of timeout, it's not reachable
     req.on('timeout', () => {
-      resolve(false);
+      resolve(undefined);
     });
 
     req.end();


### PR DESCRIPTION
### What does this PR do?

Fixes #14120 

Context: we ping the docker socket `/var/run/docker.sock` on path `libpod/_ping` that can return 200 on Podman or 404 with Docker.

But when the ping timeouts or has an error (see https://nodejs.org/api/http.html for details about 'timeout' and 'error' events), I introduce an undefined state for the response.

When the response is undefined, either I show a message if the user was waiting for a message, either I just finish the flow for the periodic check.

Next fix to come: also ensure the Docker socket compatibility is still enabled, because we do this check if it has been enabled in the past.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
