### PR TITLE
chore: prevent feedback form from closing when clicking on a non-submission link in the form

### DIFF
--- a/packages/renderer/src/lib/feedback/SendFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/SendFeedback.svelte
@@ -56,7 +56,7 @@ function handleUpdate(e: boolean): void {
 
 {#if displayModal}
 <div class='z-40'>
-  <Modal name="Share your feedback" onclose={(): Promise<void> => hideModal()}>
+  <Modal name="Share your feedback" onclose={(): Promise<void> => hideModal()} ignoreFocusOut={true}>
     <div class="flex items-center justify-between pl-4 pr-3 py-3 space-x-2 text-[var(--pd-modal-header-text)]">
       <h1 class="grow text-lg font-bold capitalize">Share your feedback</h1>
       <CloseButton onclick={(): Promise<void> => hideModal()} />

--- a/packages/renderer/src/lib/feedback/feedbackForms/DirectFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/feedbackForms/DirectFeedback.spec.ts
@@ -158,7 +158,8 @@ test('Expect message for happy-smiley to use like', async () => {
 });
 
 test('Expect GitHub dialog visible when very-happy-smiley selected', async () => {
-  render(DirectFeedback, { category: 'developers', contentChange: vi.fn(), onCloseForm: vi.fn() });
+  const onCloseFormMock = vi.fn();
+  render(DirectFeedback, { category: 'developers', contentChange: vi.fn(), onCloseForm: onCloseFormMock });
 
   // click on a smiley
   const smiley = await screen.findByRole('button', { name: 'very-happy-smiley' });
@@ -174,6 +175,8 @@ test('Expect GitHub dialog visible when very-happy-smiley selected', async () =>
     expect(window.telemetryTrack).toHaveBeenCalledWith('feedback.openGitHub');
     expect(window.openExternal).toHaveBeenCalledWith('https://github.com/containers/podman-desktop');
   });
+
+  expect(onCloseFormMock).not.toHaveBeenCalled();
 });
 
 test('Expect category to be sent', async () => {

--- a/packages/renderer/src/lib/feedback/feedbackForms/DirectFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/feedbackForms/DirectFeedback.svelte
@@ -70,7 +70,6 @@ async function sendFeedback(): Promise<void> {
 }
 
 async function openGitHub(): Promise<void> {
-  onCloseForm(false);
   await window.telemetryTrack('feedback.openGitHub');
   await window.openExternal('https://github.com/containers/podman-desktop');
 }

--- a/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.spec.ts
@@ -182,9 +182,10 @@ test.each<GitHubFeedbackCategory>([
   'bug',
   'feature',
 ])('Expect %s to be included in previewOnGitHub call', async category => {
+  const onCloseFormMock = vi.fn();
   const { preview, title, description } = renderGitHubIssueFeedback({
     category: category,
-    onCloseForm: vi.fn(),
+    onCloseForm: onCloseFormMock,
     contentChange: vi.fn(),
   });
 
@@ -205,6 +206,8 @@ test.each<GitHubFeedbackCategory>([
       category: category,
     }),
   );
+
+  expect(onCloseFormMock).toHaveBeenCalled();
 });
 
 describe('includeSystemInfo', () => {
@@ -365,4 +368,21 @@ test('Expect close confirmation to be true if cancel clicked', async () => {
   // expect close to have been call with confirmation=true
   expect(closeMock).toHaveBeenCalledOnce();
   expect(closeMock).toHaveBeenCalledWith(true);
+});
+
+test('Expect opening existing GitHub issues to not close the feedback window', async () => {
+  const onCloseFormMock = vi.fn();
+  const { getByLabelText } = renderGitHubIssueFeedback({
+    category: 'bug',
+    onCloseForm: onCloseFormMock,
+    contentChange: vi.fn(),
+  });
+
+  const gitHubLink = getByLabelText('GitHub issues');
+  expect(gitHubLink).toBeInTheDocument();
+
+  await userEvent.click(gitHubLink);
+
+  expect(window.openExternal).toHaveBeenCalled();
+  expect(onCloseFormMock).not.toHaveBeenCalled();
 });

--- a/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.svelte
@@ -48,7 +48,6 @@ onMount(async () => {
 });
 
 async function openGitHubIssues(): Promise<void> {
-  onCloseForm(false);
   await window.openExternal(existingIssuesLink);
 }
 


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR updates the feedback forms to not close when clicking on a non-submission link. This change also means that clicking outside the form doesn't close it

Note: We can keep the close on outside click behavior, but it means that clicking on a non-submission link will result in confirmation message popping up

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Fixes https://github.com/podman-desktop/podman-desktop/issues/15992

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
