### PR TITLE
fix(compose): show compose updates on Resources page 

### DIFF
--- a/extensions/compose/src/extension.spec.ts
+++ b/extensions/compose/src/extension.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 import * as fs from 'node:fs';
 
-import type { CliTool, Logger } from '@podman-desktop/api';
+import type { CliTool, Logger, Provider } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -49,6 +49,10 @@ beforeEach(() => {
     get: vi.fn(),
     has: vi.fn(),
   });
+  vi.mocked(extensionApi.provider.createProvider).mockReturnValue({
+    registerUpdate: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+    updateVersion: vi.fn(),
+  } as unknown as Provider);
 });
 
 afterEach(() => {

--- a/extensions/compose/src/extension.spec.ts
+++ b/extensions/compose/src/extension.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 import * as fs from 'node:fs';
 
-import type { CliTool, Logger, Provider } from '@podman-desktop/api';
+import type { CliTool, Logger, Provider, ProviderUpdate } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -478,5 +478,117 @@ describe('registerCLITool', () => {
     vi.mocked(extensionApi.window.showErrorMessage).mockResolvedValue(undefined);
     await downloadCommandHandler();
     expect(extensionApi.window.showErrorMessage).toHaveBeenCalledOnce();
+  });
+});
+
+describe('provider registerUpdate (Resources page)', () => {
+  let registerUpdateSpy: ReturnType<typeof vi.fn>;
+  let updateVersionSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    registerUpdateSpy = vi.fn().mockReturnValue({ dispose: vi.fn() });
+    updateVersionSpy = vi.fn();
+    vi.mocked(extensionApi.provider.createProvider).mockReturnValue({
+      registerUpdate: registerUpdateSpy,
+      updateVersion: updateVersionSpy,
+    } as unknown as Provider);
+  });
+
+  function mockExtensionInstalledCompose(): void {
+    vi.mocked(Detect.prototype.checkSystemWideDockerCompose).mockResolvedValue(true);
+    vi.mocked(Detect.prototype.getDockerComposeBinaryInfo).mockResolvedValue({
+      version: 'v2.0.0',
+      path: 'system-wide-path',
+      updatable: true,
+    });
+    vi.spyOn(cliRun, 'getSystemBinaryPath').mockReturnValue('system-wide-path');
+  }
+
+  function mockCliToolWithVersion(
+    resolveRegisterUpdate: (listener: extensionApi.CliToolSelectUpdate) => void,
+    options: { version?: string },
+  ): CliTool {
+    return {
+      registerUpdate: (listener: extensionApi.CliToolSelectUpdate | extensionApi.CliToolUpdate) => {
+        if ('selectVersion' in listener) {
+          resolveRegisterUpdate(listener);
+        }
+        return { dispose: vi.fn() };
+      },
+      registerInstaller: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+      updateVersion: vi.fn(),
+      dispose: vi.fn(),
+      onDidUpdateVersion: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+      get version(): string | undefined {
+        return options.version;
+      },
+    } as unknown as CliTool;
+  }
+
+  test('registers provider update when a newer compose version is available', async () => {
+    mockExtensionInstalledCompose();
+    vi.mocked(ComposeDownload.prototype.getLatestVersionAsset).mockResolvedValue({
+      tag: 'v2.5.0',
+    } as unknown as ComposeGithubReleaseArtifactMetadata);
+
+    const deferredCliUpdate: Promise<extensionApi.CliToolSelectUpdate> = new Promise(resolve => {
+      vi.mocked(extensionApi.cli.createCliTool).mockImplementation(opts =>
+        mockCliToolWithVersion(resolve, opts as { version?: string }),
+      );
+    });
+
+    await activate(extensionContextMock);
+    await deferredCliUpdate;
+
+    expect(registerUpdateSpy).toHaveBeenCalledOnce();
+    expect(registerUpdateSpy.mock.calls[0][0]).toEqual(expect.objectContaining({ version: '2.5.0' }));
+  });
+
+  test('does not register provider update when compose is already the latest version', async () => {
+    vi.mocked(Detect.prototype.checkSystemWideDockerCompose).mockResolvedValue(true);
+    vi.mocked(Detect.prototype.getDockerComposeBinaryInfo).mockResolvedValue({
+      version: 'v2.5.0',
+      path: 'system-wide-path',
+      updatable: true,
+    });
+    vi.spyOn(cliRun, 'getSystemBinaryPath').mockReturnValue('system-wide-path');
+    vi.mocked(ComposeDownload.prototype.getLatestVersionAsset).mockResolvedValue({
+      tag: 'v2.5.0',
+    } as unknown as ComposeGithubReleaseArtifactMetadata);
+
+    const deferredCliUpdate: Promise<extensionApi.CliToolSelectUpdate> = new Promise(resolve => {
+      vi.mocked(extensionApi.cli.createCliTool).mockImplementation(opts =>
+        mockCliToolWithVersion(resolve, opts as { version?: string }),
+      );
+    });
+
+    await activate(extensionContextMock);
+    await deferredCliUpdate;
+
+    expect(registerUpdateSpy).not.toHaveBeenCalled();
+  });
+
+  test('provider update callback downloads and installs compose', async () => {
+    mockExtensionInstalledCompose();
+    vi.mocked(ComposeDownload.prototype.getLatestVersionAsset).mockResolvedValue({
+      tag: 'v2.5.0',
+    } as unknown as ComposeGithubReleaseArtifactMetadata);
+    vi.mocked(Detect.prototype.getStoragePath).mockResolvedValue('storage-path');
+
+    const deferredCliUpdate: Promise<extensionApi.CliToolSelectUpdate> = new Promise(resolve => {
+      vi.mocked(extensionApi.cli.createCliTool).mockImplementation(opts =>
+        mockCliToolWithVersion(resolve, opts as { version?: string }),
+      );
+    });
+
+    await activate(extensionContextMock);
+    await deferredCliUpdate;
+
+    const providerUpdate = registerUpdateSpy.mock.calls[0][0] as ProviderUpdate;
+    await providerUpdate.update({} as unknown as Logger);
+
+    expect(ComposeDownload.prototype.download).toHaveBeenCalled();
+    expect(cliRun.installBinaryToSystem).toHaveBeenCalledWith('storage-path', 'docker-compose');
+    expect(updateVersionSpy).toHaveBeenCalledWith('2.5.0');
   });
 });

