### PR TITLE
fix(renderer): hide update button when provider has no installed version 

### DIFF
--- a/extensions/kind/src/extension.spec.ts
+++ b/extensions/kind/src/extension.spec.ts
@@ -601,6 +601,15 @@ describe('provider#update', () => {
     expect(PROVIDER_MOCK.registerUpdate).toHaveBeenCalled();
   });
 
+  test('Register update in provider is not called if CLI is not installed', async () => {
+    vi.mocked(util.getKindBinaryInfo).mockRejectedValue(new Error('not found'));
+    vi.mocked(KindInstaller.prototype.getLatestVersionAsset).mockResolvedValue({
+      tag: 'v1.5.6',
+    } as unknown as KindGithubReleaseArtifactMetadata);
+    await activate();
+    expect(PROVIDER_MOCK.registerUpdate).not.toHaveBeenCalled();
+  });
+
   test('Register update in provider is not called if there is no update available', async () => {
     vi.mocked(KindInstaller.prototype.getLatestVersionAsset).mockResolvedValue({
       tag: 'v0.0.1',

--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -370,7 +370,7 @@ export async function createProvider(
     }),
   );
 
-  if (latestAsset && latestAsset.tag.slice(1) !== kindCli?.version && providerUpdate) {
+  if (kindPath && latestAsset && latestAsset.tag.slice(1) !== kindCli?.version && providerUpdate) {
     currentUpdateDisposable = provider.registerUpdate(providerUpdate);
   }
 

--- a/packages/renderer/src/lib/dashboard/ProviderUpdateButton.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderUpdateButton.svelte
@@ -49,7 +49,7 @@ async function performUpdate(provider: ProviderInfo): Promise<void> {
 }
 </script>
 
-{#if provider?.updateInfo?.version}
+{#if provider?.version && provider?.updateInfo?.version && provider.version !== provider.updateInfo.version}
   <Button
     inProgress={updateInProgress}
     disabled={preflightChecksFailed}

--- a/packages/renderer/src/lib/preferences/ProviderActionButtons.spec.ts
+++ b/packages/renderer/src/lib/preferences/ProviderActionButtons.spec.ts
@@ -371,6 +371,29 @@ describe('ProviderActionButtons', () => {
     expect(ProviderUpdateButton).toHaveBeenCalled();
   });
 
+  test('does not show update button when provider has no version even if update is available', async () => {
+    const provider: ProviderInfo = {
+      ...baseProviderInfo,
+      status: 'unknown',
+      version: undefined,
+      updateInfo: {
+        version: '1.1.0',
+      },
+    };
+
+    render(ProviderActionButtons, {
+      provider,
+      globalContext: mockGlobalContext,
+      providerInstallationInProgress: false,
+      onCreateNew: vi.fn(),
+      onUpdatePreflightChecks: vi.fn(),
+      isOnboardingEnabled: vi.fn().mockReturnValue(false),
+      hasAnyConfiguration: vi.fn().mockReturnValue(false),
+    });
+
+    expect(ProviderUpdateButton).not.toHaveBeenCalled();
+  });
+
   test('does not show update button when no update is available', async () => {
     const provider: ProviderInfo = {
       ...baseProviderInfo,

--- a/packages/renderer/src/lib/preferences/ProviderActionButtons.svelte
+++ b/packages/renderer/src/lib/preferences/ProviderActionButtons.svelte
@@ -74,7 +74,9 @@ const showSetupButton = $derived(
   globalContext && (isOnboardingEnabled(provider, globalContext) || hasAnyConfiguration(provider)),
 );
 
-const showUpdateButton = $derived(provider.updateInfo?.version && provider.version !== provider.updateInfo?.version);
+const showUpdateButton = $derived(
+  provider.version && provider.updateInfo?.version && provider.version !== provider.updateInfo?.version,
+);
 
 function handleCreateNew(): Promise<void> {
   return onCreateNew(provider, providerDisplayName);


### PR DESCRIPTION
### What does this PR do?

Prevents the Update button from being shown on the Resources page for providers that have no installed version. Previously, if an extension (e.g. Kind) reported `updateInfo` with a newer version but the CLI was not actually installed, the Resources page would still render an Update button. Clicking it would call `updateProvider`, which would spin indefinitely since there is nothing to update.

Root cause: the Kind extension registers a provider update via `provider.registerUpdate()` even when `kindPath` is undefined (CLI not installed). Additionally, the renderer only compared versions without checking that the provider has a version at all.

Fixes:
- **Kind extension:** skip `provider.registerUpdate` when `kindPath` is not set
- **Renderer (`ProviderActionButtons`):** require `provider.version` to exist before showing the Update button
- **`ProviderUpdateButton`:** add the same version guard as defense-in-depth

### Screenshot / video of UI

<!-- Video to be added: uninstall Kind → no Update button → install latest → no Update button → downgrade via CLI Tools → Update button appears in Resources → click Update → version updates in the UI -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/13639

### How to test this PR?

1. Make sure Kind CLI is **not** installed on your system.
2. Open Podman Desktop and go to **Settings > CLI Tools** — verify Kind is not detected / not installed.
3. Navigate to the **Settings > Resources** page.
4. Find the Kind provider card. Confirm the **Update** button is **not** shown.
5. Install Kind CLI (e.g. via the CLI Tools page). Confirm the Update button still does not appear (latest version installed).
6. Downgrade Kind via the CLI Tools page to an older version.
7. Go back to **Settings > Resources** — the Update button should now appear.
8. Click Update — it should complete successfully and the version should update in the UI.

- [x] Tests are covering the bug fix or the new feature