### PR TITLE
feat(renderer): use SearchTermParser in extension catalog

### DIFF
--- a/packages/renderer/src/lib/extensions/ExtensionList.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionList.svelte
@@ -5,6 +5,7 @@ import { Button, FilteredEmptyScreen, NavPage } from '@podman-desktop/ui-svelte'
 import type { ExtensionListScreen } from '/@/lib/extensions/extension-list';
 import InstalledExtensionList from '/@/lib/extensions/InstalledExtensionList.svelte';
 import ExtensionIcon from '/@/lib/images/ExtensionIcon.svelte';
+import { SearchTermParser } from '/@/lib/search/search-term-parser';
 import { type CombinedExtensionInfoUI, combinedInstalledExtensions } from '/@/stores/all-installed-extensions';
 import { catalogExtensionInfos } from '/@/stores/catalog-extensions';
 import { featuredExtensionInfos } from '/@/stores/featuredExtensions';
@@ -67,7 +68,7 @@ function changeScreen(newScreen: 'installed' | 'catalog' | 'development'): void 
     return;
   }
   screen = newScreen;
-  searchTerm = extensionsUtils.filterTerms(searchTerm).join(' ');
+  searchTerm = new SearchTermParser(searchTerm, ExtensionsUtils.CATALOG_FILTERS).terms.join(' ');
 }
 </script>
 

--- a/packages/renderer/src/lib/extensions/extensions-utils.spec.ts
+++ b/packages/renderer/src/lib/extensions/extensions-utils.spec.ts
@@ -20,6 +20,7 @@ import type { CatalogExtension } from '@podman-desktop/core-api/extension-catalo
 import type { FeaturedExtension } from '@podman-desktop/core-api/featured';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
+import { SearchTermParser } from '/@/lib/search/search-term-parser';
 import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
 
 import { ExtensionsUtils } from './extensions-utils';
@@ -535,5 +536,77 @@ describe('filters', () => {
     const filteredInstalledExtensions = extensionsUtils.filterInstalledExtensions(combined, 'bar');
     expect(filteredInstalledExtensions.length).toBe(1);
     expect(filteredInstalledExtensions[0].id).toBe('idAInstalled');
+  });
+
+  describe('quoted values with spaces', () => {
+    const extWithSpacedCategory: CatalogExtension = {
+      id: 'idSpacedCategory',
+      publisherName: 'FooPublisher',
+      shortDescription: 'extension with spaced category',
+      publisherDisplayName: 'Foo Publisher',
+      extensionName: 'spaced-category-extension',
+      displayName: 'Spaced Category Extension',
+      categories: ['Extension Packs', 'Containers'],
+      keywords: ['Vulnerability Scanner', 'security'],
+      unlisted: false,
+      versions: [
+        {
+          version: '1.0.0',
+          preview: false,
+          files: [{ assetType: 'icon', data: 'iconSpaced' }],
+          ociUri: 'linkSpaced',
+          lastUpdated: new Date(),
+        },
+      ],
+    };
+
+    test('filterCatalogExtensions with quoted category containing spaces', () => {
+      const extensions = extensionsUtils.extractCatalogExtensions([extWithSpacedCategory, bFakeExtension], [], []);
+      const filtered = extensionsUtils.filterCatalogExtensions(extensions, 'category:"Extension Packs"');
+      expect(filtered.length).toBe(1);
+      expect(filtered[0].id).toBe('idSpacedCategory');
+    });
+
+    test('filterCatalogExtensions with quoted keyword containing spaces', () => {
+      const extensions = extensionsUtils.extractCatalogExtensions([extWithSpacedCategory, bFakeExtension], [], []);
+      const filtered = extensionsUtils.filterCatalogExtensions(extensions, 'keyword:"Vulnerability Scanner"');
+      expect(filtered.length).toBe(1);
+      expect(filtered[0].id).toBe('idSpacedCategory');
+    });
+
+    test('filterCatalogExtensions with quoted category and additional search term', () => {
+      const extensions = extensionsUtils.extractCatalogExtensions([extWithSpacedCategory, bFakeExtension], [], []);
+      const filtered = extensionsUtils.filterCatalogExtensions(extensions, 'spaced category:"Extension Packs"');
+      expect(filtered.length).toBe(1);
+      expect(filtered[0].id).toBe('idSpacedCategory');
+    });
+
+    test('filterCatalogExtensions with unquoted spaced category does not match', () => {
+      const extensions = extensionsUtils.extractCatalogExtensions([extWithSpacedCategory, bFakeExtension], [], []);
+      const filtered = extensionsUtils.filterCatalogExtensions(extensions, 'category:Extension Packs');
+      expect(filtered.length).toBe(0);
+    });
+
+    test('SearchTermParser separates terms from quoted filters', () => {
+      const parsed = new SearchTermParser('hello category:"Extension Packs" world', ExtensionsUtils.CATALOG_FILTERS);
+      expect(parsed.terms).toEqual(['hello', 'world']);
+      expect(parsed.getFilter('category')).toEqual(['extension packs']);
+    });
+
+    test('SearchTermParser extracts multiple category values', () => {
+      const parsed = new SearchTermParser(
+        'category:"Extension Packs" category:containers',
+        ExtensionsUtils.CATALOG_FILTERS,
+      );
+      expect(parsed.getFilter('category')).toEqual(['extension packs', 'containers']);
+    });
+
+    test('SearchTermParser extracts keyword values', () => {
+      const parsed = new SearchTermParser(
+        'keyword:"Vulnerability Scanner" keyword:security',
+        ExtensionsUtils.CATALOG_FILTERS,
+      );
+      expect(parsed.getFilter('keyword')).toEqual(['vulnerability scanner', 'security']);
+    });
   });
 });