--- a/extensions/compose/src/extension.ts
+++ b/extensions/compose/src/extension.ts
@@ -20,6 +20,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 import { Octokit } from '@octokit/rest';
+import type { Logger, ProviderUpdate } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
 
 import { getSystemBinaryPath, installBinaryToSystem } from './cli-run';
@@ -71,6 +72,21 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
 
   const composeGitHubReleases = new ComposeGitHubReleases(octokit);
   const composeDownload = new ComposeDownload(extensionContext, composeGitHubReleases, os);
+
+  // Need to "ADD" a provider so we can actually press the button!
+  // We set this to "unknown" so it does not appear on the dashboard (we only want it in preferences).
+  const providerOptions: extensionApi.ProviderOptions = {
+    name: composeDisplayName,
+    id: composeDisplayName,
+    status: 'unknown',
+    images: {
+      icon: imageLocation,
+    },
+  };
+
+  providerOptions.emptyConnectionMarkdownDescription = composeDescription;
+  const provider = extensionApi.provider.createProvider(providerOptions);
+  extensionContext.subscriptions.push(provider);
 
   // add a command to display the onboarding page
   const openOnboardingCommand = extensionApi.commands.registerCommand('compose.openComposeOnboarding', async () => {
@@ -135,7 +151,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
 
         // register the cli tool if necessary
         if (!composeCliTool) {
-          await registerCLITool(composeDownload, detect, extensionContext);
+          await registerCLITool(composeDownload, detect, extensionContext, provider);
         }
       } catch (error) {
         await extensionApi.window.showErrorMessage(`Unable to download docker-compose binary: ${error}`);
@@ -217,24 +233,9 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
     onboardingInstallSystemWideCommand,
   );
 
-  // Need to "ADD" a provider so we can actually press the button!
-  // We set this to "unknown" so it does not appear on the dashboard (we only want it in preferences).
-  const providerOptions: extensionApi.ProviderOptions = {
-    name: composeDisplayName,
-    id: composeDisplayName,
-    status: 'unknown',
-    images: {
-      icon: imageLocation,
-    },
-  };
-
-  providerOptions.emptyConnectionMarkdownDescription = composeDescription;
-  const provider = extensionApi.provider.createProvider(providerOptions);
-  extensionContext.subscriptions.push(provider);
-
   // Push the CLI tool as well (but it will do it postActivation so it does not block the activate() function)
   // Post activation
-  registerCLITool(composeDownload, detect, extensionContext).catch((error: unknown) => {
+  registerCLITool(composeDownload, detect, extensionContext, provider).catch((error: unknown) => {
     console.error('Error activating extension', error);
   });
 }
@@ -244,6 +245,7 @@ async function registerCLITool(
   composeDownload: ComposeDownload,
   detect: Detect,
   context: extensionApi.ExtensionContext,
+  provider: extensionApi.Provider,
 ): Promise<void> {
   // build executable name for current platform
   const executable = os.isWindows() ? composeCliName + '.exe' : composeCliName;
@@ -311,6 +313,9 @@ async function registerCLITool(
 
   const latestVersion = latestVersionAsset ? removeVersionPrefix(latestVersionAsset.tag) : undefined;
 
+  let composeProviderUpdateDisposable: extensionApi.Disposable | undefined;
+  let composeProviderUpdate: ProviderUpdate | undefined;
+
   const update = {
     version: latestVersion !== composeCliTool.version ? latestVersion : undefined,
     selectVersion: async (): Promise<string> => {
@@ -345,12 +350,14 @@ async function registerCLITool(
       // get the binary in the extension folder
       const storagePath = await detect.getStoragePath();
       binaryPath = await installBinaryToSystem(storagePath, composeCliName);
+      const installedVersion = releaseVersionToUpdateTo;
       composeCliTool?.updateVersion({
-        version: releaseVersionToUpdateTo,
+        version: installedVersion,
         path: binaryPath,
         installationSource: 'extension',
       });
-      binaryVersion = releaseVersionToUpdateTo;
+      binaryVersion = installedVersion;
+      provider.updateVersion(installedVersion);
       releaseVersionToUpdateTo = undefined;
       releaseToUpdateTo = undefined;
     },
@@ -364,8 +371,14 @@ async function registerCLITool(
     composeCliTool.onDidUpdateVersion((version: string) => {
       if (version === latestVersion) {
         delete update.version;
+        composeProviderUpdateDisposable?.dispose();
       } else {
         update.version = latestVersion;
+        if (composeProviderUpdate) {
+          composeProviderUpdate.version = latestVersion ?? composeProviderUpdate.version;
+          composeProviderUpdateDisposable?.dispose();
+          composeProviderUpdateDisposable = provider.registerUpdate(composeProviderUpdate);
+        }
       }
     }),
   );
@@ -424,6 +437,7 @@ async function registerCLITool(
       binaryVersion = undefined;
       binaryPath = undefined;
       extensionApi.context.setValue('compose.isComposeInstalledSystemWide', false);
+      composeProviderUpdateDisposable?.dispose();
     },
   });
 
@@ -433,6 +447,18 @@ async function registerCLITool(
   }
 
   composeCliToolUpdaterDisposable = composeCliTool.registerUpdate(update);
+
+  if (update.version) {
+    composeProviderUpdate = {
+      version: update.version,
+      update: async (_logger: Logger): Promise<void> => {
+        releaseToUpdateTo = undefined;
+        releaseVersionToUpdateTo = undefined;
+        await update.doUpdate();
+      },
+    };
+    composeProviderUpdateDisposable = provider.registerUpdate(composeProviderUpdate);
+  }
 }
 
 async function deleteFile(filePath: string): Promise<void> {


### PR DESCRIPTION
### What does this PR do?

Registers `provider.registerUpdate` in the Compose extension when a CLI update is available, using the same approach as the Kind extension. The **Resources** page reads provider `updateInfo` for the **Update to …** button; Compose previously only registered a CLI updater, so the button appeared on **CLI Tools** but not on **Resources**.

The provider is created before onboarding commands so the onboarding download flow can pass `provider` into `registerCLITool`.

### Screenshot / video of UI

<img width="1162" height="856" alt="Screenshot 2026-04-08 at 18 29 11" src="https://github.com/user-attachments/assets/aa3a3ea3-6183-4a74-a0f6-47b64e527ac3" />


### What issues does this PR fix or reference?

Related to https://github.com/podman-desktop/podman-desktop/issues/13640 (Compose; kubectl is handled separately).

### How to test this PR?

- Start Podman Desktop on this branch (`pnpm watch`)
- Downgrade compose from CLI tools settings page of Podman Desktop
- In Settings > Resources: see the update button for Compose (see screenshot above)
- Do the update, and validate the new version is displayed


- [x] Extension unit tests (`createProvider` mock includes `registerUpdate` / `updateVersion`)

Developed with assistance from Cursor.