### PR TITLE
feat(renderer): add SearchTermParser for filtered search inputs 

### DIFF
--- a/packages/renderer/src/lib/search/search-term-parser.spec.ts
+++ b/packages/renderer/src/lib/search/search-term-parser.spec.ts
@@ -1,0 +1,121 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { describe, expect, test } from 'vitest';
+
+import { SearchTermParser } from './search-term-parser';
+
+describe('SearchTermParser', () => {
+  const FILTERS = ['category', 'keyword', 'is', 'not'] as const;
+  type Filter = (typeof FILTERS)[number];
+
+  test.each<{
+    input: string;
+    terms: string[];
+    filters?: Record<string, string[]>;
+  }>([
+    {
+      input: 'foo bar baz',
+      terms: ['foo', 'bar', 'baz'],
+    },
+    {
+      input: '',
+      terms: [],
+    },
+    {
+      input: '   ',
+      terms: [],
+    },
+    {
+      input: 'podman',
+      terms: ['podman'],
+    },
+    {
+      input: '"multi word search"',
+      terms: ['multi word search'],
+    },
+    {
+      input: 'category:containers keyword:docker',
+      terms: [],
+      filters: { category: ['containers'], keyword: ['docker'] },
+    },
+    {
+      input: 'category:"Extension Packs"',
+      terms: [],
+      filters: { category: ['extension packs'] },
+    },
+    {
+      input: 'category:"Extension Packs" keyword:"Vulnerability Scanner"',
+      terms: [],
+      filters: { category: ['extension packs'], keyword: ['vulnerability scanner'] },
+    },
+    {
+      input: 'foo category:"Extension Packs" bar keyword:simple',
+      terms: ['foo', 'bar'],
+      filters: { category: ['extension packs'], keyword: ['simple'] },
+    },
+    {
+      input: 'category:"Extension Packs" is:installed',
+      terms: [],
+      filters: { category: ['extension packs'], is: ['installed'] },
+    },
+    {
+      input: 'category:""',
+      terms: [],
+      filters: { category: [''] },
+    },
+    {
+      input: 'unknown:value category:test',
+      terms: ['unknown:value'],
+      filters: { category: ['test'] },
+    },
+    {
+      input: 'category:a category:b',
+      terms: [],
+      filters: { category: ['a', 'b'] },
+    },
+    {
+      input: 'FOO category:Containers keyword:"My Key"',
+      terms: ['foo'],
+      filters: { category: ['containers'], keyword: ['my key'] },
+    },
+    {
+      input: `category:'Extension Packs'`,
+      terms: [],
+      filters: { category: ['extension packs'] },
+    },
+    {
+      input: `foo category:'My Category' bar`,
+      terms: ['foo', 'bar'],
+      filters: { category: ['my category'] },
+    },
+  ])('parses "$input"', ({ input, terms, filters = {} }) => {
+    const parsed = new SearchTermParser(input, FILTERS);
+    expect(parsed.terms).toEqual(terms);
+    for (const [name, values] of Object.entries(filters)) {
+      expect(parsed.getFilter(name as Filter)).toEqual(values);
+    }
+  });
+
+  test('initializes all allowed filters even when unused', () => {
+    const parsed = new SearchTermParser('foo', FILTERS);
+    for (const filter of FILTERS) {
+      expect(parsed.getFilter(filter)).toEqual([]);
+    }
+  });
+});

--- a/packages/renderer/src/lib/search/search-term-parser.ts
+++ b/packages/renderer/src/lib/search/search-term-parser.ts
@@ -1,0 +1,73 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import SearchString from 'search-string';
+
+/**
+ * Parses a search string into plain-text terms and filter values,
+ * respecting quoted values (double or single) via the `search-string` library.
+ *
+ * All terms and filter values are lowercased.
+ *
+ * @example
+ * const parsed = new SearchTermParser('Foo category:"Extension Packs" is:installed', ['category', 'keyword', 'is', 'not']);
+ * parsed.terms              // => ['foo']
+ * parsed.getFilter('category') // => ['extension packs']
+ * parsed.getFilter('is')      // => ['installed']
+ */
+export class SearchTermParser<F extends string> {
+  readonly terms: string[];
+  readonly #filters: ReadonlyMap<F, string[]>;
+
+  constructor(searchTerm: string, allowedFilters: readonly F[]) {
+    const terms: string[] = [];
+    const filters = new Map<F, string[]>();
+    const allowedSet = new Set<string>(allowedFilters);
+    const normalized = searchTerm.toLowerCase();
+
+    for (const filter of allowedFilters) {
+      filters.set(filter, []);
+    }
+
+    const parsed = SearchString.parse(normalized);
+
+    for (const segment of parsed.getTextSegments()) {
+      if (!segment.negated && segment.text.length > 0) {
+        terms.push(segment.text);
+      }
+    }
+
+    for (const condition of parsed.getConditionArray()) {
+      if (condition.negated) continue;
+      const key = condition.keyword as F;
+      const bucket = allowedSet.has(key) ? filters.get(key) : undefined;
+      if (bucket) {
+        bucket.push(condition.value);
+      } else {
+        terms.push(`${condition.keyword}:${condition.value}`);
+      }
+    }
+
+    this.terms = terms;
+    this.#filters = filters;
+  }
+
+  getFilter(name: F): string[] {
+    return this.#filters.get(name) ?? [];
+  }
+}


### PR DESCRIPTION
### What does this PR do?

Introduces a generic `SearchTermParser` class that parses a search string into plain-text terms and typed filter values, respecting double-quoted multi-word values (e.g. `category:"Extension Packs"`).

The class:
- Takes allowed filter prefixes in its constructor (e.g. `category`, `keyword`, `is`, `not`)
- Normalizes input to lowercase
- Exposes `terms: string[]` for plain-text search words
- Provides a type-safe `getFilter(name): string[]` method constrained to the declared filter prefixes via generics (`SearchTermParser<F extends string>`)

This is extracted as a standalone building block so it can be validated independently. The integration into the extension catalog filters is available for review in the draft PR #16993.

### Screenshot / video of UI

N/A — no UI changes, this adds a utility class with tests only.

### What issues does this PR fix or reference?

Part of #16971

### How to test this PR?

```bash
pnpm exec vitest run packages/renderer/src/stores/search-term-parser.spec.ts
```

- [x] Tests are covering the bug fix or the new feature

AI-assisted: cursor

Made with [Cursor](https://cursor.com)