### PR TITLE
fix(kubectl-cli): show kubectl updates on Resources page

### DIFF
--- a/extensions/kubectl-cli/src/extension.spec.ts
+++ b/extensions/kubectl-cli/src/extension.spec.ts
@@ -20,7 +20,7 @@ import * as fs from 'node:fs';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 
-import type { CliToolSelectUpdate, Configuration, Logger, Provider } from '@podman-desktop/api';
+import type { CliToolSelectUpdate, Configuration, Logger, Provider, ProviderUpdate } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -712,5 +712,137 @@ describe('postActivate', () => {
       [path.join(extensionContext.storagePath, 'bin', 'kubectl')],
       { isAdmin: true },
     );
+  });
+
+  describe('provider registerUpdate (Resources page)', () => {
+    let registerUpdateSpy: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      registerUpdateSpy = vi.fn().mockReturnValue({ dispose: vi.fn() });
+      vi.mocked(extensionApi.provider.createProvider).mockReturnValue({
+        registerUpdate: registerUpdateSpy,
+        updateVersion: vi.fn(),
+      } as unknown as Provider);
+    });
+
+    function mockExtensionInstalledKubectl(): void {
+      vi.spyOn(cliRun, 'getSystemBinaryPath').mockReturnValue('system-path');
+      vi.mocked(extensionApi.process.exec).mockImplementation(
+        (_command: string, _args?: string[], _options?: extensionApi.RunOptions) =>
+          new Promise<extensionApi.RunResult>(resolve => {
+            if (_args?.[0] === 'version') {
+              resolve({
+                stderr: '',
+                stdout: JSON.stringify(jsonStdout),
+                command: 'kubectl version --client=true -o=json',
+              });
+              return;
+            }
+            resolve({
+              stderr: '',
+              stdout: 'system-path',
+              command: 'which kubectl',
+            });
+          }),
+      );
+    }
+
+    /** Real CliTool exposes `version`; the extension compares it to the latest release tag. */
+    function mockCliToolWithVersion(
+      resolveRegisterUpdate: (listener: CliToolSelectUpdate) => void,
+      options: { version?: string },
+    ): extensionApi.CliTool {
+      return {
+        registerUpdate: (listener: CliToolSelectUpdate) => {
+          resolveRegisterUpdate(listener);
+          return {
+            dispose: vi.fn(),
+          };
+        },
+        registerInstaller: vi.fn(),
+        updateVersion: vi.fn(),
+        get version(): string | undefined {
+          return options.version;
+        },
+      } as unknown as extensionApi.CliTool;
+    }
+
+    test('registers provider update when a newer kubectl version is available', async () => {
+      mockExtensionInstalledKubectl();
+      const deferredCliUpdate: Promise<CliToolSelectUpdate> = new Promise<CliToolSelectUpdate>(resolve => {
+        vi.mocked(extensionApi.cli.createCliTool).mockImplementation(opts =>
+          mockCliToolWithVersion(resolve, opts as { version?: string }),
+        );
+      });
+
+      await KubectlExtension.activate(extensionContext);
+      await deferredCliUpdate;
+
+      expect(registerUpdateSpy).toHaveBeenCalledOnce();
+      expect(registerUpdateSpy.mock.calls[0][0]).toEqual(expect.objectContaining({ version: '1.30.3' }));
+    });
+
+    test('does not register provider update when kubectl is already the latest version', async () => {
+      vi.mocked(KubectlGitHubReleases.prototype.grabLatestsReleasesMetadata).mockResolvedValue([
+        {
+          label: 'Kubernetes v1.28.3',
+          tag: 'v1.28.3',
+          id: 165829199,
+        },
+      ]);
+      vi.spyOn(cliRun, 'getSystemBinaryPath').mockReturnValue('system-path');
+      vi.mocked(extensionApi.process.exec).mockImplementation(
+        (_command: string, _args?: string[], _options?: extensionApi.RunOptions) =>
+          new Promise<extensionApi.RunResult>(resolve => {
+            if (_args?.[0] === 'version') {
+              resolve({
+                stderr: '',
+                stdout: JSON.stringify(jsonStdout),
+                command: 'kubectl version --client=true -o=json',
+              });
+              return;
+            }
+            resolve({
+              stderr: '',
+              stdout: 'system-path',
+              command: 'which kubectl',
+            });
+          }),
+      );
+      const deferredCliUpdate: Promise<CliToolSelectUpdate> = new Promise<CliToolSelectUpdate>(resolve => {
+        vi.mocked(extensionApi.cli.createCliTool).mockImplementation(opts =>
+          mockCliToolWithVersion(resolve, opts as { version?: string }),
+        );
+      });
+
+      await KubectlExtension.activate(extensionContext);
+      await deferredCliUpdate;
+
+      expect(registerUpdateSpy).not.toHaveBeenCalled();
+    });
+
+    test('provider update callback downloads and installs kubectl', async () => {
+      mockExtensionInstalledKubectl();
+      const deferredCliUpdate: Promise<CliToolSelectUpdate> = new Promise<CliToolSelectUpdate>(resolve => {
+        vi.mocked(extensionApi.cli.createCliTool).mockImplementation(opts =>
+          mockCliToolWithVersion(resolve, opts as { version?: string }),
+        );
+      });
+
+      await KubectlExtension.activate(extensionContext);
+      await deferredCliUpdate;
+
+      const providerUpdate = registerUpdateSpy.mock.calls[0][0] as ProviderUpdate;
+      await providerUpdate.update({} as unknown as Logger);
+
+      expect(KubectlGitHubReleases.prototype.downloadReleaseAsset).toHaveBeenCalledWith(
+        'dummy download url',
+        expect.anything(),
+      );
+      expect(cliRun.installBinaryToSystem).toHaveBeenCalledWith(expect.anything(), 'kubectl');
+      expect(vi.mocked(cliRun.installBinaryToSystem).mock.calls[0][0]).toContain(
+        path.resolve(extensionContext.storagePath, 'bin', 'kubectl'),
+      );
+    });
   });
 });

