### PR TITLE
refactor(website): vi.mock imports

### DIFF
--- a/website/release-notes-parser.spec.ts
+++ b/website/release-notes-parser.spec.ts
@@ -16,29 +16,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { createNotesFiles } from './release-notes-parser';
 
-const mocks = vi.hoisted(() => ({
-  existsSyncMock: vi.fn(),
-  mkdirMock: vi.fn(),
-  readFileMock: vi.fn(),
-  writeFileMock: vi.fn(),
-}));
-
-vi.mock('node:fs', () => {
-  return {
-    default: {
-      existsSync: mocks.existsSyncMock,
-      promises: {
-        mkdir: mocks.mkdirMock,
-        readFile: mocks.readFileMock,
-        writeFile: mocks.writeFileMock,
-      },
-    },
-  };
-});
+vi.mock(import('node:fs/promises'));
+vi.mock(import('node:fs'));
 
 const notesInfo =
   '--- title: test1\nslug: podman-desktop-release-test1\nimage: /img/blog/podman-desktop-release-test1/test1.png\n---';
@@ -71,23 +57,23 @@ const params = {
 
 beforeEach(() => {
   vi.resetAllMocks();
-  mocks.readFileMock.mockReturnValue(notesInfo + notesText + notesPoints);
-  mocks.existsSyncMock.mockReturnValue(true);
+  vi.mocked(readFile).mockResolvedValue(notesInfo + notesText + notesPoints);
+  vi.mocked(existsSync).mockReturnValue(true);
   defaultParseFrontMatterMock.mockResolvedValue(defaultParseFrontMatterResultMock);
 });
 
 test('create release-notes directory when it does not exist', async () => {
-  mocks.existsSyncMock.mockReturnValue(false);
+  vi.mocked(existsSync).mockReturnValue(false);
   await createNotesFiles(params);
-  expect(mocks.mkdirMock).toHaveBeenCalled();
+  expect(mkdir).toHaveBeenCalled();
 });
 
 test('Do not create release-nnotes directory when it exists', async () => {
   await createNotesFiles(params);
-  expect(mocks.mkdirMock).not.toHaveBeenCalled();
+  expect(mkdir).not.toHaveBeenCalled();
 });
 
 test('parse provided release notes as expected', async () => {
   await createNotesFiles(params);
-  expect(mocks.writeFileMock).toBeCalledWith('./static/release-notes/1.0.json', JSON.stringify(jsonResult));
+  expect(writeFile).toBeCalledWith('./static/release-notes/1.0.json', JSON.stringify(jsonResult));
 });

--- a/website/release-notes-parser.ts
+++ b/website/release-notes-parser.ts
@@ -16,7 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import fs from 'node:fs';
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
 
 import type {
   DefaultParseFrontMatter,
@@ -41,7 +42,7 @@ export async function createNotesFiles(
     const version = versionMatch ? versionMatch[0] : '';
     if (version) {
       const folderName = './static/release-notes';
-      const fileContent = await fs.promises.readFile(params.filePath, { encoding: 'utf-8' });
+      const fileContent = await readFile(params.filePath, { encoding: 'utf-8' });
       const resultText = fileContent.split('---', 3);
 
       // get release image url
@@ -65,15 +66,15 @@ export async function createNotesFiles(
 
       const jsonInput = { image: imageUrl, blog: blogUrl, title: titleText, summary: summaryText };
 
-      if (!fs.existsSync(folderName)) {
+      if (!existsSync(folderName)) {
         try {
-          await fs.promises.mkdir(folderName);
+          await mkdir(folderName);
         } catch (error) {
           // directory already exists
         }
       }
 
-      await fs.promises.writeFile(`${folderName}/${version}.json`, JSON.stringify(jsonInput));
+      await writeFile(`${folderName}/${version}.json`, JSON.stringify(jsonInput));
     }
   }
   return result;

--- a/website/sidebar-content-parser.spec.ts
+++ b/website/sidebar-content-parser.spec.ts
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { extractNavigationFromSidebar, generateJsonOverviewFile } from './sidebar-content-parser';
 
 // Mock the writeFile function
-vi.mock('node:fs/promises', () => ({
+vi.mock(import('node:fs/promises'), () => ({
   writeFile: vi.fn(),
 }));
 


### PR DESCRIPTION
### What does this PR do?

Sometime the `--fix` is not enough, so we need to update a bit the way the `node:fs` and `node:fs/promise` modules are imported to be able to match the eslint rule `prefer-import-in-mock` to avoid typecheck error.

The main issue is that a `vi.mock` accept a Partial<T>, but when mocking `node:fs`, and specifying a `promise`, if you only pass one promise property, typecheck will complain that the promise provided is not complete, as Partial<T> is not deep Partial. 

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Parts of https://github.com/podman-desktop/podman-desktop/issues/16503

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- CI should be 🟢 
