### PR TITLE
feat: add network create page

### DIFF
--- a/packages/api/src/container-info.ts
+++ b/packages/api/src/container-info.ts
@@ -275,12 +275,24 @@ export interface ContainerCreateOptions {
   pod?: string;
 }
 
-export interface NetworkCreateOptions {
-  Name: string;
-}
+export type NetworkCreateOptions = Dockerode.NetworkCreateOptions;
 
 export interface NetworkCreateResult {
   Id: string;
+}
+
+// Form state interface for creating networks in the UI
+export interface NetworkCreateFormInfo {
+  networkName: string;
+  labels: string[];
+  subnet: string;
+  ipRange: string;
+  gateway: string;
+  ipv6Enabled: boolean;
+  internalEnabled: boolean;
+  driver: string;
+  options: string[];
+  selectedProvider: ProviderContainerConnectionInfo | undefined;
 }
 
 export interface VolumeCreateOptions {

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -3763,6 +3763,19 @@ declare module '@podman-desktop/api' {
 
   export interface NetworkCreateOptions {
     Name: string;
+    CheckDuplicate?: boolean;
+    Driver?: string;
+    Scope?: string;
+    EnableIPv4?: boolean;
+    EnableIPv6?: boolean;
+    IPAM?: IPAM;
+    Internal?: boolean;
+    Attachable?: boolean;
+    Ingress?: boolean;
+    ConfigOnly?: boolean;
+    ConfigFrom?: { Network: string };
+    Options?: { [option: string]: string };
+    Labels?: { [label: string]: string };
   }
 
   export interface NetworkCreateResult {

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -3763,7 +3763,6 @@ declare module '@podman-desktop/api' {
 
   export interface NetworkCreateOptions {
     Name: string;
-    CheckDuplicate?: boolean;
     Driver?: string;
     Scope?: string;
     EnableIPv4?: boolean;

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -76,6 +76,8 @@ import type {
   ContainerInfo,
   ImageLoadOptions,
   ImagesSaveOptions,
+  NetworkCreateOptions,
+  NetworkCreateResult,
   SimpleContainerInfo,
   VolumeCreateOptions,
   VolumeCreateResponseInfo,
@@ -840,6 +842,16 @@ export class PluginSystem {
         removeDNSServers: string[],
       ): Promise<void> => {
         return containerProviderRegistry.updateNetwork(engineId, networkId, addDNSServers, removeDNSServers);
+      },
+    );
+    this.ipcHandle(
+      'container-provider-registry:createNetwork',
+      async (
+        _listener,
+        providerContainerConnectionInfo: ProviderContainerConnectionInfo,
+        options: NetworkCreateOptions,
+      ): Promise<NetworkCreateResult> => {
+        return containerProviderRegistry.createNetwork(providerContainerConnectionInfo, options);
       },
     );
     this.ipcHandle(

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -54,6 +54,8 @@ import type {
   ContainerInfo,
   ImageLoadOptions,
   ImagesSaveOptions,
+  NetworkCreateOptions,
+  NetworkCreateResult,
   SimpleContainerInfo,
   VolumeCreateOptions,
 } from '/@api/container-info';
@@ -312,6 +314,16 @@ export function initExposure(): void {
     'updateNetwork',
     async (engine: string, networkId: string, addDNSServers: string[], removeDNSServers: string[]): Promise<void> => {
       return ipcInvoke('container-provider-registry:updateNetwork', engine, networkId, addDNSServers, removeDNSServers);
+    },
+  );
+
+  contextBridge.exposeInMainWorld(
+    'createNetwork',
+    async (
+      providerContainerConnectionInfo: ProviderContainerConnectionInfo,
+      options: NetworkCreateOptions,
+    ): Promise<NetworkCreateResult> => {
+      return ipcInvoke('container-provider-registry:createNetwork', providerContainerConnectionInfo, options);
     },
   );
 

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -55,6 +55,7 @@ import KubePodDetails from './lib/kube/pods/PodDetails.svelte';
 import KubePodsList from './lib/kube/pods/PodsList.svelte';
 import PortForwardingList from './lib/kubernetes-port-forward/PortForwardingList.svelte';
 import ManifestDetails from './lib/manifest/ManifestDetails.svelte';
+import CreateNetwork from './lib/network/CreateNetwork.svelte';
 import NetworksList from './lib/network/NetworksList.svelte';
 import NodeDetails from './lib/node/NodeDetails.svelte';
 import NodesList from './lib/node/NodesList.svelte';
@@ -187,6 +188,9 @@ tablePersistence.storage = new PodmanDesktopStoragePersist();
         </Route>
         <Route path="/images/:id/:engineId" breadcrumb="Images" let:meta navigationHint="root">
           <ImagesList searchTerm={meta.params.id} imageEngineId={meta.params.engineId} />
+        </Route>
+        <Route path="/networks/create" breadcrumb="Create Network">
+          <CreateNetwork />
         </Route>
         <Route
           path="/manifests/:id/:engineId/:base64RepoTag/*"

--- a/packages/renderer/src/lib/network/CreateNetwork.spec.ts
+++ b/packages/renderer/src/lib/network/CreateNetwork.spec.ts
@@ -1,0 +1,249 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import type { ProviderStatus } from '@podman-desktop/api';
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import CreateNetwork from '/@/lib/network/CreateNetwork.svelte';
+import { providerInfos } from '/@/stores/providers';
+import type { ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provider-info';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.restoreAllMocks();
+});
+
+// Helper to create a provider connection
+function createProviderConnection(
+  overrides?: Partial<ProviderContainerConnectionInfo>,
+): ProviderContainerConnectionInfo {
+  return {
+    name: 'test',
+    displayName: 'test',
+    status: 'started',
+    endpoint: {
+      socketPath: '',
+    },
+    type: 'podman',
+    ...overrides,
+  };
+}
+
+// Helper to render the CreateNetwork component with optional provider setup
+function renderCreate(connections?: ProviderContainerConnectionInfo[]): ReturnType<typeof render> {
+  const defaultConnection = createProviderConnection();
+  const pStatus: ProviderStatus = 'started';
+  const providerInfo = {
+    id: 'test',
+    internalId: 'id',
+    name: '',
+    containerConnections: connections ?? [defaultConnection],
+    kubernetesConnections: undefined,
+    status: pStatus,
+    containerProviderConnectionCreation: false,
+    containerProviderConnectionInitialization: false,
+    kubernetesProviderConnectionCreation: false,
+    kubernetesProviderConnectionInitialization: false,
+    links: undefined,
+    detectionChecks: undefined,
+    warnings: undefined,
+    images: undefined,
+    installationSupport: undefined,
+  } as unknown as ProviderInfo;
+  providerInfos.set([providerInfo]);
+  return render(CreateNetwork, {});
+}
+
+test('Expect Create button is disabled when name is empty', async () => {
+  renderCreate();
+
+  const createButton = screen.getByRole('button', { name: 'Create' });
+  expect(createButton).toBeInTheDocument();
+  expect(createButton).toBeDisabled();
+});
+
+test.each([
+  ['Name *', 'textbox'],
+  ['Labels (key=value):', 'label-group'],
+  ['Subnet', 'textbox'],
+  ['IP range', 'textbox'],
+  ['Gateway', 'textbox'],
+  ['Advanced Options (driver-specific):', 'label-group'],
+  ['Driver', 'label'],
+  ['IPv6', 'label'],
+  ['Internal', 'label'],
+])('Expect %s field to be present', async (fieldName, elementType) => {
+  renderCreate();
+
+  if (elementType === 'textbox') {
+    expect(screen.getByRole('textbox', { name: fieldName })).toBeInTheDocument();
+  } else if (elementType === 'label-group') {
+    expect(screen.getByText(content => content.includes(fieldName))).toBeInTheDocument();
+  } else {
+    expect(screen.getByLabelText(fieldName)).toBeInTheDocument();
+  }
+});
+
+test('Expect createNetwork to be called with correct parameters', async () => {
+  vi.mocked(window.createNetwork).mockResolvedValue({ Id: 'network123' });
+  renderCreate();
+
+  const networkName = screen.getByRole('textbox', { name: 'Name *' });
+  await userEvent.type(networkName, 'my-test-network');
+
+  const subnet = screen.getByRole('textbox', { name: 'Subnet' });
+  await userEvent.type(subnet, '10.89.0.0/24');
+
+  const createButton = screen.getByRole('button', { name: 'Create' });
+  await userEvent.click(createButton);
+
+  expect(window.createNetwork).toHaveBeenCalledWith(
+    expect.anything(), // provider
+    expect.objectContaining({
+      Name: 'my-test-network',
+      IPAM: expect.objectContaining({
+        Config: expect.arrayContaining([
+          expect.objectContaining({
+            Subnet: '10.89.0.0/24',
+          }),
+        ]),
+      }),
+    }),
+  );
+});
+
+test('Expect error message to be displayed when network creation fails', async () => {
+  const errorMessage = 'Failed to create network: network already exists';
+  vi.mocked(window.createNetwork).mockRejectedValue(new Error(errorMessage));
+  renderCreate();
+
+  const networkName = screen.getByRole('textbox', { name: 'Name *' });
+  await userEvent.type(networkName, 'existing-network');
+
+  const createButton = screen.getByRole('button', { name: 'Create' });
+  await userEvent.click(createButton);
+
+  // Wait for error to appear
+  const error = await screen.findByText(`Error: ${errorMessage}`);
+  expect(error).toBeInTheDocument();
+});
+
+test('Expect error when network creation returns no ID', async () => {
+  // Mock a response without an ID
+  vi.mocked(window.createNetwork).mockResolvedValue({ Id: '' });
+  renderCreate();
+
+  const networkName = screen.getByRole('textbox', { name: 'Name *' });
+  await userEvent.type(networkName, 'test-network');
+
+  const createButton = screen.getByRole('button', { name: 'Create' });
+  await userEvent.click(createButton);
+
+  // Wait for error to appear
+  const error = await screen.findByText(/Network creation failed: No network ID returned/);
+  expect(error).toBeInTheDocument();
+});
+
+test('Expect container engine dropdown to appear when multiple providers', async () => {
+  const podman = createProviderConnection({
+    name: 'podman',
+    displayName: 'Podman',
+    endpoint: { socketPath: '/run/podman/podman.sock' },
+    type: 'podman',
+  });
+  const docker = createProviderConnection({
+    name: 'docker',
+    displayName: 'Docker',
+    endpoint: { socketPath: '/var/run/docker.sock' },
+    type: 'docker',
+  });
+
+  renderCreate([podman, docker]);
+
+  const engineDropdown = screen.getByLabelText('Container engine');
+  expect(engineDropdown).toBeInTheDocument();
+});
+
+test('Expect no container engine dropdown when single provider', async () => {
+  renderCreate(); // default single provider
+
+  const engineDropdown = screen.queryByLabelText('Container engine');
+  expect(engineDropdown).not.toBeInTheDocument();
+});
+
+test('Expect empty screen when no providers available', async () => {
+  providerInfos.set([]);
+
+  render(CreateNetwork, {});
+
+  // Form fields should not be visible
+  const networkName = screen.queryByRole('textbox', { name: 'Name *' });
+  expect(networkName).not.toBeInTheDocument();
+});
+
+test('Expect all optional fields to be included in network creation', async () => {
+  vi.mocked(window.createNetwork).mockResolvedValue({ Id: 'network123' });
+  renderCreate();
+
+  const networkName = screen.getByRole('textbox', { name: 'Name *' });
+  await userEvent.type(networkName, 'full-network');
+
+  const labelInput = screen.getByPlaceholderText('e.g., env=prod or app=backend');
+  await userEvent.type(labelInput, 'label=test-label');
+
+  const subnet = screen.getByRole('textbox', { name: 'Subnet' });
+  await userEvent.type(subnet, '10.89.0.0/24');
+
+  const ipRange = screen.getByRole('textbox', { name: 'IP range' });
+  await userEvent.type(ipRange, '10.89.0.0/25');
+
+  const gateway = screen.getByRole('textbox', { name: 'Gateway' });
+  await userEvent.type(gateway, '10.89.0.1');
+
+  const ipv6Toggle = screen.getByLabelText('IPv6');
+  await userEvent.click(ipv6Toggle);
+
+  const internalToggle = screen.getByLabelText('Internal');
+  await userEvent.click(internalToggle);
+
+  const createButton = screen.getByRole('button', { name: 'Create' });
+  await userEvent.click(createButton);
+
+  expect(window.createNetwork).toHaveBeenCalledWith(
+    expect.anything(),
+    expect.objectContaining({
+      Name: 'full-network',
+      Labels: { label: 'test-label' },
+      EnableIPv6: true,
+      Internal: true,
+      IPAM: expect.objectContaining({
+        Config: expect.arrayContaining([
+          expect.objectContaining({
+            Subnet: '10.89.0.0/24',
+            IPRange: '10.89.0.0/25',
+            Gateway: '10.89.0.1',
+          }),
+        ]),
+      }),
+    }),
+  );
+});

--- a/packages/renderer/src/lib/network/CreateNetwork.svelte
+++ b/packages/renderer/src/lib/network/CreateNetwork.svelte
@@ -1,0 +1,347 @@
+<script lang="ts">
+import { faMinusCircle, faNetworkWired, faPlusCircle } from '@fortawesome/free-solid-svg-icons';
+import { Button, Dropdown, Input } from '@podman-desktop/ui-svelte';
+import { Icon } from '@podman-desktop/ui-svelte/icons';
+
+import ContainerConnectionDropdown from '/@/lib/forms/ContainerConnectionDropdown.svelte';
+import { handleNavigation } from '/@/navigation';
+import type { NetworkCreateFormInfo, NetworkCreateOptions, NetworkCreateResult } from '/@api/container-info';
+import { NavigationPage } from '/@api/navigation-page';
+import type { ProviderContainerConnectionInfo } from '/@api/provider-info';
+
+import { providerInfos } from '../../stores/providers';
+import EngineFormPage from '../ui/EngineFormPage.svelte';
+import SlideToggle from '../ui/SlideToggle.svelte';
+
+let networkInfo: NetworkCreateFormInfo = $state({
+  networkName: '',
+  labels: [''] as string[],
+  subnet: '',
+  ipRange: '',
+  gateway: '',
+  ipv6Enabled: false,
+  internalEnabled: false,
+  driver: 'bridge',
+  options: [''] as string[],
+  selectedProvider: undefined,
+});
+
+let createError: string | undefined = $state(undefined);
+let inProgress: boolean = $state(false);
+
+let availableDrivers = $state<{ label: string; value: string }[]>([
+  { label: 'bridge', value: 'bridge' },
+  { label: 'macvlan', value: 'macvlan' },
+  { label: 'ipvlan', value: 'ipvlan' },
+]);
+
+function addOption(): void {
+  networkInfo.options.push('');
+}
+
+function deleteOption(index: number): void {
+  networkInfo.options.splice(index, 1);
+}
+
+function addLabel(): void {
+  networkInfo.labels.push('');
+}
+
+function deleteLabel(index: number): void {
+  networkInfo.labels.splice(index, 1);
+}
+
+async function createNetwork(): Promise<void> {
+  createError = undefined;
+  inProgress = true;
+
+  try {
+    if (!networkInfo.selectedProvider) {
+      throw new Error('There is no container engine available.');
+    }
+
+    // Parse driver-specific options with validation
+    let parsedOptions: Record<string, string> | undefined;
+    if (networkInfo.options) {
+      const pairs = networkInfo.options.map(option => option.trim()).filter(option => option.length > 0);
+      const validOptions: [string, string][] = [];
+      const malformedOptions: string[] = [];
+
+      for (const pair of pairs) {
+        if (!pair.includes('=')) {
+          malformedOptions.push(pair);
+          continue;
+        }
+        const [key, value] = pair.split('=', 2);
+        const trimmedKey = key?.trim();
+        const trimmedValue = value?.trim();
+
+        if (trimmedKey && trimmedValue) {
+          validOptions.push([trimmedKey, trimmedValue]);
+        } else {
+          malformedOptions.push(pair);
+        }
+      }
+
+      if (malformedOptions.length > 0) {
+        console.warn(`Malformed network options ignored (expected key=value format): ${malformedOptions.join(', ')}`);
+      }
+
+      parsedOptions = validOptions.length > 0 ? Object.fromEntries(validOptions) : undefined;
+    }
+
+    // Parse labels (key=value)
+    let parsedLabels: Record<string, string> | undefined;
+    if (networkInfo.labels && Array.isArray(networkInfo.labels)) {
+      const validLabels: [string, string][] = [];
+      const malformedLabels: string[] = [];
+
+      for (const label of networkInfo.labels) {
+        const trimmed = label.trim();
+        if (!trimmed) continue;
+
+        if (!trimmed.includes('=')) {
+          malformedLabels.push(trimmed);
+          continue;
+        }
+
+        const [key, value] = trimmed.split('=', 2);
+        const trimmedKey = key?.trim();
+        const trimmedValue = value?.trim();
+
+        if (trimmedKey && trimmedValue) {
+          validLabels.push([trimmedKey, trimmedValue]);
+        } else {
+          malformedLabels.push(trimmed);
+        }
+      }
+
+      if (malformedLabels.length > 0) {
+        console.warn(`Malformed labels ignored (expected key=value format): ${malformedLabels.join(', ')}`);
+      }
+
+      parsedLabels = validLabels.length > 0 ? Object.fromEntries(validLabels) : undefined;
+    }
+
+    // Build the network create options - Docker/Podman API will ignore undefined fields
+    const networkOptions: NetworkCreateOptions = {
+      Name: networkInfo.networkName,
+      Driver: networkInfo.driver || undefined,
+      Labels: parsedLabels,
+      EnableIPv6: networkInfo.ipv6Enabled || undefined,
+      Internal: networkInfo.internalEnabled || undefined,
+      IPAM: networkInfo.subnet
+        ? {
+            Config: [
+              {
+                Subnet: networkInfo.subnet,
+                IPRange: networkInfo.ipRange || undefined,
+                Gateway: networkInfo.gateway || undefined,
+              },
+            ],
+          }
+        : undefined,
+      Options: parsedOptions,
+    };
+
+    const result: NetworkCreateResult = await window.createNetwork(
+      $state.snapshot(networkInfo.selectedProvider),
+      networkOptions,
+    );
+
+    // Verify network was created successfully
+    if (!result?.Id) {
+      throw new Error('Network creation failed: No network ID returned');
+    }
+
+    console.log('Network created successfully:', result.Id);
+
+    // Navigate back or show success
+    handleNavigation({ page: NavigationPage.IMAGES }); // TODO: Navigate to networks page when it exists
+  } catch (error: unknown) {
+    createError = error instanceof Error ? error.message : String(error);
+    console.error('Error creating network:', error);
+  } finally {
+    inProgress = false;
+  }
+}
+
+function navigateBack(): void {
+  handleNavigation({ page: NavigationPage.IMAGES });
+}
+
+let providerConnections = $derived(
+  $providerInfos.reduce<ProviderContainerConnectionInfo[]>((acc, provider) => {
+    const startedConnections = provider.containerConnections.filter(connection => connection.status === 'started');
+    return acc.concat(startedConnections);
+  }, []),
+);
+let selectedProvider = $derived(providerConnections.length > 0 ? providerConnections[0] : undefined);
+$effect(() => {
+  networkInfo.selectedProvider = selectedProvider;
+});
+
+let hasInvalidFields = $derived(!networkInfo.networkName || !networkInfo.selectedProvider);
+</script>
+
+<EngineFormPage
+  title="Create a Network"
+  inProgress={inProgress}
+  showEmptyScreen={providerConnections.length === 0 && !inProgress}>
+  {#snippet icon()}
+    <Icon icon={faNetworkWired} class="fa-2x" />
+  {/snippet}
+  {#snippet content()}
+    <div class="space-y-6">
+      <div hidden={inProgress}>
+        <label for="networkName" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]"
+          >Name <span class="text-red-500">*</span></label>
+        <Input
+          bind:value={networkInfo.networkName}
+          name="networkName"
+          id="networkName"
+          placeholder="Network name"
+          required
+          class="w-full" />
+      </div>
+
+      <div hidden={inProgress}>
+        <label
+          for="labels"
+          class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]"
+          >Labels (key=value):</label
+        >
+      
+        {#each networkInfo.labels as _, index (index)}
+          <div class="flex flex-row justify-center items-center w-full py-1">
+            <Input
+              bind:value={networkInfo.labels[index]}
+              placeholder="e.g., env=prod or app=backend"
+              class="ml-2 w-full" />
+      
+            <Button
+              type="link"
+              hidden={index === networkInfo.labels.length - 1}
+              on:click={(): void => deleteLabel(index)}
+              icon={faMinusCircle} />
+      
+            <Button
+              type="link"
+              hidden={index < networkInfo.labels.length - 1}
+              on:click={addLabel}
+              icon={faPlusCircle} />
+          </div>
+        {/each}
+      </div>
+      
+
+      {#if providerConnections.length > 1}
+        <div hidden={inProgress}>
+          <label for="providerChoice" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]"
+            >Container engine</label>
+          <ContainerConnectionDropdown
+            id="providerChoice"
+            name="providerChoice"
+            bind:value={networkInfo.selectedProvider}
+            connections={providerConnections} />
+        </div>
+      {/if}
+
+      <div hidden={inProgress}>
+        <label for="subnet" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]">Subnet</label>
+        <Input
+          bind:value={networkInfo.subnet}
+          name="subnet"
+          id="subnet"
+          placeholder="Subnet (e.g., 10.89.0.0/24)"
+          class="w-full" />
+      </div>
+
+      <div hidden={inProgress}>
+        <label for="ipv6" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]">IPv6</label>
+        <SlideToggle id="ipv6" name="ipv6" bind:checked={networkInfo.ipv6Enabled} />
+      </div>
+
+      <div hidden={inProgress}>
+        <label for="ipRange" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]">IP range</label>
+        <Input
+          bind:value={networkInfo.ipRange}
+          name="ipRange"
+          id="ipRange"
+          placeholder="IP range (e.g., 10.89.0.0/25)"
+          class="w-full" />
+      </div>
+
+      <div hidden={inProgress}>
+        <label for="gateway" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]">Gateway</label>
+        <Input
+          bind:value={networkInfo.gateway}
+          name="gateway"
+          id="gateway"
+          placeholder="Gateway (e.g., 10.89.0.1)"
+          class="w-full" />
+      </div>
+
+      <div hidden={inProgress}>
+        <label for="internal" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]"
+          >Internal</label>
+        <SlideToggle id="internal" name="internal" bind:checked={networkInfo.internalEnabled} />
+      </div>
+
+      <div hidden={inProgress}>
+        <label for="driver" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]">Driver</label>
+        <Dropdown
+          id="driver"
+          name="driver"
+          bind:value={networkInfo.driver}
+          options={availableDrivers}
+          class="w-full" />
+      </div>
+
+      <div hidden={inProgress}>
+        <label
+          for="options"
+          class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]"
+          >Advanced Options (driver-specific):</label
+        >
+      
+        {#each networkInfo.options as _, index (index)}
+          <div class="flex flex-row justify-center items-center w-full py-1">
+            <Input
+              bind:value={networkInfo.options[index]}
+              placeholder="e.g., com.docker.network.bridge.name=mybr0"
+              class="ml-2 w-full" />
+      
+            <Button
+              type="link"
+              hidden={index === networkInfo.options.length - 1}
+              on:click={(): void => deleteOption(index)}
+              icon={faMinusCircle} />
+      
+            <Button
+              type="link"
+              hidden={index < networkInfo.options.length - 1}
+              on:click={addOption}
+              icon={faPlusCircle} />
+          </div>
+        {/each}
+      </div>
+
+      <div class="w-full flex flex-row space-x-4">
+        {#if !inProgress}
+          <Button on:click={createNetwork} disabled={hasInvalidFields} class="w-full" icon={faNetworkWired}>
+            Create
+          </Button>
+          <Button on:click={navigateBack} class="w-full">Cancel</Button>
+        {/if}
+      </div>
+
+      {#if createError}
+        <div class="text-red-500 text-sm">
+          Error: {createError}
+        </div>
+      {/if}
+    </div>
+  {/snippet}
+</EngineFormPage>
+

--- a/packages/renderer/src/lib/network/CreateNetwork.svelte
+++ b/packages/renderer/src/lib/network/CreateNetwork.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-import { faMinusCircle, faNetworkWired, faPlusCircle } from '@fortawesome/free-solid-svg-icons';
-import { Button, Dropdown, Input } from '@podman-desktop/ui-svelte';
+import { faNetworkWired } from '@fortawesome/free-solid-svg-icons';
+import { Button, Input } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { router } from 'tinro';
 
@@ -10,49 +10,24 @@ import type { ProviderContainerConnectionInfo } from '/@api/provider-info';
 
 import { providerInfos } from '../../stores/providers';
 import EngineFormPage from '../ui/EngineFormPage.svelte';
-import SlideToggle from '../ui/SlideToggle.svelte';
 
 let networkInfo: NetworkCreateFormInfo = $state({
   networkName: '',
-  labels: [''] as string[],
   subnet: '',
+  selectedProvider: undefined,
+  // Unused fields for the simplified form
+  labels: [],
   ipRange: '',
   gateway: '',
   ipv6Enabled: false,
   internalEnabled: false,
   driver: 'bridge',
-  options: [''] as string[],
-  selectedProvider: undefined,
+  options: [],
 });
 
 let createError: string | undefined = $state(undefined);
 let createNetworkInProgress: boolean = $state(false);
 let createNetworkFinished: boolean = $state(false);
-
-let availableDrivers = $state<{ label: string; value: string }[]>([
-  { label: 'bridge', value: 'bridge' },
-  { label: 'macvlan', value: 'macvlan' },
-  { label: 'ipvlan', value: 'ipvlan' },
-]);
-
-// Track previous driver for auto-population
-let previousDriver = $state<string>('bridge');
-
-function addOption(): void {
-  networkInfo.options.push('');
-}
-
-function deleteOption(index: number): void {
-  networkInfo.options.splice(index, 1);
-}
-
-function addLabel(): void {
-  networkInfo.labels.push('');
-}
-
-function deleteLabel(index: number): void {
-  networkInfo.labels.splice(index, 1);
-}
 
 async function createNetwork(): Promise<void> {
   createError = undefined;
@@ -63,28 +38,18 @@ async function createNetwork(): Promise<void> {
       throw new Error('There is no container engine available.');
     }
 
-    // Parse driver options
-    const parsedOptions = parseKeyValueArray(networkInfo.options);
-    const parsedLabels = parseKeyValueArray(networkInfo.labels);
-
     const networkOptions: NetworkCreateOptions = {
       Name: networkInfo.networkName,
-      Driver: networkInfo.driver || undefined,
-      Labels: parsedLabels,
-      EnableIPv6: networkInfo.ipv6Enabled || undefined,
-      Internal: networkInfo.internalEnabled || undefined,
       IPAM: networkInfo.subnet
         ? {
+            Driver: 'default',
             Config: [
               {
                 Subnet: networkInfo.subnet,
-                IPRange: networkInfo.ipRange || undefined,
-                Gateway: networkInfo.gateway || undefined,
               },
             ],
           }
         : undefined,
-      Options: parsedOptions,
     };
 
     const result = await window.createNetwork($state.snapshot(networkInfo.selectedProvider), networkOptions);
@@ -102,17 +67,7 @@ async function createNetwork(): Promise<void> {
   }
 }
 
-function parseKeyValueArray(list: string[]): Record<string, string> | undefined {
-  const validPairs: [string, string][] = [];
-  for (const entry of list.map(s => s.trim()).filter(Boolean)) {
-    const [key, value] = entry.split('=');
-    if (key && value) validPairs.push([key.trim(), value.trim()]);
-  }
-  return validPairs.length > 0 ? Object.fromEntries(validPairs) : undefined;
-}
-
 function end(): void {
-  // redirect to the networks page
   router.goto('/networks');
 }
 
@@ -122,21 +77,11 @@ let providerConnections = $derived(
     return acc.concat(startedConnections);
   }, []),
 );
-let selectedProvider = $derived(providerConnections.length > 0 ? providerConnections[0] : undefined);
-$effect(() => {
-  networkInfo.selectedProvider = selectedProvider;
-});
 
-// Auto-populate default subnet for ipvlan to help beginners
+let autoSelectedProvider = $derived(providerConnections.length > 0 ? providerConnections[0] : undefined);
+
 $effect(() => {
-  // Only auto-populate when switching TO ipvlan from another driver
-  if (networkInfo.driver === 'ipvlan' && previousDriver !== 'ipvlan' && !networkInfo.subnet) {
-    // eslint-disable-next-line sonarjs/no-hardcoded-ip
-    networkInfo.subnet = '192.168.210.0/24';
-    // eslint-disable-next-line sonarjs/no-hardcoded-ip
-    networkInfo.gateway = '192.168.210.1';
-  }
-  previousDriver = networkInfo.driver;
+  networkInfo.selectedProvider = autoSelectedProvider;
 });
 
 let hasInvalidFields = $derived(!networkInfo.networkName || !networkInfo.selectedProvider);
@@ -151,6 +96,19 @@ let hasInvalidFields = $derived(!networkInfo.networkName || !networkInfo.selecte
   {/snippet}
   {#snippet content()}
     <div class="space-y-6">
+
+      {#if providerConnections.length > 1}
+        <div hidden={createNetworkInProgress}>
+          <label for="providerChoice" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]"
+            >Container engine <span class="text-red-500">*</span></label>
+          <ContainerConnectionDropdown
+            id="providerChoice"
+            name="providerChoice"
+            bind:value={networkInfo.selectedProvider}
+            connections={providerConnections} />
+        </div>
+      {/if}
+
       <div hidden={createNetworkInProgress}>
         <label for="networkName" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]"
           >Name <span class="text-red-500">*</span></label>
@@ -164,151 +122,27 @@ let hasInvalidFields = $derived(!networkInfo.networkName || !networkInfo.selecte
       </div>
 
       <div hidden={createNetworkInProgress}>
-        <label
-          for="labels"
-          class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]"
-          >Labels (key=value):</label
-        >
-      
-        {#each networkInfo.labels as _, index (index)}
-          <div class="flex flex-col w-full py-1">
-            <div class="flex flex-row justify-center items-center w-full">
-              <Input
-                bind:value={networkInfo.labels[index]}
-                placeholder="e.g., env=prod or app=backend"
-                class="ml-2 w-full" />
-
-              <Button
-                type="link"
-                hidden={index === networkInfo.labels.length - 1}
-                on:click={(): void => deleteLabel(index)}
-                icon={faMinusCircle} />
-
-              <Button
-                type="link"
-                hidden={index < networkInfo.labels.length - 1}
-                on:click={addLabel}
-                icon={faPlusCircle} />
-            </div>
-          </div>
-        {/each}
-      </div>
-      
-
-      {#if providerConnections.length > 1}
-        <div hidden={createNetworkInProgress}>
-          <label for="providerChoice" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]"
-            >Container engine</label>
-          <ContainerConnectionDropdown
-            id="providerChoice"
-            name="providerChoice"
-            bind:value={networkInfo.selectedProvider}
-            connections={providerConnections} />
-        </div>
-      {/if}
-
-      <div hidden={createNetworkInProgress}>
         <label for="subnet" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]">Subnet</label>
         <Input
           bind:value={networkInfo.subnet}
           name="subnet"
           id="subnet"
-          placeholder="Subnet (e.g., 10.89.0.0/24 or 2001:db8::/32)"
+          placeholder="10.89.0.0/24"
           class="w-full" />
       </div>
 
-      <div hidden={createNetworkInProgress}>
-        <label for="ipv6" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]"
-          >IPv6 (Dual Stack)</label>
-        <SlideToggle id="ipv6" name="ipv6" bind:checked={networkInfo.ipv6Enabled} />
-      </div>
-
-      <div hidden={createNetworkInProgress}>
-        <label for="ipRange" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]">IP range</label>
-        <Input
-          bind:value={networkInfo.ipRange}
-          name="ipRange"
-          id="ipRange"
-          placeholder="IP range (e.g., 10.89.0.0/25 or 2001:db8::/64)"
-          class="w-full" />
-      </div>
-
-      <div hidden={createNetworkInProgress}>
-        <label for="gateway" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]">Gateway</label>
-        <Input
-          bind:value={networkInfo.gateway}
-          name="gateway"
-          id="gateway"
-          placeholder="Gateway (e.g., 10.89.0.1 or 2001:db8::1)"
-          class="w-full" />
-      </div>
-
-      <div hidden={createNetworkInProgress}>
-        <label for="internal" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]"
-          >Internal</label>
-        <SlideToggle id="internal" name="internal" bind:checked={networkInfo.internalEnabled} />
-      </div>
-
-        <div hidden={createNetworkInProgress}>
-        <label for="driver" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]">Driver</label>
-        <Dropdown
-          id="driver"
-          name="driver"
-          bind:value={networkInfo.driver}
-          options={availableDrivers}
-          class="w-full" />
-      </div>
-
-      <div hidden={createNetworkInProgress}>
-        <label
-          for="options"
-          class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]"
-          >Advanced Options (driver-specific):</label
-        >
-      
-        {#each networkInfo.options as _, index (index)}
-          <div class="flex flex-col w-full py-1">
-            <div class="flex flex-row justify-center items-center w-full">
-              <Input
-                bind:value={networkInfo.options[index]}
-                placeholder="e.g., com.docker.network.bridge.name=mybr0"
-                class="ml-2 w-full" />
-
-              <Button
-                type="link"
-                hidden={index === networkInfo.options.length - 1}
-                on:click={(): void => deleteOption(index)}
-                icon={faMinusCircle} />
-
-              <Button
-                type="link"
-                hidden={index < networkInfo.options.length - 1}
-                on:click={addOption}
-                icon={faPlusCircle} />
-            </div>
-          </div>
-        {/each}
-      </div>
-
-      <div class="w-full flex flex-row space-x-4">
+      {#if createNetworkFinished}
+        <Button class="w-full" onclick={end}>Done</Button>
+      {:else}
         <Button
-          disabled={hasInvalidFields || createNetworkInProgress || createNetworkFinished}
+          disabled={hasInvalidFields || createNetworkInProgress}
           inProgress={createNetworkInProgress}
           class="w-full"
-          hidden={createNetworkFinished}
           icon={faNetworkWired}
           onclick={createNetwork}>
           Create
         </Button>
-      
-        <Button
-          on:click={end}
-          class="w-full"
-          hidden={!createNetworkFinished}
-          onclick={end}>
-          Done
-        </Button>
-      </div>      
+      {/if}      
 
       {#if createError}
         <div class="text-red-500 text-sm">

--- a/packages/renderer/src/lib/network/NetworksList.svelte
+++ b/packages/renderer/src/lib/network/NetworksList.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-import { faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faPlusCircle, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { Button, FilteredEmptyScreen, NavPage, Table, TableColumn, TableRow } from '@podman-desktop/ui-svelte';
 import { ContainerIcon } from '@podman-desktop/ui-svelte/icons';
+import { router } from 'tinro';
 
 import { filtered, searchPattern } from '/@/stores/networks';
 import { providerInfos } from '/@/stores/providers';
@@ -66,6 +67,10 @@ async function deleteSelectedNetworks(): Promise<void> {
   bulkDeleteInProgress = false;
 }
 
+function gotoCreateNetwork(): void {
+  router.goto('/networks/create');
+}
+
 let idColumn = new TableColumn<NetworkInfoUI>('Id', {
   width: '100px',
   renderer: NetworkColumnId,
@@ -111,6 +116,13 @@ function key(network: NetworkInfoUI): string {
 
 <NavPage bind:searchTerm={searchTerm} title="networks">
 
+  {#snippet additionalActions()}
+    {#if providerConnections.length > 0}
+      <Button on:click={gotoCreateNetwork} icon={faPlusCircle} title="Create a volume" aria-label="Create"
+        >Create</Button>
+    {/if}
+  {/snippet}
+
   {#snippet bottomAdditionalActions()}
     {#if selectedItemsNumber > 0}
       <Button
@@ -127,7 +139,7 @@ function key(network: NetworkInfoUI): string {
   {/snippet}
 
   {#snippet content()}
-  <div class="flex min-w-full h-full">
+  <div class="flex min-w-full h-full">  
 
     {#if providerConnections.length === 0}
       <NoContainerEngineEmptyScreen />

--- a/packages/renderer/src/lib/network/NetworksList.svelte
+++ b/packages/renderer/src/lib/network/NetworksList.svelte
@@ -118,7 +118,7 @@ function key(network: NetworkInfoUI): string {
 
   {#snippet additionalActions()}
     {#if providerConnections.length > 0}
-      <Button on:click={gotoCreateNetwork} icon={faPlusCircle} title="Create a volume" aria-label="Create"
+      <Button onclick={gotoCreateNetwork} icon={faPlusCircle} title="Create a network" aria-label="Create"
         >Create</Button>
     {/if}
   {/snippet}
@@ -126,7 +126,7 @@ function key(network: NetworkInfoUI): string {
   {#snippet bottomAdditionalActions()}
     {#if selectedItemsNumber > 0}
       <Button
-        on:click={(): void =>
+        onclick={(): void =>
           withBulkConfirmation(
             deleteSelectedNetworks,
             `delete ${selectedItemsNumber} network${selectedItemsNumber > 1 ? 's' : ''}`,


### PR DESCRIPTION
used existing network create tools to create a page that allows users to create a network.

### What does this PR do?

### Screenshot / video of UI

https://github.com/user-attachments/assets/c3bd7d6f-1025-4c3b-9b33-0dcc5d0e0fb2

<img width="1060" height="1009" alt="Screenshot From 2025-10-06 19-36-09" src="https://github.com/user-attachments/assets/4e91c831-b54d-4853-b095-6d20f88cc9eb" />


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes: https://github.com/podman-desktop/podman-desktop/issues/14111

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

in the devtools enter "router.goto('/networks/create');" into the console it will take you to the page
create a network and use "podman network list" to see it on the cli

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
