### PR TITLE
fix(tests): use SetupServer interface instead of SetupServerApi class

### DIFF
--- a/extensions/podman/packages/extension/scripts/podman-download.spec.ts
+++ b/extensions/podman/packages/extension/scripts/podman-download.spec.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { setupServer, SetupServerApi } from 'msw/node';
+import { setupServer, type SetupServer } from 'msw/node';
 import { beforeEach, afterEach, describe, expect, test, vi } from 'vitest';
 import { DownloadAndCheck, Podman5DownloadMachineOS, PodmanDownload, ShaCheck } from './podman-download';
 import * as podman5JSON from '../src/podman5.json';
@@ -79,7 +79,7 @@ class TestPodmanDownload extends PodmanDownload {
   }
 }
 
-let server: SetupServerApi | undefined = undefined;
+let server: SetupServer | undefined = undefined;
 
 afterEach(() => {
   server?.close();

--- a/extensions/podman/packages/extension/src/utils/warnings.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/warnings.spec.ts
@@ -17,13 +17,13 @@
  ***********************************************************************/
 
 import { delay, http, HttpResponse } from 'msw';
-import type { SetupServerApi } from 'msw/node';
+import type { SetupServer } from 'msw/node';
 import { setupServer } from 'msw/node';
 import { afterEach, expect, test } from 'vitest';
 
 import { isDisguisedPodmanPath } from './warnings';
 
-let server: SetupServerApi | undefined = undefined;
+let server: SetupServer | undefined = undefined;
 
 afterEach(() => {
   server?.close();

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -37,7 +37,7 @@ import type { ContainerCreateOptions as PodmanContainerCreateOptions } from '@po
 import Dockerode from 'dockerode';
 import moment from 'moment';
 import { http, HttpResponse } from 'msw';
-import { setupServer, type SetupServerApi } from 'msw/node';
+import { type SetupServer, setupServer } from 'msw/node';
 import type { Headers, PackOptions } from 'tar-fs';
 import * as tarstream from 'tar-stream';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
@@ -323,7 +323,7 @@ const fakeContainerInspectInfoWithVolume = {
   },
 };
 
-let server: SetupServerApi | undefined = undefined;
+let server: SetupServer | undefined = undefined;
 
 class TestContainerProviderRegistry extends ContainerProviderRegistry {
   public override extractContainerEnvironment(container: ContainerInspectInfo): { [key: string]: string } {

--- a/packages/main/src/plugin/docker-extension/docker-desktop-installation.spec.ts
+++ b/packages/main/src/plugin/docker-extension/docker-desktop-installation.spec.ts
@@ -25,7 +25,7 @@ import type Dockerode from 'dockerode';
 import type { IpcMainEvent } from 'electron';
 import type { Method } from 'got';
 import { http, HttpResponse } from 'msw';
-import { setupServer, type SetupServerApi } from 'msw/node';
+import { type SetupServer, setupServer } from 'msw/node';
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { ContainerProviderRegistry } from '/@/plugin/container-registry.js';
@@ -66,7 +66,7 @@ const apiSender: ApiSenderType = {
   receive: vi.fn(),
 };
 
-let server: SetupServerApi | undefined = undefined;
+let server: SetupServer | undefined = undefined;
 
 class TestDockerDesktopInstallation extends DockerDesktopInstallation {
   // transform the method name to a got method

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.spec.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.spec.ts
@@ -29,14 +29,14 @@ import type DockerModem from 'docker-modem';
 import Dockerode from 'dockerode';
 import type { DefaultBodyType, HttpResponseResolver, PathParams, ResponseResolverReturnType } from 'msw';
 import { http, HttpResponse } from 'msw';
-import { setupServer, type SetupServerApi } from 'msw/node';
+import { type SetupServer, setupServer } from 'msw/node';
 import { afterAll, afterEach, assert, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { DockerodeInternals, LibPod } from '/@/plugin/dockerode/libpod-dockerode.js';
 import { LibpodDockerode } from '/@/plugin/dockerode/libpod-dockerode.js';
 import podmanInfo from '/@tests/resources/data/plugin/podman-info.json' with { type: 'json' };
 
-let server: SetupServerApi | undefined = undefined;
+let server: SetupServer | undefined = undefined;
 
 beforeAll(() => {
   const libpod = new LibpodDockerode();

--- a/packages/main/src/plugin/extension/catalog/extensions-catalog.spec.ts
+++ b/packages/main/src/plugin/extension/catalog/extensions-catalog.spec.ts
@@ -19,7 +19,7 @@
 import type { Configuration, ProxySettings } from '@podman-desktop/api';
 import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { delay, http, HttpResponse } from 'msw';
-import { setupServer, type SetupServerApi } from 'msw/node';
+import { type SetupServer, setupServer } from 'msw/node';
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
 import type { Certificates } from '/@/plugin/certificates.js';
@@ -46,7 +46,7 @@ const extensionApiVersion: ExtensionApiVersion = {
   getApiVersion: vi.fn(),
 } as ExtensionApiVersion;
 
-let server: SetupServerApi | undefined = undefined;
+let server: SetupServer | undefined = undefined;
 
 // unlisted field is not present (assuming it should be listed then)
 const fakePublishedExtension1 = {

--- a/packages/main/src/plugin/image-registry.spec.ts
+++ b/packages/main/src/plugin/image-registry.spec.ts
@@ -27,7 +27,7 @@ import type { Registry } from '@podman-desktop/api';
 import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import * as fzstd from 'fzstd';
 import { http, HttpResponse } from 'msw';
-import { setupServer, type SetupServerApi } from 'msw/node';
+import { type SetupServer, setupServer } from 'msw/node';
 import * as nodeTar from 'tar';
 import { afterEach, beforeEach, describe, expect, expectTypeOf, test, vi } from 'vitest';
 
@@ -49,7 +49,7 @@ import type { EventType, Telemetry } from './telemetry/telemetry.js';
 import type { Disposable } from './types/disposable.js';
 
 let imageRegistry: ImageRegistry;
-let server: SetupServerApi | undefined = undefined;
+let server: SetupServer | undefined = undefined;
 
 const pxoxyIsEnabledMock = vi.fn();
 const proxyGetProxyMock = vi.fn();


### PR DESCRIPTION
### What does this PR do?

MSW v2.13.0 added `network` and `#private` properties to the `SetupServerApi` class, making it incompatible with the return type of `setupServer()` which is the `SetupServer` interface.

Replace `SetupServerApi` with `SetupServer` in all test files so the Dependabot PR for msw >=2.13.0 can land without typecheck failures.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/16960

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

Try to update msw (you can cherry-pick https://github.com/podman-desktop/podman-desktop/pull/16997/changes/3481dac28698fe1d0cafc3da963f6d5e0ebf924f) and do a `typecheck` and unit test run (after `pnpm install`).

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
