### PR TITLE
feat: add ability to update image build to latest

### DIFF
--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -6098,3 +6098,72 @@ describe('kube play', () => {
     expect(PODMAN_PROVIDER.libpodApi.playKube).toHaveBeenCalledWith('dummy-file');
   });
 });
+
+describe('updateImage', () => {
+  test('should reject if no provider', async () => {
+    await expect(containerRegistry.updateImage('dummy', 'image:latest')).rejects.toThrowError(
+      'no engine matching this engine',
+    );
+  });
+
+  test('should reject images with no registry tags', async () => {
+    const mockImage = {
+      inspect: vi.fn().mockResolvedValue({ RepoTags: [] }),
+    };
+    const engine = {
+      getImage: vi.fn().mockReturnValue(mockImage),
+    };
+    vi.spyOn(containerRegistry, 'getMatchingEngine').mockReturnValue(engine as unknown as Dockerode);
+
+    await expect(containerRegistry.updateImage('engine1', 'imageId')).rejects.toThrowError(
+      'Image has no registry tags and cannot be updated',
+    );
+  });
+
+  test('should pull new image and delete old image successfully when new version available', async () => {
+    const oldImageId = 'sha256:old123';
+    const newImageId = 'sha256:new456';
+    const mockOldImage = {
+      inspect: vi.fn().mockResolvedValue({ Id: oldImageId, RepoTags: ['nginx:latest'] }),
+    };
+    const mockNewImage = {
+      inspect: vi.fn().mockResolvedValue({ Id: newImageId, RepoTags: ['nginx:latest'] }),
+    };
+    const mockPullStream = { on: vi.fn() };
+    const engine = {
+      getImage: vi.fn().mockReturnValueOnce(mockOldImage).mockReturnValueOnce(mockNewImage),
+      pull: vi.fn().mockResolvedValue(mockPullStream),
+      modem: {
+        followProgress: vi.fn((_stream, onFinished) => onFinished(null)),
+      },
+    };
+    vi.spyOn(containerRegistry, 'getMatchingEngine').mockReturnValue(engine as unknown as Dockerode);
+    vi.spyOn(containerRegistry, 'deleteImage').mockResolvedValue(undefined);
+
+    const result = await containerRegistry.updateImage('engine1', 'imageId');
+    expect(result).toBeUndefined();
+    expect(engine.pull).toHaveBeenCalledWith('nginx:latest', expect.any(Object));
+    expect(containerRegistry.deleteImage).toHaveBeenCalledOnce();
+    expect(containerRegistry.deleteImage).toHaveBeenCalledWith('engine1', oldImageId);
+  });
+
+  test('should reject if image is already latest version', async () => {
+    const imageId = 'sha256:abc123';
+    const mockImage = {
+      inspect: vi.fn().mockResolvedValue({ Id: imageId, RepoTags: ['nginx:latest'] }),
+    };
+    const mockPullStream = { on: vi.fn() };
+    const engine = {
+      getImage: vi.fn().mockReturnValue(mockImage),
+      pull: vi.fn().mockResolvedValue(mockPullStream),
+      modem: {
+        followProgress: vi.fn((_stream, onFinished) => onFinished(null)),
+      },
+    };
+    vi.spyOn(containerRegistry, 'getMatchingEngine').mockReturnValue(engine as unknown as Dockerode);
+
+    await expect(containerRegistry.updateImage('engine1', 'imageId')).rejects.toThrowError(
+      'Image is already the latest version',
+    );
+  });
+});

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -6161,9 +6161,11 @@ describe('updateImage', () => {
       },
     };
     vi.spyOn(containerRegistry, 'getMatchingEngine').mockReturnValue(engine as unknown as Dockerode);
+    const deleteSpy = vi.spyOn(containerRegistry, 'deleteImage');
 
     await expect(containerRegistry.updateImage('engine1', 'imageId')).rejects.toThrowError(
       'Image is already the latest version',
     );
