### PR TITLE
refactor(color-registry): updated color for unknown connection state

### DIFF
--- a/packages/main/src/plugin/color-registry.spec.ts
+++ b/packages/main/src/plugin/color-registry.spec.ts
@@ -1260,7 +1260,7 @@ describe('initStatusColors', () => {
     { id: 'status-stopped-bg', description: 'gray/charcoal alpha background' },
     { id: 'status-terminated-bg', description: 'red alpha background' },
     { id: 'status-starting-bg', description: 'green alpha background' },
-    { id: 'status-unknown-bg', description: 'gray/charcoal alpha background' },
+    { id: 'status-unknown-bg', description: 'amber alpha background' },
   ])('registers $id with $description', ({ id }) => {
     const call = vi.mocked(colorRegistry.registerColorDefinition).mock.calls.find(c => c?.[0]?.id === id);
     expect(call).toBeDefined();

--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -1919,10 +1919,9 @@ export class ColorRegistry {
       light: red[950],
     });
 
-    // If we don't know the status, use gray
     this.registerColor(`${status}unknown`, {
-      dark: gray[100],
-      light: gray[400],
+      dark: amber[600],
+      light: amber[950],
     });
 
     // Connections / login


### PR DESCRIPTION
### What does this PR do?
While working on https://github.com/podman-desktop/podman-desktop/pull/16111 we have ran into a issue that the connections does not have really a 'error' state
```
ProviderConnectionStatus = 'started' | 'stopped' | 'starting' | 'stopping' | 'unknown';
```
this means that the `unknown` state is being used as some temporary state or error state without actually being one
For this unknown state there is a gray color ~ same as stopped 
this creates a ilusion saying "we dont know in which state we are but it is fine", actualy it is not... we should ALWAYS know in which state we are thus this change.

In future the ideal thing would be to probably change or add new 'error' status and update the relevant files extensions etc but I think this would be big change 

`If an unknown error has occurred, the status is set to unknown` https://podman-desktop.io/docs/extensions/developing#using-providerconnectionstatus

### Screenshot / video of UI

<img width="1186" height="899" alt="Screenshot 2026-04-14 at 14 12 37" src="https://github.com/user-attachments/assets/3a9e972c-adf4-4bf2-a5a9-efb4e087e887" />


<img width="1186" height="899" alt="Screenshot 2026-04-14 at 14 13 01" src="https://github.com/user-attachments/assets/ed964942-60fa-4d14-b692-6bf967fcb045" />


### What issues does this PR fix or reference?
Relevant PR https://github.com/podman-desktop/podman-desktop/pull/16111

### How to test this PR?
Add `podmanMachinesStatuses.set(machine.Name, 'unknown');` to line 260 in podman extension.ts file 

- [ ] Tests are covering the bug fix or the new feature
