### PR TITLE
refactor(details): refactor details page when resource disappear

### DIFF
--- a/packages/renderer/src/lib/container/ContainerDetails.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetails.svelte
@@ -38,6 +38,13 @@ let container: ContainerInfoUI | undefined = $derived(
   getContainerInfoUI($containersInfos.find(c => c.Id === containerID)),
 );
 
+// track if the container has been deleted
+let deleted = false;
+
+$effect.pre(() => {
+  deleted = !container;
+});
+
 $effect(() => {
   if (container) {
     window
@@ -55,8 +62,14 @@ $effect(() => {
         }
       })
       .catch((err: unknown) => console.error(`Error getting container inspect ${container?.id}: ${err}`));
-  } else {
-    detailsPage?.close();
+  }
+  const page = detailsPage;
+  if (page) {
+    return (): void => {
+      if (deleted) {
+        page.close();
+      }
+    };
   }
 });
 

--- a/packages/renderer/src/lib/image/ImageDetails.svelte
+++ b/packages/renderer/src/lib/image/ImageDetails.svelte
@@ -78,10 +78,21 @@ let detailsPage: DetailsPage | undefined = $state();
 let showCheckTab: boolean = $derived($imageCheckerProviders.length > 0);
 let showFilesTab: boolean = $derived($imageFilesProviders.length > 0);
 
+// track if the image has been deleted
+let deleted = false;
+
+$effect.pre(() => {
+  deleted = !image;
+});
+
 $effect(() => {
-  if (!image) {
-    // the image has been deleted
-    detailsPage?.close();
+  const page = detailsPage;
+  if (page) {
+    return (): void => {
+      if (deleted) {
+        page.close();
+      }
+    };
   }
 });
 </script>

--- a/packages/renderer/src/lib/network/NetworkDetails.svelte
+++ b/packages/renderer/src/lib/network/NetworkDetails.svelte
@@ -32,9 +32,21 @@ let network: NetworkInfoUI | undefined = $derived(
 );
 let detailsPage: DetailsPage | undefined = $state();
 
+// track if the network has been deleted
+let deleted = false;
+
+$effect.pre(() => {
+  deleted = !network;
+});
+
 $effect(() => {
-  if (!network && detailsPage) {
-    detailsPage.close();
+  const page = detailsPage;
+  if (page) {
+    return (): void => {
+      if (deleted) {
+        page.close();
+      }
+    };
   }
 });
 </script>

--- a/packages/renderer/src/lib/volume/VolumeDetails.svelte
+++ b/packages/renderer/src/lib/volume/VolumeDetails.svelte
@@ -36,8 +36,22 @@ let volume: VolumeInfoUI | undefined = $derived.by(() => {
   return undefined;
 });
 
+// track if the volume has been deleted
+let deleted = false;
+
+$effect.pre(() => {
+  deleted = !volume;
+});
+
 $effect(() => {
-  if (!volume) detailsPage?.close();
+  const page = detailsPage;
+  if (page) {
+    return (): void => {
+      if (deleted) {
+        page.close();
+      }
+    };
+  }
 });
 </script>
 


### PR DESCRIPTION



### What does this PR do?
in recent svelte release, the detailsPage is set to undefined before executing full pre hook, so it's failing

allowing to upgrade svelte will allow to fix a CVE in devalue

and tests are failing (this is why svelte upgrade was stuck)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/pull/16604
related to https://github.com/podman-desktop/podman-desktop/pull/16607

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

you may try to update svelte to the latest version to check as well