### PR TITLE
chore: renames layout editor/manager to list organizer

### DIFF
--- a/packages/api/src/list-organizer.ts
+++ b/packages/api/src/list-organizer.ts
@@ -16,9 +16,24 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-export interface LayoutEditItem {
-  id: string;
+export interface ListOrganizerItem extends SavedListOrganizerConfig {
   label: string;
-  enabled: boolean;
   originalOrder: number;
+}
+
+export interface SavedListOrganizerConfig {
+  id: string;
+  enabled: boolean;
+}
+
+export interface ListOrganizerCallbacks {
+  onLoad: () => Promise<ListOrganizerItem[]>;
+  onSave: (items: ListOrganizerItem[]) => Promise<void>;
+  onReset: () => Promise<ListOrganizerItem[]>;
+}
+
+export interface ListOrganizerRegistration {
+  kind: string;
+  defaultColumns: string[];
+  columnLabels?: Record<string, string>;
 }

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -103,7 +103,6 @@ import type { ForwardConfig, ForwardOptions } from '/@api/kubernetes-port-forwar
 import type { ResourceCount } from '/@api/kubernetes-resource-count.js';
 import type { KubernetesContextResources } from '/@api/kubernetes-resources.js';
 import type { KubernetesTroubleshootingInformation } from '/@api/kubernetes-troubleshooting.js';
-import type { LayoutEditItem } from '/@api/layout-manager-info.js';
 import type { ManifestCreateOptions, ManifestInspectInfo, ManifestPushOptions } from '/@api/manifest-info.js';
 import type { Menu } from '/@api/menu.js';
 import type { NetworkInspectInfo } from '/@api/network-info.js';
@@ -127,6 +126,7 @@ import type { ViewInfoUI } from '/@api/view-info.js';
 import type { VolumeInspectInfo, VolumeListInfo } from '/@api/volume-info.js';
 import type { WebviewInfo } from '/@api/webview-info.js';
 
+import type { ListOrganizerItem } from '../../../api/src/list-organizer.js';
 import { securityRestrictionCurrentHandler } from '../security-restrictions-handler.js';
 import { TrayMenu } from '../tray-menu.js';
 import { isMac } from '../util.js';
@@ -182,10 +182,10 @@ import { ImageRegistry } from './image-registry.js';
 import { InputQuickPickRegistry } from './input-quickpick/input-quickpick-registry.js';
 import { ExtensionInstaller } from './install/extension-installer.js';
 import { KubernetesClient } from './kubernetes/kubernetes-client.js';
-import { LayoutRegistry } from './layout-registry.js';
 import { downloadGuideList } from './learning-center/learning-center.js';
 import { LearningCenterInit } from './learning-center-init.js';
 import { LibpodApiInit } from './libpod-api-enable/libpod-api-init.js';
+import { ListOrganizerRegistry } from './list-organizer.js';
 import { MessageBox } from './message-box.js';
 import { NavigationItemsInit } from './navigation-items-init.js';
 import { OnboardingRegistry } from './onboarding-registry.js';
@@ -710,8 +710,8 @@ export class PluginSystem {
     const extensionDevelopmentFolders = container.get<ExtensionDevelopmentFolders>(ExtensionDevelopmentFolders);
     extensionDevelopmentFolders.init();
 
-    container.bind<LayoutRegistry>(LayoutRegistry).toSelf().inSingletonScope();
-    const layoutRegistry = container.get<LayoutRegistry>(LayoutRegistry);
+    container.bind<ListOrganizerRegistry>(ListOrganizerRegistry).toSelf().inSingletonScope();
+    const listOrganizerRegistry = container.get<ListOrganizerRegistry>(ListOrganizerRegistry);
 
     container.bind<PinRegistry>(PinRegistry).toSelf().inSingletonScope();
     const pinRegistry = container.get<PinRegistry>(PinRegistry);
@@ -2046,31 +2046,31 @@ export class PluginSystem {
     );
 
     this.ipcHandle(
-      'layout-registry:loadLayoutConfig',
+      'list-organizer-registry:loadListConfig',
       async (
         _listener: Electron.IpcMainInvokeEvent,
         key: string,
         availableColumns: string[],
-      ): Promise<LayoutEditItem[]> => {
-        return layoutRegistry.loadLayoutConfig(key, availableColumns);
+      ): Promise<ListOrganizerItem[]> => {
+        return listOrganizerRegistry.loadListConfig(key, availableColumns);
       },
     );
 
     this.ipcHandle(
-      'layout-registry:saveLayoutConfig',
-      async (_listener: Electron.IpcMainInvokeEvent, key: string, items: LayoutEditItem[]): Promise<void> => {
-        return layoutRegistry.saveLayoutConfig(key, items);
+      'list-organizer-registry:saveListConfig',
+      async (_listener: Electron.IpcMainInvokeEvent, key: string, items: ListOrganizerItem[]): Promise<void> => {
+        return listOrganizerRegistry.saveListConfig(key, items);
       },
     );
 
     this.ipcHandle(
-      'layout-registry:resetLayoutConfig',
+      'list-organizer-registry:resetListConfig',
       async (
         _listener: Electron.IpcMainInvokeEvent,
         key: string,
         availableColumns: string[],
-      ): Promise<LayoutEditItem[]> => {
-        return layoutRegistry.resetLayoutConfig(key, availableColumns);
+      ): Promise<ListOrganizerItem[]> => {
+        return listOrganizerRegistry.resetListConfig(key, availableColumns);
       },
     );
 

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -82,7 +82,6 @@ import type { ForwardConfig, ForwardOptions } from '/@api/kubernetes-port-forwar
 import type { ResourceCount } from '/@api/kubernetes-resource-count';
 import type { KubernetesContextResources } from '/@api/kubernetes-resources';
 import type { KubernetesTroubleshootingInformation } from '/@api/kubernetes-troubleshooting';
-import type { LayoutEditItem } from '/@api/layout-manager-info';
 import type { ManifestCreateOptions, ManifestInspectInfo, ManifestPushOptions } from '/@api/manifest-info';
 import type { Menu } from '/@api/menu.js';
 import { NavigationPage } from '/@api/navigation-page';
@@ -108,6 +107,7 @@ import type { ViewInfoUI } from '/@api/view-info';
 import type { VolumeInspectInfo, VolumeListInfo } from '/@api/volume-info';
 import type { WebviewInfo } from '/@api/webview-info';
 
+import type { ListOrganizerItem } from '../../api/src/list-organizer';
 import type { ApiSenderType } from '../../main/src/plugin/api';
 import type { ContextInfo } from '../../main/src/plugin/api/context-info';
 import type { KubernetesGeneratorInfo } from '../../main/src/plugin/api/KubernetesGeneratorInfo';
@@ -2515,20 +2515,18 @@ export function initExposure(): void {
 
   // Layout Registry functions
   contextBridge.exposeInMainWorld(
-    'loadLayoutConfig',
-    async (kind: string, availableColumns: string[]): Promise<LayoutEditItem[]> => {
-      return ipcInvoke('layout-registry:loadLayoutConfig', kind, availableColumns);
+    'loadListConfig',
+    async (kind: string, availableColumns: string[]): Promise<ListOrganizerItem[]> => {
+      return ipcInvoke('list-organizer-registry:loadListConfig', kind, availableColumns);
     },
   );
-
-  contextBridge.exposeInMainWorld('saveLayoutConfig', async (kind: string, items: LayoutEditItem[]): Promise<void> => {
-    return ipcInvoke('layout-registry:saveLayoutConfig', kind, items);
+  contextBridge.exposeInMainWorld('saveListConfig', async (kind: string, items: ListOrganizerItem[]): Promise<void> => {
+    return ipcInvoke('list-organizer-registry:saveListConfig', kind, items);
   });
-
   contextBridge.exposeInMainWorld(
-    'resetLayoutConfig',
-    async (kind: string, availableColumns: string[]): Promise<LayoutEditItem[]> => {
-      return ipcInvoke('layout-registry:resetLayoutConfig', kind, availableColumns);
+    'resetListConfig',
+    async (kind: string, availableColumns: string[]): Promise<ListOrganizerItem[]> => {
+      return ipcInvoke('list-organizer-registry:resetListConfig', kind, availableColumns);
     },
   );
 

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -29,8 +29,8 @@ import NumberInput from './inputs/NumberInput.svelte';
 import SearchInput from './inputs/SearchInput.svelte';
 import DetailsPage from './layouts/DetailsPage.svelte';
 import FormPage from './layouts/FormPage.svelte';
-import type { LayoutEditItem } from './layouts/LayoutEditor';
-import LayoutManager from './layouts/LayoutEditor.svelte';
+import type { ListOrganizerItem } from './layouts/ListOrganizer';
+import ListOrganizer from './layouts/ListOrganizer.svelte';
 import NavPage from './layouts/NavPage.svelte';
 import Page from './layouts/Page.svelte';
 import Link from './link/Link.svelte';
@@ -49,7 +49,7 @@ import Table from './table/Table.svelte';
 import Tooltip from './tooltip/Tooltip.svelte';
 import { isFontAwesomeIcon } from './utils/icon-utils';
 
-export type { ButtonType, LayoutEditItem };
+export type { ButtonType, ListOrganizerItem };
 export {
   Button,
   Carousel,
@@ -64,9 +64,9 @@ export {
   FilteredEmptyScreen,
   FormPage,
   Input,
-  LayoutManager,
   LinearProgress,
   Link,
+  ListOrganizer,
   Modal,
   NavPage,
   NumberInput,

--- a/packages/ui/src/lib/layouts/ListOrganizer.spec.ts
+++ b/packages/ui/src/lib/layouts/ListOrganizer.spec.ts
@@ -23,10 +23,10 @@ import userEvent from '@testing-library/user-event';
 import { SvelteMap } from 'svelte/reactivity';
 import { beforeEach, expect, test, vi } from 'vitest';
 
-import type { LayoutEditItem } from './LayoutEditor';
-import LayoutEditor from './LayoutEditor.svelte';
+import type { ListOrganizerItem } from './ListOrganizer';
+import ListOrganizer from './ListOrganizer.svelte';
 
-const mockItems: LayoutEditItem[] = [
+const mockItems: ListOrganizerItem[] = [
   { id: 'item1', label: 'First Item', enabled: true, originalOrder: 0 },
   { id: 'item2', label: 'Second Item', enabled: true, originalOrder: 1 },
   { id: 'item3', label: 'Third Item', enabled: false, originalOrder: 2 },
@@ -39,7 +39,7 @@ beforeEach(() => {
 
 test('Expect trigger button is visible and has correct title', async () => {
   const title = 'Manage Layout';
-  render(LayoutEditor, {
+  render(ListOrganizer, {
     items: mockItems,
     title,
   });
@@ -50,7 +50,7 @@ test('Expect trigger button is visible and has correct title', async () => {
 });
 
 test('Expect dropdown opens when trigger button is clicked', async () => {
-  render(LayoutEditor, {
+  render(ListOrganizer, {
     items: mockItems,
     title: 'Manage Layout',
   });
@@ -71,7 +71,7 @@ test('Expect dropdown opens when trigger button is clicked', async () => {
 });
 
 test.skip('Expect dropdown closes when clicking outside', async () => {
-  render(LayoutEditor, {
+  render(ListOrganizer, {
     items: mockItems,
     title: 'Manage Layout',
   });
@@ -90,7 +90,7 @@ test.skip('Expect dropdown closes when clicking outside', async () => {
 });
 
 test('Expect enabled items show check icon', async () => {
-  render(LayoutEditor, {
+  render(ListOrganizer, {
     items: mockItems,
     title: 'Manage Layout',
     enableToggle: true,
@@ -117,7 +117,7 @@ test('Expect enabled items show check icon', async () => {
 test('Expect item toggle functionality works when enableToggle is true', async () => {
   const updatedItems = [...mockItems];
 
-  const component = render(LayoutEditor, {
+  const component = render(ListOrganizer, {
     items: updatedItems,
     title: 'Manage Layout',
     enableToggle: true,
@@ -139,7 +139,7 @@ test('Expect item toggle functionality works when enableToggle is true', async (
 });
 
 test('Expect grip icons are visible when enableReorder is true', async () => {
-  render(LayoutEditor, {
+  render(ListOrganizer, {
     items: mockItems,
     title: 'Manage Layout',
     enableReorder: true,
@@ -156,7 +156,7 @@ test('Expect grip icons are visible when enableReorder is true', async () => {
 test('Expect reset button is visible when onReset is provided', async () => {
   const onResetMock = vi.fn();
 
-  render(LayoutEditor, {
+  render(ListOrganizer, {
     items: mockItems,
     title: 'Manage Layout',
     onReset: onResetMock,
@@ -173,7 +173,7 @@ test('Expect reset button is visible when onReset is provided', async () => {
 test('Expect reset button calls onReset when clicked', async () => {
   const onResetMock = vi.fn();
 
-  render(LayoutEditor, {
+  render(ListOrganizer, {
     items: mockItems,
     title: 'Manage Layout',
     onReset: onResetMock,
@@ -195,7 +195,7 @@ test('Expect reset button is disabled when items are in default state', async ()
   // All items enabled and in original order = default state
   const defaultItems = mockItems.map(item => ({ ...item, enabled: true }));
 
-  render(LayoutEditor, {
+  render(ListOrganizer, {
     items: defaultItems,
     title: 'Manage Layout',
     onReset: onResetMock,
@@ -215,7 +215,7 @@ test('Expect reset button is enabled when items are modified', async () => {
   // Some items disabled = modified state
   const modifiedItems = [...mockItems]; // Already has item3 disabled
 
-  render(LayoutEditor, {
+  render(ListOrganizer, {
     items: modifiedItems,
     title: 'Manage Layout',
     onReset: onResetMock,
@@ -240,7 +240,7 @@ test('Expect reset button is enabled when items are reordered', async () => {
     { id: 'item4', label: 'Fourth Item', enabled: true, originalOrder: 3 },
   ];
 
-  const component = render(LayoutEditor, {
+  const component = render(ListOrganizer, {
     items: originalItems,
     title: 'Manage Layout',
     onReset: onResetMock,
@@ -272,7 +272,7 @@ test('Expect reset button is enabled when items are reordered', async () => {
 });
 
 test('Expect drag handles are draggable when enableReorder is true', async () => {
-  render(LayoutEditor, {
+  render(ListOrganizer, {
     items: mockItems,
     title: 'Manage Layout',
     enableReorder: true,
@@ -288,7 +288,7 @@ test('Expect drag handles are draggable when enableReorder is true', async () =>
 });
 
 test('Expect mouse events work on drag handles', async () => {
-  render(LayoutEditor, {
+  render(ListOrganizer, {
     items: mockItems,
     title: 'Manage Layout',
     enableReorder: true,
@@ -307,7 +307,7 @@ test('Expect mouse events work on drag handles', async () => {
 });
 
 test('Expect grip handle accepts click events', async () => {
-  render(LayoutEditor, {
+  render(ListOrganizer, {
     items: mockItems,
     title: 'Manage Layout',
     enableToggle: true,
@@ -328,7 +328,7 @@ test('Expect grip handle accepts click events', async () => {
 test('Expect custom title is used', async () => {
   const customTitle = 'Custom Layout Manager';
 
-  render(LayoutEditor, {
+  render(ListOrganizer, {
     items: mockItems,
     title: customTitle,
   });
@@ -341,7 +341,7 @@ test('Expect custom reset button label is used', async () => {
   const onResetMock = vi.fn();
   const customLabel = 'Restore Defaults';
 
-  render(LayoutEditor, {
+  render(ListOrganizer, {
     items: mockItems,
     title: 'Manage Layout',
     onReset: onResetMock,
@@ -356,7 +356,7 @@ test('Expect custom reset button label is used', async () => {
 });
 
 test('Expect no reset button when onReset is not provided', async () => {
-  render(LayoutEditor, {
+  render(ListOrganizer, {
     items: mockItems,
     title: 'Manage Layout',
   });
@@ -371,7 +371,7 @@ test('Expect no reset button when onReset is not provided', async () => {
 test('Expect reset button has proper styling', async () => {
   const onResetMock = vi.fn();
 
-  render(LayoutEditor, {
+  render(ListOrganizer, {
     items: mockItems,
     title: 'Manage Layout',
     onReset: onResetMock,
@@ -388,14 +388,14 @@ test('Expect reset button has proper styling', async () => {
 test('Expect reset button disabled in default state (all enabled, original order)', async () => {
   const onResetMock = vi.fn();
 
-  const defaultItems: LayoutEditItem[] = [
+  const defaultItems: ListOrganizerItem[] = [
     { id: 'item1', label: 'First Item', enabled: true, originalOrder: 0 },
     { id: 'item2', label: 'Second Item', enabled: true, originalOrder: 1 },
     { id: 'item3', label: 'Third Item', enabled: true, originalOrder: 2 },
     { id: 'item4', label: 'Fourth Item', enabled: true, originalOrder: 3 },
   ];
 
-  render(LayoutEditor, {
+  render(ListOrganizer, {
     items: defaultItems,
     title: 'Manage Layout',
     enableToggle: true,
@@ -414,14 +414,14 @@ test('Expect reset button disabled in default state (all enabled, original order
 test('Expect reset button enabled after toggling item', async () => {
   const onResetMock = vi.fn();
 
-  const defaultItems: LayoutEditItem[] = [
+  const defaultItems: ListOrganizerItem[] = [
     { id: 'item1', label: 'First Item', enabled: true, originalOrder: 0 },
     { id: 'item2', label: 'Second Item', enabled: true, originalOrder: 1 },
     { id: 'item3', label: 'Third Item', enabled: true, originalOrder: 2 },
     { id: 'item4', label: 'Fourth Item', enabled: true, originalOrder: 3 },
   ];
 
-  const component = render(LayoutEditor, {
+  const component = render(ListOrganizer, {
     items: defaultItems,
     title: 'Manage Layout',
     enableToggle: true,
@@ -455,14 +455,14 @@ test('Expect reset button enabled after toggling item', async () => {
 test('Expect reset button enabled after reordering items', async () => {
   const onResetMock = vi.fn();
 
-  const defaultItems: LayoutEditItem[] = [
+  const defaultItems: ListOrganizerItem[] = [
     { id: 'item1', label: 'First Item', enabled: true, originalOrder: 0 },
     { id: 'item2', label: 'Second Item', enabled: true, originalOrder: 1 },
     { id: 'item3', label: 'Third Item', enabled: true, originalOrder: 2 },
     { id: 'item4', label: 'Fourth Item', enabled: true, originalOrder: 3 },
   ];
 
-  const component = render(LayoutEditor, {
+  const component = render(ListOrganizer, {
     items: defaultItems,
     title: 'Manage Layout',
     enableToggle: true,
@@ -501,14 +501,14 @@ test('Expect clicking reset button resets state and disables button', async () =
   const onResetMock = vi.fn();
 
   // Start with default state, then modify, then reset
-  const defaultItems: LayoutEditItem[] = [
+  const defaultItems: ListOrganizerItem[] = [
     { id: 'item1', label: 'First Item', enabled: true, originalOrder: 0 },
     { id: 'item2', label: 'Second Item', enabled: true, originalOrder: 1 },
     { id: 'item3', label: 'Third Item', enabled: true, originalOrder: 2 },
     { id: 'item4', label: 'Fourth Item', enabled: true, originalOrder: 3 },
   ];
 
-  const component = render(LayoutEditor, {
+  const component = render(ListOrganizer, {
     items: defaultItems,
     title: 'Manage Layout',
     enableToggle: true,

--- a/packages/ui/src/lib/layouts/ListOrganizer.svelte
+++ b/packages/ui/src/lib/layouts/ListOrganizer.svelte
@@ -3,18 +3,18 @@ import { faCheck, faGripVertical, faPen, faUndo } from '@fortawesome/free-solid-
 import { SvelteMap } from 'svelte/reactivity';
 
 import { Icon } from '../icons';
-import type { LayoutEditItem } from './LayoutEditor';
+import type { ListOrganizerItem } from './ListOrganizer';
 
 /**
- * LayoutEditor Component
+ * ListOrganizer Component
  *
  * A dropdown component that allows users to toggle visibility and reorder items in a layout.
  * Displays as a hamburger menu button that opens a dropdown with checkboxes and drag handles.
  *
  * Usage:
  * ```svelte
- * <LayoutEditor
- *   items={layoutItems}
+ * <ListOrganizer
+ *   items={listItems}
  *   ordering={columnOrdering}
  *   enableToggle={true}
  *   enableReorder={true}
@@ -31,7 +31,7 @@ import type { LayoutEditItem } from './LayoutEditor';
  * - Fully keyboard accessible
  */
 interface Props {
-  items: LayoutEditItem[];
+  items: ListOrganizerItem[];
   ordering?: SvelteMap<string, number>;
   title?: string;
   enableReorder?: boolean;
@@ -106,13 +106,13 @@ function closeDropdown(): void {
   isOpen = false;
 }
 
-function handleItemToggle(item: LayoutEditItem): void {
+function handleItemToggle(item: ListOrganizerItem): void {
   if (!enableToggle || isDraggingActive) return;
   onToggle?.(item.id, !item.enabled);
 }
 
 // Creates a visual preview of the list while dragging.
-function createDragPreview(dragIndex: number, hoverIndex: number): LayoutEditItem[] {
+function createDragPreview(dragIndex: number, hoverIndex: number): ListOrganizerItem[] {
   const newItems = [...orderedItems];
   const draggedItem = newItems[dragIndex];
   newItems.splice(dragIndex, 1);

--- a/packages/ui/src/lib/layouts/ListOrganizer.ts
+++ b/packages/ui/src/lib/layouts/ListOrganizer.ts
@@ -16,24 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-export interface LayoutEditItem extends SavedLayoutConfig {
-  label: string;
-  originalOrder: number;
-}
-
-export interface SavedLayoutConfig {
+export interface ListOrganizerItem {
   id: string;
+  label: string;
   enabled: boolean;
-}
-
-export interface LayoutCallbacks {
-  onLoad: () => Promise<LayoutEditItem[]>;
-  onSave: (items: LayoutEditItem[]) => Promise<void>;
-  onReset: () => Promise<LayoutEditItem[]>;
-}
-
-export interface LayoutRegistration {
-  kind: string;
-  defaultColumns: string[];
-  columnLabels?: Record<string, string>;
+  originalOrder: number;
 }


### PR DESCRIPTION
### What does this PR do?
Renames layout editor/manager to list organizer
No functional changes

### Screenshot / video of UI
N/A

### What issues does this PR fix or reference?

### How to test this PR?
Only renaming 

- [x] Tests are covering the bug fix or the new feature
