### PR TITLE
fix: volume route

### DIFF
--- a/packages/api/src/navigation-request.ts
+++ b/packages/api/src/navigation-request.ts
@@ -39,7 +39,7 @@ export interface NavigationParameters {
   [NavigationPage.PODMAN_PODS]: never;
   [NavigationPage.PODMAN_POD]: { name: string; engineId: string };
   [NavigationPage.VOLUMES]: never;
-  [NavigationPage.VOLUME]: { name: string };
+  [NavigationPage.VOLUME]: { engineId: string; name: string };
   [NavigationPage.CONTRIBUTION]: { name: string };
   [NavigationPage.TROUBLESHOOTING]: never;
   [NavigationPage.HELP]: never;

--- a/packages/main/src/plugin/extension/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension/extension-loader.spec.ts
@@ -1451,6 +1451,7 @@ describe('Navigation', async () => {
       page: NavigationPage.VOLUME,
       parameters: {
         name: 'valid-name',
+        engineId: 'valid-engine',
       },
     });
 

--- a/packages/main/src/plugin/navigation/navigation-manager.ts
+++ b/packages/main/src/plugin/navigation/navigation-manager.ts
@@ -235,6 +235,7 @@ export class NavigationManager {
       page: NavigationPage.VOLUME,
       parameters: {
         name: name,
+        engineId: engineId,
       },
     });
   }

--- a/packages/renderer/src/navigation.spec.ts
+++ b/packages/renderer/src/navigation.spec.ts
@@ -166,10 +166,11 @@ test(`Test navigationHandle for ${NavigationPage.VOLUME}`, () => {
     page: NavigationPage.VOLUME,
     parameters: {
       name: 'dummyVolumeName',
+      engineId: 'dummyEngineId',
     },
   });
 
-  expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/volumes/dummyVolumeName/');
+  expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/volumes/dummyVolumeName/dummyEngineId/summary');
 });
 
 test(`Test navigationHandle for ${NavigationPage.CONTRIBUTION}`, () => {

--- a/packages/renderer/src/navigation.ts
+++ b/packages/renderer/src/navigation.ts
@@ -101,7 +101,7 @@ export const handleNavigation = (request: InferredNavigationRequest<NavigationPa
       router.goto('/volumes');
       break;
     case NavigationPage.VOLUME:
-      router.goto(`/volumes/${request.parameters.name}/`);
+      router.goto(`/volumes/${request.parameters.name}/${request.parameters.engineId}/summary`);
       break;
     case NavigationPage.CONTRIBUTION:
       router.goto(`/contribs/${request.parameters.name}/`);


### PR DESCRIPTION
### What does this PR do?
Updates volume routes -> adds engine id (without this the volume is not found) + adds summary so one tab is selected

### Screenshot / video of UI

### What issues does this PR fix or reference?
Required for https://github.com/podman-desktop/podman-desktop/pull/14192

### How to test this PR?
Testable in https://github.com/podman-desktop/podman-desktop/pull/14192
- [x] Tests are covering the bug fix or the new feature
