### PR TITLE
feat: add navigate to provider new connection to API

### DIFF
--- a/packages/api/src/navigation-page.ts
+++ b/packages/api/src/navigation-page.ts
@@ -47,5 +47,5 @@ export enum NavigationPage {
   EDIT_CONTAINER_CONNECTION = 'edit-container-connection',
   DEPLOY_TO_KUBE = 'deploy-to-kube',
   EXPERIMENTAL_FEATURES = 'experimental',
-  PROVIDER_NEW_CONNECTION = 'provider-new-connection',
+  CREATE_PROVIDER_CONNECTION = 'create-provider-connection',
 }

--- a/packages/api/src/navigation-page.ts
+++ b/packages/api/src/navigation-page.ts
@@ -47,4 +47,5 @@ export enum NavigationPage {
   EDIT_CONTAINER_CONNECTION = 'edit-container-connection',
   DEPLOY_TO_KUBE = 'deploy-to-kube',
   EXPERIMENTAL_FEATURES = 'experimental',
+  PROVIDER_NEW_CONNECTION = 'provider-new-connection',
 }

--- a/packages/api/src/navigation-request.ts
+++ b/packages/api/src/navigation-request.ts
@@ -48,6 +48,7 @@ export interface NavigationParameters {
   [NavigationPage.RESOURCES]: never;
   [NavigationPage.CLI_TOOLS]: never;
   [NavigationPage.EDIT_CONTAINER_CONNECTION]: { provider: string; name: string };
+  [NavigationPage.PROVIDER_NEW_CONNECTION]: { provider: string };
   [NavigationPage.PROVIDER_TASK]: { internalId: string; taskId: number | undefined };
   [NavigationPage.EXPERIMENTAL_FEATURES]: never;
 }