+    expect(deleteSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -1273,11 +1273,8 @@ export class ContainerProviderRegistry {
       if (!imageInfo.RepoTags || imageInfo.RepoTags.length === 0) {
         throw new Error('Image has no registry tags and cannot be updated');
       }
-      // get the first repo tag
-      const repoTag = imageInfo.RepoTags[0];
-      if (!repoTag) {
-        throw new Error('Image has no valid repository tag and cannot be updated');
-      }
+      // get the first repo tag (we know it exists because length > 0)
+      const repoTag = imageInfo.RepoTags[0]!;
 
       // check if this is a localhost image
       if (repoTag.startsWith('localhost/') || repoTag.startsWith('127.0.0.1')) {
@@ -1312,7 +1309,7 @@ export class ContainerProviderRegistry {
       }
 
       // Only delete the old image if it had a single tag
-      if (updatedImageInfo.RepoTags && updatedImageInfo.RepoTags.length === 1) {
+      if (updatedImageInfo.RepoTags?.length === 1) {
         try {
           await this.deleteImage(engineId, oldImageId);
         } catch (error) {

--- a/packages/main/src/plugin/index.spec.ts
+++ b/packages/main/src/plugin/index.spec.ts
@@ -814,3 +814,45 @@ describe('Log race condition fix', () => {
     }).not.toThrow();
   });
 });
+
+describe('updateImage handler', () => {
+  test('should update image and set task status to success', async () => {
+    const handle = handlers.get('container-provider-registry:updateImage');
+    expect(handle).not.equal(undefined);
+
+    const engineId = 'engine1';
+    const imageId = 'alpine:latest';
+
+    vi.spyOn(ContainerProviderRegistry.prototype, 'updateImage').mockResolvedValue(undefined);
+
+    const createTaskSpy = vi.spyOn(TaskManager.prototype, 'createTask');
+
+    await handle(undefined, engineId, imageId);
+
+    expect(ContainerProviderRegistry.prototype.updateImage).toHaveBeenCalledWith(engineId, imageId);
+    expect(createTaskSpy).toHaveBeenCalledWith({
+      title: `Updating image '${imageId}'`,
+    });
+  });
+
+  test('should handle update errors and set task error', async () => {
+    const handle = handlers.get('container-provider-registry:updateImage');
+    expect(handle).not.equal(undefined);
+
+    const engineId = 'engine1';
+    const imageId = 'invalid:image';
+
+    vi.spyOn(ContainerProviderRegistry.prototype, 'updateImage').mockRejectedValue(new Error('Network error'));
+
+    const createTaskSpy = vi.spyOn(TaskManager.prototype, 'createTask');
+
+    const result = await handle(undefined, engineId, imageId);
+    expect(result).toHaveProperty('error');
+    expect(result.error).toBeInstanceOf(Error);
+    expect(result.error.message).toBe('Network error');
+
+    expect(createTaskSpy).toHaveBeenCalledWith({
+      title: `Updating image '${imageId}'`,
+    });
+  });
+});

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1212,6 +1212,23 @@ export class PluginSystem {
         );
       },
     );
+
+    this.ipcHandle(
+      'container-provider-registry:updateImage',
+      async (_listener, engineId: string, imageId: string): Promise<void> => {
+        const task = taskManager.createTask({
+          title: `Updating image '${imageId}'`,
+        });
+        try {
+          await containerProviderRegistry.updateImage(engineId, imageId);
+          task.status = 'success';
+        } catch (error: unknown) {
+          task.error = String(error);
+          throw error;
+        }
+      },
+    );
+
     this.ipcHandle(
       'container-provider-registry:pushImage',
       async (_listener, engine: string, imageId: string, callbackId: number): Promise<void> => {

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -574,6 +574,10 @@ export function initExposure(): void {
     return ipcInvoke('container-provider-registry:saveImages', options);
   });
 
+  contextBridge.exposeInMainWorld('updateImage', async (engineId: string, imageId: string): Promise<void> => {
+    return ipcInvoke('container-provider-registry:updateImage', engineId, imageId);
+  });
+
   contextBridge.exposeInMainWorld('loadImages', async (options: ImageLoadOptions): Promise<void> => {
     return ipcInvoke('container-provider-registry:loadImages', options);
   });

--- a/packages/renderer/src/lib/image/ImageActions.spec.ts
+++ b/packages/renderer/src/lib/image/ImageActions.spec.ts
@@ -259,3 +259,43 @@ test('Expect withConfirmation to indicate image name and tag', async () => {
     expect(withConfirmation).toHaveBeenNthCalledWith(1, expect.anything(), 'delete image image-name:1.0');
   });
 });
