### PR TITLE
chore: use mockResolvedValue / mockReturn in some tests

### DIFF
--- a/extensions/compose/src/compose-github-releases.spec.ts
+++ b/extensions/compose/src/compose-github-releases.spec.ts
@@ -179,12 +179,8 @@ test('should download the file if parent folder does not exist', async () => {
   });
 
   // mock fs
-  const existSyncSpy = vi.spyOn(fs, 'existsSync').mockImplementation(() => {
-    return false;
-  });
-  const mkdirSpy = vi.spyOn(fs.promises, 'mkdir').mockImplementation(async () => {
-    return '';
-  });
+  const existSyncSpy = vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+  const mkdirSpy = vi.spyOn(fs.promises, 'mkdir').mockResolvedValue('');
 
   const writeFileSpy = vi.spyOn(fs.promises, 'writeFile').mockResolvedValue();
 

--- a/extensions/kind/src/kind-installer.spec.ts
+++ b/extensions/kind/src/kind-installer.spec.ts
@@ -332,12 +332,8 @@ describe('downloadReleaseAsset', () => {
     });
 
     // mock fs
-    const existSyncSpy = vi.spyOn(fs, 'existsSync').mockImplementation(() => {
-      return false;
-    });
-    const mkdirSpy = vi.spyOn(fs.promises, 'mkdir').mockImplementation(async () => {
-      return '';
-    });
+    const existSyncSpy = vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+    const mkdirSpy = vi.spyOn(fs.promises, 'mkdir').mockResolvedValue('');
 
     const writeFileSpy = vi.spyOn(fs.promises, 'writeFile').mockResolvedValue();
 

--- a/extensions/kubectl-cli/src/kubectl-github-releases.spec.ts
+++ b/extensions/kubectl-cli/src/kubectl-github-releases.spec.ts
@@ -142,17 +142,11 @@ test('should download the file if parent folder does exist', async () => {
 test('should download the file if parent folder does not exist', async () => {
   vi.mock('node:fs');
 
-  getReleaseAssetMock.mockImplementation(() => {
-    return { data: 'foo' };
-  });
+  getReleaseAssetMock.mockReturnValue({ data: 'foo' });
 
   // mock fs
-  const existSyncSpy = vi.spyOn(fs, 'existsSync').mockImplementation(() => {
-    return false;
-  });
-  const mkdirSpy = vi.spyOn(fs.promises, 'mkdir').mockImplementation(async () => {
-    return '';
-  });
+  const existSyncSpy = vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+  const mkdirSpy = vi.spyOn(fs.promises, 'mkdir').mockResolvedValue('');
 
   const writeFileSpy = vi.spyOn(fs.promises, 'writeFile').mockResolvedValue();
 

--- a/extensions/podman/packages/extension/src/utils/notifications.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/notifications.spec.ts
@@ -148,7 +148,7 @@ describe('macOS: tests for notifying if disguised podman socket fails / passes',
     vi.mocked(extensionApi.env).isLinux = false;
 
     // Mock "isDisguisedPodman" to return true to indicate a failed socket
-    vi.mocked(isDisguisedPodman).mockImplementation(async () => true);
+    vi.mocked(isDisguisedPodman).mockResolvedValue(true);
 
     await extensionNotifications.checkMacSocket();
 
@@ -168,7 +168,7 @@ describe('macOS: tests for notifying if disguised podman socket fails / passes',
     vi.mocked(extensionApi.env).isLinux = false;
 
     // Mock "isDisguisedPodman" to return false to indicate a failed socket
-    vi.mocked(isDisguisedPodman).mockImplementation(async () => false);
+    vi.mocked(isDisguisedPodman).mockResolvedValue(false);
 
     await extensionNotifications.checkMacSocket();
 

--- a/packages/renderer/src/lib/image/ImageDetailsCheck.spec.ts
+++ b/packages/renderer/src/lib/image/ImageDetailsCheck.spec.ts
@@ -52,10 +52,8 @@ test('expect to display wait message before to receive results', async () => {
     },
   ]);
 
-  imageCheckMock.mockImplementation(async () => {
-    // never returns results
-    return new Promise(() => {});
-  });
+  // never returns results
+  imageCheckMock.mockResolvedValue(new Promise(() => {}));
 
   render(ImageDetailsCheck, {
     imageInfo: {
@@ -88,10 +86,8 @@ test('expect to cancel when clicking the Cancel button', async () => {
     },
   ]);
 
-  imageCheckMock.mockImplementation(async () => {
-    // never returns results
-    return new Promise(() => {});
-  });
+  // never returns results
+  imageCheckMock.mockResolvedValue(new Promise(() => {}));
 
   render(ImageDetailsCheck, {
     imageInfo: {
@@ -130,10 +126,8 @@ test('expect to cancel when destroying the component', async () => {
     },
   ]);
 
-  imageCheckMock.mockImplementation(async () => {
-    // never returns results
-    return new Promise(() => {});
-  });
+  // never returns results
+  imageCheckMock.mockResolvedValue(new Promise(() => {}));
 
   const result = render(ImageDetailsCheck, {
     imageInfo: {
@@ -169,10 +163,8 @@ test('expect to not cancel again when destroying the component after manual canc
     },
   ]);
 
-  imageCheckMock.mockImplementation(async () => {
-    // never returns results
-    return new Promise(() => {});
-  });
+  // never returns results
+  imageCheckMock.mockResolvedValue(new Promise(() => {}));
 
   const result = render(ImageDetailsCheck, {
     imageInfo: {

--- a/packages/renderer/src/stores/kubernetes-experimental.spec.ts
+++ b/packages/renderer/src/stores/kubernetes-experimental.spec.ts
@@ -23,9 +23,7 @@ import { configurationProperties } from './configurationProperties';
 import { isKubernetesExperimentalModeStore } from './kubernetes-experimental';
 
 test('experimental mode is set', async () => {
-  vi.mocked(window.isExperimentalConfigurationEnabled).mockImplementation(async () => {
-    return true;
-  });
+  vi.mocked(window.isExperimentalConfigurationEnabled).mockResolvedValue(true);
   configurationProperties.set([]);
   await vi.waitFor(() => {
     const result = get(isKubernetesExperimentalModeStore);
@@ -34,9 +32,7 @@ test('experimental mode is set', async () => {
 });
 
 test('experimental mode is not set', async () => {
-  vi.mocked(window.isExperimentalConfigurationEnabled).mockImplementation(async () => {
-    return false;
-  });
+  vi.mocked(window.isExperimentalConfigurationEnabled).mockResolvedValue(false);
   configurationProperties.set([]);
   await vi.waitFor(() => {
     const result = get(isKubernetesExperimentalModeStore);


### PR DESCRIPTION
### What does this PR do?

This PR converts some mockImplementation to mockResolvedValue / mockReturn in some tests because it was suggested to use more of this syntax in https://github.com/podman-desktop/podman-desktop/pull/14226#discussion_r2400975465, so it will make future tests that are copied from this more likely to use this syntax.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
