### PR TITLE
feat(extension: podman): introduce InversifyBinding class

### DIFF
--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -42,6 +42,7 @@ import { PodmanBinaryLocationHelper } from './helpers/podman-binary-location-hel
 import { PodmanInfoHelper } from './helpers/podman-info-helper';
 import { QemuHelper } from './helpers/qemu-helper';
 import { WslHelper } from './helpers/wsl-helper';
+import { InversifyBinding } from './inject/inversify-binding';
 import { PodmanInstall } from './installer/podman-install';
 import { PodmanRemoteConnections } from './remote/podman-remote-connections';
 import { getSocketCompatibility } from './utils/compatibility-mode';
@@ -64,7 +65,6 @@ import {
   VMTYPE,
 } from './utils/util';
 import { isDisguisedPodman } from './utils/warnings';
-import { InversifyBinding } from './inject/inversify-binding';
 
 let inversifyBinding: InversifyBinding | undefined;
 
@@ -1892,7 +1892,7 @@ export async function deactivate(): Promise<void> {
   containerProviderConnections.clear();
 
   await inversifyBinding?.dispose();
-  inversifyBinding = undefined
+  inversifyBinding = undefined;
 }
 
 const PODMAN_MINIMUM_VERSION_FOR_NOW_FLAG_INIT = '4.0.0';

--- a/extensions/podman/packages/extension/src/inject/inversify-binding.spec.ts
+++ b/extensions/podman/packages/extension/src/inject/inversify-binding.spec.ts
@@ -1,0 +1,44 @@
+/*********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************/
+
+import type { ExtensionContext, TelemetryLogger } from '@podman-desktop/api';
+import type { Container as InversifyContainer } from 'inversify';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { InversifyBinding } from './inversify-binding';
+import { ExtensionContextSymbol, TelemetryLoggerSymbol } from './symbols';
+
+const extensionContextMock = {} as ExtensionContext;
+const telemetryLoggerMock = {} as TelemetryLogger;
+
+describe('inversifyBinding', () => {
+  let inversifyBinding: InversifyBinding;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    inversifyBinding = new InversifyBinding(extensionContextMock, telemetryLoggerMock);
+  });
+
+  test('should initialize bindings correctly', async () => {
+    // Initialize bindings
+    const container: InversifyContainer = await inversifyBinding.init();
+
+    expect(container.get(ExtensionContextSymbol)).toBe(extensionContextMock);
+    expect(container.get(TelemetryLoggerSymbol)).toBe(telemetryLoggerMock);
+  });
+});

--- a/extensions/podman/packages/extension/src/inject/inversify-binding.ts
+++ b/extensions/podman/packages/extension/src/inject/inversify-binding.ts
@@ -1,0 +1,49 @@
+/*********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************/
+
+import type { ExtensionContext, TelemetryLogger } from '@podman-desktop/api';
+import { Container as InversifyContainer } from 'inversify';
+
+import { ExtensionContextSymbol, TelemetryLoggerSymbol } from './symbols';
+
+export class InversifyBinding {
+  #inversifyContainer: InversifyContainer | undefined;
+
+  readonly #extensionContext: ExtensionContext;
+  readonly #telemetryLogger: TelemetryLogger;
+
+  constructor(extensionContext: ExtensionContext, telemetryLogger: TelemetryLogger) {
+    this.#extensionContext = extensionContext;
+    this.#telemetryLogger = telemetryLogger;
+  }
+
+  public async init(): Promise<InversifyContainer> {
+    this.#inversifyContainer = new InversifyContainer();
+
+    this.#inversifyContainer.bind(ExtensionContextSymbol).toConstantValue(this.#extensionContext);
+    this.#inversifyContainer.bind(TelemetryLoggerSymbol).toConstantValue(this.#telemetryLogger);
+
+    return this.#inversifyContainer;
+  }
+
+  async dispose(): Promise<void> {
+    if (this.#inversifyContainer) {
+      await this.#inversifyContainer.unbindAll();
+    }
+  }
+}

--- a/extensions/podman/packages/extension/src/inject/inversify-binding.ts
+++ b/extensions/podman/packages/extension/src/inject/inversify-binding.ts
@@ -44,6 +44,7 @@ export class InversifyBinding {
   async dispose(): Promise<void> {
     if (this.#inversifyContainer) {
       await this.#inversifyContainer.unbindAll();
+      this.#inversifyContainer = undefined;
     }
   }
 }

--- a/extensions/podman/packages/extension/src/inject/symbols.ts
+++ b/extensions/podman/packages/extension/src/inject/symbols.ts
@@ -1,0 +1,20 @@
+/*********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************/
+
+export const ExtensionContextSymbol = Symbol.for('ExtensionContext');
+export const TelemetryLoggerSymbol = Symbol.for('TelemetryLogger');

--- a/extensions/podman/packages/extension/src/installer/podman-install.ts
+++ b/extensions/podman/packages/extension/src/installer/podman-install.ts
@@ -47,6 +47,8 @@ import { PodmanInfoImpl } from '../utils/podman-info';
 import type { Installer } from './installer';
 import { MacOSInstaller } from './mac-os-installer';
 import { WinInstaller } from './win-installer';
+import { injectable, inject } from 'inversify';
+import { ExtensionContextSymbol, TelemetryLoggerSymbol } from '/@/inject/symbols';
 
 export interface UpdateCheck {
   hasUpdate: boolean;
@@ -54,6 +56,7 @@ export interface UpdateCheck {
   bundledVersion?: string;
 }
 
+@injectable()
 export class PodmanInstall {
   private podmanInfo: PodmanInfo | undefined;
 
@@ -64,7 +67,9 @@ export class PodmanInstall {
   protected providerCleanup: extensionApi.ProviderCleanup | undefined;
 
   constructor(
+    @inject(ExtensionContextSymbol)
     readonly extensionContext: extensionApi.ExtensionContext,
+    @inject(TelemetryLoggerSymbol)
     readonly telemetryLogger: extensionApi.TelemetryLogger,
   ) {
     this.storagePath = extensionContext.storagePath;

--- a/extensions/podman/packages/extension/src/installer/podman-install.ts
+++ b/extensions/podman/packages/extension/src/installer/podman-install.ts
@@ -21,6 +21,9 @@ import * as path from 'node:path';
 
 import * as extensionApi from '@podman-desktop/api';
 import { compare } from 'compare-versions';
+import { inject, injectable } from 'inversify';
+
+import { ExtensionContextSymbol, TelemetryLoggerSymbol } from '/@/inject/symbols';
 
 import { getDetectionChecks } from '../checks/detection-checks';
 import { PodmanCleanupMacOS } from '../cleanup/podman-cleanup-macos';
@@ -47,8 +50,6 @@ import { PodmanInfoImpl } from '../utils/podman-info';
 import type { Installer } from './installer';
 import { MacOSInstaller } from './mac-os-installer';
 import { WinInstaller } from './win-installer';
-import { injectable, inject } from 'inversify';
-import { ExtensionContextSymbol, TelemetryLoggerSymbol } from '/@/inject/symbols';
 
 export interface UpdateCheck {
   hasUpdate: boolean;


### PR DESCRIPTION
### What does this PR do?

Adding the `InversifyBinding` class, creating and managing the lifecycle of the Inversify Container.

### Notes

Copied some code from https://github.com/podman-desktop/extension-apple-container

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Requires rebase after
- https://github.com/podman-desktop/podman-desktop/pull/14306
- https://github.com/podman-desktop/podman-desktop/pull/14305

Fixes https://github.com/podman-desktop/podman-desktop/issues/14279

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
