### PR TITLE
refactor(renderer): rename 'Play Kubernetes YAML' page to 'Podman Kube Play' #14193

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -164,7 +164,7 @@ window.events?.receive('kubernetes-navigation', (args: unknown) => {
           </Route>
         </Route>
 
-        <Route path="/kube/play" breadcrumb="Play Kubernetes YAML">
+        <Route path="/kube/play" breadcrumb="Podman Kube Play">
           <KubePlayYAML />
         </Route>
         <Route path="/image/run/*" breadcrumb="Run Image">


### PR DESCRIPTION
### What issues does this PR fix or reference?
Refactor(renderer): rename 'Play Kubernetes YAML' page to 'Podman Kube Play. Fixes #14193 

### What does this PR do?
This PR updates the Pods page in Podman Desktop to ensure consistency between the button label and the page it opens.
- The button previously labeled “Play Kubernetes YAML” has been renamed to “Podman Kube Play”.

- The corresponding page title has also been updated to match the button, providing a consistent user experience.
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->
<img width="743" height="461" alt="Podeman Kuber Play" src="https://github.com/user-attachments/assets/71cb0bed-299f-45ea-ba88-41a422619c34" />



<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
