### PR TITLE
Feat 15956/danger button styling

### DIFF
--- a/packages/api/src/dialog.ts
+++ b/packages/api/src/dialog.ts
@@ -55,7 +55,7 @@ export interface MessageBoxOptions {
    */
   buttons?: ButtonsType[];
   /**
-   * The (optional) type, one of 'none' | 'info' | 'error' | 'question' | 'warning'.
+   * The (optional) type, one of 'none' | 'info' | 'error' | 'question' | 'warning' | 'danger'.
    */
   type?: string;
   /**

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -2227,6 +2227,16 @@ declare module '@podman-desktop/api' {
     export function showErrorMessage(message: string, ...items: string[]): Promise<string | undefined>;
 
     /**
+     * Show a danger message. Optionally provide an array of items which will be presented as
+     * clickable buttons.
+     *
+     * @param message The message to show.
+     * @param items A set of items that will be rendered as actions in the message.
+     * @return A promise that resolves to the selected item or `undefined` when being dismissed.
+     */
+    export function showDangerMessage(message: string, ...items: string[]): Promise<string | undefined>;
+
+    /**
      * Show progress in Podman Desktop. Progress is shown while running the given callback
      * and while the promise it returned isn't resolved nor rejected. The location at which
      * progress should show (and other details) is defined via the passed {@linkcode ProgressOptions}.

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -1073,6 +1073,9 @@ export class ExtensionLoader implements IAsyncDisposable {
       showErrorMessage: (message: string, ...items: string[]) => {
         return messageBox.showDialog('error', extManifest.displayName, message, items);
       },
+      showDangerMessage: (message: string, ...items: string[]) => {
+        return messageBox.showDialog('danger', extManifest.displayName, message, items);
+      },
 
       showInputBox: (options?: containerDesktopAPI.InputBoxOptions, token?: containerDesktopAPI.CancellationToken) => {
         return inputQuickPickRegistry.showInputBox(options, token);

--- a/packages/main/src/plugin/message-box.ts
+++ b/packages/main/src/plugin/message-box.ts
@@ -19,7 +19,7 @@ import type { ButtonsType, DropdownType, MessageBoxOptions, MessageBoxReturnValu
 import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { inject, injectable } from 'inversify';
 
-type DialogType = 'none' | 'info' | 'error' | 'question' | 'warning';
+type DialogType = 'none' | 'info' | 'error' | 'question' | 'warning' | 'danger';
 
 @injectable()
 export class MessageBox {

--- a/packages/renderer/src/lib/actions/BulkActions.ts
+++ b/packages/renderer/src/lib/actions/BulkActions.ts
@@ -16,11 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ConfirmationOptions } from '/@/lib/dialogs/messagebox-utils';
 import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
 
-export function withBulkConfirmation(callback: () => unknown, text: string): void {
+export function withBulkConfirmation(callback: () => unknown, text: string, options?: ConfirmationOptions): void {
   window
     .getConfigurationValue('userConfirmation.bulk')
-    .then(confirm => (confirm ? withConfirmation(callback, text) : callback()))
+    .then(confirm => (confirm ? withConfirmation(callback, text, options) : callback()))
     .catch((err: unknown) => console.error('Error getting configuration value userConfirmation.bulk', err));
 }

--- a/packages/renderer/src/lib/compose/ComposeActions.svelte
+++ b/packages/renderer/src/lib/compose/ComposeActions.svelte
@@ -155,7 +155,7 @@ if (dropdownMenu) {
 
 <ListItemButtonIcon
   title="Delete Compose"
-  onClick={(): void => withConfirmation(deleteCompose, `delete compose ${compose.name}`)}
+  onClick={(): void => withConfirmation(deleteCompose, `delete compose ${compose.name}`, { variant: 'delete' })}
   icon={faTrash}
   detailed={detailed}
   inProgress={compose.actionInProgress && compose.status === 'DELETING'} />

--- a/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretActions.svelte
+++ b/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretActions.svelte
@@ -29,6 +29,7 @@ async function deleteConfigMapSecret(): Promise<void> {
     withConfirmation(
       deleteConfigMapSecret,
       `delete ${configmapSecretUtils.isSecret(configMapSecret) ? 'secret' : 'configmap'} ${configMapSecret.name}`,
+      {variant: 'delete'}
     )}
   detailed={detailed}
   icon={faTrash} />

--- a/packages/renderer/src/lib/container/ContainerActions.svelte
+++ b/packages/renderer/src/lib/container/ContainerActions.svelte
@@ -202,7 +202,7 @@ if (dropdownMenu) {
 
 <ListItemButtonIcon
   title="Delete Container"
-  onClick={(): void => withConfirmation(deleteContainer, `delete container ${container.name}`)}
+  onClick={(): void => withConfirmation(deleteContainer, `delete container ${container.name}`, {variant:'delete'})}
   icon={faTrash}
   detailed={detailed}
   inProgress={container.actionInProgress && container.state === 'DELETING'} />

--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -416,6 +416,7 @@ function label(item: ContainerGroupInfoUI | ContainerInfoUI): string {
               withBulkConfirmation(
                 deleteSelectedContainers,
                 `delete ${selectedItemsNumber} container${selectedItemsNumber > 1 ? 's' : ''}`,
+                { variant: 'delete' }
               );
             }
           }}

--- a/packages/renderer/src/lib/cronjob/CronJobActions.svelte
+++ b/packages/renderer/src/lib/cronjob/CronJobActions.svelte
@@ -21,6 +21,6 @@ async function deleteCronJob(): Promise<void> {
 
 <ListItemButtonIcon
   title="Delete CronJob"
-  onClick={(): void => withConfirmation(deleteCronJob, `delete cronjob ${cronjob.name}`)}
+  onClick={(): void => withConfirmation(deleteCronJob, `delete cronjob ${cronjob.name}`, {variant:'delete'})}
   detailed={detailed}
   icon={faTrash} />

--- a/packages/renderer/src/lib/deployments/DeploymentActions.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentActions.svelte
@@ -22,6 +22,6 @@ async function deleteDeployment(): Promise<void> {
 
 <ListItemButtonIcon
   title="Delete Deployment"
-  onClick={(): void => withConfirmation(deleteDeployment, `delete deployment ${deployment.name}`)}
+  onClick={(): void => withConfirmation(deleteDeployment, `delete deployment ${deployment.name}`, {variant:'delete'})}
   detailed={detailed}
   icon={faTrash} />

--- a/packages/renderer/src/lib/dialogs/MessageBox.svelte
+++ b/packages/renderer/src/lib/dialogs/MessageBox.svelte
@@ -105,9 +105,11 @@ async function onClose(): Promise<void> {
   await window.sendShowMessageBoxOnSelect(currentId, cancelId >= 0 ? cancelId : undefined);
 }
 
-function getButtonType(b: boolean): ButtonType {
+function getButtonType(b: boolean, type: string | undefined): ButtonType {
   // eslint-disable-next-line sonarjs/no-selector-parameter
-  if (b) {
+  if (b && type === 'danger') {
+    return 'danger';
+  } else if (b) {
     return 'primary';
   } else {
     return 'secondary';
@@ -175,7 +177,7 @@ function getButtonType(b: boolean): ButtonType {
               <Button type="primary" icon={button.icon} on:click={async (): Promise<void> => await clickButton(i)}>{button.label}</Button>
             {/if}
           {:else}
-            <Button type={getButtonType(defaultId === i)} on:click={async (): Promise<void> => await clickButton(i)}>{buttonsType[i]}</Button>
+            <Button type={getButtonType(defaultId === i, type)} on:click={async (): Promise<void> => await clickButton(i)}>{buttonsType[i]}</Button>
           {/if}
         {/each}
       

--- a/packages/renderer/src/lib/dialogs/messagebox-utils.ts
+++ b/packages/renderer/src/lib/dialogs/messagebox-utils.ts
@@ -16,6 +16,14 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+type ConfirmationType = 'none' | 'info' | 'error' | 'question' | 'warning' | 'danger';
+type ConfirmationVariant = 'default' | 'delete';
+
+export interface ConfirmationOptions {
+  type?: ConfirmationType;
+  variant?: ConfirmationVariant;
+}
+
 /**
  * Utility method to create a confirmation dialog for a given action.
  * This method follow the common error-first callback style, therefore you
@@ -23,13 +31,22 @@
  *
  * @param func the function to call on confirmation or error
  * @param action the action label to use
+ * @param options the options to use for the confirmation dialog
  */
-export function withConfirmation(func: (err?: unknown) => unknown, action: string): void {
+export function withConfirmation(
+  func: (err?: unknown) => unknown,
+  action: string,
+  options?: ConfirmationOptions,
+): void {
+  const isDelete = options?.variant === 'delete';
+  const actionButton = isDelete ? 'Delete' : 'Yes';
+
   window
     .showMessageBox({
       title: 'Confirmation',
       message: 'Are you sure you want to ' + action + '?',
-      buttons: ['Yes', 'Cancel'],
+      buttons: [actionButton, 'Cancel'],
+      type: options?.type ?? (isDelete ? 'danger' : 'question'),
     })
     .then(result => {
       if (result?.response === 0) {

--- a/packages/renderer/src/lib/extensions/dev-mode/table/ListTable.svelte
+++ b/packages/renderer/src/lib/extensions/dev-mode/table/ListTable.svelte
@@ -75,6 +75,7 @@ function label(extensionFolder: SelectableExtensionDevelopmentFolderInfoUI): str
         withBulkConfirmation(
           deleteSelectedFolders,
           `Untrack loading extension from ${selectedItemsNumber} folder${selectedItemsNumber > 1 ? 's' : ''}`,
+          {variant: 'delete'}
         )}
       title="Untrack {selectedItemsNumber} selected items"
       inProgress={bulkDeleteInProgress}

--- a/packages/renderer/src/lib/image/ImageActions.svelte
+++ b/packages/renderer/src/lib/image/ImageActions.svelte
@@ -104,7 +104,7 @@ function saveImage(): void {
 
 <ListItemButtonIcon
   title="Delete Image"
-  onClick={(): void => withConfirmation(deleteImage, `delete image ${image.name}:${image.tag}`)}
+  onClick={(): void => withConfirmation(deleteImage, `delete image ${image.name}:${image.tag}`, {variant:'delete'})}
   detailed={detailed}
   icon={faTrash}
   enabled={image.status === 'UNUSED'} />

--- a/packages/renderer/src/lib/image/ImagesList.svelte
+++ b/packages/renderer/src/lib/image/ImagesList.svelte
@@ -335,6 +335,7 @@ function label(item: ImageInfoUI): string {
           if (selectedItemsNumber) {withBulkConfirmation(
             deleteSelectedImages,
             `delete ${selectedItemsNumber} image${selectedItemsNumber > 1 ? 's' : ''}`,
+            { variant: 'delete' }
           );}}}
         title="Delete {selectedItemsNumber} selected items"
         inProgress={bulkDeleteInProgress}

--- a/packages/renderer/src/lib/image/ManifestActions.svelte
+++ b/packages/renderer/src/lib/image/ManifestActions.svelte
@@ -44,7 +44,7 @@ async function onError(error: string): Promise<void> {
 
 <ListItemButtonIcon
   title="Delete Manifest"
-  onClick={(): void => withConfirmation(deleteManifest, `delete manifest ${manifest.name}`)}
+  onClick={(): void => withConfirmation(deleteManifest, `delete manifest ${manifest.name}`, {variant:'delete'})}
   detailed={detailed}
   icon={faTrash}
   enabled={manifest.status === 'UNUSED'} />

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteActions.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteActions.svelte
@@ -30,6 +30,7 @@ async function deleteIngressRoute(): Promise<void> {
     withConfirmation(
       deleteIngressRoute,
       `delete ${ingressRouteUtils.isIngress(ingressRoute) ? 'ingress' : 'route'} ${ingressRoute.name}`,
+      {variant:'delete'}
     )}
   detailed={detailed}
   icon={faTrash} />

--- a/packages/renderer/src/lib/job/JobActions.svelte
+++ b/packages/renderer/src/lib/job/JobActions.svelte
@@ -21,6 +21,6 @@ async function deleteJob(): Promise<void> {
 
 <ListItemButtonIcon
   title="Delete Job"
-  onClick={(): void => withConfirmation(deleteJob, `delete job ${job.name}`)}
+  onClick={(): void => withConfirmation(deleteJob, `delete job ${job.name}`, {variant:'delete'})}
   detailed={detailed}
   icon={faTrash} />

--- a/packages/renderer/src/lib/kube/pods/PodActions.svelte
+++ b/packages/renderer/src/lib/kube/pods/PodActions.svelte
@@ -58,7 +58,7 @@ if (dropdownMenu) {
 
 <ListItemButtonIcon
   title="Delete Pod"
-  onClick={():void => withConfirmation(deletePod, `delete pod ${pod.name}`)}
+  onClick={():void => withConfirmation(deletePod, `delete pod ${pod.name}`, {variant:'delete'})}
   icon={faTrash}
   detailed={detailed}/>
 

--- a/packages/renderer/src/lib/kubernetes-port-forward/PortForwardActions.svelte
+++ b/packages/renderer/src/lib/kubernetes-port-forward/PortForwardActions.svelte
@@ -39,5 +39,5 @@ async function openExternal(): Promise<void> {
   icon={faSquareUpRight} />
 <ListItemButtonIcon
   title="Delete forwarded port"
-  onClick={(): void => withConfirmation(deletePortForward, `Delete port forward`)}
+  onClick={(): void => withConfirmation(deletePortForward, `Delete port forward`, {variant:'delete'})}
   icon={faTrash} />

--- a/packages/renderer/src/lib/network/NetworkActions.svelte
+++ b/packages/renderer/src/lib/network/NetworkActions.svelte
@@ -42,7 +42,7 @@ function closeUpdateDialog(): void {
 
 <ListItemButtonIcon
   title="Delete Network"
-  onClick={(): void => withConfirmation(removeNetwork, `delete network ${object.name}`)}
+  onClick={(): void => withConfirmation(removeNetwork, `delete network ${object.name}`, {variant:'delete'})}
   icon={faTrash}
   detailed={detailed}
   enabled={object.status === 'UNUSED'} />

--- a/packages/renderer/src/lib/network/NetworksList.svelte
+++ b/packages/renderer/src/lib/network/NetworksList.svelte
@@ -141,6 +141,7 @@ function key(network: NetworkInfoUI): string {
           withBulkConfirmation(
             deleteSelectedNetworks,
             `delete ${selectedItemsNumber} network${selectedItemsNumber > 1 ? 's' : ''}`,
+            {variant:'delete'}
           )}
         title="Delete {selectedItemsNumber} selected items"
         inProgress={bulkDeleteInProgress}

--- a/packages/renderer/src/lib/objects/KubernetesObjectsList.svelte
+++ b/packages/renderer/src/lib/objects/KubernetesObjectsList.svelte
@@ -137,6 +137,7 @@ let selectedItemsNumber = $state<number>(0);
           withBulkConfirmation(
             deleteSelectedObjects,
             `delete ${selectedItemsNumber} ${selectedItemsNumber > 1 ? plural : singular}`,
+            {variant:'delete'}
           )}
         title="Delete {selectedItemsNumber} selected items"
         inProgress={bulkDeleteInProgress}

--- a/packages/renderer/src/lib/pod/PodActions.svelte
+++ b/packages/renderer/src/lib/pod/PodActions.svelte
@@ -159,7 +159,7 @@ const MenuComponent = $derived(dropdownMenu ? DropdownMenu : FlatMenu);
   icon={faStop} />
 <ListItemButtonIcon
   title="Delete Pod"
-  onClick={(): void => withConfirmation(deletePod, `delete pod ${pod.name}`)}
+  onClick={(): void => withConfirmation(deletePod, `delete pod ${pod.name}`, {variant:'delete'})}
   icon={faTrash}
   detailed={detailed}
   inProgress={pod.actionInProgress && pod.status === 'DELETING'} />

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -198,6 +198,7 @@ function label(pod: PodInfoUI): string {
           withBulkConfirmation(
             deleteSelectedPods,
             `delete ${selectedItemsNumber} pod${selectedItemsNumber > 1 ? 's' : ''}`,
+            {variant:'delete'}
           )}
         title="Delete {selectedItemsNumber} selected items"
         inProgress={bulkDeleteInProgress}

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionActions.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionActions.svelte
@@ -191,7 +191,7 @@ function getLoggerHandler(provider: ProviderInfo, containerConnectionInfo: Provi
         {/if}
         {#if connection.lifecycleMethods.includes('delete')}
           <LoadingIconButton
-            clickAction={withConfirmation.bind(undefined, deleteConnectionProvider.bind(undefined, provider, connection), `delete ${connection.name}`)}
+            clickAction={withConfirmation.bind(undefined, deleteConnectionProvider.bind(undefined, provider, connection), `delete ${connection.name}`, {variant:'delete'})}
             action="delete"
             icon={faTrash}
             state={connectionStatus}

--- a/packages/renderer/src/lib/pvc/PVCActions.svelte
+++ b/packages/renderer/src/lib/pvc/PVCActions.svelte
@@ -18,6 +18,6 @@ async function deletePVC(): Promise<void> {
 
 <ListItemButtonIcon
   title="Delete PersistentVolumeClaim"
-  onClick={(): void => withConfirmation(deletePVC, `delete pvc ${pvc.name}`)}
+  onClick={(): void => withConfirmation(deletePVC, `delete pvc ${pvc.name}`, {variant:'delete'})}
   detailed={detailed}
   icon={faTrash} />

--- a/packages/renderer/src/lib/service/ServiceActions.svelte
+++ b/packages/renderer/src/lib/service/ServiceActions.svelte
@@ -18,6 +18,6 @@ async function deleteService(): Promise<void> {
 
 <ListItemButtonIcon
   title="Delete Service"
-  onClick={(): void => withConfirmation(deleteService, `delete service ${service.name}`)}
+  onClick={(): void => withConfirmation(deleteService, `delete service ${service.name}`, {variant:'delete'})}
   detailed={detailed}
   icon={faTrash} />

--- a/packages/renderer/src/lib/task-manager/button/TaskManagerBulkDeleteButton.svelte
+++ b/packages/renderer/src/lib/task-manager/button/TaskManagerBulkDeleteButton.svelte
@@ -29,7 +29,7 @@ async function deleteSelectedTasks(): Promise<void> {
 }
 
 function onClick(): void {
-  withBulkConfirmation(deleteSelectedTasks, bulkOperationTitle);
+  withBulkConfirmation(deleteSelectedTasks, bulkOperationTitle, { variant: 'delete' });
 }
 </script>
 

--- a/packages/renderer/src/lib/volume/VolumeActions.svelte
+++ b/packages/renderer/src/lib/volume/VolumeActions.svelte
@@ -23,7 +23,7 @@ async function removeVolume(): Promise<void> {
 {#if volume.status === 'UNUSED'}
   <ListItemButtonIcon
     title="Delete Volume"
-    onClick={(): void => withConfirmation(removeVolume, `delete volume ${volume.name}`)}
+    onClick={(): void => withConfirmation(removeVolume, `delete volume ${volume.name}`, {variant:'delete'})}
     detailed={detailed}
     icon={faTrash} />
 {/if}

--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -220,6 +220,7 @@ function label(obj: VolumeInfoUI): string {
           withBulkConfirmation(
             deleteSelectedVolumes,
             `delete ${selectedItemsNumber} volume${selectedItemsNumber > 1 ? 's' : ''}`,
+            {variant:'delete'},
           )}
         title="Delete {selectedItemsNumber} selected items"
         inProgress={bulkDeleteInProgress}


### PR DESCRIPTION
### What does this PR do?

This PR adds danger styling for destructive actions

Adds `showDangerMessage` for Extension API

Adds option for `withConfirmation` utility function 

### Screenshot / video of UI

Before:
<img width="543" height="227" alt="image" src="https://github.com/user-attachments/assets/9ff99fe8-d0d2-4809-8a52-398118228ceb" />

After:
<img width="548" height="226" alt="image" src="https://github.com/user-attachments/assets/c9e11ac6-b730-477b-9f4f-a3fd18a0404e" />


### What issues does this PR fix or reference?

Closes #15956 

### How to test this PR?

Try to delete image/pod/container and you should see `Delete` button with danger style

- [ ] Tests are covering the bug fix or the new feature
