### PR TITLE
fix(installer): hyperv only podman install now passes

### DIFF
--- a/extensions/podman/packages/extension/src/checks/windows/hyper-v-podman-version-check.spec.ts
+++ b/extensions/podman/packages/extension/src/checks/windows/hyper-v-podman-version-check.spec.ts
@@ -67,6 +67,15 @@ interface FailureTestCase {
   errorDescription: string;
 }
 
+test('expect success if Podman is not installed', async () => {
+  vi.mocked(podmanBinaryMock.getBinaryInfo).mockResolvedValue(undefined);
+
+  const hyperVPodmanVersionCheck = new HyperVPodmanVersionCheck(podmanBinaryMock);
+  const result = await hyperVPodmanVersionCheck.execute();
+
+  expect(result.successful).toBeTruthy();
+});
+
 test.each<FailureTestCase>([
   {
     name: 'expect failure if Podman version minor bellow minimum',

--- a/extensions/podman/packages/extension/src/checks/windows/hyper-v-podman-version-check.ts
+++ b/extensions/podman/packages/extension/src/checks/windows/hyper-v-podman-version-check.ts
@@ -46,7 +46,7 @@ export class HyperVPodmanVersionCheck extends BaseCheck {
 
   private async isPodmanVersionSupported(): Promise<boolean> {
     const binaryInfo = await this.podmanBinary.getBinaryInfo();
-    if (!binaryInfo) return false;
+    if (!binaryInfo) return true;
     return compare(binaryInfo?.version, HyperVPodmanVersionCheck.PODMAN_MINIMUM_VERSION_FOR_HYPERV) >= 0;
   }
 }

--- a/extensions/podman/packages/extension/src/checks/windows/hyper-v-podman-version-check.ts
+++ b/extensions/podman/packages/extension/src/checks/windows/hyper-v-podman-version-check.ts
@@ -20,6 +20,7 @@ import { inject, injectable } from 'inversify';
 import { compare } from 'semver';
 
 import { BaseCheck } from '/@/checks/base-check';
+import type { InstalledPodman } from '/@/utils/podman-binary';
 import { PodmanBinary } from '/@/utils/podman-binary';
 
 @injectable()
@@ -35,8 +36,13 @@ export class HyperVPodmanVersionCheck extends BaseCheck {
   }
 
   async execute(): Promise<CheckResult> {
-    const isPodmanVersionSupported = await this.isPodmanVersionSupported();
-    if (!isPodmanVersionSupported) {
+    const binaryInfo = await this.podmanBinary.getBinaryInfo();
+    if (!binaryInfo) {
+      // Podman is not installed => ignore
+      return this.createSuccessfulResult();
+    }
+
+    if (!this.isPodmanVersionSupported(binaryInfo)) {
       return this.createFailureResult({
         description: `Hyper-V is only supported with podman version >= ${HyperVPodmanVersionCheck.PODMAN_MINIMUM_VERSION_FOR_HYPERV}.`,
       });
@@ -44,9 +50,7 @@ export class HyperVPodmanVersionCheck extends BaseCheck {
     return this.createSuccessfulResult();
   }
 
-  private async isPodmanVersionSupported(): Promise<boolean> {
-    const binaryInfo = await this.podmanBinary.getBinaryInfo();
-    if (!binaryInfo) return true;
-    return compare(binaryInfo?.version, HyperVPodmanVersionCheck.PODMAN_MINIMUM_VERSION_FOR_HYPERV) >= 0;
+  private isPodmanVersionSupported(binaryInfo: InstalledPodman): boolean {
+    return compare(binaryInfo.version, HyperVPodmanVersionCheck.PODMAN_MINIMUM_VERSION_FOR_HYPERV) >= 0;
   }
 }


### PR DESCRIPTION
the function would wrongfully return false if there was no podman binary which caused a premature error for onboarding when hyperv was the only provider

### What does this PR do?

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes: https://github.com/podman-desktop/podman-desktop/issues/16655

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

Make sure you are on windows that has hyperv so education or pro
disable VMP and windows subsystems for linux

<img width="265" height="104" alt="image" src="https://github.com/user-attachments/assets/8cfcab65-97e2-43d6-917c-fba34f6951d4" />

enable hyper v

apply changes and restart

delete the podman.exe on host

remove any configurations

"Remove-Item -Recurse -Force "$env:USERPROFILE\.local\share\containers\podman-desktop""

do pnpm watch in an administrator window  and try to install podman

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
