### PR TITLE
fix(renderer): mock TerminalWindow in PullImage tests for jsdom 29 compatibility

### DIFF
--- a/packages/renderer/src/lib/image/PullImage.spec.ts
+++ b/packages/renderer/src/lib/image/PullImage.spec.ts
@@ -33,6 +33,8 @@ import { runImageInfo } from '/@/stores/run-image-store';
 
 import PullImage from './PullImage.svelte';
 
+vi.mock(import('/@/lib/ui/TerminalWindow.svelte'));
+
 beforeAll(() => {
   (window.events as unknown) = {
     receive: (_channel: string, func: () => void): void => {


### PR DESCRIPTION
### What does this PR do?

Fixes PullImage unit tests that fail on Ubuntu and Windows CI after upgrading jsdom from v28 to v29 (#16898).                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                                                                        
jsdom v29 introduced two performance-impacting changes:
1. **`querySelectorAll` regression** ([jsdom#3936](https://github.com/jsdom/jsdom/issues/3936)) — since v27, jsdom replaced `nwsapi` with `@asamuzakjp/dom-selector`, which is significantly slower for the `*[role~="..."]` selectors that `@testing-library` uses internally for every `getByRole` / `queryByRole` call.
2. **New CSS engine** — jsdom v29 replaced `cssstyle` with internal implementations built on `css-tree`, adding overhead to `getComputedStyle()` and `CSSStyleDeclaration` operations.

`PullImage` renders `TerminalWindow`, which instantiates a full xterm.js `Terminal`. This creates a large DOM subtree (canvas layers, accessibility rows, viewport elements) with many inline style mutations and `getComputedStyle` calls from `FitAddon.fit()`. Under jsdom v29 this amplifies both regressions, pushing timing-sensitive tests past their 5s/10s timeouts on slower CI runners.                                                                                 

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

fixes #16898 

### How to test this PR?

- All 35 PullImage tests pass on Ubuntu, Windows, and macOS CI.   

- [x] Tests are covering the bug fix or the new feature