--- a/packages/renderer/src/lib/extensions/extensions-utils.ts
+++ b/packages/renderer/src/lib/extensions/extensions-utils.ts
@@ -19,6 +19,7 @@
 import type { CatalogExtension } from '@podman-desktop/core-api/extension-catalog';
 import type { FeaturedExtension } from '@podman-desktop/core-api/featured';
 
+import { SearchTermParser } from '/@/lib/search/search-term-parser';
 import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
 
 import type { CatalogExtensionInfoUI } from './catalog-extension-info-ui';
@@ -213,12 +214,16 @@ export class ExtensionsUtils {
     });
   }
 
+  static readonly CATALOG_FILTERS = ['category', 'keyword', 'is', 'not'] as const;
+
   filterCatalogExtensions(extensions: CatalogExtensionInfoUI[], searchTerm: string): CatalogExtensionInfoUI[] {
-    const lowerCaseSearchTerm = searchTerm.toLowerCase();
-    const terms = this.filterTerms(lowerCaseSearchTerm);
-    const categories = this.filterCategories(lowerCaseSearchTerm);
-    const keywords = this.filterKeywords(lowerCaseSearchTerm);
-    const installed = this.filterBoolean(lowerCaseSearchTerm, 'installed');
+    const parsed = new SearchTermParser(searchTerm, ExtensionsUtils.CATALOG_FILTERS);
+    const terms = parsed.terms;
+    const categories = parsed.getFilter('category');
+    const keywords = parsed.getFilter('keyword');
+    const isValues = parsed.getFilter('is');
+    const notValues = parsed.getFilter('not');
+    const installed = isValues.includes('installed') ? true : notValues.includes('installed') ? false : undefined;
     return extensions.filter(extension => {
       return (
         (terms.length === 0 ||
@@ -232,40 +237,5 @@ export class ExtensionsUtils {
         (installed === undefined || installed === extension.isInstalled)
       );
     });
-  }
-
-  filterTerms(searchTerm: string): string[] {
-    return searchTerm
-      .split(' ')
-      .filter(
-        part =>
-          !part.startsWith('category:') &&
-          !part.startsWith('keyword:') &&
-          !part.startsWith('is:') &&
-          !part.startsWith('not:'),
-      );
-  }
-
-  filterCategories(searchTerm: string): string[] {
-    return searchTerm
-      .split(' ')
-      .filter(part => part.startsWith('category:'))
-      .map(part => part.replace('category:', ''));
-  }
-
-  filterKeywords(searchTerm: string): string[] {
-    return searchTerm
-      .split(' ')
-      .filter(part => part.startsWith('keyword:'))
-      .map(part => part.replace('keyword:', ''));
-  }
-
-  // filter for boolean values like is:installed or not:installed, and only get the first value in consideration
-  filterBoolean(searchTerm: string, key: string): boolean | undefined {
-    const filter = searchTerm.split(' ').find(part => part === `is:${key}` || part === `not:${key}`);
-    if (!filter) {
-      return undefined;
-    }
-    return filter === `is:${key}`;
   }
 }


### PR DESCRIPTION
### What does this PR do?

This PR uses the new SearchTermParser for filtering search inputs of extension canalog.

This enables searching for categories and keywords containing spaces using double-quoted values.

### Screenshot / video of UI

<img width="1162" height="856" alt="Screenshot 2026-04-13 at 16 21 47" src="https://github.com/user-attachments/assets/8bb7abf1-8675-4c55-b90d-644ec6c85e0d" />

<img width="1162" height="856" alt="Screenshot 2026-04-13 at 16 22 02" src="https://github.com/user-attachments/assets/f8a63c66-4ade-4a5b-9677-7c6d8cacd752" />

<img width="1162" height="856" alt="Screenshot 2026-04-13 at 16 22 38" src="https://github.com/user-attachments/assets/a1c06ef3-c57b-4dcb-9d99-995eb4eb8c1c" />

<img width="1162" height="856" alt="Screenshot 2026-04-13 at 16 22 53" src="https://github.com/user-attachments/assets/5814471f-40b6-4498-973f-4e146483786e" />

### What issues does this PR fix or reference?

Fixes #16971

### How to test this PR?

In the **Extensions** page, switch to the **Catalog** tab and try the following searches:

| Search input | Expected result |
|---|---|
| `category:"Extension Packs"` | Shows only extensions in the "Extension Packs" category |
| `red category:"Extension Packs"` | Shows the Red Hat extension pack only |
| `kube category:"Extension Packs"` | Shows the Kubernetes extension pack only |
| `category:containers` | Single-word values still work without quotes |

Also verify that **switching tabs** (Installed / Catalog / Local Extensions) while a filter is active strips the filter prefixes and keeps only the plain-text search terms.


- [x] Tests are covering the bug fix or the new feature

AI-assisted: cursor

Made with [Cursor](https://cursor.com)