### PR TITLE
revert: use mockResolvedValue / mockReturn in some tests

### DIFF
--- a/extensions/compose/src/compose-github-releases.spec.ts
+++ b/extensions/compose/src/compose-github-releases.spec.ts
@@ -179,8 +179,12 @@ test('should download the file if parent folder does not exist', async () => {
   });
 
   // mock fs
-  const existSyncSpy = vi.spyOn(fs, 'existsSync').mockReturnValue(false);
-  const mkdirSpy = vi.spyOn(fs.promises, 'mkdir').mockResolvedValue('');
+  const existSyncSpy = vi.spyOn(fs, 'existsSync').mockImplementation(() => {
+    return false;
+  });
+  const mkdirSpy = vi.spyOn(fs.promises, 'mkdir').mockImplementation(async () => {
+    return '';
+  });
 
   const writeFileSpy = vi.spyOn(fs.promises, 'writeFile').mockResolvedValue();
 

--- a/extensions/kind/src/kind-installer.spec.ts
+++ b/extensions/kind/src/kind-installer.spec.ts
@@ -332,8 +332,12 @@ describe('downloadReleaseAsset', () => {
     });
 
     // mock fs
-    const existSyncSpy = vi.spyOn(fs, 'existsSync').mockReturnValue(false);
-    const mkdirSpy = vi.spyOn(fs.promises, 'mkdir').mockResolvedValue('');
+    const existSyncSpy = vi.spyOn(fs, 'existsSync').mockImplementation(() => {
+      return false;
+    });
+    const mkdirSpy = vi.spyOn(fs.promises, 'mkdir').mockImplementation(async () => {
+      return '';
+    });
 
     const writeFileSpy = vi.spyOn(fs.promises, 'writeFile').mockResolvedValue();
 

--- a/extensions/kubectl-cli/src/kubectl-github-releases.spec.ts
+++ b/extensions/kubectl-cli/src/kubectl-github-releases.spec.ts
@@ -142,11 +142,17 @@ test('should download the file if parent folder does exist', async () => {
 test('should download the file if parent folder does not exist', async () => {
   vi.mock('node:fs');
 
-  getReleaseAssetMock.mockReturnValue({ data: 'foo' });
+  getReleaseAssetMock.mockImplementation(() => {
+    return { data: 'foo' };
+  });
 
   // mock fs
-  const existSyncSpy = vi.spyOn(fs, 'existsSync').mockReturnValue(false);
-  const mkdirSpy = vi.spyOn(fs.promises, 'mkdir').mockResolvedValue('');
+  const existSyncSpy = vi.spyOn(fs, 'existsSync').mockImplementation(() => {
+    return false;
+  });
+  const mkdirSpy = vi.spyOn(fs.promises, 'mkdir').mockImplementation(async () => {
+    return '';
+  });
 
   const writeFileSpy = vi.spyOn(fs.promises, 'writeFile').mockResolvedValue();
 

--- a/extensions/podman/packages/extension/src/utils/notifications.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/notifications.spec.ts
@@ -148,7 +148,7 @@ describe('macOS: tests for notifying if disguised podman socket fails / passes',
     vi.mocked(extensionApi.env).isLinux = false;
 
     // Mock "isDisguisedPodman" to return true to indicate a failed socket
-    vi.mocked(isDisguisedPodman).mockResolvedValue(true);
+    vi.mocked(isDisguisedPodman).mockImplementation(async () => true);
 
     await extensionNotifications.checkMacSocket();
 
@@ -168,7 +168,7 @@ describe('macOS: tests for notifying if disguised podman socket fails / passes',
     vi.mocked(extensionApi.env).isLinux = false;
 
     // Mock "isDisguisedPodman" to return false to indicate a failed socket
-    vi.mocked(isDisguisedPodman).mockResolvedValue(false);
+    vi.mocked(isDisguisedPodman).mockImplementation(async () => false);
 
     await extensionNotifications.checkMacSocket();
 

--- a/packages/renderer/src/lib/image/ImageDetailsCheck.spec.ts
+++ b/packages/renderer/src/lib/image/ImageDetailsCheck.spec.ts
@@ -52,8 +52,10 @@ test('expect to display wait message before to receive results', async () => {
     },
   ]);
 
-  // never returns results
-  imageCheckMock.mockResolvedValue(new Promise(() => {}));
+  imageCheckMock.mockImplementation(async () => {
+    // never returns results
+    return new Promise(() => {});
+  });
 
   render(ImageDetailsCheck, {
     imageInfo: {
@@ -86,8 +88,10 @@ test('expect to cancel when clicking the Cancel button', async () => {
     },
   ]);
 
-  // never returns results
-  imageCheckMock.mockResolvedValue(new Promise(() => {}));
+  imageCheckMock.mockImplementation(async () => {
+    // never returns results
+    return new Promise(() => {});
+  });
 
   render(ImageDetailsCheck, {
     imageInfo: {
@@ -126,8 +130,10 @@ test('expect to cancel when destroying the component', async () => {
     },
   ]);
 
-  // never returns results
-  imageCheckMock.mockResolvedValue(new Promise(() => {}));
+  imageCheckMock.mockImplementation(async () => {
+    // never returns results
+    return new Promise(() => {});
+  });
 
   const result = render(ImageDetailsCheck, {
     imageInfo: {
@@ -163,8 +169,10 @@ test('expect to not cancel again when destroying the component after manual canc
     },
   ]);
 
-  // never returns results
-  imageCheckMock.mockResolvedValue(new Promise(() => {}));
+  imageCheckMock.mockImplementation(async () => {
+    // never returns results
+    return new Promise(() => {});
+  });
 
   const result = render(ImageDetailsCheck, {
     imageInfo: {

--- a/packages/renderer/src/stores/kubernetes-experimental.spec.ts
+++ b/packages/renderer/src/stores/kubernetes-experimental.spec.ts
@@ -23,7 +23,9 @@ import { configurationProperties } from './configurationProperties';
 import { isKubernetesExperimentalModeStore } from './kubernetes-experimental';
 
 test('experimental mode is set', async () => {
-  vi.mocked(window.isExperimentalConfigurationEnabled).mockResolvedValue(true);
+  vi.mocked(window.isExperimentalConfigurationEnabled).mockImplementation(async () => {
+    return true;
+  });
   configurationProperties.set([]);
   await vi.waitFor(() => {
     const result = get(isKubernetesExperimentalModeStore);
@@ -32,7 +34,9 @@ test('experimental mode is set', async () => {
 });
 
 test('experimental mode is not set', async () => {
-  vi.mocked(window.isExperimentalConfigurationEnabled).mockResolvedValue(false);
+  vi.mocked(window.isExperimentalConfigurationEnabled).mockImplementation(async () => {
+    return false;
+  });
   configurationProperties.set([]);
   await vi.waitFor(() => {
     const result = get(isKubernetesExperimentalModeStore);


### PR DESCRIPTION
### What does this PR do?

Reverts podman-desktop/podman-desktop#14236

NB: this was created by the "revert" button on Github and it is on the upstream, sorry about that.

Following https://github.com/podman-desktop/podman-desktop/pull/14236 that was auto-merged, I am reverting it to continue the conversation on a new PR.


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