+
+test('Expect Update Image button to be disabled for unnamed images', async () => {
+  getContributedMenusMock.mockImplementation(() => Promise.resolve([]));
+
+  const image: ImageInfoUI = {
+    name: '<none>',
+    status: 'UNUSED',
+    tag: '',
+  } as ImageInfoUI;
+
+  render(ImageActions, {
+    onPushImage: vi.fn(),
+    onRenameImage: vi.fn(),
+    image,
+  });
+
+  const button = screen.getByTitle('Update Image');
+  expect(button).toBeDefined();
+  expect(button).toBeDisabled();
+});
+
+test('Expect Update Image button to be enabled for named images', async () => {
+  getContributedMenusMock.mockImplementation(() => Promise.resolve([]));
+
+  const image: ImageInfoUI = {
+    name: 'image-name',
+    status: 'UNUSED',
+    tag: '1.0',
+  } as ImageInfoUI;
+
+  render(ImageActions, {
+    onPushImage: vi.fn(),
+    onRenameImage: vi.fn(),
+    image,
+  });
+
+  const button = screen.getByTitle('Update Image');
+  expect(button).toBeDefined();
+  expect(button).toBeEnabled();
+});

--- a/packages/renderer/src/lib/image/ImageActions.spec.ts
+++ b/packages/renderer/src/lib/image/ImageActions.spec.ts
@@ -34,6 +34,7 @@ vi.mock('./image-utils', () => {
   return {
     ImageUtils: vi.fn().mockImplementation(() => ({
       deleteImage: vi.fn().mockImplementation(() => Promise.reject(new Error('Cannot delete image in test'))),
+      updateImage: vi.fn().mockImplementation(() => Promise.resolve()),
     })),
   };
 });

