### PR TITLE
feat: add autostop all podman machines on exit (#12944)

### DIFF
--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -65,6 +65,7 @@ const provider: extensionApi.Provider = {
   registerInstallation: vi.fn(),
   registerUpdate: registerUpdateMock,
   registerAutostart: vi.fn(),
+  registerAutostop: vi.fn(),
   registerCleanup: vi.fn(),
   dispose: vi.fn(),
   name: '',

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -639,6 +639,10 @@ declare module '@podman-desktop/api' {
     start(logger: Logger, context?: AutostartContext): Promise<void>;
   }
 
+  export interface ProviderAutostop {
+    setAutostop(logger: Logger, value: boolean): Promise<void>;
+  }
+
   /**
    * Allow to clean some resources in case for example
    */
@@ -701,6 +705,9 @@ declare module '@podman-desktop/api' {
 
     // register autostart flow
     registerAutostart(autostart: ProviderAutostart): Disposable;
+
+    // register autostop flow
+    registerAutostop(autostop: ProviderAutostop): Disposable;
 
     registerCleanup(cleanup: ProviderCleanup): Disposable;
 

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -639,6 +639,14 @@ declare module '@podman-desktop/api' {
     start(logger: Logger, context?: AutostartContext): Promise<void>;
   }
 
+  /**
+   * Interface representing a provider that manages the autostop feature.
+   * Can be turned on / off by the user.
+   *
+   * @param {Logger} logger - the logger to use to log messages
+   * @param {boolean} value - true to enable autostop, false to disable autostop
+   * @returns {Promise<void>} - a promise that resolves when the autostop feature has been enabled / disabled
+   */
   export interface ProviderAutostop {
     setAutostop(logger: Logger, value: boolean): Promise<void>;
   }

--- a/packages/main/src/plugin/autostop-engine.spec.ts
+++ b/packages/main/src/plugin/autostop-engine.spec.ts
@@ -1,0 +1,128 @@
+import type { Configuration } from '@podman-desktop/api';
+import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
+
+import type { ApiSenderType } from '/@/plugin/api.js';
+import { CONFIGURATION_DEFAULT_SCOPE, CONFIGURATION_ONBOARDING_SCOPE } from '/@api/configuration/constants.js';
+import type { IConfigurationNode } from '/@api/configuration/models.js';
+
+import { AutostopEngine } from './autostop-engine.js';
+import { ConfigurationRegistry } from './configuration-registry.js';
+import type { Directories } from './directories.js';
+import type { ProviderRegistry } from './provider-registry.js';
+
+let configurationRegistry: ConfigurationRegistry;
+let providerRegistry: ProviderRegistry;
+let autostopEngine: AutostopEngine;
+
+const extensionId = 'id';
+const extensionDisplayName = 'name';
+
+const mockRegisterConfiguration = vi.fn();
+const mockSetAutostop = vi.fn().mockResolvedValue('');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+/* eslint-disable @typescript-eslint/no-empty-function */
+beforeAll(() => {
+  configurationRegistry = new ConfigurationRegistry({} as ApiSenderType, {} as Directories);
+  providerRegistry = {} as unknown as ProviderRegistry;
+  autostopEngine = new AutostopEngine(configurationRegistry, providerRegistry);
+  configurationRegistry.registerConfigurations = mockRegisterConfiguration;
+  configurationRegistry.deregisterConfigurations = vi.fn();
+  providerRegistry.setAutostop = mockSetAutostop;
+});
+
+test('Check that default value is false if provider autostop setting is not set', async () => {
+  vi.spyOn(configurationRegistry, 'getConfiguration').mockImplementation(() => {
+    return {
+      get: (_section: string, defaultValue: boolean) => defaultValue,
+    } as Configuration;
+  });
+
+  const autostopConfigurationNode: IConfigurationNode = {
+    id: `preferences.${extensionId}.engine.autostop`,
+    title: `Autostop ${extensionDisplayName} engine`,
+    type: 'object',
+    extension: {
+      id: extensionId,
+    },
+    properties: {
+      [`preferences.${extensionId}.engine.autostop`]: {
+        description: `Automatically stop ${extensionDisplayName} engine when exiting Podman Desktop, even if it was started manually`,
+        type: 'boolean',
+        default: false,
+        scope: [CONFIGURATION_DEFAULT_SCOPE, CONFIGURATION_ONBOARDING_SCOPE],
+      },
+    },
+  };
+
+  const disposable = autostopEngine.registerProvider(extensionId, extensionDisplayName, 'internalId');
+  disposable.dispose();
+
+  expect(mockRegisterConfiguration).toBeCalledWith([autostopConfigurationNode]);
+});
+
+test('Disposing the provider should not delete the configuration', async () => {
+  vi.spyOn(configurationRegistry, 'getConfiguration').mockImplementation(() => {
+    return {
+      get: (_section: string, defaultValue: boolean) => defaultValue,
+    } as Configuration;
+  });
+
+  const disposable = autostopEngine.registerProvider(extensionId, extensionDisplayName, 'internalId');
+  disposable.dispose();
+
+  expect(configurationRegistry.deregisterConfigurations).not.toHaveBeenCalled();
+});
+
+test('Check that setAutostop is called once if only one provider has registered autostop process and its setting is true', async () => {
+  vi.spyOn(configurationRegistry, 'getConfiguration').mockImplementation(() => {
+    return {
+      get: (_section: string, _defaultValue: boolean) => true,
+    } as Configuration;
+  });
+
+  const disposable = autostopEngine.registerProvider(extensionId, extensionDisplayName, 'internalId');
+  await autostopEngine.setConfigurationForProviders();
+
+  disposable.dispose();
+  expect(mockSetAutostop).toBeCalledTimes(1);
+  expect(mockSetAutostop).toBeCalledWith('internalId', true);
+});
+
+test('Check that setAutostop is called once if only one provider has registered autostart process and its setting is false', async () => {
+  vi.spyOn(configurationRegistry, 'getConfiguration').mockImplementation(() => {
+    return {
+      get: (_section: string, _defaultValue: boolean) => false,
+    } as Configuration;
+  });
+
+  const disposable = autostopEngine.registerProvider(extensionId, extensionDisplayName, 'internalId');
+
+  await autostopEngine.setConfigurationForProviders();
+
+  disposable.dispose();
+  expect(mockSetAutostop).toBeCalledTimes(1);
+  expect(mockSetAutostop).toBeCalledWith('internalId', false);
+});
+
+test('Check that setAutostop is called twice if only two providers has registered autstop process', async () => {
+  vi.spyOn(configurationRegistry, 'getConfiguration').mockImplementation(() => {
+    return {
+      get: (_section: string, _defaultValue: boolean) => true,
+    } as Configuration;
+  });
+
+  const disposable1 = autostopEngine.registerProvider(extensionId, extensionDisplayName, 'internalId1');
+  const disposable2 = autostopEngine.registerProvider(extensionId, extensionDisplayName, 'internalId2');
+
+  await autostopEngine.setConfigurationForProviders();
+
+  disposable1.dispose();
+  disposable2.dispose();
+  expect(mockSetAutostop).toBeCalledTimes(2);
+  expect(mockSetAutostop).toHaveBeenNthCalledWith(1, 'internalId1', true);
+  expect(mockSetAutostop).toHaveBeenLastCalledWith('internalId2', true);
+});

--- a/packages/main/src/plugin/autostop-engine.spec.ts
+++ b/packages/main/src/plugin/autostop-engine.spec.ts
@@ -85,7 +85,6 @@ test('Check that setAutostop is called once if only one provider has registered 
   });
 
   const disposable = autostopEngine.registerProvider(extensionId, extensionDisplayName, 'internalId');
-  await autostopEngine.setConfigurationForProviders();
 
   disposable.dispose();
   expect(mockSetAutostop).toBeCalledTimes(1);
@@ -101,8 +100,6 @@ test('Check that setAutostop is called once if only one provider has registered 
 
   const disposable = autostopEngine.registerProvider(extensionId, extensionDisplayName, 'internalId');
 
-  await autostopEngine.setConfigurationForProviders();
-
   disposable.dispose();
   expect(mockSetAutostop).toBeCalledTimes(1);
   expect(mockSetAutostop).toBeCalledWith('internalId', false);
@@ -117,8 +114,6 @@ test('Check that setAutostop is called twice if only two providers has registere
 
   const disposable1 = autostopEngine.registerProvider(extensionId, extensionDisplayName, 'internalId1');
   const disposable2 = autostopEngine.registerProvider(extensionId, extensionDisplayName, 'internalId2');
-
-  await autostopEngine.setConfigurationForProviders();
 
   disposable1.dispose();
   disposable2.dispose();

--- a/packages/main/src/plugin/autostop-engine.ts
+++ b/packages/main/src/plugin/autostop-engine.ts
@@ -1,0 +1,69 @@
+import { inject, injectable } from 'inversify';
+
+import { CONFIGURATION_DEFAULT_SCOPE, CONFIGURATION_ONBOARDING_SCOPE } from '/@api/configuration/constants.js';
+import { type IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
+
+import { ProviderRegistry } from './provider-registry.js';
+import { Disposable } from './types/disposable.js';
+
+@injectable()
+export class AutostopEngine {
+  private providerExtension = new Map<string, string>();
+
+  constructor(
+    @inject(IConfigurationRegistry)
+    private configurationRegistry: IConfigurationRegistry,
+    @inject(ProviderRegistry)
+    private providerRegistry: ProviderRegistry,
+  ) {}
+
+  registerProvider(extensionId: string, extensionDisplayName: string, providerInternalId: string): Disposable {
+    this.providerExtension.set(providerInternalId, extensionId);
+    this.registerProviderConfiguration(extensionId, extensionDisplayName);
+    return Disposable.create(() => {
+      this.providerExtension.delete(providerInternalId);
+    });
+  }
+
+  private registerProviderConfiguration(extensionId: string, extensionDisplayName: string): IConfigurationNode {
+    const autoStopConfigurationNode: IConfigurationNode = {
+      id: `preferences.${extensionId}.engine.autostop`,
+      title: `Autostop ${extensionDisplayName} engine`,
+      type: 'object',
+      extension: {
+        id: extensionId,
+      },
+      properties: {
+        [`preferences.${extensionId}.engine.autostop`]: {
+          description: `Automatically stop ${extensionDisplayName} engine when exiting Podman Desktop, even if it was started manually`,
+          type: 'boolean',
+          default: false,
+          scope: [CONFIGURATION_DEFAULT_SCOPE, CONFIGURATION_ONBOARDING_SCOPE],
+        },
+      },
+    };
+
+    this.configurationRegistry.registerConfigurations([autoStopConfigurationNode]);
+    return autoStopConfigurationNode;
+  }
+
+  async setConfigurationForProviders(): Promise<void> {
+    this.providerExtension.forEach((extensionId, providerInternalId) => {
+      const autostopConfiguration = this.configurationRegistry.getConfiguration(`preferences.${extensionId}`);
+
+      const autostop = autostopConfiguration.get<boolean>('engine.autostop', false);
+
+      this.providerRegistry.setAutostop(providerInternalId, autostop).catch((e: unknown) => {
+        console.error(`Failed to autostop ${extensionId} container engine`, e);
+      });
+
+      // set the value if we toggle the property
+      this.configurationRegistry.onDidChangeConfiguration(async e => {
+        if (e.key === `preferences.${extensionId}.engine.autostop`) {
+          const value = e.value as boolean;
+          await this.providerRegistry.setAutostop(providerInternalId, value);
+        }
+      });
+    });
+  }
+}

--- a/packages/main/src/plugin/autostop-engine.ts
+++ b/packages/main/src/plugin/autostop-engine.ts
@@ -21,9 +21,16 @@ export class AutostopEngine {
       const m = /^preferences\.(.+)\.engine\.autostop$/.exec(e.key);
       if (!m) return;
       const extensionId = m[1];
-      const providerIds = this.providerExtension.get(extensionId!);
-      if (!providerIds?.size) return;
-      await Promise.all(Array.from(providerIds, id => this.providerRegistry.setAutostop(id, e.value as boolean)));
+      const providerIds = Array.from(this.providerExtension.get(extensionId!) ?? []);
+      if (providerIds.length === 0) return;
+      const results = await Promise.allSettled(
+        Array.from(providerIds, id => this.providerRegistry.setAutostop(id, e.value as boolean)),
+      );
+      results.forEach((result, idx) => {
+        if (result.status === 'rejected') {
+          console.log(`Failed to set autostop for provider ${providerIds[idx]}`, result.reason);
+        }
+      });
     });
   }
 

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -136,6 +136,7 @@ import { AppearanceInit } from './appearance-init.js';
 import type { AuthenticationProviderInfo } from './authentication.js';
 import { AuthenticationImpl } from './authentication.js';
 import { AutostartEngine } from './autostart-engine.js';
+import { AutostopEngine } from './autostop-engine.js';
 import { CancellationTokenRegistry } from './cancellation-token-registry.js';
 import { Certificates } from './certificates.js';
 import { CliToolRegistry } from './cli-tool-registry.js';
@@ -590,10 +591,13 @@ export class PluginSystem {
     });
 
     container.bind<AutostartEngine>(AutostartEngine).toSelf().inSingletonScope();
+    container.bind<AutostopEngine>(AutostopEngine).toSelf().inSingletonScope();
     const autoStartEngine = container.get<AutostartEngine>(AutostartEngine);
+    const autostopEngine = container.get<AutostopEngine>(AutostopEngine);
 
     const providerRegistry = container.get<ProviderRegistry>(ProviderRegistry);
     providerRegistry.registerAutostartEngine(autoStartEngine);
+    providerRegistry.registerAutostopEngine(autostopEngine);
 
     providerRegistry.addProviderListener((name: string, providerInfo: ProviderInfo) => {
       if (name === 'provider:update-status') {
@@ -3210,6 +3214,9 @@ export class PluginSystem {
     }
     extensionsUpdater.init().catch((err: unknown) => console.error('Unable to perform extension updates', err));
     autoStartEngine.start().catch((err: unknown) => console.error('Unable to perform autostart', err));
+    autostopEngine
+      .setConfigurationForProviders()
+      .catch((err: unknown) => console.error('Unable to perform autostop', err));
     return this.extensionLoader;
   }
 

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -3214,9 +3214,6 @@ export class PluginSystem {
     }
     extensionsUpdater.init().catch((err: unknown) => console.error('Unable to perform extension updates', err));
     autoStartEngine.start().catch((err: unknown) => console.error('Unable to perform autostart', err));
-    autostopEngine
-      .setConfigurationForProviders()
-      .catch((err: unknown) => console.error('Unable to perform autostop', err));
     return this.extensionLoader;
   }
 

--- a/packages/main/src/plugin/provider-impl.ts
+++ b/packages/main/src/plugin/provider-impl.ts
@@ -298,6 +298,12 @@ export class ProviderImpl implements Provider, IDisposable {
     return this.providerRegistry.registerAutostart(this, update);
   }
 
+  /**
+   * Registers an autostop handler with the provider registry.
+   *
+   * @param {ProviderAutostop} update - The autostop configuration or handler to be registered.
+   * @return {Disposable} A disposable reference allowing the caller to unregister the autostop handler.
+   */
   registerAutostop(update: ProviderAutostop): Disposable {
     return this.providerRegistry.registerAutostop(this, update);
   }

--- a/packages/main/src/plugin/provider-impl.ts
+++ b/packages/main/src/plugin/provider-impl.ts
@@ -25,6 +25,7 @@ import type {
   KubernetesProviderConnectionFactory,
   Provider,
   ProviderAutostart,
+  ProviderAutostop,
   ProviderCleanup,
   ProviderConnectionStatus,
   ProviderDetectionCheck,
@@ -295,6 +296,10 @@ export class ProviderImpl implements Provider, IDisposable {
 
   registerAutostart(update: ProviderAutostart): Disposable {
     return this.providerRegistry.registerAutostart(this, update);
+  }
+
+  registerAutostop(update: ProviderAutostop): Disposable {
+    return this.providerRegistry.registerAutostop(this, update);
   }
 
   registerCleanup(cleanup: ProviderCleanup): Disposable {

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -309,10 +309,24 @@ export class ProviderRegistry {
     });
   }
 
+  /**
+   * Registers an AutostopEngine instance to be used by the system.
+   *
+   * @param {AutostopEngine} engine - The AutostopEngine instance to be registered.
+   * @return {void} Does not return a value.
+   */
   registerAutostopEngine(engine: AutostopEngine): void {
     this.autostopEngine = engine;
   }
 
+  /**
+   * Registers an autostop provider with the autostop system.
+   *
+   * @param {ProviderImpl} providerImpl - The provider implementation containing metadata to register the autostop.
+   * @param {ProviderAutostop} autostop - The autostop logic or configurations associated with the provider.
+   * @return {Disposable} A disposable object that can be used to unregister the autostop provider.
+   * @throws {Error} If no autostop engine has been registered.
+   */
   registerAutostop(providerImpl: ProviderImpl, autostop: ProviderAutostop): Disposable {
     if (!this.autostopEngine) {
       throw new Error('no autostop engine has been registered. Autostop feature is disabled');
@@ -471,6 +485,14 @@ export class ProviderRegistry {
     });
   }
 
+  /**
+   * Sets the autostop configuration for the specified provider.
+   *
+   * @param {string} internalId - The unique identifier of the provider.
+   * @param {boolean} value - The desired state for autostop (true to enable, false to disable).
+   * @return {Promise<void>} A promise that resolves when the operation is complete.
+   * @throws {Error} If no autostop configuration matches the specified provider ID.
+   */
   async setAutostop(internalId: string, value: boolean): Promise<void> {
     const autostop = this.providerAutostops.get(internalId);
     if (!autostop) {


### PR DESCRIPTION
### What does this PR do?
Implements an option for the users to shut down all Podman machines when exiting Podman Desktop. Currently only the machine started with the autostart features is shutdown when the user exits the application. The machine is not shutdown in case it was started before or after launching Podman Desktop. If the option is turned on (default value is false) all Podman machines are stopped when the application is exited. No restart needed to change the value of the toggle.

Maybe some useful info, in case the setting is off, the current behaviour of shutting down the machine that was auto started by Podman Desktop is still active. If the setting is turned on it ignores that part of the code and just shuts down all machines.

### Screenshot / video of UI
<img width="982" height="540" alt="image" src="https://github.com/user-attachments/assets/70e98a7f-0c4e-4272-b1ac-dabdf9309197" />

### What issues does this PR fix or reference?

Closes #12944 

### How to test this PR?

1. Start one or more Podman machines before starting Podman Desktop. Enable the settings, exit Podman Desktop. Machines should be stopped. Redo the same when the setting is disabled, they should be left running.
2. Same as above but starting the machines after Podman Desktop. Results should be the same

- [ ] Tests are covering the bug fix or the new feature
I'm not really feeling confident checking this box, I just added unit test for the settings thingy and made sure all tests are still running.
