### PR TITLE
fix: broken podman-cli extension podman installation discovery on unix/macos

### DIFF
--- a/extensions/podman/packages/extension/src/utils/podman-cli.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-cli.spec.ts
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import fs from 'node:fs';
+
 import { type Configuration, env, process } from '@podman-desktop/api';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -26,6 +28,15 @@ const config: Configuration = {
   has: vi.fn().mockReturnValue(false),
   update: vi.fn(),
 };
+
+// Mock fs module
+vi.mock('node:fs', () => {
+  return {
+    default: {
+      lstatSync: vi.fn(),
+    },
+  };
+});
 
 // Mock external dependencies
 vi.mock('@podman-desktop/api', () => {
@@ -50,6 +61,14 @@ describe('findPodmanInstallations', () => {
     vi.mocked(env).isWindows = false;
     vi.mocked(env).isMac = true;
     vi.mocked(env).isLinux = false;
+
+    // Setup default fs mocks
+    vi.mocked(fs.lstatSync).mockReturnValue({
+      isFile: vi.fn().mockReturnValue(true),
+      isSymbolicLink: vi.fn().mockReturnValue(false),
+      // Cast through 'unknown' because fs.Stats has many properties we don't need to mock
+      // We only mock the methods actually used in the implementation (isFile, isSymbolicLink)
+    } as unknown as fs.Stats);
   });
 
   describe('Windows platform', () => {
@@ -57,6 +76,14 @@ describe('findPodmanInstallations', () => {
       vi.mocked(env).isWindows = true;
       vi.mocked(env).isMac = false;
       vi.mocked(env).isLinux = false;
+
+      // Reset fs mocks to defaults for Windows tests
+      vi.mocked(fs.lstatSync).mockReturnValue({
+        isFile: vi.fn().mockReturnValue(true),
+        isSymbolicLink: vi.fn().mockReturnValue(false),
+        // Cast through 'unknown' because fs.Stats has many properties we don't need to mock
+        // We only mock the methods actually used in the implementation (isFile, isSymbolicLink)
+      } as unknown as fs.Stats);
     });
 
     test('should return empty array when where command fails', async () => {
@@ -124,62 +151,62 @@ C:\\tools\\podman\\podman.exe`,
   });
 
   describe('Linux/macOS platform', () => {
-    test('should return empty array when type command fails', async () => {
+    test('should return empty array when which command fails', async () => {
       vi.mocked(process.exec).mockRejectedValue(new Error('Command failed'));
 
       const result = await findPodmanInstallations();
 
       expect(result).toEqual([]);
-      expect(process.exec).toHaveBeenCalledWith('sh', ['-c', 'type -a podman']);
+      expect(process.exec).toHaveBeenCalledWith('which', ['-a', 'podman']);
     });
 
-    test('should extract paths from "podman is" format', async () => {
+    test('should return single installation path', async () => {
       vi.mocked(process.exec).mockResolvedValue({
-        stdout: 'podman is /usr/local/bin/podman',
+        stdout: '/usr/local/bin/podman',
         stderr: '',
-        command: 'sh -c type -a podman',
+        command: 'which -a podman',
       });
 
       const result = await findPodmanInstallations();
 
       expect(result).toEqual(['/usr/local/bin/podman']);
-      expect(process.exec).toHaveBeenCalledWith('sh', ['-c', 'type -a podman']);
+      expect(process.exec).toHaveBeenCalledWith('which', ['-a', 'podman']);
     });
 
     test('should return multiple extracted paths', async () => {
       vi.mocked(process.exec).mockResolvedValue({
-        stdout: `podman is /usr/local/bin/podman
-podman is /opt/homebrew/bin/podman`,
+        stdout: `/usr/local/bin/podman
+/opt/homebrew/bin/podman`,
         stderr: '',
-        command: 'sh -c type -a podman',
+        command: 'which -a podman',
       });
 
       const result = await findPodmanInstallations();
 
       expect(result).toEqual(['/usr/local/bin/podman', '/opt/homebrew/bin/podman']);
-      expect(process.exec).toHaveBeenCalledWith('sh', ['-c', 'type -a podman']);
+      expect(process.exec).toHaveBeenCalledWith('which', ['-a', 'podman']);
     });
 
     test('should handle empty stdout', async () => {
       vi.mocked(process.exec).mockResolvedValue({
         stdout: '',
         stderr: '',
-        command: 'sh -c type -a podman',
+        command: 'which -a podman',
       });
 
       const result = await findPodmanInstallations();
 
       expect(result).toEqual([]);
-      expect(process.exec).toHaveBeenCalledWith('sh', ['-c', 'type -a podman']);
+      expect(process.exec).toHaveBeenCalledWith('which', ['-a', 'podman']);
     });
 
     test('should extract paths using generic parsing (last part)', async () => {
       vi.mocked(process.exec).mockResolvedValue({
-        stdout: `podman is /usr/bin/podman
-podman is /opt/podman/bin /podman
-podman is /usr/local/bin/podman`,
+        stdout: `/usr/bin/podman
+/opt/podman/bin /podman
+/usr/local/bin/podman`,
         stderr: '',
-        command: 'sh -c type -a podman',
+        command: 'which -a podman',
       });
 
       const result = await findPodmanInstallations();
@@ -189,16 +216,117 @@ podman is /usr/local/bin/podman`,
 
     test('should remove duplicates from mixed output', async () => {
       vi.mocked(process.exec).mockResolvedValue({
-        stdout: `podman is /usr/local/bin/podman
-podman is /usr/local/bin/podman
-podman is /opt/homebrew/bin/podman`,
+        stdout: `/usr/local/bin/podman
+/usr/local/bin/podman
+/opt/homebrew/bin/podman`,
         stderr: '',
-        command: 'sh -c type -a podman',
+        command: 'which -a podman',
       });
 
       const result = await findPodmanInstallations();
 
       expect(result).toEqual(['/usr/local/bin/podman', '/opt/homebrew/bin/podman']);
+    });
+
+    test('should filter out symbolic links', async () => {
+      vi.mocked(process.exec).mockResolvedValue({
+        stdout: `/usr/local/bin/podman
+/usr/bin/podman-symlink
+/opt/homebrew/bin/podman`,
+        stderr: '',
+        command: 'which -a podman',
+      });
+
+      // Mock lstatSync to return different results for different paths
+      vi.mocked(fs.lstatSync).mockImplementation(path => {
+        const mockStats = {
+          isFile: vi.fn().mockReturnValue(true),
+          isSymbolicLink: vi.fn(),
+        };
+
+        // Simulate that the symlink path returns true for isSymbolicLink
+        if (String(path) === '/usr/bin/podman-symlink') {
+          mockStats.isSymbolicLink.mockReturnValue(true);
+        } else {
+          mockStats.isSymbolicLink.mockReturnValue(false);
+        }
+
+        // Cast through 'unknown' to satisfy TypeScript - fs.Stats has 20+ properties
+        // but we only need to mock isFile() and isSymbolicLink() methods for this test
+        return mockStats as unknown as fs.Stats;
+      });
+
+      const result = await findPodmanInstallations();
+
+      expect(result).toEqual(['/usr/local/bin/podman', '/opt/homebrew/bin/podman']);
+      expect(fs.lstatSync).toHaveBeenCalledWith('/usr/local/bin/podman');
+      expect(fs.lstatSync).toHaveBeenCalledWith('/usr/bin/podman-symlink');
+      expect(fs.lstatSync).toHaveBeenCalledWith('/opt/homebrew/bin/podman');
+    });
+
+    test('should filter out non-files (directories)', async () => {
+      vi.mocked(process.exec).mockResolvedValue({
+        stdout: `/usr/local/bin/podman
+/usr/bin/podman-dir
+/opt/homebrew/bin/podman`,
+        stderr: '',
+        command: 'which -a podman',
+      });
+
+      // Mock lstatSync to return different results for different paths
+      vi.mocked(fs.lstatSync).mockImplementation(path => {
+        const mockStats = {
+          isFile: vi.fn(),
+          isSymbolicLink: vi.fn().mockReturnValue(false),
+        };
+
+        // Simulate that the directory returns false for isFile
+        if (String(path) === '/usr/bin/podman-dir') {
+          mockStats.isFile.mockReturnValue(false);
+        } else {
+          mockStats.isFile.mockReturnValue(true);
+        }
+
+        // Cast through 'unknown' to satisfy TypeScript - fs.Stats has 20+ properties
+        // but we only need to mock isFile() and isSymbolicLink() methods for this test
+        return mockStats as unknown as fs.Stats;
+      });
+
+      const result = await findPodmanInstallations();
+
+      expect(result).toEqual(['/usr/local/bin/podman', '/opt/homebrew/bin/podman']);
+      expect(fs.lstatSync).toHaveBeenCalledWith('/usr/local/bin/podman');
+      expect(fs.lstatSync).toHaveBeenCalledWith('/usr/bin/podman-dir');
+      expect(fs.lstatSync).toHaveBeenCalledWith('/opt/homebrew/bin/podman');
+    });
+
+    test('should filter out paths when lstatSync throws an error', async () => {
+      vi.mocked(process.exec).mockResolvedValue({
+        stdout: `/usr/local/bin/podman
+/inaccessible/path/podman
+/opt/homebrew/bin/podman`,
+        stderr: '',
+        command: 'which -a podman',
+      });
+
+      // Mock lstatSync to throw an error for the inaccessible path
+      vi.mocked(fs.lstatSync).mockImplementation(path => {
+        if (String(path) === '/inaccessible/path/podman') {
+          throw new Error('Permission denied');
+        }
+
+        return {
+          isFile: vi.fn().mockReturnValue(true),
+          isSymbolicLink: vi.fn().mockReturnValue(false),
+        } as unknown as fs.Stats;
+      });
+
+      const result = await findPodmanInstallations();
+
+      expect(result).toEqual(['/usr/local/bin/podman', '/opt/homebrew/bin/podman']);
+      expect(fs.lstatSync).toHaveBeenCalledWith('/usr/local/bin/podman');
+      expect(fs.lstatSync).toHaveBeenCalledWith('/inaccessible/path/podman');
+      expect(fs.lstatSync).toHaveBeenCalledWith('/opt/homebrew/bin/podman');
     });
   });
 });

--- a/extensions/podman/packages/extension/src/utils/podman-cli.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-cli.ts
@@ -57,7 +57,11 @@ export async function findPodmanInstallations(): Promise<string[]> {
         .replace(/^podman:\s*/, '')
         .split(/\s+/)
         .filter(
-          path => path.startsWith('/') && !path.includes('/man/') && !path.includes('.gz') && path.includes('/bin/'),
+          path =>
+            path.startsWith('/') &&
+            !path.includes('/man/') &&
+            !path.includes('.gz') &&
+            (path.includes('/bin/') || path.includes('/libexec/') || path.includes('/local/bin/')),
         );
     } else {
       // where output: "C:\\Program\ Files\\podman\\podman.exe\nC:\\Users\\<user>\\AppData\\Local\\Microsoft\\WindowsApps\\podman.exe"

--- a/extensions/podman/packages/extension/src/utils/podman-cli.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-cli.ts
@@ -67,8 +67,8 @@ export async function findPodmanInstallations(): Promise<string[]> {
       // where output: "C:\\Program\ Files\\podman\\podman.exe\nC:\\Users\\<user>\\AppData\\Local\\Microsoft\\WindowsApps\\podman.exe"
       // which -a output: "/usr/bin/podman\n/usr/bin/podman\n/bin/podman"
       paths = result.stdout
-        .trim()
-        .split('\n')
+        .split(/\r?\n/)
+        .map(line => line.trim())
         .filter(path => path.trim().length > 0);
     }
 

--- a/extensions/podman/packages/extension/src/utils/podman-cli.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-cli.ts
@@ -31,19 +31,45 @@ export async function findPodmanInstallations(): Promise<string[]> {
       // Windows: Use 'where podman' command
       result = await extensionApi.process.exec('where', ['podman']);
     } else {
-      // Unix/macOS: Use 'type -a podman' command
-      result = await extensionApi.process.exec('sh', ['-c', 'type -a podman']);
+      // Unix/macOS: Try which first, then whereis as fallback
+      let whichError: Error | undefined;
+      try {
+        // Try 'which -a podman' first
+        result = await extensionApi.process.exec('which', ['-a', 'podman']);
+      } catch (error) {
+        whichError = error as Error;
+        try {
+          // Fallback to 'whereis podman' if which is not available
+          result = await extensionApi.process.exec('whereis', ['podman']);
+        } catch (whereisError) {
+          throw new Error(
+            `Neither which nor whereis commands are available. which error: ${whichError.message}, whereis error: ${(whereisError as Error).message}`,
+          );
+        }
+      }
     }
 
-    // Remove duplicates and return array of unique lines (installations)
-    const uniqueLines = new Set(
-      result.stdout
+    // Parse output based on command used
+    let paths: string[];
+    if (result.stdout.startsWith('podman:')) {
+      // whereis output: "podman: /usr/bin/podman /usr/libexec/podman /usr/share/man/man1/podman.1.gz"
+      paths = result.stdout
+        .replace(/^podman:\s*/, '')
+        .split(/\s+/)
+        .filter(
+          path => path.startsWith('/') && !path.includes('/man/') && !path.includes('.gz') && path.includes('/bin/'),
+        );
+    } else {
+      // where output: "C:\\Program\ Files\\podman\\podman.exe\nC:\\Users\\<user>\\AppData\\Local\\Microsoft\\WindowsApps\\podman.exe"
+      // which -a output: "/usr/bin/podman\n/usr/bin/podman\n/bin/podman"
+      paths = result.stdout
         .trim()
         .split('\n')
-        .filter(line => line.trim().length > 0)
-        .map(line => line.replace(/podman is /g, '')),
-    );
-    return Array.from(uniqueLines);
+        .filter(path => path.trim().length > 0);
+    }
+
+    // Return unique paths only
+    return paths.filter((path, index) => paths.indexOf(path) === index);
   } catch (error) {
     console.warn('Failed to detect podman installations:', error);
     return [];

--- a/extensions/podman/packages/extension/src/utils/podman-cli.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-cli.ts
@@ -39,7 +39,7 @@ export async function findPodmanInstallations(): Promise<string[]> {
     const paths: string[] = result.stdout
       .split(/\r?\n/)
       .map(line => line.trim())
-      .filter(path => path.trim().length > 0);
+      .filter(path => path.length > 0);
 
     // Return unique paths only
     return paths.filter((path, index) => paths.indexOf(path) === index);

--- a/extensions/podman/packages/extension/src/utils/podman-cli.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-cli.ts
@@ -31,50 +31,19 @@ export async function findPodmanInstallations(): Promise<string[]> {
       // Windows: Use 'where podman' command
       result = await extensionApi.process.exec('where', ['podman']);
     } else {
-      // Unix/macOS: Try which first, then whereis as fallback
-      let whichError: Error | undefined;
-      try {
-        // Try 'which -a podman' first
-        result = await extensionApi.process.exec('which', ['-a', 'podman']);
-      } catch (error) {
-        whichError = error as Error;
-        try {
-          // Fallback to 'whereis podman' if which is not available
-          result = await extensionApi.process.exec('whereis', ['podman']);
-        } catch (whereisError) {
-          throw new Error(
-            `Neither which nor whereis commands are available. which error: ${whichError.message}, whereis error: ${(whereisError as Error).message}`,
-          );
-        }
-      }
+      // Unix/macOS: use 'which -a podman' command
+      result = await extensionApi.process.exec('which', ['-a', 'podman']);
     }
 
-    // Parse output based on command used
-    let paths: string[];
-    if (result.stdout.startsWith('podman:')) {
-      // whereis output: "podman: /usr/bin/podman /usr/libexec/podman /usr/share/man/man1/podman.1.gz"
-      paths = result.stdout
-        .replace(/^podman:\s*/, '')
-        .split(/\s+/)
-        .filter(
-          path =>
-            path.startsWith('/') &&
-            !path.includes('/man/') &&
-            !path.includes('.gz') &&
-            (path.includes('/bin/') || path.includes('/libexec/') || path.includes('/local/bin/')),
-        );
-    } else {
-      // where output: "C:\\Program\ Files\\podman\\podman.exe\nC:\\Users\\<user>\\AppData\\Local\\Microsoft\\WindowsApps\\podman.exe"
-      // which -a output: "/usr/bin/podman\n/usr/bin/podman\n/bin/podman"
-      paths = result.stdout
-        .split(/\r?\n/)
-        .map(line => line.trim())
-        .filter(path => path.trim().length > 0);
-    }
+    // Parse output for which and where combined
+    const paths: string[] = result.stdout
+      .split(/\r?\n/)
+      .map(line => line.trim())
+      .filter(path => path.trim().length > 0);
 
     // Return unique paths only
     return paths.filter((path, index) => paths.indexOf(path) === index);
-  } catch (error) {
+  } catch (error: unknown) {
     console.warn('Failed to detect podman installations:', error);
     return [];
   }


### PR DESCRIPTION
### What does this PR do?
* Fixes broken use of `type` bash unreliable built-in `podman-cli.ts/findPodmanInstallations()`
The use of this built-in was causing the output to be broken, as `process.exec(args: string[])` parses it differently compared to directly calling `sh -c 'type -a podman'`
* Switches the unix/macOS branch to use `which` and `whereis` instead

### Screenshot / video of UI
Instead of:
https://github.com/ScrewTSW/podman-desktop-extension-ai-lab/actions/runs/18314434154/job/52150777651#step:16:125
<img width="1158" height="260" alt="Screenshot_20251007_154645" src="https://github.com/user-attachments/assets/acd3a01a-6a1f-47d5-9bdd-0e29f47c5fc4" />
We now get clean execution:
https://github.com/ScrewTSW/podman-desktop-extension-ai-lab/actions/runs/18314434154/job/52157559238#step:16:119
<img width="1168" height="562" alt="Screenshot_20251007_164901" src="https://github.com/user-attachments/assets/04f9aed9-a3ec-482c-85ac-c6a17e4722ab" />
<img width="1168" height="680" alt="Screenshot_20251007_164916" src="https://github.com/user-attachments/assets/64f17a08-75aa-49fd-8e52-dec9b580f924" />

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/13834

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
