### PR TITLE
chore(test): add nonblocking k8s sanity tests to pr check

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -366,6 +366,54 @@ jobs:
           path: |
             ./tests/**/output/
             !./tests/**/traces/raw
+  
+  k8s-sanity-e2e-tests:
+    name: k8s sanity e2e tests
+    runs-on: ubuntu-24.04
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Install Podman v5 using external action
+        uses: redhat-actions/podman-install@16601a3a718acf7d6986140459092a2f5b941a03
+
+      - name: Setup testenv using external action
+        uses: podman-desktop/e2e/.github/actions/pde2e-testenv-prepare@13e2c57c759137bfc1f437f221967461e8a98e2a
+
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+        name: Install pnpm
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Execute pnpm
+        run: pnpm install
+
+      - name: Run Smoke E2E tests in Development Mode
+        run: pnpm test:e2e:k8s-sanity
+
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@3585e9575db828022551b4231f165eb59a0e74e3 # v5.6.2
+        if: always() # always run even if the previous step fails
+        with:
+          fail_on_failure: true
+          include_passed: true
+          detailed_summary: true
+          annotate_only: true
+          require_tests:  true
+          report_paths: '**/*results.xml'
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: always()
+        with:
+          name: k8s-sanity-e2e-tests
+          path: |
+            ./tests/**/output/
+            !./tests/**/traces/raw
 
   detect_pnpm_changes:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'area/ci') || !github.event.pull_request.draft }}

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -374,6 +374,12 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
+      - name: Set the default provider type variable
+        env:
+          DEFAULT_KIND_PROVIDER: 'docker'
+        run: |
+          echo "KIND_PROVIDER=${{ env.DEFAULT_KIND_PROVIDER }}" >> $GITHUB_ENV
+
       - name: Install Podman v5 using external action
         uses: redhat-actions/podman-install@16601a3a718acf7d6986140459092a2f5b941a03
 
@@ -394,6 +400,9 @@ jobs:
         run: pnpm install
 
       - name: Run Smoke E2E tests in Development Mode
+        env:
+          SKIP_KIND_INSTALL: 'true'
+          KIND_PROVIDER_GHA: ${{ env.KIND_PROVIDER }}
         run: pnpm test:e2e:k8s-sanity
 
       - name: Publish Test Report

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -368,6 +368,7 @@ jobs:
             !./tests/**/traces/raw
   
   k8s-sanity-e2e-tests:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'area/ci') || !github.event.pull_request.draft }}
     name: k8s sanity e2e tests
     runs-on: ubuntu-24.04
     continue-on-error: true

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -399,7 +399,7 @@ jobs:
       - name: Execute pnpm
         run: pnpm install
 
-      - name: Run Smoke E2E tests in Development Mode
+      - name: Run k8s sanity E2E tests in Development Mode
         env:
           SKIP_KIND_INSTALL: 'true'
           KIND_PROVIDER_GHA: ${{ env.KIND_PROVIDER }}

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -413,7 +413,7 @@ jobs:
           include_passed: true
           detailed_summary: true
           annotate_only: true
-          require_tests:  true
+          require_tests: true
           report_paths: '**/*results.xml'
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     "test:e2e:ui-stress:run": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- npx playwright test tests/playwright/src/special-specs/ui-stress/ -g @ui-stress",
     "test:e2e:k8s": "pnpm run test:e2e:build && pnpm run test:e2e:k8s:run",
     "test:e2e:k8s:run": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- npx playwright test tests/playwright/src/specs/ -g @k8s_e2e",
+    "test:e2e:k8s-sanity": "pnpm run test:e2e:build && pnpm run test:e2e:k8s-sanity:run",
+    "test:e2e:k8s-sanity:run": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- npx playwright test tests/playwright/src/specs/ -g @k8s_sanity",
     "test:e2e:extension": "pnpm run test:e2e:build && pnpm run test:e2e:extension:run",
     "test:e2e:extension:run": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- npx playwright test tests/playwright/src/specs/extension-installation.spec.ts",
     "test:e2e:remote": "pnpm run test:e2e:build && pnpm run test:e2e:remote:run",

--- a/tests/playwright/src/specs/kubernetes.spec.ts
+++ b/tests/playwright/src/specs/kubernetes.spec.ts
@@ -138,7 +138,7 @@ test.afterAll(async ({ runner, page }) => {
   }
 });
 
-test.describe('Kubernetes resources End-to-End test', { tag: '@k8s_e2e' }, () => {
+test.describe('Kubernetes resources End-to-End test', { tag: ['@k8s_e2e', '@k8s_sanity'] }, () => {
   test('Kubernetes Nodes test', async ({ page }) => {
     await checkKubernetesResourceState(page, KubernetesResources.Nodes, KIND_NODE, KubernetesResourceState.Running);
   });


### PR DESCRIPTION
### What does this PR do?
Adds nonblocking k8s sanity e2e tests to pr check workflow

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/14091