### PR TITLE
fix: flaky ExtensionDetailsReadme.svelte component test

### DIFF
--- a/packages/renderer/src/lib/extensions/ExtensionDetailsReadme.spec.ts
+++ b/packages/renderer/src/lib/extensions/ExtensionDetailsReadme.spec.ts
@@ -59,7 +59,7 @@ test('Expect to have readme with content', async () => {
   // expect Markdown
   const markdownContent = screen.getByRole('region', { name: 'markdown-content' });
   expect(markdownContent).toBeInTheDocument();
-  expect(markdownContent).toContainHTML('<h1 id="my-readme">my README</h1>');
+  await vi.waitFor(() => expect(markdownContent).toContainHTML('<h1 id="my-readme">my README</h1>'));
 });
 
 test('Expect empty screen if no content', async () => {


### PR DESCRIPTION
### What does this PR do?

Fixes flaky test

```
 ❯  renderer  src/lib/extensions/ExtensionDetailsReadme.spec.ts (3 tests | 1 failed) 169ms
   ✓ Expect to have readme with URI 123ms
   × Expect to have readme with content 35ms (retry x3)
   ✓ Expect empty screen if no content 11ms

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

 FAIL   renderer  src/lib/extensions/ExtensionDetailsReadme.spec.ts > Expect to have readme with content
 FAIL   renderer  src/lib/extensions/ExtensionDetailsReadme.spec.ts > Expect to have readme with content
 FAIL   renderer  src/lib/extensions/ExtensionDetailsReadme.spec.ts > Expect to have readme with content
Error: expect(element).toContainHTML()
Expected:
  <h1 id="my-readme">my README</h1>
Received:
  <section
  aria-label="markdown-content"
  class="markdown svelte-ljga2w"
>
  <h1>
    my README
  </h1>
  <!---->
</section>
 ❯ src/lib/extensions/ExtensionDetailsReadme.spec.ts:62:27
     60|   const markdownContent = screen.getByRole('region', { name: 'markdown-content' });
     61|   expect(markdownContent).toBeInTheDocument();
     62|   expect(markdownContent).toContainHTML('<h1 id="my-readme">my README</h1>');
       |                           ^
     63| });
     64|
``` 

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Related to https://github.com/podman-desktop/podman-desktop/actions/runs/24104538210/job/70324302489?pr=16964

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