--- a/extensions/kubectl-cli/src/extension.spec.ts
+++ b/extensions/kubectl-cli/src/extension.spec.ts
@@ -20,7 +20,7 @@ import * as fs from 'node:fs';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 
-import type { CliToolSelectUpdate, Configuration, Logger } from '@podman-desktop/api';
+import type { CliToolSelectUpdate, Configuration, Logger, Provider } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -44,6 +44,10 @@ beforeEach(() => {
     update: vi.fn(),
   } as unknown as Configuration);
   vi.mocked(extensionApi.process.exec).mockClear();
+  vi.mocked(extensionApi.provider.createProvider).mockReturnValue({
+    registerUpdate: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+    updateVersion: vi.fn(),
+  } as unknown as Provider);
 
   vi.mocked(KubectlGitHubReleases.prototype.grabLatestsReleasesMetadata).mockResolvedValue([
     {

--- a/extensions/kubectl-cli/src/extension.ts
+++ b/extensions/kubectl-cli/src/extension.ts
@@ -20,7 +20,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 import { Octokit } from '@octokit/rest';
-import type { CliTool } from '@podman-desktop/api';
+import type { CliTool, Logger, ProviderUpdate } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
 
 import { getSystemBinaryPath, installBinaryToSystem } from './cli-run';
@@ -239,7 +239,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
 
   // Push the CLI tool as well (but it will do it postActivation so it does not block the activate() function)
   // Post activation
-  postActivate(extensionContext, kubectlDownload).catch((error: unknown) => {
+  postActivate(extensionContext, kubectlDownload, provider).catch((error: unknown) => {
     console.error('Error activating extension', error);
   });
 }
@@ -309,6 +309,7 @@ export async function findKubeCtl(extensionContext: extensionApi.ExtensionContex
 async function postActivate(
   extensionContext: extensionApi.ExtensionContext,
   kubectlDownload: KubectlDownload,
+  provider: extensionApi.Provider,
 ): Promise<void> {
   await findKubeCtl(extensionContext);
 
@@ -352,6 +353,9 @@ async function postActivate(
     console.error('Error when downloading kubectl CLI latest release information.', String(error));
   }
 
+  let kubectlProviderUpdateDisposable: extensionApi.Disposable | undefined;
+  let kubectlProviderUpdate: ProviderUpdate | undefined;
+
   const update = {
     version: latestAsset?.tag.slice(1) !== kubectlCliTool.version ? latestAsset?.tag.slice(1) : undefined,
     selectVersion: async (): Promise<string> => {
@@ -377,10 +381,17 @@ async function postActivate(
         installationSource: 'extension',
       });
       vpState.version = releaseVersionToUpdateTo;
+      provider.updateVersion(releaseVersionToUpdateTo);
       if (releaseToUpdateTo === latestAsset) {
         delete update.version;
+        kubectlProviderUpdateDisposable?.dispose();
       } else {
         update.version = latestAsset?.tag.slice(1);
+        if (kubectlProviderUpdate) {
+          kubectlProviderUpdate.version = latestAsset?.tag.slice(1) ?? kubectlProviderUpdate.version;
+          kubectlProviderUpdateDisposable?.dispose();
+          kubectlProviderUpdateDisposable = provider.registerUpdate(kubectlProviderUpdate);
+        }
       }
       releaseVersionToUpdateTo = undefined;
       releaseToUpdateTo = undefined;
@@ -437,6 +448,7 @@ async function postActivate(
 
       // update the version to undefined
       vpState.version = undefined;
+      kubectlProviderUpdateDisposable?.dispose();
     },
   });
 
@@ -450,6 +462,18 @@ async function postActivate(
   kubectlCliToolUpdaterDisposable = kubectlCliTool.registerUpdate(update);
 
   extensionContext.subscriptions.push(kubectlCliToolUpdaterDisposable);
+
+  if (update.version) {
+    kubectlProviderUpdate = {
+      version: update.version,
+      update: async (_logger: Logger): Promise<void> => {
+        releaseToUpdateTo = undefined;
+        releaseVersionToUpdateTo = undefined;
+        await update.doUpdate();
+      },
+    };
+    kubectlProviderUpdateDisposable = provider.registerUpdate(kubectlProviderUpdate);
+  }
 }
 
 function extractVersion(stdout: string): string {


### PR DESCRIPTION
### What does this PR do?

Register provider.update when a CLI update is available so the Resources page matches CLI Tools (same pattern as Kind).

### Screenshot / video of UI

<img width="1162" height="856" alt="Screenshot 2026-04-08 at 18 05 47" src="https://github.com/user-attachments/assets/04d83171-ad71-47bf-9c40-1cc30bbfdbf6" />
<img width="1162" height="856" alt="Screenshot 2026-04-08 at 18 11 14" src="https://github.com/user-attachments/assets/1f6b3a3e-8181-44c1-a51c-04751ff924b9" />


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Partial fix of https://github.com/podman-desktop/podman-desktop/issues/13640

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

Choice 1:
- Install an older version of kubectl: instructions at https://kubernetes.io/docs/tasks/tools/

Choice 2:
- Downgrade kubectl from CLI tools settings page of Podman Desktop

Then:
- Start Podman Desktop on this branch (`pnpm watch`)
- In Settings > Resources: see the update button for Kubectl (see screenshot above)
- Do the update, and validate the new version is displayed

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
