### PR TITLE
feat: support danger message boxes in extension API and internal utilities

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -2227,6 +2227,16 @@ declare module '@podman-desktop/api' {
     export function showErrorMessage(message: string, ...items: string[]): Promise<string | undefined>;
 
     /**
+     * Show a danger message. Optionally provide an array of items which will be presented as
+     * clickable buttons.
+     *
+     * @param message The message to show.
+     * @param items A set of items that will be rendered as actions in the message.
+     * @return A promise that resolves to the selected item or `undefined` when being dismissed.
+     */
+    export function showDangerMessage(message: string, ...items: string[]): Promise<string | undefined>;
+
+    /**
      * Show progress in Podman Desktop. Progress is shown while running the given callback
      * and while the promise it returned isn't resolved nor rejected. The location at which
      * progress should show (and other details) is defined via the passed {@linkcode ProgressOptions}.

--- a/packages/main/src/plugin/extension/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension/extension-loader.spec.ts
@@ -167,7 +167,9 @@ const apiSender: ApiSenderType = { send: vi.fn() } as unknown as ApiSenderType;
 
 const trayMenuRegistry: TrayMenuRegistry = {} as unknown as TrayMenuRegistry;
 
-const messageBox: MessageBox = {} as MessageBox;
+const messageBox: MessageBox = {
+  showDialog: vi.fn(),
+} as unknown as MessageBox;
 
 const progress: ProgressImpl = {
   withProgress: vi.fn(),
@@ -1255,6 +1257,30 @@ describe('setContextValue', async () => {
 
     api.context.setValue('key', 'value', 'DockerCompatibility');
     expect(setValueSpy).toBeCalledWith('publisher.extension-name.DockerCompatibility.key', 'value');
+  });
+});
+
+describe('showDangerMessage', () => {
+  test('should call messageBox.showDialog with danger type', async () => {
+    const api = createApi();
+
+    vi.mocked(messageBox.showDialog).mockResolvedValue('Yes');
+
+    const result = await api.window.showDangerMessage('Are you sure?', 'Yes', 'No');
+
+    expect(messageBox.showDialog).toHaveBeenCalledWith('danger', 'dname', 'Are you sure?', ['Yes', 'No']);
+    expect(result).toBe('Yes');
+  });
+
+  test('should call messageBox.showDialog with no items', async () => {
+    const api = createApi();
+
+    vi.mocked(messageBox.showDialog).mockResolvedValue(undefined);
+
+    const result = await api.window.showDangerMessage('Danger message');
+
+    expect(messageBox.showDialog).toHaveBeenCalledWith('danger', 'dname', 'Danger message', []);
+    expect(result).toBeUndefined();
   });
 });
 

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -1095,6 +1095,9 @@ export class ExtensionLoader implements IAsyncDisposable {
       showErrorMessage: (message: string, ...items: string[]) => {
         return messageBox.showDialog('error', extManifest.displayName, message, items);
       },
+      showDangerMessage: (message: string, ...items: string[]) => {
+        return messageBox.showDialog('danger', extManifest.displayName, message, items);
+      },
 
       showInputBox: (options?: containerDesktopAPI.InputBoxOptions, token?: containerDesktopAPI.CancellationToken) => {
         return inputQuickPickRegistry.showInputBox(options, token);

--- a/packages/renderer/src/lib/actions/BulkActions.ts
+++ b/packages/renderer/src/lib/actions/BulkActions.ts
@@ -16,11 +16,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
+import { type ConfirmationOptions, withConfirmation } from '/@/lib/dialogs/messagebox-utils';
 
-export function withBulkConfirmation(callback: () => unknown, text: string): void {
+export function withBulkConfirmation(callback: () => unknown, text: string, options?: ConfirmationOptions): void {
   window
     .getConfigurationValue('userConfirmation.bulk')
-    .then(confirm => (confirm ? withConfirmation(callback, text) : callback()))
+    .then(confirm => (confirm ? withConfirmation(callback, text, options) : callback()))
     .catch((err: unknown) => console.error('Error getting configuration value userConfirmation.bulk', err));
 }

--- a/packages/renderer/src/lib/dialogs/messagebox-utils.spec.ts
+++ b/packages/renderer/src/lib/dialogs/messagebox-utils.spec.ts
@@ -60,3 +60,53 @@ test('expect withConfirmation to propagate error', async () => {
     expect(callback).toHaveBeenCalledWith(error);
   });
 });
+
+test('expect withConfirmation to use default variant when no options provided', async () => {
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+
+  const callback = vi.fn();
+  withConfirmation(callback, 'Destroy world');
+
+  await vi.waitFor(() => {
+    expect(window.showMessageBox).toHaveBeenCalledWith({
+      title: 'Confirmation',
+      message: 'Are you sure you want to Destroy world?',
+      buttons: ['Yes', 'Cancel'],
+      type: 'question',
+    });
+  });
+});
+
+test('expect withConfirmation to use delete variant with Delete button and danger type', async () => {
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+
+  const callback = vi.fn();
+  withConfirmation(callback, 'delete this resource', { variant: 'delete' });
+
+  await vi.waitFor(() => {
+    expect(window.showMessageBox).toHaveBeenCalledWith({
+      title: 'Confirmation',
+      message: 'Are you sure you want to delete this resource?',
+      buttons: ['Delete', 'Cancel'],
+      type: 'danger',
+    });
+    expect(callback).toHaveBeenCalled();
+  });
+});
+
+test('expect withConfirmation to use default variant explicitly', async () => {
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+
+  const callback = vi.fn();
+  withConfirmation(callback, 'continue', { variant: 'default' });
+
+  await vi.waitFor(() => {
+    expect(window.showMessageBox).toHaveBeenCalledWith({
+      title: 'Confirmation',
+      message: 'Are you sure you want to continue?',
+      buttons: ['Yes', 'Cancel'],
+      type: 'question',
+    });
+    expect(callback).toHaveBeenCalled();
+  });
+});

--- a/packages/renderer/src/lib/dialogs/messagebox-utils.ts
+++ b/packages/renderer/src/lib/dialogs/messagebox-utils.ts
@@ -15,6 +15,11 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
+type ConfirmationVariant = 'default' | 'delete';
+
+export interface ConfirmationOptions {
+  variant?: ConfirmationVariant;
+}
 
 /**
  * Utility method to create a confirmation dialog for a given action.
@@ -23,13 +28,21 @@
  *
  * @param func the function to call on confirmation or error
  * @param action the action label to use
+ * @param options the options to use for the confirmation dialog
  */
-export function withConfirmation(func: (err?: unknown) => unknown, action: string): void {
+export function withConfirmation(
+  func: (err?: unknown) => unknown,
+  action: string,
+  options?: ConfirmationOptions,
+): void {
+  const isDelete = options?.variant === 'delete';
+  const activationButton = isDelete ? 'Delete' : 'Yes';
   window
     .showMessageBox({
       title: 'Confirmation',
       message: 'Are you sure you want to ' + action + '?',
-      buttons: ['Yes', 'Cancel'],
+      buttons: [activationButton, 'Cancel'],
+      type: isDelete ? 'danger' : 'question',
     })
     .then(result => {
       if (result?.response === 0) {

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionActions.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionActions.spec.ts
@@ -173,6 +173,7 @@ describe('delete', () => {
         title: 'Confirmation',
         message: `Are you sure you want to delete ${containerConnection.name}?`,
         buttons: ['Yes', 'Cancel'],
+        type: 'question',
       });
     });
   });

--- a/packages/renderer/src/lib/task-manager/button/TaskManagerBulkDeleteButton.spec.ts
+++ b/packages/renderer/src/lib/task-manager/button/TaskManagerBulkDeleteButton.spec.ts
@@ -83,6 +83,7 @@ test('Expect bulk button is bringing confirmation but not deleting anything', as
     buttons: ['Yes', 'Cancel'],
     message: 'Are you sure you want to bulk delete operation?',
     title: 'Confirmation',
+    type: 'question',
   });
 
   // expect we did not call the clearTask method


### PR DESCRIPTION
### What does this PR do?

This PR adds support for danger message boxes in extension API and utilities :

1. **Extension API**: Adds a new `showDangerMessage()` function to the extension API, allowing extensions to display danger/warning dialogs to users
2. **Internal utilities**: Enhances the confirmation dialog utilities to support different variants (default and delete), enabling customized button text ("Delete" vs "Yes") and danger styling

### Screenshot / video of UI

### What issues does this PR fix or reference?

Relates to #15956 
Blocked by #17055 

### How to test this PR?

**Extension API:**
- Create or modify an extension to call `window.showDangerMessage("Test message", "OK", "Cancel")`
- Verify the dialog appears with danger styling

**Internal utilities:**
- Test confirmation dialogs that use `withConfirmation` with `{ variant: 'delete' }` option
- Verify the dialog shows "Delete" button instead of "Yes"
- Verify the dialog type is set to 'danger'
- Test `withBulkConfirmation` with options parameter

- [x] Tests are covering the bug fix or the new feature