### PR TITLE
feat(ui): redesign LinearProgress component with semantic color tokens and improved accessibility

### DIFF
--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
@@ -422,7 +422,7 @@ let hasInvalidFields = $derived(
               icon={faMinusCircle}
               disabled={buildImageInfo.buildArgs.length === 1 && buildArg.key === '' && buildArg.value === ''}
               aria-label="Delete build argument" />
-            <Button on:click={addBuildArg} icon={faPlusCircle} title="Add build argument" />
+            <Button on:click={addBuildArg} icon={faPlusCircle} title="Add build argument" aria-label="Add build argument" />
           </div>
         {/each}
       </div>

--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -709,11 +709,13 @@ const envDialogOptions: OpenDialogOptions = {
                   <Button
                     type="link"
                     hidden={index === volumeMounts.length - 1}
+                    aria-label="Delete volume mount at index {index}"
                     on:click={(): void => deleteVolumeMount(index)}
                     icon={faMinusCircle} />
                   <Button
                     type="link"
                     hidden={index < volumeMounts.length - 1}
+                    aria-label="Add volume mount after index {index}"
                     on:click={addVolumeMount}
                     icon={faPlusCircle} />
                 </div>
@@ -780,11 +782,13 @@ const envDialogOptions: OpenDialogOptions = {
                   <Button
                     type="link"
                     hidden={index === environmentVariables.length - 1}
+                    aria-label="Delete environment variable at index {index}"
                     on:click={(): void => deleteEnvVariable(index)}
                     icon={faMinusCircle} />
                   <Button
                     type="link"
                     hidden={index < environmentVariables.length - 1}
+                    aria-label="Add environment variable after index {index}"
                     on:click={addEnvVariable}
                     icon={faPlusCircle} />
                 </div>
@@ -957,11 +961,13 @@ const envDialogOptions: OpenDialogOptions = {
                   <Button
                     type="link"
                     hidden={index === securityOpts.length - 1}
+                    aria-label="Delete security option at index {index}"
                     on:click={(): void => deleteSecurityOpt(index)}
                     icon={faMinusCircle} />
                   <Button
                     type="link"
                     hidden={index < securityOpts.length - 1}
+                    aria-label="Add security option after index {index}"
                     on:click={addSecurityOpt}
                     icon={faPlusCircle} />
                 </div>
@@ -1042,11 +1048,13 @@ const envDialogOptions: OpenDialogOptions = {
                   <Button
                     type="link"
                     hidden={index === dnsServers.length - 1}
+                    aria-label="Delete DNS server at index {index}"
                     on:click={(): void => deleteDnsServer(index)}
                     icon={faMinusCircle} />
                   <Button
                     type="link"
                     hidden={index < dnsServers.length - 1}
+                    aria-label="Add DNS server after index {index}"
                     on:click={addDnsServer}
                     icon={faPlusCircle} />
                 </div>
@@ -1065,11 +1073,13 @@ const envDialogOptions: OpenDialogOptions = {
                   <Button
                     type="link"
                     hidden={index === extraHosts.length - 1}
+                    aria-label="Delete extra host at index {index}"
                     on:click={(): void => deleteExtraHost(index)}
                     icon={faMinusCircle} />
                   <Button
                     type="link"
                     hidden={index < extraHosts.length - 1}
+                    aria-label="Add extra host after index {index}"
                     on:click={addExtraHost}
                     icon={faPlusCircle} />
                 </div>

--- a/packages/renderer/src/lib/task-manager/button/TaskManagerBulkDeleteButton.svelte
+++ b/packages/renderer/src/lib/task-manager/button/TaskManagerBulkDeleteButton.svelte
@@ -33,4 +33,4 @@ function onClick(): void {
 }
 </script>
 
-<Button title={title} on:click={onClick} inProgress={bulkDeleteInProgress} icon={faTrash} />
+<Button title={title} aria-label={title} on:click={onClick} inProgress={bulkDeleteInProgress} icon={faTrash} />

--- a/packages/ui/src/lib/progress/LinearProgress.spec.ts
+++ b/packages/ui/src/lib/progress/LinearProgress.spec.ts
@@ -32,7 +32,7 @@ test('should render a progress element', () => {
 test('should use color-registry text color instead of hardcoded Tailwind color', () => {
   render(LinearProgress);
   const progress = screen.getByRole('progressbar');
-  expect(progress).toHaveClass('text-[var(--pd-progressBar-text)]');
+  expect(progress).toHaveClass('text-(--pd-progressBar-text)');
   expect(progress).not.toHaveClass('text-purple-500');
 });
 

--- a/packages/ui/src/lib/progress/LinearProgress.spec.ts
+++ b/packages/ui/src/lib/progress/LinearProgress.spec.ts
@@ -1,0 +1,47 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import LinearProgress from './LinearProgress.svelte';
+
+test('should render a progress element', () => {
+  render(LinearProgress);
+  const progress = screen.getByRole('progressbar');
+  expect(progress).toBeInTheDocument();
+});
+
+test('should use color-registry text color instead of hardcoded Tailwind color', () => {
+  render(LinearProgress);
+  const progress = screen.getByRole('progressbar');
+  expect(progress).toHaveClass('text-[var(--pd-progressBar-text)]');
+  expect(progress).not.toHaveClass('text-purple-500');
+});
+
+test('should have full width and correct base classes', () => {
+  render(LinearProgress);
+  const progress = screen.getByRole('progressbar');
+  expect(progress).toHaveClass('w-full');
+  expect(progress).toHaveClass('appearance-none');
+  expect(progress).toHaveClass('border-none');
+  expect(progress).toHaveClass('h-0.5');
+  expect(progress).toHaveClass('pure-material-progress-linear');
+});

--- a/packages/ui/src/lib/progress/LinearProgress.svelte
+++ b/packages/ui/src/lib/progress/LinearProgress.svelte
@@ -52,5 +52,5 @@
 }
 </style>
 
-<progress class="w-full appearance-none border-none h-0.5 text-purple-500 text-base pure-material-progress-linear"
+<progress class="w-full appearance-none border-none h-0.5 text-[var(--pd-progressBar-text)] text-base pure-material-progress-linear"
 ></progress>

--- a/packages/ui/src/lib/progress/LinearProgress.svelte
+++ b/packages/ui/src/lib/progress/LinearProgress.svelte
@@ -52,5 +52,5 @@
 }
 </style>
 
-<progress class="w-full appearance-none border-none h-0.5 text-[var(--pd-progressBar-text)] text-base pure-material-progress-linear"
+<progress class="w-full appearance-none border-none h-0.5 text-(--pd-progressBar-text) text-base pure-material-progress-linear"
 ></progress>


### PR DESCRIPTION
### What does this PR do?

Replaces the hardcoded `text-purple-500` Tailwind color in `LinearProgress` with a `color-registry` CSS variable token, and adds missing `aria-label` attributes to icon-only buttons across several renderer components:

- Replaces `text-purple-500` with `text-[var(--pd-progressBar-text)]` in `LinearProgress.svelte` so the progress bar color follows the active theme via the color registry
- Adds unit tests for `LinearProgress` covering element rendering, color token usage, and base class names
- Adds `aria-label` to five pairs of add/delete icon buttons in `RunImage.svelte` (volume mounts, env variables, security options, DNS servers, extra hosts)
- Adds `aria-label` to the bulk delete button in `TaskManagerBulkDeleteButton.svelte` (reuses the existing title prop)
- Adds `aria-label` to the `add-build-argument` button in `BuildImageFromContainerfile.svelte`

### Screenshot / video of UI

No visual changes. Color token adoption makes the progress bar follow existing theme definitions. Accessibility fixes have no visual impact.

### What issues does this PR fix or reference?

Resolves #16777

### How to test this PR?

1. Run `pnpm test:unit` to verify all unit tests pass
2. Run `pnpm exec vitest run packages/ui/src/lib/progress/LinearProgress.spec.ts` to verify the three new `LinearProgress` tests
3. Launch the app with `pnpm watch` and verify the linear progress bar renders correctly in light, dark, high-contrast light, and high-contrast dark themes
4. In the Run Image dialog, verify add/delete buttons for volume mounts, env variables, security options, DNS servers, and extra hosts have accessible labels (inspect with a screen reader or browser accessibility tools)
5. In the Task Manager, verify the bulk delete button has an accessible label
6. In Build Image from Containerfile, verify the add-build-argument button has an accessible label

- [x] Tests are covering the bug fix or the new feature

Tests Co-Authored-By: Claude Sonnet 4.6 noreply@anthropic.com