--- a/packages/renderer/src/lib/image/ImageActions.svelte
+++ b/packages/renderer/src/lib/image/ImageActions.svelte
@@ -165,7 +165,8 @@ async function updateImage(): Promise<void> {
     onClick={(): void => withConfirmation(updateImage, `update image ${image.name}:${image.tag} to latest build`)}
     menu={dropdownMenu}
     detailed={detailed}
-    icon={faArrowCircleUp} />
+    icon={faArrowCircleUp}
+    enabled={image.name !== '<none>'} />
 
   <ActionsWrapper dropdownMenu={groupingContributions} dropdownMenuAsMenuActionItem={groupingContributions}>
     <ContributionActions

--- a/packages/renderer/src/lib/image/ImageActions.svelte
+++ b/packages/renderer/src/lib/image/ImageActions.svelte
@@ -1,5 +1,13 @@
 <script lang="ts">
-import { faArrowUp, faDownload, faEdit, faLayerGroup, faPlay, faTrash } from '@fortawesome/free-solid-svg-icons';
+import {
+  faArrowCircleUp,
+  faArrowUp,
+  faDownload,
+  faEdit,
+  faLayerGroup,
+  faPlay,
+  faTrash,
+} from '@fortawesome/free-solid-svg-icons';
 import { createEventDispatcher, onMount } from 'svelte';
 import { router } from 'tinro';
 
@@ -98,6 +106,12 @@ function saveImage(): void {
   saveImagesInfo.set([image]);
   router.goto('/images/save');
 }
+
+async function updateImage(): Promise<void> {
+  await imageUtils.updateImage(image);
+  image.selected = false;
+  dispatch('update', image);
+}
 </script>
 
 <ListItemButtonIcon title="Run Image" onClick={(): Promise<void> => runImage(image)} detailed={detailed} icon={faPlay} />
@@ -144,6 +158,14 @@ function saveImage(): void {
     menu={dropdownMenu}
     detailed={detailed}
     icon={faDownload} />
+
+  <ListItemButtonIcon
+    title="Update Image"
+    tooltip="Update image to the latest build"
+    onClick={(): void => withConfirmation(updateImage, `update image ${image.name}:${image.tag} to latest build`)}
+    menu={dropdownMenu}
+    detailed={detailed}
+    icon={faArrowCircleUp} />
 
   <ActionsWrapper dropdownMenu={groupingContributions} dropdownMenuAsMenuActionItem={groupingContributions}>
     <ContributionActions

--- a/packages/renderer/src/lib/image/ImageInfoUI.ts
+++ b/packages/renderer/src/lib/image/ImageInfoUI.ts
@@ -34,7 +34,7 @@ export interface ImageInfoUI {
   // no tag, we encode <none>
   base64RepoTag: string;
   selected: boolean;
-  status: 'USED' | 'UNUSED' | 'DELETING';
+  status: 'USED' | 'UNUSED' | 'DELETING' | 'UPDATING';
   icon: unknown;
   labels?: { [label: string]: string };
   badges: ViewContributionBadgeValue[];

--- a/packages/renderer/src/lib/image/ImagesList.svelte
+++ b/packages/renderer/src/lib/image/ImagesList.svelte
@@ -241,7 +241,12 @@ async function updateSelectedImages(): Promise<void> {
   await selectedImages.reduce((prev: Promise<void>, image) => {
     return prev
       .then(() => imageUtils.updateImage(image))
-      .catch((e: unknown) => console.error('error while updating image', e));
+      .catch((e: unknown) => {
+        console.error('error while updating image', e);
+        // Reset status on error to prevent getting stuck in UPDATING state
+        image.status = 'UNUSED';
+        images = images;
+      });
   }, Promise.resolve());
   bulkUpdateInProgress = false;
 }

--- a/packages/renderer/src/lib/image/image-utils.ts
+++ b/packages/renderer/src/lib/image/image-utils.ts
@@ -247,6 +247,11 @@ export class ImageUtils {
     return window.deleteImage(image.engineId, imageId);
   }
 
+  updateImage(image: ImageInfoUI): Promise<void> {
+    const imageId = image.name === '<none>' ? image.id : `${image.name}:${image.tag}`;
+    return window.updateImage(image.engineId, imageId);
+  }
+
   getImageInfoUI(
     imageInfo: ImageInfo,
     base64RepoTag: string,

--- a/packages/ui/src/lib/statusIcon/StatusIcon.spec.ts
+++ b/packages/ui/src/lib/statusIcon/StatusIcon.spec.ts
@@ -68,3 +68,16 @@ test('Expect deleting styling', async () => {
   expect(spinner).toBeInTheDocument();
   expect(spinner).toHaveAttribute('width', '1.4em');
 });
+
+test('Expect updating styling', async () => {
+  const status = 'UPDATING';
+  render(StatusIcon, { status });
+  const icon = screen.getByRole('status');
+  expect(icon).toBeInTheDocument();
+  expect(icon).toHaveAttribute('title', status);
+  expect(icon).not.toHaveAttribute('border');
+
+  const spinner = screen.getByRole('img');
+  expect(spinner).toBeInTheDocument();
+  expect(spinner).toHaveAttribute('width', '1.4em');
+});

--- a/packages/ui/src/lib/statusIcon/StatusIcon.svelte
+++ b/packages/ui/src/lib/statusIcon/StatusIcon.svelte
@@ -4,9 +4,9 @@ import StarIcon from '../icons/StarIcon.svelte';
 import Spinner from '../progress/Spinner.svelte';
 
 interface Props {
-  // status: one of RUNNING, STARTING, USED, CREATED, DELETING, or DEGRADED
+  // status: one of RUNNING, STARTING, USED, CREATED, DELETING, UPDATING, or DEGRADED
   // any other status will result in a standard outlined box
-  status?: 'RUNNING' | 'STARTING' | 'USED' | 'DEGRADED' | 'DELETING' | 'CREATED' | string;
+  status?: 'RUNNING' | 'STARTING' | 'USED' | 'DEGRADED' | 'DELETING' | 'UPDATING' | 'CREATED' | string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   icon?: any;
   size?: number;
@@ -22,7 +22,7 @@ let solid = $derived(status === 'RUNNING' || status === 'STARTING' || status ===
     class:bg-[var(--pd-status-running)]={status === 'RUNNING' || status === 'USED'}
     class:bg-[var(--pd-status-starting)]={status === 'STARTING'}
     class:bg-[var(--pd-status-degraded)]={status === 'DEGRADED'}
-    class:border-2={!solid && status !== 'DELETING'}
+    class:border-2={!solid && status !== 'DELETING' && status !== 'UPDATING'}
     class:p-0.5={!solid}
     class:p-1={solid}
     class:border-[var(--pd-status-not-running)]={!solid}
@@ -30,7 +30,7 @@ let solid = $derived(status === 'RUNNING' || status === 'STARTING' || status ===
     class:text-[var(--pd-status-contrast)]={solid}
     role="status"
     title={status}>
-    {#if status === 'DELETING'}
+    {#if status === 'DELETING' || status === 'UPDATING'}
       <Spinner size="1.4em" />
     {:else if typeof icon === 'string'}
        <Icon icon={icon} />


### PR DESCRIPTION
the button works the same ui wise as image delete where a user can select multiple images to check for update. Image will update based on rolling tag vs immutable tag. 

### What does this PR do?

adds a new feature to update the digest of an image

### Screenshot / video of UI


https://github.com/user-attachments/assets/8253100a-22c1-43b7-9937-9982d0457beb




<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes: https://github.com/podman-desktop/podman-desktop/issues/923

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

download alpine3:15 in the ui
on the cli tag alpine3:15 as alpine:latest
update in ui

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