--- a/packages/api/src/navigation-request.ts
+++ b/packages/api/src/navigation-request.ts
@@ -48,7 +48,7 @@ export interface NavigationParameters {
   [NavigationPage.RESOURCES]: never;
   [NavigationPage.CLI_TOOLS]: never;
   [NavigationPage.EDIT_CONTAINER_CONNECTION]: { provider: string; name: string };
-  [NavigationPage.PROVIDER_NEW_CONNECTION]: { provider: string };
+  [NavigationPage.CREATE_PROVIDER_CONNECTION]: { provider: string };
   [NavigationPage.PROVIDER_TASK]: { internalId: string; taskId: number | undefined };
   [NavigationPage.EXPERIMENTAL_FEATURES]: never;
 }

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -4957,6 +4957,8 @@ declare module '@podman-desktop/api' {
      */
     export function navigateToEditProviderContainerConnection(connection: ProviderContainerConnection): Promise<void>;
 
+    export function navigateToProviderNewConnection(providerId: string): Promise<void>;
+
     /**
      *  Navigate to a specific onboarding page referenced by its extensionId
      * @param extensionId The id of the extension to navigate to or if missing, default to the extension calling the method

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -4957,7 +4957,7 @@ declare module '@podman-desktop/api' {
      */
     export function navigateToEditProviderContainerConnection(connection: ProviderContainerConnection): Promise<void>;
 
-    export function navigateToProviderNewConnection(providerId: string): Promise<void>;
+    export function navigateToCreateProviderConnection(providerId: string): Promise<void>;
 
     /**
      *  Navigate to a specific onboarding page referenced by its extensionId

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -1528,6 +1528,9 @@ export class ExtensionLoader implements AsyncDisposable {
       ): Promise<void> => {
         await this.navigationManager.navigateToEditProviderContainerConnection(connection);
       },
+      navigateToProviderNewConnection: async (providerId: string): Promise<void> => {
+        await this.navigationManager.navigateToProviderNewConnection(providerId);
+      },
       navigateToOnboarding: async (extensionId?: string): Promise<void> => {
         let onboardingExtensionId = extensionId;
         onboardingExtensionId ??= extensionInfo.id;

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -1528,8 +1528,8 @@ export class ExtensionLoader implements AsyncDisposable {
       ): Promise<void> => {
         await this.navigationManager.navigateToEditProviderContainerConnection(connection);
       },
-      navigateToProviderNewConnection: async (providerId: string): Promise<void> => {
-        await this.navigationManager.navigateToProviderNewConnection(providerId);
+      navigateToCreateProviderConnection: async (providerId: string): Promise<void> => {
+        await this.navigationManager.navigateToCreateProviderConnection(providerId);
       },
       navigateToOnboarding: async (extensionId?: string): Promise<void> => {
         let onboardingExtensionId = extensionId;

--- a/packages/main/src/plugin/navigation/navigation-manager.spec.ts
+++ b/packages/main/src/plugin/navigation/navigation-manager.spec.ts
@@ -280,3 +280,16 @@ describe('register route', () => {
     }).rejects.toThrowError('Dummy error');
   });
 });
+
+test('check navigateToProviderNewConnection', async () => {
+  vi.mocked(providerRegistry.getMatchingProviderInternalId).mockReturnValue('anInternalId');
+
+  await navigationManager.navigateToProviderNewConnection('my.extension');
+
+  expect(apiSender.send).toHaveBeenCalledWith('navigate', {
+    page: NavigationPage.PROVIDER_NEW_CONNECTION,
+    parameters: {
+      provider: 'anInternalId',
+    },
+  });
+});

--- a/packages/main/src/plugin/navigation/navigation-manager.spec.ts
+++ b/packages/main/src/plugin/navigation/navigation-manager.spec.ts
@@ -281,13 +281,13 @@ describe('register route', () => {
   });
 });
 
-test('check navigateToProviderNewConnection', async () => {
+test('check navigateToCreateProviderConnection', async () => {
   vi.mocked(providerRegistry.getMatchingProviderInternalId).mockReturnValue('anInternalId');
 
-  await navigationManager.navigateToProviderNewConnection('my.extension');
+  await navigationManager.navigateToCreateProviderConnection('my.extension');
 
   expect(apiSender.send).toHaveBeenCalledWith('navigate', {
-    page: NavigationPage.PROVIDER_NEW_CONNECTION,
+    page: NavigationPage.CREATE_PROVIDER_CONNECTION,
     parameters: {
       provider: 'anInternalId',
     },

--- a/packages/main/src/plugin/navigation/navigation-manager.ts
+++ b/packages/main/src/plugin/navigation/navigation-manager.ts
@@ -331,4 +331,14 @@ export class NavigationManager {
       },
     });
   }
+
+  async navigateToProviderNewConnection(providerId: string): Promise<void> {
+    const internalId = this.providerRegistry.getMatchingProviderInternalId(providerId);
+    this.navigateTo({
+      page: NavigationPage.PROVIDER_NEW_CONNECTION,
+      parameters: {
+        provider: internalId,
+      },
+    });
+  }
 }

--- a/packages/main/src/plugin/navigation/navigation-manager.ts
+++ b/packages/main/src/plugin/navigation/navigation-manager.ts
@@ -332,10 +332,10 @@ export class NavigationManager {
     });
   }
 
-  async navigateToProviderNewConnection(providerId: string): Promise<void> {
+  async navigateToCreateProviderConnection(providerId: string): Promise<void> {
     const internalId = this.providerRegistry.getMatchingProviderInternalId(providerId);
     this.navigateTo({
-      page: NavigationPage.PROVIDER_NEW_CONNECTION,
+      page: NavigationPage.CREATE_PROVIDER_CONNECTION,
       parameters: {
         provider: internalId,
       },

--- a/packages/renderer/src/navigation.spec.ts
+++ b/packages/renderer/src/navigation.spec.ts
@@ -255,3 +255,14 @@ test(`Test navigationHandle for ${NavigationPage.EXPERIMENTAL_FEATURES}`, () => 
 
   expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/preferences/experimental');
 });
+
+test(`Test navigationHandle for ${NavigationPage.PROVIDER_NEW_CONNECTION}`, () => {
+  handleNavigation({
+    page: NavigationPage.PROVIDER_NEW_CONNECTION,
+    parameters: {
+      provider: 'dummyProviderId',
+    },
+  });
+
+  expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/preferences/provider/dummyProviderId');
+});

--- a/packages/renderer/src/navigation.spec.ts
+++ b/packages/renderer/src/navigation.spec.ts
@@ -256,9 +256,9 @@ test(`Test navigationHandle for ${NavigationPage.EXPERIMENTAL_FEATURES}`, () => 
   expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/preferences/experimental');
 });
 
-test(`Test navigationHandle for ${NavigationPage.PROVIDER_NEW_CONNECTION}`, () => {
+test(`Test navigationHandle for ${NavigationPage.CREATE_PROVIDER_CONNECTION}`, () => {
   handleNavigation({
-    page: NavigationPage.PROVIDER_NEW_CONNECTION,
+    page: NavigationPage.CREATE_PROVIDER_CONNECTION,
     parameters: {
       provider: 'dummyProviderId',
     },

--- a/packages/renderer/src/navigation.ts
+++ b/packages/renderer/src/navigation.ts
@@ -133,5 +133,8 @@ export const handleNavigation = (request: InferredNavigationRequest<NavigationPa
     case NavigationPage.EXPERIMENTAL_FEATURES:
       router.goto('/preferences/experimental');
       break;
+    case NavigationPage.PROVIDER_NEW_CONNECTION:
+      router.goto(`/preferences/provider/${request.parameters.provider}`);
+      break;
   }
 };

--- a/packages/renderer/src/navigation.ts
+++ b/packages/renderer/src/navigation.ts
@@ -133,7 +133,7 @@ export const handleNavigation = (request: InferredNavigationRequest<NavigationPa
     case NavigationPage.EXPERIMENTAL_FEATURES:
       router.goto('/preferences/experimental');
       break;
-    case NavigationPage.PROVIDER_NEW_CONNECTION:
+    case NavigationPage.CREATE_PROVIDER_CONNECTION:
       router.goto(`/preferences/provider/${request.parameters.provider}`);
       break;
   }


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Adds a function `navigateToProviderNewConnection` to the API, so an extension can redirect a user to a page to create a new connection for a provider.

The providerId will be obtained with the help of #14167

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #14180
### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
